### PR TITLE
Use builtin TimeoutError [k-n]

### DIFF
--- a/homeassistant/components/kaiterra/api_data.py
+++ b/homeassistant/components/kaiterra/api_data.py
@@ -54,7 +54,7 @@ class KaiterraApiData:
         try:
             async with asyncio.timeout(10):
                 data = await self._api.get_latest_sensor_readings(self._devices)
-        except (ClientResponseError, ClientConnectorError, asyncio.TimeoutError) as err:
+        except (ClientResponseError, ClientConnectorError, TimeoutError) as err:
             _LOGGER.debug("Couldn't fetch data from Kaiterra API: %s", err)
             self.data = {}
             async_dispatcher_send(self._hass, DISPATCHER_KAITERRA)

--- a/homeassistant/components/kostal_plenticore/config_flow.py
+++ b/homeassistant/components/kostal_plenticore/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow for Kostal Plenticore Solar Inverter integration."""
-import asyncio
 import logging
 
 from aiohttp.client_exceptions import ClientError
@@ -57,7 +56,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except AuthenticationException as ex:
                 errors[CONF_PASSWORD] = "invalid_auth"
                 _LOGGER.error("Error response: %s", ex)
-            except (ClientError, asyncio.TimeoutError):
+            except (ClientError, TimeoutError):
                 errors[CONF_HOST] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/kostal_plenticore/helper.py
+++ b/homeassistant/components/kostal_plenticore/helper.py
@@ -1,7 +1,6 @@
 """Code to handle the Plenticore API."""
 from __future__ import annotations
 
-import asyncio
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from datetime import datetime, timedelta
@@ -66,7 +65,7 @@ class Plenticore:
                 "Authentication exception connecting to %s: %s", self.host, err
             )
             return False
-        except (ClientError, asyncio.TimeoutError) as err:
+        except (ClientError, TimeoutError) as err:
             _LOGGER.error("Error connecting to %s", self.host)
             raise ConfigEntryNotReady from err
         else:

--- a/homeassistant/components/landisgyr_heat_meter/config_flow.py
+++ b/homeassistant/components/landisgyr_heat_meter/config_flow.py
@@ -108,7 +108,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # validate and retrieve the model and device number for a unique id
                 data = await self.hass.async_add_executor_job(heat_meter.read)
 
-        except (asyncio.TimeoutError, serial.SerialException) as err:
+        except (TimeoutError, serial.SerialException) as err:
             _LOGGER.warning("Failed read data from: %s. %s", port, err)
             raise CannotConnect(f"Error communicating with device: {err}") from err
 

--- a/homeassistant/components/laundrify/coordinator.py
+++ b/homeassistant/components/laundrify/coordinator.py
@@ -34,7 +34,7 @@ class LaundrifyUpdateCoordinator(DataUpdateCoordinator[dict[str, LaundrifyDevice
     async def _async_update_data(self) -> dict[str, LaundrifyDevice]:
         """Fetch data from laundrify API."""
         try:
-            # Note: asyncio.TimeoutError and aiohttp.ClientError are already
+            # Note: TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(REQUEST_TIMEOUT):
                 return {m["_id"]: m for m in await self.laundrify_api.get_machines()}

--- a/homeassistant/components/led_ble/__init__.py
+++ b/homeassistant/components/led_ble/__init__.py
@@ -79,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         async with asyncio.timeout(DEVICE_TIMEOUT):
             await startup_event.wait()
-    except asyncio.TimeoutError as ex:
+    except TimeoutError as ex:
         raise ConfigEntryNotReady(
             "Unable to communicate with the device; "
             f"Try moving the Bluetooth adapter closer to {led_ble.name}"

--- a/homeassistant/components/lifx/config_flow.py
+++ b/homeassistant/components/lifx/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow flow LIFX."""
 from __future__ import annotations
 
-import asyncio
 import socket
 from typing import Any
 
@@ -242,7 +241,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 DEFAULT_ATTEMPTS,
                 OVERALL_TIMEOUT,
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             return None
         finally:
             connection.async_stop()

--- a/homeassistant/components/lifx/coordinator.py
+++ b/homeassistant/components/lifx/coordinator.py
@@ -315,7 +315,7 @@ class LIFXUpdateCoordinator(DataUpdateCoordinator[None]):
         """Get updated color information for all zones."""
         try:
             await async_execute_lifx(self.device.get_extended_color_zones)
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(
                 f"Timeout getting color zones from {self.name}"
             ) from ex

--- a/homeassistant/components/lifx/light.py
+++ b/homeassistant/components/lifx/light.py
@@ -281,7 +281,7 @@ class LIFXLight(LIFXEntity, LightEntity):
         """Send a power change to the bulb."""
         try:
             await self.coordinator.async_set_power(pwr, duration)
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(f"Timeout setting power for {self.name}") from ex
 
     async def set_color(
@@ -294,7 +294,7 @@ class LIFXLight(LIFXEntity, LightEntity):
         merged_hsbk = merge_hsbk(self.bulb.color, hsbk)
         try:
             await self.coordinator.async_set_color(merged_hsbk, duration)
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(f"Timeout setting color for {self.name}") from ex
 
     async def get_color(
@@ -303,7 +303,7 @@ class LIFXLight(LIFXEntity, LightEntity):
         """Send a get color message to the bulb."""
         try:
             await self.coordinator.async_get_color()
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(
                 f"Timeout setting getting color for {self.name}"
             ) from ex
@@ -429,7 +429,7 @@ class LIFXMultiZone(LIFXColor):
                 await self.coordinator.async_set_color_zones(
                     zone, zone, zone_hsbk, duration, apply
                 )
-            except asyncio.TimeoutError as ex:
+            except TimeoutError as ex:
                 raise HomeAssistantError(
                     f"Timeout setting color zones for {self.name}"
                 ) from ex
@@ -444,7 +444,7 @@ class LIFXMultiZone(LIFXColor):
         """Send a get color zones message to the device."""
         try:
             await self.coordinator.async_get_color_zones()
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(
                 f"Timeout getting color zones from {self.name}"
             ) from ex
@@ -477,7 +477,7 @@ class LIFXExtendedMultiZone(LIFXMultiZone):
             await self.coordinator.async_set_extended_color_zones(
                 color_zones, duration=duration
             )
-        except asyncio.TimeoutError as ex:
+        except TimeoutError as ex:
             raise HomeAssistantError(
                 f"Timeout setting color zones on {self.name}"
             ) from ex

--- a/homeassistant/components/lifx/util.py
+++ b/homeassistant/components/lifx/util.py
@@ -202,7 +202,7 @@ async def async_multi_execute_lifx_with_retries(
     a response again.
 
     If we don't get a result after all attempts, we will raise an
-    asyncio.TimeoutError exception.
+    TimeoutError exception.
     """
     loop = asyncio.get_running_loop()
     futures: list[asyncio.Future] = [loop.create_future() for _ in methods]
@@ -236,8 +236,6 @@ async def async_multi_execute_lifx_with_retries(
 
     if failed:
         failed_methods = ", ".join(failed)
-        raise asyncio.TimeoutError(
-            f"{failed_methods} timed out after {attempts} attempts"
-        )
+        raise TimeoutError(f"{failed_methods} timed out after {attempts} attempts")
 
     return results

--- a/homeassistant/components/lifx_cloud/scene.py
+++ b/homeassistant/components/lifx_cloud/scene.py
@@ -50,7 +50,7 @@ async def async_setup_platform(
         async with asyncio.timeout(timeout):
             scenes_resp = await httpsession.get(url, headers=headers)
 
-    except (asyncio.TimeoutError, aiohttp.ClientError):
+    except (TimeoutError, aiohttp.ClientError):
         _LOGGER.exception("Error on %s", url)
         return
 
@@ -92,5 +92,5 @@ class LifxCloudScene(Scene):
             async with asyncio.timeout(self._timeout):
                 await httpsession.put(url, headers=self._headers)
 
-        except (asyncio.TimeoutError, aiohttp.ClientError):
+        except (TimeoutError, aiohttp.ClientError):
             _LOGGER.exception("Error on %s", url)

--- a/homeassistant/components/logi_circle/__init__.py
+++ b/homeassistant/components/logi_circle/__init__.py
@@ -170,7 +170,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             notification_id=NOTIFICATION_ID,
         )
         return False
-    except asyncio.TimeoutError:
+    except TimeoutError:
         # The TimeoutError exception object returns nothing when casted to a
         # string, so we'll handle it separately.
         err = f"{_TIMEOUT}s timeout exceeded when connecting to Logi Circle API"

--- a/homeassistant/components/logi_circle/config_flow.py
+++ b/homeassistant/components/logi_circle/config_flow.py
@@ -162,7 +162,7 @@ class LogiCircleFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except AuthorizationFailed:
             (self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]) = "invalid_auth"
             return self.async_abort(reason="external_error")
-        except asyncio.TimeoutError:
+        except TimeoutError:
             (
                 self.hass.data[DATA_FLOW_IMPL][DOMAIN][EXTERNAL_ERRORS]
             ) = "authorize_url_timeout"

--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -101,7 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         lookin_device = await lookin_protocol.get_info()
         devices = await lookin_protocol.get_devices()
-    except (asyncio.TimeoutError, aiohttp.ClientError, NoUsableService) as ex:
+    except (TimeoutError, aiohttp.ClientError, NoUsableService) as ex:
         raise ConfigEntryNotReady from ex
 
     if entry.unique_id != (found_uuid := lookin_device.id.upper()):

--- a/homeassistant/components/loqed/__init__.py
+++ b/homeassistant/components/loqed/__init__.py
@@ -1,7 +1,6 @@
 """The loqed integration."""
 from __future__ import annotations
 
-import asyncio
 import logging
 import re
 
@@ -40,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ),
         )
     except (
-        asyncio.TimeoutError,
+        TimeoutError,
         aiohttp.ClientError,
     ) as ex:
         raise ConfigEntryNotReady(f"Unable to connect to bridge at {host}") from ex

--- a/homeassistant/components/lutron_caseta/__init__.py
+++ b/homeassistant/components/lutron_caseta/__init__.py
@@ -171,7 +171,7 @@ async def async_setup_entry(
         return False
 
     timed_out = True
-    with contextlib.suppress(asyncio.TimeoutError):
+    with contextlib.suppress(TimeoutError):
         async with asyncio.timeout(BRIDGE_TIMEOUT):
             await bridge.connect()
             timed_out = False

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -117,7 +117,7 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             assets = None
             try:
                 assets = await async_pair(self.data[CONF_HOST])
-            except (asyncio.TimeoutError, OSError):
+            except (TimeoutError, OSError):
                 errors["base"] = "cannot_connect"
 
             if not errors:
@@ -227,7 +227,7 @@ class LutronCasetaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             async with asyncio.timeout(BRIDGE_TIMEOUT):
                 await bridge.connect()
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error(
                 "Timeout while trying to connect to bridge at %s",
                 self.data[CONF_HOST],

--- a/homeassistant/components/mailbox/__init__.py
+++ b/homeassistant/components/mailbox/__init__.py
@@ -262,7 +262,7 @@ class MailboxMediaView(MailboxView):
         """Retrieve media."""
         mailbox = self.get_mailbox(platform)
 
-        with suppress(asyncio.CancelledError, asyncio.TimeoutError):
+        with suppress(asyncio.CancelledError, TimeoutError):
             async with asyncio.timeout(10):
                 try:
                     stream = await mailbox.async_get_media(msgid)

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -64,7 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         async with asyncio.timeout(CONNECT_TIMEOUT):
             await matter_client.connect()
-    except (CannotConnect, asyncio.TimeoutError) as err:
+    except (CannotConnect, TimeoutError) as err:
         raise ConfigEntryNotReady("Failed to connect to matter server") from err
     except InvalidServerVersion as err:
         if use_addon:
@@ -109,7 +109,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         async with asyncio.timeout(LISTEN_READY_TIMEOUT):
             await init_ready.wait()
-    except asyncio.TimeoutError as err:
+    except TimeoutError as err:
         listen_task.cancel()
         raise ConfigEntryNotReady("Matter client not ready") from err
 

--- a/homeassistant/components/meater/__init__.py
+++ b/homeassistant/components/meater/__init__.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data() -> dict[str, MeaterProbe]:
         """Fetch data from API endpoint."""
         try:
-            # Note: asyncio.TimeoutError and aiohttp.ClientError are already
+            # Note: TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(10):
                 devices: list[MeaterProbe] = await meater_api.get_all_devices()

--- a/homeassistant/components/media_player/__init__.py
+++ b/homeassistant/components/media_player/__init__.py
@@ -1345,7 +1345,7 @@ async def async_fetch_image(
     """Retrieve an image."""
     content, content_type = (None, None)
     websession = async_get_clientsession(hass)
-    with suppress(asyncio.TimeoutError):
+    with suppress(TimeoutError):
         async with asyncio.timeout(10):
             response = await websession.get(url)
             if response.status == HTTPStatus.OK:

--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if isinstance(ex, ClientResponseError) and ex.code == 401:
             raise ConfigEntryAuthFailed from ex
         raise ConfigEntryNotReady from ex
-    except (asyncio.TimeoutError, ClientConnectionError) as ex:
+    except (TimeoutError, ClientConnectionError) as ex:
         raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {}).update({entry.entry_id: mel_devices})

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -60,7 +60,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             if err.status in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN):
                 return self.async_abort(reason="invalid_auth")
             return self.async_abort(reason="cannot_connect")
-        except (asyncio.TimeoutError, ClientError):
+        except (TimeoutError, ClientError):
             return self.async_abort(reason="cannot_connect")
 
         return await self._create_entry(username, acquired_token)
@@ -136,7 +136,7 @@ class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             else:
                 errors["base"] = "cannot_connect"
         except (
-            asyncio.TimeoutError,
+            TimeoutError,
             ClientError,
         ):
             errors["base"] = "cannot_connect"

--- a/homeassistant/components/microsoft_face/__init__.py
+++ b/homeassistant/components/microsoft_face/__init__.py
@@ -334,7 +334,7 @@ class MicrosoftFace:
         except aiohttp.ClientError:
             _LOGGER.warning("Can't connect to microsoft face api")
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Timeout from microsoft face api %s", response.url)
 
         raise HomeAssistantError("Network error on microsoft face api.")

--- a/homeassistant/components/mjpeg/camera.py
+++ b/homeassistant/components/mjpeg/camera.py
@@ -149,7 +149,7 @@ class MjpegCamera(Camera):
                 image = await response.read()
                 return image
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             LOGGER.error("Timeout getting camera image from %s", self.name)
 
         except aiohttp.ClientError as err:
@@ -169,7 +169,7 @@ class MjpegCamera(Camera):
         try:
             if self._still_image_url:
                 # Fallback to MJPEG stream if still image URL is not available
-                with suppress(asyncio.TimeoutError, httpx.HTTPError):
+                with suppress(TimeoutError, httpx.HTTPError):
                     return (
                         await client.get(
                             self._still_image_url, auth=auth, timeout=TIMEOUT
@@ -183,7 +183,7 @@ class MjpegCamera(Camera):
                     stream.aiter_bytes(BUFFER_SIZE)
                 )
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             LOGGER.error("Timeout getting camera image from %s", self.name)
 
         except httpx.HTTPError as err:
@@ -201,7 +201,7 @@ class MjpegCamera(Camera):
             response = web.StreamResponse(headers=stream.headers)
             await response.prepare(request)
             # Stream until we are done or client disconnects
-            with suppress(asyncio.TimeoutError, httpx.HTTPError):
+            with suppress(TimeoutError, httpx.HTTPError):
                 async for chunk in stream.aiter_bytes(BUFFER_SIZE):
                     if not self.hass.is_running:
                         break

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -197,7 +197,7 @@ class MobileAppNotificationService(BaseNotificationService):
             else:
                 _LOGGER.error(message)
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.error("Timeout sending notification to %s", push_url)
         except aiohttp.ClientError as err:
             _LOGGER.error("Error sending notification to %s: %r", push_url, err)

--- a/homeassistant/components/moehlenhoff_alpha2/config_flow.py
+++ b/homeassistant/components/moehlenhoff_alpha2/config_flow.py
@@ -1,5 +1,4 @@
 """Alpha2 config flow."""
-import asyncio
 import logging
 from typing import Any
 
@@ -27,7 +26,7 @@ async def validate_input(data: dict[str, Any]) -> dict[str, str]:
     base = Alpha2Base(data[CONF_HOST])
     try:
         await base.update_data()
-    except (aiohttp.client_exceptions.ClientConnectorError, asyncio.TimeoutError):
+    except (aiohttp.client_exceptions.ClientConnectorError, TimeoutError):
         return {"error": "cannot_connect"}
     except Exception:  # pylint: disable=broad-except
         _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/mpd/media_player.py
+++ b/homeassistant/components/mpd/media_player.py
@@ -128,18 +128,16 @@ class MpdDevice(MediaPlayerEntity):
                 try:
                     async with asyncio.timeout(self._client.timeout + 5):
                         await self._client.connect(self.server, self.port)
-                except asyncio.TimeoutError as error:
+                except TimeoutError as error:
                     # TimeoutError has no message (which hinders logging further
                     # down the line), so provide one.
-                    raise asyncio.TimeoutError(
-                        "Connection attempt timed out"
-                    ) from error
+                    raise TimeoutError("Connection attempt timed out") from error
                 if self.password is not None:
                     await self._client.password(self.password)
                 self._is_available = True
                 yield
             except (
-                asyncio.TimeoutError,
+                TimeoutError,
                 gaierror,
                 mpd.ConnectionError,
                 OSError,

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -921,7 +921,7 @@ class MQTT:
         try:
             async with asyncio.timeout(TIMEOUT_ACK):
                 await self._pending_operations[mid].wait()
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning(
                 "No ACK from MQTT server in %s seconds (mid: %s)", TIMEOUT_ACK, mid
             )

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -74,7 +74,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         async with asyncio.timeout(AVAILABILITY_TIMEOUT):
             # Await the client setup or an error state was received
             return await state_reached_future
-    except asyncio.TimeoutError:
+    except TimeoutError:
         return False
 
 

--- a/homeassistant/components/mutesync/config_flow.py
+++ b/homeassistant/components/mutesync/config_flow.py
@@ -32,7 +32,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
         if error.status == 403:
             raise InvalidAuth from error
         raise CannotConnect from error
-    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+    except (aiohttp.ClientError, TimeoutError) as error:
         raise CannotConnect from error
 
     return token

--- a/homeassistant/components/mysensors/gateway.py
+++ b/homeassistant/components/mysensors/gateway.py
@@ -109,7 +109,7 @@ async def try_connect(
             async with asyncio.timeout(GATEWAY_READY_TIMEOUT):
                 await gateway_ready.wait()
                 return True
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.info("Try gateway connect failed with timeout")
             return False
         finally:
@@ -301,7 +301,7 @@ async def _gw_start(
     try:
         async with asyncio.timeout(GATEWAY_READY_TIMEOUT):
             await gateway_ready.wait()
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.warning(
             "Gateway %s not connected after %s secs so continuing with setup",
             entry.data[CONF_DEVICE],

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -49,7 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     options = ConnectionOptions(host=host, username=username, password=password)
     try:
         nam = await NettigoAirMonitor.create(websession, options)
-    except (ApiError, ClientError, ClientConnectorError, asyncio.TimeoutError) as err:
+    except (ApiError, ClientError, ClientConnectorError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
 
     try:

--- a/homeassistant/components/nam/config_flow.py
+++ b/homeassistant/components/nam/config_flow.py
@@ -92,7 +92,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 config = await async_get_config(self.hass, self.host)
-            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+            except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except CannotGetMacError:
                 return self.async_abort(reason="device_unsupported")
@@ -128,7 +128,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 await async_check_credentials(self.hass, self.host, user_input)
             except AuthFailedError:
                 errors["base"] = "invalid_auth"
-            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+            except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
@@ -155,7 +155,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             self._config = await async_get_config(self.hass, self.host)
-        except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+        except (ApiError, ClientConnectorError, TimeoutError):
             return self.async_abort(reason="cannot_connect")
         except CannotGetMacError:
             return self.async_abort(reason="device_unsupported")
@@ -209,7 +209,7 @@ class NAMFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ApiError,
                 AuthFailedError,
                 ClientConnectorError,
-                asyncio.TimeoutError,
+                TimeoutError,
             ):
                 return self.async_abort(reason="reauth_unsuccessful")
 

--- a/homeassistant/components/netatmo/data_handler.py
+++ b/homeassistant/components/netatmo/data_handler.py
@@ -1,7 +1,6 @@
 """The Netatmo data handler."""
 from __future__ import annotations
 
-import asyncio
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -239,7 +238,7 @@ class NetatmoDataHandler:
             _LOGGER.debug(err)
             has_error = True
 
-        except (asyncio.TimeoutError, aiohttp.ClientConnectorError) as err:
+        except (TimeoutError, aiohttp.ClientConnectorError) as err:
             _LOGGER.debug(err)
             return True
 

--- a/homeassistant/components/nexia/__init__.py
+++ b/homeassistant/components/nexia/__init__.py
@@ -1,5 +1,4 @@
 """Support for Nexia / Trane XL Thermostats."""
-import asyncio
 import logging
 
 import aiohttp
@@ -45,7 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     try:
         await nexia_home.login()
-    except asyncio.TimeoutError as ex:
+    except TimeoutError as ex:
         raise ConfigEntryNotReady(
             f"Timed out trying to connect to Nexia service: {ex}"
         ) from ex

--- a/homeassistant/components/nexia/config_flow.py
+++ b/homeassistant/components/nexia/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow for Nexia integration."""
-import asyncio
 import logging
 
 import aiohttp
@@ -57,7 +56,7 @@ async def validate_input(hass: core.HomeAssistant, data):
     )
     try:
         await nexia_home.login()
-    except asyncio.TimeoutError as ex:
+    except TimeoutError as ex:
         _LOGGER.error("Unable to connect to Nexia service: %s", ex)
         raise CannotConnect from ex
     except aiohttp.ClientResponseError as http_ex:

--- a/homeassistant/components/nextdns/__init__.py
+++ b/homeassistant/components/nextdns/__init__.py
@@ -163,7 +163,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     try:
         async with asyncio.timeout(10):
             nextdns = await NextDns.create(websession, api_key)
-    except (ApiError, ClientConnectorError, asyncio.TimeoutError) as err:
+    except (ApiError, ClientConnectorError, TimeoutError) as err:
         raise ConfigEntryNotReady from err
 
     tasks = []

--- a/homeassistant/components/nextdns/config_flow.py
+++ b/homeassistant/components/nextdns/config_flow.py
@@ -43,7 +43,7 @@ class NextDnsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     )
             except InvalidApiKeyError:
                 errors["base"] = "invalid_api_key"
-            except (ApiError, ClientConnectorError, asyncio.TimeoutError):
+            except (ApiError, ClientConnectorError, TimeoutError):
                 errors["base"] = "cannot_connect"
             except Exception:  # pylint: disable=broad-except
                 errors["base"] = "unknown"

--- a/homeassistant/components/nextdns/switch.py
+++ b/homeassistant/components/nextdns/switch.py
@@ -1,7 +1,6 @@
 """Support for the NextDNS service."""
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Generic
@@ -647,7 +646,7 @@ class NextDnsSwitch(CoordinatorEntity[NextDnsSettingsUpdateCoordinator], SwitchE
         except (
             ApiError,
             ClientConnectorError,
-            asyncio.TimeoutError,
+            TimeoutError,
             ClientError,
         ) as err:
             raise HomeAssistantError(

--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -228,7 +228,7 @@ class NmapDeviceScanner:
             )
         )
         self._mac_vendor_lookup = AsyncMacLookup()
-        with contextlib.suppress((asyncio.TimeoutError, aiohttp.ClientError)):
+        with contextlib.suppress((TimeoutError, aiohttp.ClientError)):
             # We don't care if this fails since it only
             # improves the data when we don't have it from nmap
             await self._mac_vendor_lookup.load_vendors()

--- a/homeassistant/components/no_ip/__init__.py
+++ b/homeassistant/components/no_ip/__init__.py
@@ -114,7 +114,7 @@ async def _update_no_ip(
     except aiohttp.ClientError:
         _LOGGER.warning("Can't connect to NO-IP API")
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.warning("Timeout from NO-IP API for domain: %s", domain)
 
     return False

--- a/homeassistant/components/nuki/__init__.py
+++ b/homeassistant/components/nuki/__init__.py
@@ -304,7 +304,7 @@ class NukiCoordinator(DataUpdateCoordinator[None]):  # pylint: disable=hass-enfo
     async def _async_update_data(self) -> None:
         """Fetch data from Nuki bridge."""
         try:
-            # Note: asyncio.TimeoutError and aiohttp.ClientError are already
+            # Note: TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(10):
                 events = await self.hass.async_add_executor_job(

--- a/tests/components/kmtronic/test_init.py
+++ b/tests/components/kmtronic/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the KMtronic component."""
-import asyncio
 
 from homeassistant.components.kmtronic.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -46,7 +45,7 @@ async def test_config_entry_not_ready(
 
     aioclient_mock.get(
         "http://1.1.1.1/status.xml",
-        exc=asyncio.TimeoutError(),
+        exc=TimeoutError(),
     )
 
     config_entry = MockConfigEntry(

--- a/tests/components/kmtronic/test_switch.py
+++ b/tests/components/kmtronic/test_switch.py
@@ -1,5 +1,4 @@
 """The tests for the KMtronic switch platform."""
-import asyncio
 from datetime import timedelta
 from http import HTTPStatus
 
@@ -156,7 +155,7 @@ async def test_failed_update(
     aioclient_mock.clear_requests()
     aioclient_mock.get(
         "http://1.1.1.1/status.xml",
-        exc=asyncio.TimeoutError(),
+        exc=TimeoutError(),
     )
     async_fire_time_changed(hass, future)
 

--- a/tests/components/kostal_plenticore/test_config_flow.py
+++ b/tests/components/kostal_plenticore/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Kostal Plenticore Solar Inverter config flow."""
-import asyncio
 from collections.abc import Generator
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -212,7 +211,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         # mock of the context manager instance
         mock_api_ctx = MagicMock()
         mock_api_ctx.login = AsyncMock(
-            side_effect=asyncio.TimeoutError(),
+            side_effect=TimeoutError(),
         )
 
         # mock of the return instance of ApiClient

--- a/tests/components/logi_circle/test_config_flow.py
+++ b/tests/components/logi_circle/test_config_flow.py
@@ -146,7 +146,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
-        (asyncio.TimeoutError, "authorize_url_timeout"),
+        (TimeoutError, "authorize_url_timeout"),
         (AuthorizationFailed, "invalid_auth"),
     ],
 )

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the Lutron Caseta config flow."""
-import asyncio
 from ipaddress import ip_address
 from pathlib import Path
 import ssl
@@ -114,7 +113,7 @@ async def test_bridge_cannot_connect_unknown_error(hass: HomeAssistant) -> None:
 
     with patch.object(Smartbridge, "create_tls") as create_tls:
         mock_bridge = MockBridge()
-        mock_bridge.connect = AsyncMock(side_effect=asyncio.TimeoutError)
+        mock_bridge.connect = AsyncMock(side_effect=TimeoutError)
         create_tls.return_value = mock_bridge
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -270,7 +269,7 @@ async def test_form_user_pairing_fails(hass: HomeAssistant, tmp_path: Path) -> N
 
     with patch(
         "homeassistant.components.lutron_caseta.config_flow.async_pair",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ), patch(
         "homeassistant.components.lutron_caseta.async_setup", return_value=True
     ) as mock_setup, patch(

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -1,5 +1,4 @@
 """Test the base functions of the media player."""
-import asyncio
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -103,7 +102,7 @@ async def test_get_image_http_log_credentials_redacted(
         state = hass.states.get("media_player.bedroom")
         assert "entity_picture_local" not in state.attributes
 
-        aioclient_mock.get(url, exc=asyncio.TimeoutError())
+        aioclient_mock.get(url, exc=TimeoutError())
 
         client = await hass_client_no_auth()
 

--- a/tests/components/melcloud/test_config_flow.py
+++ b/tests/components/melcloud/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the MELCloud config flow."""
-import asyncio
 from http import HTTPStatus
 from unittest.mock import patch
 
@@ -75,7 +74,7 @@ async def test_form(hass: HomeAssistant, mock_login, mock_get_devices) -> None:
 
 @pytest.mark.parametrize(
     ("error", "reason"),
-    [(ClientError(), "cannot_connect"), (asyncio.TimeoutError(), "cannot_connect")],
+    [(ClientError(), "cannot_connect"), (TimeoutError(), "cannot_connect")],
 )
 async def test_form_errors(
     hass: HomeAssistant, mock_login, mock_get_devices, error, reason
@@ -195,7 +194,7 @@ async def test_token_reauthentication(
 @pytest.mark.parametrize(
     ("error", "reason"),
     [
-        (asyncio.TimeoutError(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
         (AttributeError(name="get"), "invalid_auth"),
     ],
 )

--- a/tests/components/microsoft_face/test_init.py
+++ b/tests/components/microsoft_face/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the microsoft face platform."""
-import asyncio
 from unittest.mock import patch
 
 import pytest
@@ -339,7 +338,7 @@ async def test_service_status_timeout(
     aioclient_mock.put(
         ENDPOINT_URL.format("persongroups/service_group"),
         status=400,
-        exc=asyncio.TimeoutError(),
+        exc=TimeoutError(),
     )
 
     with assert_setup_component(3, mf.DOMAIN):

--- a/tests/components/moehlenhoff_alpha2/test_config_flow.py
+++ b/tests/components/moehlenhoff_alpha2/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the moehlenhoff_alpha2 config flow."""
-import asyncio
 from unittest.mock import patch
 
 from homeassistant import config_entries
@@ -74,9 +73,7 @@ async def test_form_cannot_connect_error(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    with patch(
-        "moehlenhoff_alpha2.Alpha2Base.update_data", side_effect=asyncio.TimeoutError
-    ):
+    with patch("moehlenhoff_alpha2.Alpha2Base.update_data", side_effect=TimeoutError):
         result2 = await hass.config_entries.flow.async_configure(
             flow_id=result["flow_id"],
             user_input={"host": MOCK_BASE_HOST},

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -2480,7 +2480,7 @@ async def test_delayed_birth_message(
         await mqtt.async_subscribe(hass, "homeassistant/status", wait_birth)
         mqtt_client_mock.on_connect(None, None, 0, 0)
         await hass.async_block_till_done()
-        with pytest.raises(asyncio.TimeoutError):
+        with pytest.raises(TimeoutError):
             await asyncio.wait_for(birth.wait(), 0.2)
         assert not mqtt_client_mock.publish.called
         assert not birth.is_set()

--- a/tests/components/mutesync/test_config_flow.py
+++ b/tests/components/mutesync/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the mütesync config flow."""
-import asyncio
 from unittest.mock import patch
 
 import aiohttp
@@ -49,7 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
         (Exception, "unknown"),
         (aiohttp.ClientResponseError(None, None, status=403), "invalid_auth"),
         (aiohttp.ClientResponseError(None, None, status=500), "cannot_connect"),
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
     ],
 )
 async def test_form_error(

--- a/tests/components/nam/test_config_flow.py
+++ b/tests/components/nam/test_config_flow.py
@@ -1,5 +1,4 @@
 """Define tests for the Nettigo Air Monitor config flow."""
-import asyncio
 from ipaddress import ip_address
 from unittest.mock import patch
 
@@ -171,7 +170,7 @@ async def test_reauth_unsuccessful(hass: HomeAssistant) -> None:
     [
         (ApiError("API Error"), "cannot_connect"),
         (AuthFailedError("Auth Error"), "invalid_auth"),
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (ValueError, "unknown"),
     ],
 )
@@ -210,7 +209,7 @@ async def test_form_with_auth_errors(hass: HomeAssistant, error) -> None:
     "error",
     [
         (ApiError("API Error"), "cannot_connect"),
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (ValueError, "unknown"),
     ],
 )

--- a/tests/components/nexia/test_config_flow.py
+++ b/tests/components/nexia/test_config_flow.py
@@ -1,5 +1,4 @@
 """Test the nexia config flow."""
-import asyncio
 from unittest.mock import MagicMock, patch
 
 import aiohttp
@@ -81,7 +80,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.nexia.config_flow.NexiaHome.login",
-        side_effect=asyncio.TimeoutError,
+        side_effect=TimeoutError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/nextdns/test_config_flow.py
+++ b/tests/components/nextdns/test_config_flow.py
@@ -1,5 +1,4 @@
 """Define tests for the NextDNS config flow."""
-import asyncio
 from unittest.mock import patch
 
 from nextdns import ApiError, InvalidApiKeyError
@@ -53,7 +52,7 @@ async def test_form_create_entry(hass: HomeAssistant) -> None:
     [
         (ApiError("API Error"), "cannot_connect"),
         (InvalidApiKeyError, "invalid_api_key"),
-        (asyncio.TimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (ValueError, "unknown"),
     ],
 )

--- a/tests/components/nextdns/test_switch.py
+++ b/tests/components/nextdns/test_switch.py
@@ -1,5 +1,4 @@
 """Test switch of NextDNS integration."""
-import asyncio
 from datetime import timedelta
 from unittest.mock import Mock, patch
 
@@ -717,7 +716,7 @@ async def test_availability(hass: HomeAssistant) -> None:
     "exc",
     [
         ApiError(Mock()),
-        asyncio.TimeoutError,
+        TimeoutError,
         ClientConnectorError(Mock(), Mock()),
         ClientError,
     ],


### PR DESCRIPTION
## Proposed change
In Python 3.11 `asyncio.TimeoutError` was made an alias of the builtin `TimeoutError` and subsequently deprecated. This is in preparation for the ruff `0.2.0` update which will be able to detect / fix this automatically.
https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.TimeoutError

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
