### PR TITLE
Fix generic camera error when template renders to an invalid URL

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 import httpx
+import voluptuous as vol
 import yarl
 
 from homeassistant.components.camera import Camera, CameraEntityFeature
@@ -138,6 +139,12 @@ class GenericCamera(Camera):
             url = self._still_image_url.async_render(parse_result=False)
         except TemplateError as err:
             _LOGGER.error("Error parsing template %s: %s", self._still_image_url, err)
+            return self._last_image
+
+        try:
+            vol.Schema(vol.Url())(url)
+        except vol.Invalid as err:
+            _LOGGER.warning("Invalid URL '%s': %s, returning last image", url, err)
             return self._last_image
 
         if url == self._last_url and self._limit_refetch:

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -70,15 +70,20 @@ async def help_setup_mock_config_entry(
 
 @respx.mock
 async def test_fetching_url(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, fakeimgbytes_png
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    fakeimgbytes_png,
+    caplog: pytest.CaptureFixture,
 ) -> None:
     """Test that it fetches the given url."""
-    respx.get("http://example.com").respond(stream=fakeimgbytes_png)
+    hass.states.async_set("sensor.temp", "http://example.com/0a")
+    respx.get("http://example.com/0a").respond(stream=fakeimgbytes_png)
+    respx.get("http://example.com/1a").respond(stream=fakeimgbytes_png)
 
     options = {
         "name": "config_test",
         "platform": "generic",
-        "still_image_url": "http://example.com",
+        "still_image_url": "{{ states.sensor.temp.state }}",
         "username": "user",
         "password": "pass",
         "authentication": "basic",
@@ -100,6 +105,25 @@ async def test_fetching_url(
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
     assert respx.calls.call_count == 2
+
+    # If the template renders to an invalid URL we return the last image from cache
+    hass.states.async_set("sensor.temp", "invalid url")
+
+    # sleep another .1 seconds to make cached image expire
+    await asyncio.sleep(0.1)
+    resp = await client.get("/api/camera_proxy/camera.config_test")
+    assert resp.status == HTTPStatus.OK
+    assert respx.calls.call_count == 2
+    assert (
+        "Invalid URL 'invalid url': expected a URL, returning last image" in caplog.text
+    )
+
+    # Restore a valid URL
+    hass.states.async_set("sensor.temp", "http://example.com/1a")
+    await asyncio.sleep(0.1)
+    resp = await client.get("/api/camera_proxy/camera.config_test")
+    assert resp.status == HTTPStatus.OK
+    assert respx.calls.call_count == 3
 
 
 @respx.mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix generic camera error when template renders to an invalid URL. When the generic camera starts up, it might be the template does not have a correct value yet. A validation is added check if the URL has a valid structure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109739
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
