### PR TITLE
Remove homeassistant_green config entry if hassio is not present

### DIFF
--- a/homeassistant/components/homeassistant_green/__init__.py
+++ b/homeassistant/components/homeassistant_green/__init__.py
@@ -1,7 +1,7 @@
 """The Home Assistant Green integration."""
 from __future__ import annotations
 
-from homeassistant.components.hassio import get_os_info
+from homeassistant.components.hassio import get_os_info, is_hassio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -9,6 +9,11 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a Home Assistant Green config entry."""
+    if not is_hassio(hass):
+        # Not running under supervisor, Home Assistant may have been migrated
+        hass.async_create_task(hass.config_entries.async_remove(entry.entry_id))
+        return False
+
     if (os_info := get_os_info(hass)) is None:
         # The hassio integration has not yet fetched data from the supervisor
         raise ConfigEntryNotReady

--- a/homeassistant/components/homeassistant_green/manifest.json
+++ b/homeassistant/components/homeassistant_green/manifest.json
@@ -1,9 +1,10 @@
 {
   "domain": "homeassistant_green",
   "name": "Home Assistant Green",
+  "after_dependencies": ["hassio"],
   "codeowners": ["@home-assistant/core"],
   "config_flow": false,
-  "dependencies": ["hardware", "hassio", "homeassistant_hardware"],
+  "dependencies": ["hardware", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_green",
   "integration_type": "hardware"
 }

--- a/tests/components/homeassistant_green/test_config_flow.py
+++ b/tests/components/homeassistant_green/test_config_flow.py
@@ -3,9 +3,11 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.homeassistant_green.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
 
@@ -36,6 +38,7 @@ def mock_set_green_settings():
 async def test_config_flow(hass: HomeAssistant) -> None:
     """Test the config flow."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     with patch(
         "homeassistant.components.homeassistant_green.async_setup_entry",
@@ -60,6 +63,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
 async def test_config_flow_single_entry(hass: HomeAssistant) -> None:
     """Test only a single entry is allowed."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -115,6 +119,7 @@ async def test_option_flow_led_settings(
 ) -> None:
     """Test updating LED settings."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -146,6 +151,7 @@ async def test_option_flow_led_settings_unchanged(
 ) -> None:
     """Test updating LED settings."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -171,6 +177,7 @@ async def test_option_flow_led_settings_unchanged(
 async def test_option_flow_led_settings_fail_1(hass: HomeAssistant) -> None:
     """Test updating LED settings."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -196,6 +203,7 @@ async def test_option_flow_led_settings_fail_2(
 ) -> None:
     """Test updating LED settings."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(

--- a/tests/components/homeassistant_green/test_hardware.py
+++ b/tests/components/homeassistant_green/test_hardware.py
@@ -3,8 +3,10 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.homeassistant_green.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
 from tests.typing import WebSocketGenerator
@@ -15,6 +17,7 @@ async def test_hardware_info(
 ) -> None:
     """Test we can get the board info."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -66,6 +69,7 @@ async def test_hardware_info_fail(
 ) -> None:
     """Test async_info raises if os_info is not as expected."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(

--- a/tests/components/homeassistant_green/test_init.py
+++ b/tests/components/homeassistant_green/test_init.py
@@ -1,9 +1,11 @@
 """Test the Home Assistant Green integration."""
 from unittest.mock import patch
 
+from homeassistant.components.hassio import DOMAIN as HASSIO_DOMAIN
 from homeassistant.components.homeassistant_green.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
 
@@ -11,6 +13,7 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 async def test_setup_entry(hass: HomeAssistant) -> None:
     """Test setup of a config entry."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -32,9 +35,32 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_unload(config_entry.entry_id)
 
 
+async def test_setup_entry_no_hassio(hass: HomeAssistant) -> None:
+    """Test setup of a config entry without hassio."""
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={},
+        title="Home Assistant Green",
+    )
+    config_entry.add_to_hass(hass)
+    assert len(hass.config_entries.async_entries()) == 1
+
+    with patch(
+        "homeassistant.components.homeassistant_green.get_os_info"
+    ) as mock_get_os_info:
+        assert not await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert len(mock_get_os_info.mock_calls) == 0
+    assert len(hass.config_entries.async_entries()) == 0
+
+
 async def test_setup_entry_wrong_board(hass: HomeAssistant) -> None:
     """Test setup of a config entry with wrong board type."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(
@@ -60,6 +86,7 @@ async def test_setup_entry_wrong_board(hass: HomeAssistant) -> None:
 async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
     """Test setup of a config entry when hassio has not fetched os_info."""
     mock_integration(hass, MockModule("hassio"))
+    await async_setup_component(hass, HASSIO_DOMAIN, {})
 
     # Setup the config entry
     config_entry = MockConfigEntry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove `homeassistant_green` config entry if `hassio` is not present

This is intended to remove the `homeassistant_green` config entry after migrating Home Asssistant to a non supervised installation


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
