### PR TITLE
Include exception when reraising inside except

### DIFF
--- a/homeassistant/components/comelit/coordinator.py
+++ b/homeassistant/components/comelit/coordinator.py
@@ -83,8 +83,8 @@ class ComelitBaseCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return await self._async_update_system_data()
         except (exceptions.CannotConnect, exceptions.CannotRetrieveData) as err:
             raise UpdateFailed(repr(err)) from err
-        except exceptions.CannotAuthenticate:
-            raise ConfigEntryAuthFailed
+        except exceptions.CannotAuthenticate as err:
+            raise ConfigEntryAuthFailed from err
 
     @abstractmethod
     async def _async_update_system_data(self) -> dict[str, Any]:

--- a/homeassistant/components/lupusec/config_flow.py
+++ b/homeassistant/components/lupusec/config_flow.py
@@ -101,9 +101,9 @@ async def test_host_connection(
 
     try:
         await hass.async_add_executor_job(lupupy.Lupusec, username, password, host)
-    except lupupy.LupusecException:
+    except lupupy.LupusecException as ex:
         _LOGGER.error("Failed to connect to Lupusec device at %s", host)
-        raise CannotConnect
+        raise CannotConnect from ex
 
 
 class CannotConnect(HomeAssistantError):

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -96,7 +96,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
                         if history_task:
                             data[device.id].history = history_task.result()
                     except ExceptionGroup as eg:
-                        raise eg.exceptions[0] from eg
+                        raise eg.exceptions[0]
 
         return data
 

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -96,7 +96,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
                         if history_task:
                             data[device.id].history = history_task.result()
                     except ExceptionGroup as eg:
-                        raise eg.exceptions[0]
+                        raise eg.exceptions[0] from eg
 
         return data
 

--- a/homeassistant/components/roborock/__init__.py
+++ b/homeassistant/components/roborock/__init__.py
@@ -124,7 +124,7 @@ async def setup_device(
     coordinator.api.is_available = True
     try:
         await coordinator.async_config_entry_first_refresh()
-    except ConfigEntryNotReady:
+    except ConfigEntryNotReady as ex:
         if isinstance(coordinator.api, RoborockMqttClient):
             _LOGGER.warning(
                 "Not setting up %s because the we failed to get data for the first time using the online client. "
@@ -136,7 +136,7 @@ async def setup_device(
             # but in case if it isn't, the error can be included in debug logs for the user to grab.
             if coordinator.last_exception:
                 _LOGGER.debug(coordinator.last_exception)
-                raise coordinator.last_exception
+                raise coordinator.last_exception from ex
         elif coordinator.last_exception:
             # If this is reached, we have verified that we can communicate with the Vacuum locally,
             # so if there is an error here - it is not a communication issue but some other problem
@@ -147,7 +147,7 @@ async def setup_device(
                 device.name,
                 extra_error,
             )
-            raise coordinator.last_exception
+            raise coordinator.last_exception from ex
     return coordinator
 
 

--- a/homeassistant/components/suez_water/__init__.py
+++ b/homeassistant/components/suez_water/__init__.py
@@ -28,8 +28,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             if not client.check_credentials():
                 raise ConfigEntryError
             return client
-        except PySuezError:
-            raise ConfigEntryNotReady
+        except PySuezError as ex:
+            raise ConfigEntryNotReady from ex
 
     hass.data.setdefault(DOMAIN, {})[
         entry.entry_id

--- a/homeassistant/components/suez_water/config_flow.py
+++ b/homeassistant/components/suez_water/config_flow.py
@@ -40,8 +40,8 @@ def validate_input(data: dict[str, Any]) -> None:
         )
         if not client.check_credentials():
             raise InvalidAuth
-    except PySuezError:
-        raise CannotConnect
+    except PySuezError as ex:
+        raise CannotConnect from ex
 
 
 class SuezWaterConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2202,8 +2202,8 @@ class FirmwareUploadView(HomeAssistantView):
             node = async_get_node_from_device_id(hass, device_id, self._dev_reg)
         except ValueError as err:
             if "not loaded" in err.args[0]:
-                raise web_exceptions.HTTPBadRequest
-            raise web_exceptions.HTTPNotFound
+                raise web_exceptions.HTTPBadRequest from err
+            raise web_exceptions.HTTPNotFound from err
 
         # If this was not true, we wouldn't have been able to get the node from the
         # device ID above

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2249,7 +2249,7 @@ async def _load_integration(
             domain,
             err,
         )
-        raise data_entry_flow.UnknownHandler
+        raise data_entry_flow.UnknownHandler from err
 
 
 async def _async_get_flow_handler(


### PR DESCRIPTION
## Proposed change
https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
