### PR TITLE
Extend ZHA thermostat local temperature calibration range for Sonoff TRVZB

### DIFF
--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.NUMBER)
-MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.SENSOR)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.NUMBER)
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     ZHA_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -972,26 +972,18 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     _attr_icon: str = ICONS[0]
 
 
-@MULTI_MATCH(
+@CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
     models={"TRVZB"},
     stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
 )
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
-class ThermostatLocalTempCalibrationSonoffTRVZB(ZHANumberConfigurationEntity):
+class SonoffThermostatLocalTempCalibration(ThermostatLocalTempCalibration):
     """Local temperature calibration for the Sonoff TRVZB."""
 
-    _unique_id_suffix = "local_temperature_calibration"
     _attr_native_min_value: float = -7
     _attr_native_max_value: float = 7
     _attr_native_step: float = 0.2
-    _attr_multiplier: float = 0.1
-    _attribute_name = "local_temperature_calibration"
-    _attr_translation_key: str = "local_temperature_calibration"
-
-    _attr_mode: NumberMode = NumberMode.SLIDER
-    _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
-    _attr_icon: str = ICONS[0]
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -970,6 +970,20 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
     _attr_icon: str = ICONS[0]
 
+    def __init__(
+        self,
+        unique_id: str,
+        zha_device: ZHADevice,
+        cluster_handlers: list[ClusterHandler],
+        **kwargs: Any,
+    ) -> None:
+        """Init this ZHA local temperature calibration entity."""
+        self._cluster_handler: ClusterHandler = cluster_handlers[0]
+        super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
+        if zha_device.model == "TRVZB":
+            self._attr_native_max_value: float = 7
+            self._attr_native_min_value: float = -7
+
 
 @CONFIG_DIAGNOSTIC_MATCH(
     cluster_handler_names=CLUSTER_HANDLER_OCCUPANCY, models={"SNZB-06P"}

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -959,8 +959,8 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     """Local temperature calibration."""
 
     _unique_id_suffix = "local_temperature_calibration"
-    _attr_native_min_value: float = -12.8
-    _attr_native_max_value: float = 12.7
+    _attr_native_min_value: float = -2.5
+    _attr_native_max_value: float = 2.5
     _attr_native_step: float = 0.1
     _attr_multiplier: float = 0.1
     _attribute_name = "local_temperature_calibration"

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.NUMBER)
+MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.SENSOR)
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     ZHA_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )
@@ -970,20 +971,27 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
     _attr_icon: str = ICONS[0]
 
-    def __init__(
-        self,
-        unique_id: str,
-        zha_device: ZHADevice,
-        cluster_handlers: list[ClusterHandler],
-        **kwargs: Any,
-    ) -> None:
-        """Init this ZHA local temperature calibration entity."""
-        self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
-        if zha_device.model == "TRVZB":
-            self._attr_native_max_value: float = 7
-            self._attr_native_min_value: float = -7
-            self._attr_native_step: float = 0.2
+
+@MULTI_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
+    models={"TRVZB"},
+    stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
+)
+# pylint: disable-next=hass-invalid-inheritance # needs fixing
+class ThermostatLocalTempCalibrationSonoffTRVZB(ZHANumberConfigurationEntity):
+    """Local temperature calibration for the Sonoff TRVZB."""
+
+    _unique_id_suffix = "local_temperature_calibration"
+    _attr_native_min_value: float = -7
+    _attr_native_max_value: float = 7
+    _attr_native_step: float = 0.2
+    _attr_multiplier: float = 0.1
+    _attribute_name = "local_temperature_calibration"
+    _attr_translation_key: str = "local_temperature_calibration"
+
+    _attr_mode: NumberMode = NumberMode.SLIDER
+    _attr_native_unit_of_measurement: str = UnitOfTemperature.CELSIUS
+    _attr_icon: str = ICONS[0]
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -983,6 +983,7 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
         if zha_device.model == "TRVZB":
             self._attr_native_max_value: float = 7
             self._attr_native_min_value: float = -7
+            self._attr_native_step: float = 0.2
 
 
 @CONFIG_DIAGNOSTIC_MATCH(

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -959,8 +959,8 @@ class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     """Local temperature calibration."""
 
     _unique_id_suffix = "local_temperature_calibration"
-    _attr_native_min_value: float = -2.5
-    _attr_native_max_value: float = 2.5
+    _attr_native_min_value: float = -12.8
+    _attr_native_max_value: float = 12.7
     _attr_native_step: float = 0.1
     _attr_multiplier: float = 0.1
     _attribute_name = "local_temperature_calibration"

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -38,7 +38,6 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, Platform.NUMBER)
-MULTI_MATCH = functools.partial(ZHA_ENTITIES.multipass_match, Platform.NUMBER)
 CONFIG_DIAGNOSTIC_MATCH = functools.partial(
     ZHA_ENTITIES.config_diagnostic_match, Platform.NUMBER
 )
@@ -954,7 +953,10 @@ class AqaraThermostatAwayTemp(ZHANumberConfigurationEntity):
     _attr_icon: str = ICONS[0]
 
 
-@CONFIG_DIAGNOSTIC_MATCH(cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT)
+@CONFIG_DIAGNOSTIC_MATCH(
+    cluster_handler_names=CLUSTER_HANDLER_THERMOSTAT,
+    stop_on_match_group=CLUSTER_HANDLER_THERMOSTAT,
+)
 # pylint: disable-next=hass-invalid-inheritance # needs fixing
 class ThermostatLocalTempCalibration(ZHANumberConfigurationEntity):
     """Local temperature calibration."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This should not break anything. The PR just increases the range and nothing else changes for the entity.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR extends the range of `local_temperature_calibration` from `-2.5 °C - +2.5 °C` degrees to `-7 °C - +7 °C`. The temperature sensor can be way more off than 2.5 degrees. For example, currently my temperature sensor of my TRVZB is 4.6 degrees off. This makes the calibration slider not usable at the moment. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

Values are taken from https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/sonoff.ts#L540

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
