### PR TITLE
Use builtin TimeoutError [misc]

### DIFF
--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -1,5 +1,4 @@
 """The Bond integration."""
-from asyncio import TimeoutError as AsyncIOTimeoutError
 from http import HTTPStatus
 import logging
 from typing import Any
@@ -56,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.error("Bond token no longer valid: %s", ex)
             return False
         raise ConfigEntryNotReady from ex
-    except (ClientError, AsyncIOTimeoutError, OSError) as error:
+    except (ClientError, TimeoutError, OSError) as error:
         raise ConfigEntryNotReady from error
 
     bpup_subs = BPUPSubscriptions()

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from asyncio import Lock, TimeoutError as AsyncIOTimeoutError
+from asyncio import Lock
 from datetime import datetime
 import logging
 
@@ -139,7 +139,7 @@ class BondEntity(Entity):
         """Fetch via the API."""
         try:
             state: dict = await self._hub.bond.device_state(self._device_id)
-        except (ClientError, AsyncIOTimeoutError, OSError) as error:
+        except (ClientError, TimeoutError, OSError) as error:
             if self.available:
                 _LOGGER.warning(
                     "Entity %s has become unavailable", self.entity_id, exc_info=error

--- a/homeassistant/components/control4/config_flow.py
+++ b/homeassistant/components/control4/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for Control4 integration."""
 from __future__ import annotations
 
-from asyncio import TimeoutError as asyncioTimeoutError
 import logging
 
 from aiohttp.client_exceptions import ClientError
@@ -82,7 +81,7 @@ class Control4Validator:
             )
             await director.getAllItemInfo()
             return True
-        except (Unauthorized, ClientError, asyncioTimeoutError):
+        except (Unauthorized, ClientError, TimeoutError):
             _LOGGER.error("Failed to connect to the Control4 controller")
             return False
 

--- a/homeassistant/components/nightscout/__init__.py
+++ b/homeassistant/components/nightscout/__init__.py
@@ -1,5 +1,4 @@
 """The Nightscout integration."""
-from asyncio import TimeoutError as AsyncIOTimeoutError
 
 from aiohttp import ClientError
 from py_nightscout import Api as NightscoutAPI
@@ -26,7 +25,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api = NightscoutAPI(server_url, session=session, api_secret=api_key)
     try:
         status = await api.get_server_status()
-    except (ClientError, AsyncIOTimeoutError, OSError) as error:
+    except (ClientError, TimeoutError, OSError) as error:
         raise ConfigEntryNotReady from error
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/nightscout/config_flow.py
+++ b/homeassistant/components/nightscout/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow for Nightscout integration."""
-from asyncio import TimeoutError as AsyncIOTimeoutError
 import logging
 from typing import Any
 
@@ -30,7 +29,7 @@ async def _validate_input(data: dict[str, Any]) -> dict[str, str]:
             await api.get_sgvs()
     except ClientResponseError as error:
         raise InputValidationError("invalid_auth") from error
-    except (ClientError, AsyncIOTimeoutError, OSError) as error:
+    except (ClientError, TimeoutError, OSError) as error:
         raise InputValidationError("cannot_connect") from error
 
     # Return info to be stored in the config entry.

--- a/homeassistant/components/nightscout/sensor.py
+++ b/homeassistant/components/nightscout/sensor.py
@@ -1,7 +1,6 @@
 """Support for Nightscout sensors."""
 from __future__ import annotations
 
-from asyncio import TimeoutError as AsyncIOTimeoutError
 from datetime import timedelta
 import logging
 from typing import Any
@@ -51,7 +50,7 @@ class NightscoutSensor(SensorEntity):
         """Fetch the latest data from Nightscout REST API and update the state."""
         try:
             values = await self.api.get_sgvs()
-        except (ClientError, AsyncIOTimeoutError, OSError) as error:
+        except (ClientError, TimeoutError, OSError) as error:
             _LOGGER.error("Error fetching data. Failed with %s", error)
             self._attr_available = False
             return

--- a/homeassistant/components/ourgroceries/__init__.py
+++ b/homeassistant/components/ourgroceries/__init__.py
@@ -1,8 +1,6 @@
 """The OurGroceries integration."""
 from __future__ import annotations
 
-from asyncio import TimeoutError as AsyncIOTimeoutError
-
 from aiohttp import ClientError
 from ourgroceries import OurGroceries
 from ourgroceries.exceptions import InvalidLoginException
@@ -26,7 +24,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     og = OurGroceries(data[CONF_USERNAME], data[CONF_PASSWORD])
     try:
         await og.login()
-    except (AsyncIOTimeoutError, ClientError) as error:
+    except (TimeoutError, ClientError) as error:
         raise ConfigEntryNotReady from error
     except InvalidLoginException:
         return False

--- a/homeassistant/components/ourgroceries/config_flow.py
+++ b/homeassistant/components/ourgroceries/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow for OurGroceries integration."""
 from __future__ import annotations
 
-from asyncio import TimeoutError as AsyncIOTimeoutError
 import logging
 from typing import Any
 
@@ -40,7 +39,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             og = OurGroceries(user_input[CONF_USERNAME], user_input[CONF_PASSWORD])
             try:
                 await og.login()
-            except (AsyncIOTimeoutError, ClientError):
+            except (TimeoutError, ClientError):
                 errors["base"] = "cannot_connect"
             except InvalidLoginException:
                 errors["base"] = "invalid_auth"

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -1,7 +1,6 @@
 """Common methods used across tests for Bond."""
 from __future__ import annotations
 
-from asyncio import TimeoutError as AsyncIOTimeoutError
 from contextlib import nullcontext
 from datetime import timedelta
 from typing import Any
@@ -248,7 +247,7 @@ async def help_test_entity_available(
 
     assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
 
-    with patch_bond_device_state(side_effect=AsyncIOTimeoutError()):
+    with patch_bond_device_state(side_effect=TimeoutError()):
         async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
         await hass.async_block_till_done()
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -1,7 +1,6 @@
 """Test issues from supervisor issues."""
 from __future__ import annotations
 
-from asyncio import TimeoutError
 import os
 from typing import Any
 from unittest.mock import ANY, patch

--- a/tests/components/homewizard/test_init.py
+++ b/tests/components/homewizard/test_init.py
@@ -1,5 +1,4 @@
 """Tests for the homewizard component."""
-from asyncio import TimeoutError
 from unittest.mock import MagicMock
 
 from homewizard_energy.errors import DisabledError, HomeWizardEnergyException

--- a/tests/components/ourgroceries/test_config_flow.py
+++ b/tests/components/ourgroceries/test_config_flow.py
@@ -5,7 +5,6 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.ourgroceries.config_flow import (
-    AsyncIOTimeoutError,
     ClientError,
     InvalidLoginException,
 )
@@ -49,7 +48,7 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     [
         (InvalidLoginException, "invalid_auth"),
         (ClientError, "cannot_connect"),
-        (AsyncIOTimeoutError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
         (Exception, "unknown"),
     ],
 )

--- a/tests/components/ourgroceries/test_init.py
+++ b/tests/components/ourgroceries/test_init.py
@@ -3,11 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from homeassistant.components.ourgroceries import (
-    AsyncIOTimeoutError,
-    ClientError,
-    InvalidLoginException,
-)
+from homeassistant.components.ourgroceries import ClientError, InvalidLoginException
 from homeassistant.components.ourgroceries.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
@@ -41,7 +37,7 @@ def login_with_error(exception, ourgroceries: AsyncMock):
     [
         (InvalidLoginException, ConfigEntryState.SETUP_ERROR),
         (ClientError, ConfigEntryState.SETUP_RETRY),
-        (AsyncIOTimeoutError, ConfigEntryState.SETUP_RETRY),
+        (TimeoutError, ConfigEntryState.SETUP_RETRY),
     ],
 )
 async def test_init_failure(

--- a/tests/components/ourgroceries/test_todo.py
+++ b/tests/components/ourgroceries/test_todo.py
@@ -1,5 +1,4 @@
 """Unit tests for the OurGroceries todo platform."""
-from asyncio import TimeoutError as AsyncIOTimeoutError
 from unittest.mock import AsyncMock
 
 from aiohttp import ClientError
@@ -257,7 +256,7 @@ async def test_version_id_optimization(
     ("exception"),
     [
         (ClientError),
-        (AsyncIOTimeoutError),
+        (TimeoutError),
     ],
 )
 async def test_coordinator_error(


### PR DESCRIPTION
## Proposed change
In Python 3.11 `asyncio.TimeoutError` was made an alias of the builtin `TimeoutError` and subsequently deprecated. This is in preparation for the ruff `0.2.0` update which will be able to detect / fix this automatically.
https://docs.python.org/3/library/asyncio-exceptions.html#asyncio.TimeoutError

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
