### PR TITLE
Add option to block remote enabling of HA Cloud remote

### DIFF
--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import aiohttp
-from hass_nabucasa.client import CloudClient as Interface
+from hass_nabucasa.client import CloudClient as Interface, RemoteActivationNotAllowed
 
 from homeassistant.components import google_assistant, persistent_notification, webhook
 from homeassistant.components.alexa import (
@@ -234,6 +234,8 @@ class CloudClient(Interface):
 
     async def async_cloud_connect_update(self, connect: bool) -> None:
         """Process cloud remote message to client."""
+        if not self._prefs.remote_allow_remote_enable:
+            raise RemoteActivationNotAllowed
         await self._prefs.async_update(remote_enabled=connect)
 
     async def async_cloud_connection_info(
@@ -242,6 +244,7 @@ class CloudClient(Interface):
         """Process cloud connection info message to client."""
         return {
             "remote": {
+                "can_enable": self._prefs.remote_allow_remote_enable,
                 "connected": self.cloud.remote.is_connected,
                 "enabled": self._prefs.remote_enabled,
                 "instance_domain": self.cloud.remote.instance_domain,

--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -31,6 +31,7 @@ PREF_ALEXA_SETTINGS_VERSION = "alexa_settings_version"
 PREF_GOOGLE_SETTINGS_VERSION = "google_settings_version"
 PREF_TTS_DEFAULT_VOICE = "tts_default_voice"
 PREF_GOOGLE_CONNECTED = "google_connected"
+PREF_REMOTE_ALLOW_REMOTE_ENABLE = "remote_allow_remote_enable"
 DEFAULT_TTS_DEFAULT_VOICE = ("en-US", "female")
 DEFAULT_DISABLE_2FA = False
 DEFAULT_ALEXA_REPORT_STATE = True

--- a/homeassistant/components/cloud/http_api.py
+++ b/homeassistant/components/cloud/http_api.py
@@ -44,6 +44,7 @@ from .const import (
     PREF_ENABLE_GOOGLE,
     PREF_GOOGLE_REPORT_STATE,
     PREF_GOOGLE_SECURE_DEVICES_PIN,
+    PREF_REMOTE_ALLOW_REMOTE_ENABLE,
     PREF_TTS_DEFAULT_VOICE,
     REQUEST_TIMEOUT,
 )
@@ -408,6 +409,7 @@ async def websocket_subscription(
         vol.Optional(PREF_TTS_DEFAULT_VOICE): vol.All(
             vol.Coerce(tuple), vol.In(MAP_VOICE)
         ),
+        vol.Optional(PREF_REMOTE_ALLOW_REMOTE_ENABLE): bool,
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -39,6 +39,7 @@ from .const import (
     PREF_GOOGLE_SECURE_DEVICES_PIN,
     PREF_GOOGLE_SETTINGS_VERSION,
     PREF_INSTANCE_ID,
+    PREF_REMOTE_ALLOW_REMOTE_ENABLE,
     PREF_REMOTE_DOMAIN,
     PREF_TTS_DEFAULT_VOICE,
     PREF_USERNAME,
@@ -153,6 +154,7 @@ class CloudPreferences:
         alexa_settings_version: int | UndefinedType = UNDEFINED,
         google_settings_version: int | UndefinedType = UNDEFINED,
         google_connected: bool | UndefinedType = UNDEFINED,
+        remote_allow_remote_enable: bool | UndefinedType = UNDEFINED,
     ) -> None:
         """Update user preferences."""
         prefs = {**self._prefs}
@@ -171,6 +173,7 @@ class CloudPreferences:
             (PREF_TTS_DEFAULT_VOICE, tts_default_voice),
             (PREF_REMOTE_DOMAIN, remote_domain),
             (PREF_GOOGLE_CONNECTED, google_connected),
+            (PREF_REMOTE_ALLOW_REMOTE_ENABLE, remote_allow_remote_enable),
         ):
             if value is not UNDEFINED:
                 prefs[key] = value
@@ -212,8 +215,15 @@ class CloudPreferences:
             PREF_GOOGLE_DEFAULT_EXPOSE: self.google_default_expose,
             PREF_GOOGLE_REPORT_STATE: self.google_report_state,
             PREF_GOOGLE_SECURE_DEVICES_PIN: self.google_secure_devices_pin,
+            PREF_REMOTE_ALLOW_REMOTE_ENABLE: self.remote_allow_remote_enable,
             PREF_TTS_DEFAULT_VOICE: self.tts_default_voice,
         }
+
+    @property
+    def remote_allow_remote_enable(self) -> bool:
+        """Return if it's allowed to remotely activate remote."""
+        allowed: bool = self._prefs.get(PREF_REMOTE_ALLOW_REMOTE_ENABLE, True)
+        return allowed
 
     @property
     def remote_enabled(self) -> bool:
@@ -375,5 +385,6 @@ class CloudPreferences:
             PREF_INSTANCE_ID: uuid.uuid4().hex,
             PREF_GOOGLE_SECURE_DEVICES_PIN: None,
             PREF_REMOTE_DOMAIN: None,
+            PREF_REMOTE_ALLOW_REMOTE_ENABLE: True,
             PREF_USERNAME: username,
         }

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -380,7 +380,7 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
         "instance_id": "12345678901234567890",
         "remote": {
             "alias": None,
-            "can_activate": True,
+            "can_enable": True,
             "connected": False,
             "enabled": False,
             "instance_domain": None,

--- a/tests/components/cloud/test_client.py
+++ b/tests/components/cloud/test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import aiohttp
 from aiohttp import web
+from hass_nabucasa.client import RemoteActivationNotAllowed
 import pytest
 
 from homeassistant.components.cloud import DOMAIN
@@ -376,14 +377,15 @@ async def test_cloud_connection_info(hass: HomeAssistant) -> None:
     response = await cloud.client.async_cloud_connection_info({})
 
     assert response == {
+        "instance_id": "12345678901234567890",
         "remote": {
+            "alias": None,
+            "can_activate": True,
             "connected": False,
             "enabled": False,
             "instance_domain": None,
-            "alias": None,
         },
         "version": HA_VERSION,
-        "instance_id": "12345678901234567890",
     }
 
 
@@ -481,6 +483,19 @@ async def test_remote_enable(hass: HomeAssistant) -> None:
     client = CloudClient(hass, prefs, None, {}, {})
     client.cloud = MagicMock(is_logged_in=True, username="mock-username")
 
-    result = await client.async_cloud_connect_update(True)
-    assert result is None
+    await client.async_cloud_connect_update(True)
     prefs.async_update.assert_called_once_with(remote_enabled=True)
+
+
+async def test_remote_enable_not_allowed(hass: HomeAssistant) -> None:
+    """Test enabling remote UI."""
+    prefs = MagicMock(
+        async_update=AsyncMock(return_value=None),
+        remote_allow_remote_enable=False,
+    )
+    client = CloudClient(hass, prefs, None, {}, {})
+    client.cloud = MagicMock(is_logged_in=True, username="mock-username")
+
+    with pytest.raises(RemoteActivationNotAllowed):
+        await client.async_cloud_connect_update(True)
+    prefs.async_update.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add option to block remote enabling of HA Cloud remote

When blocked, it's not possible to enable the remote UI from account.nabucasa.com, it has to be done locally

Frontend support is needed to allow users to control the new setting

Depends on <https://github.com/home-assistant/core/pull/109699>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
