### PR TITLE
Use builtin TimeoutError [socket.timeout]

### DIFF
--- a/homeassistant/components/blackbird/media_player.py
+++ b/homeassistant/components/blackbird/media_player.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import socket
 
 from pyblackbird import get_blackbird
 from serial import SerialException
@@ -93,7 +92,7 @@ def setup_platform(
         try:
             blackbird = get_blackbird(host, False)
             connection = host
-        except socket.timeout:
+        except TimeoutError:
             _LOGGER.error("Error connecting to the Blackbird controller")
             return
 

--- a/homeassistant/components/deluge/__init__.py
+++ b/homeassistant/components/deluge/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import socket
 from ssl import SSLError
 
 from deluge_client.client import DelugeRPCClient
@@ -40,11 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api.web_port = entry.data[CONF_WEB_PORT]
     try:
         await hass.async_add_executor_job(api.connect)
-    except (
-        ConnectionRefusedError,
-        socket.timeout,
-        SSLError,
-    ) as ex:
+    except (ConnectionRefusedError, TimeoutError, SSLError) as ex:
         raise ConfigEntryNotReady("Connection to Deluge Daemon failed") from ex
     except Exception as ex:  # pylint:disable=broad-except
         if type(ex).__name__ == "BadLoginError":

--- a/homeassistant/components/deluge/config_flow.py
+++ b/homeassistant/components/deluge/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import socket
 from ssl import SSLError
 from typing import Any
 
@@ -91,11 +90,7 @@ class DelugeFlowHandler(ConfigFlow, domain=DOMAIN):
         )
         try:
             await self.hass.async_add_executor_job(api.connect)
-        except (
-            ConnectionRefusedError,
-            socket.timeout,
-            SSLError,
-        ):
+        except (ConnectionRefusedError, TimeoutError, SSLError):
             return "cannot_connect"
         except Exception as ex:  # pylint:disable=broad-except
             if type(ex).__name__ == "BadLoginError":

--- a/homeassistant/components/deluge/coordinator.py
+++ b/homeassistant/components/deluge/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-import socket
 from ssl import SSLError
 from typing import Any
 
@@ -52,7 +51,7 @@ class DelugeDataUpdateCoordinator(
             )
         except (
             ConnectionRefusedError,
-            socket.timeout,
+            TimeoutError,
             SSLError,
             FailedToReconnectException,
         ) as ex:

--- a/homeassistant/components/ebusd/__init__.py
+++ b/homeassistant/components/ebusd/__init__.py
@@ -1,6 +1,5 @@
 """Support for Ebusd daemon for communication with eBUS heating systems."""
 import logging
-import socket
 
 import ebusdpy
 import voluptuous as vol
@@ -80,7 +79,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         _LOGGER.debug("Ebusd integration setup completed")
         return True
-    except (socket.timeout, OSError):
+    except (TimeoutError, OSError):
         return False
 
 

--- a/homeassistant/components/lg_soundbar/config_flow.py
+++ b/homeassistant/components/lg_soundbar/config_flow.py
@@ -1,7 +1,6 @@
 """Config flow to configure the LG Soundbar integration."""
 import logging
 from queue import Empty, Full, Queue
-import socket
 
 import temescal
 import voluptuous as vol
@@ -60,7 +59,7 @@ def test_connect(host, port):
         details["uuid"] = uuid_q.get(timeout=QUEUE_TIMEOUT)
     except Empty:
         pass
-    except socket.timeout as err:
+    except TimeoutError as err:
         raise ConnectionError(f"Connection timeout with server: {host}:{port}") from err
     except OSError as err:
         raise ConnectionError(f"Cannot resolve hostname: {host}") from err

--- a/homeassistant/components/maxcube/__init__.py
+++ b/homeassistant/components/maxcube/__init__.py
@@ -1,6 +1,5 @@
 """Support for the MAX! Cube LAN Gateway."""
 import logging
-from socket import timeout
 from threading import Lock
 import time
 
@@ -65,7 +64,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
         try:
             cube = MaxCube(host, port, now=now)
             hass.data[DATA_KEY][host] = MaxCubeHandle(cube, scan_interval)
-        except timeout as ex:
+        except TimeoutError as ex:
             _LOGGER.error("Unable to connect to Max!Cube gateway: %s", str(ex))
             persistent_notification.create(
                 hass,
@@ -108,7 +107,7 @@ class MaxCubeHandle:
 
                 try:
                     self.cube.update()
-                except timeout:
+                except TimeoutError:
                     _LOGGER.error("Max!Cube connection failed")
                     return False
 

--- a/homeassistant/components/maxcube/climate.py
+++ b/homeassistant/components/maxcube/climate.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import socket
 from typing import Any
 
 from maxcube.device import (
@@ -152,7 +151,7 @@ class MaxCubeClimate(ClimateEntity):
         with self._cubehandle.mutex:
             try:
                 self._cubehandle.cube.set_temperature_mode(self._device, temp, mode)
-            except (socket.timeout, OSError):
+            except (TimeoutError, OSError):
                 _LOGGER.error("Setting HVAC mode failed")
 
     @property

--- a/homeassistant/components/mikrotik/hub.py
+++ b/homeassistant/components/mikrotik/hub.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-import socket
 import ssl
 from typing import Any
 
@@ -227,7 +226,7 @@ class MikrotikData:
         except (
             librouteros.exceptions.ConnectionClosed,
             OSError,
-            socket.timeout,
+            TimeoutError,
         ) as api_error:
             _LOGGER.error("Mikrotik %s connection error %s", self._host, api_error)
             # try to reconnect
@@ -330,7 +329,7 @@ def get_api(entry: dict[str, Any]) -> librouteros.Api:
     except (
         librouteros.exceptions.LibRouterosError,
         OSError,
-        socket.timeout,
+        TimeoutError,
     ) as api_error:
         _LOGGER.error("Mikrotik %s error: %s", entry[CONF_HOST], api_error)
         if "invalid user name or password" in str(api_error):

--- a/homeassistant/components/motion_blinds/coordinator.py
+++ b/homeassistant/components/motion_blinds/coordinator.py
@@ -2,7 +2,6 @@
 import asyncio
 from datetime import timedelta
 import logging
-from socket import timeout
 from typing import Any
 
 from motionblinds import DEVICE_TYPES_WIFI, ParseException
@@ -50,7 +49,7 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
         """Fetch data from gateway."""
         try:
             self._gateway.Update()
-        except (timeout, ParseException):
+        except (TimeoutError, ParseException):
             # let the error be logged and handled by the motionblinds library
             return {ATTR_AVAILABLE: False}
 
@@ -65,7 +64,7 @@ class DataUpdateCoordinatorMotionBlinds(DataUpdateCoordinator):
                 blind.Update()
             else:
                 blind.Update_trigger()
-        except (timeout, ParseException):
+        except (TimeoutError, ParseException):
             # let the error be logged and handled by the motionblinds library
             return {ATTR_AVAILABLE: False}
 

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -50,7 +50,7 @@ class ConnectMotionGateway:
         try:
             # update device info and get the connected sub devices
             await self._hass.async_add_executor_job(self.update_gateway)
-        except socket.timeout:
+        except TimeoutError:
             _LOGGER.error(
                 "Timeout trying to connect to Motion Gateway with host %s", host
             )

--- a/homeassistant/components/pilight/__init__.py
+++ b/homeassistant/components/pilight/__init__.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from datetime import timedelta
 import functools
 import logging
-import socket
 import threading
 from typing import Any, ParamSpec
 
@@ -75,7 +74,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     try:
         pilight_client = pilight.Client(host=host, port=port)
-    except (OSError, socket.timeout) as err:
+    except (OSError, TimeoutError) as err:
         _LOGGER.error("Unable to connect to %s on port %s: %s", host, port, err)
         return False
 

--- a/homeassistant/components/pjlink/media_player.py
+++ b/homeassistant/components/pjlink/media_player.py
@@ -1,8 +1,6 @@
 """Support for controlling projector via the PJLink protocol."""
 from __future__ import annotations
 
-import socket
-
 from pypjlink import MUTE_AUDIO, Projector
 from pypjlink.projector import ProjectorError
 import voluptuous as vol
@@ -116,7 +114,7 @@ class PjLinkDevice(MediaPlayerEntity):
         try:
             projector = Projector.from_address(self._host, self._port)
             projector.authenticate(self._password)
-        except (socket.timeout, OSError) as err:
+        except (TimeoutError, OSError) as err:
             self._attr_available = False
             raise ProjectorError(ERR_PROJECTOR_UNAVAILABLE) from err
 

--- a/homeassistant/components/radiotherm/__init__.py
+++ b/homeassistant/components/radiotherm/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from collections.abc import Coroutine
-from socket import timeout
 from typing import Any, TypeVar
 from urllib.error import URLError
 
@@ -32,7 +31,7 @@ async def _async_call_or_raise_not_ready(
     except RadiothermTstatError as ex:
         msg = f"{host} was busy (invalid value returned): {ex}"
         raise ConfigEntryNotReady(msg) from ex
-    except timeout as ex:
+    except TimeoutError as ex:
         msg = f"{host} timed out waiting for a response: {ex}"
         raise ConfigEntryNotReady(msg) from ex
     except (OSError, URLError) as ex:

--- a/homeassistant/components/radiotherm/config_flow.py
+++ b/homeassistant/components/radiotherm/config_flow.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from socket import timeout
 from typing import Any
 from urllib.error import URLError
 
@@ -30,7 +29,7 @@ async def validate_connection(hass: HomeAssistant, host: str) -> RadioThermInitD
     """Validate the connection."""
     try:
         return await async_get_init_data(hass, host)
-    except (timeout, RadiothermTstatError, URLError, OSError) as ex:
+    except (TimeoutError, RadiothermTstatError, URLError, OSError) as ex:
         raise CannotConnect(f"Failed to connect to {host}: {ex}") from ex
 
 

--- a/homeassistant/components/radiotherm/coordinator.py
+++ b/homeassistant/components/radiotherm/coordinator.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from socket import timeout
 from urllib.error import URLError
 
 from radiotherm.validate import RadiothermTstatError
@@ -39,7 +38,7 @@ class RadioThermUpdateCoordinator(DataUpdateCoordinator[RadioThermUpdate]):
         except RadiothermTstatError as ex:
             msg = f"{self._description} was busy (invalid value returned): {ex}"
             raise UpdateFailed(msg) from ex
-        except timeout as ex:
+        except TimeoutError as ex:
             msg = f"{self._description}) timed out waiting for a response: {ex}"
             raise UpdateFailed(msg) from ex
         except (OSError, URLError) as ex:


### PR DESCRIPTION
## Proposed change
Since Python 3.10, `socket.timeout` is an alias for `TimeoutError`. Also part of ruff `0.2.0`.
https://docs.python.org/3/library/socket.html#socket.timeout

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
