### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -26,7 +26,7 @@
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.111",
     "zigpy-deconz==0.23.0",
-    "zigpy==0.62.1",
+    "zigpy==0.62.2",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,12 +21,12 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.37.6",
+    "bellows==0.38.0",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
-    "zha-quirks==0.0.110",
-    "zigpy-deconz==0.22.4",
-    "zigpy==0.61.0",
+    "zha-quirks==0.0.111",
+    "zigpy-deconz==0.23.0",
+    "zigpy==0.62.1",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -30,7 +30,7 @@
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",
-    "universal-silabs-flasher==0.0.15",
+    "universal-silabs-flasher==0.0.18",
     "pyserial-asyncio-fast==0.11"
   ],
   "usb": [

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -535,7 +535,7 @@ beautifulsoup4==4.12.2
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.37.6
+bellows==0.38.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2913,7 +2913,7 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.110
+zha-quirks==0.0.111
 
 # homeassistant.components.zhong_hong
 zhong-hong-hvac==1.0.9
@@ -2922,7 +2922,7 @@ zhong-hong-hvac==1.0.9
 ziggo-mediabox-xl==1.1.0
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.4
+zigpy-deconz==0.23.0
 
 # homeassistant.components.zha
 zigpy-xbee==0.20.1
@@ -2934,7 +2934,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.61.0
+zigpy==0.62.1
 
 # homeassistant.components.zoneminder
 zm-py==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2934,7 +2934,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.62.1
+zigpy==0.62.2
 
 # homeassistant.components.zoneminder
 zm-py==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2757,7 +2757,7 @@ unifi_ap==0.0.1
 unifiled==0.11
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.15
+universal-silabs-flasher==0.0.18
 
 # homeassistant.components.upb
 upb-lib==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2098,7 +2098,7 @@ ultraheat-api==0.5.7
 unifi-discovery==1.1.7
 
 # homeassistant.components.zha
-universal-silabs-flasher==0.0.15
+universal-silabs-flasher==0.0.18
 
 # homeassistant.components.upb
 upb-lib==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2248,7 +2248,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.62.1
+zigpy==0.62.2
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.55.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -457,7 +457,7 @@ base36==0.1.1
 beautifulsoup4==4.12.2
 
 # homeassistant.components.zha
-bellows==0.37.6
+bellows==0.38.0
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6
@@ -2233,10 +2233,10 @@ zeroconf==0.131.0
 zeversolar==0.3.1
 
 # homeassistant.components.zha
-zha-quirks==0.0.110
+zha-quirks==0.0.111
 
 # homeassistant.components.zha
-zigpy-deconz==0.22.4
+zigpy-deconz==0.23.0
 
 # homeassistant.components.zha
 zigpy-xbee==0.20.1
@@ -2248,7 +2248,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.61.0
+zigpy==0.62.1
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.55.3

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -205,7 +205,7 @@ def make_packet(zigpy_device, cluster, cmd_name: str, **kwargs):
         command_id=cluster.commands_by_name[cmd_name].id,
         schema=cluster.commands_by_name[cmd_name].schema,
         disable_default_response=False,
-        direction=foundation.Direction.Server_to_Client,
+        direction=foundation.Direction.Client_to_Server,
         args=(),
         kwargs=kwargs,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump ZHA dependencies:
 - bellows to [0.38.0](https://github.com/zigpy/bellows/releases/tag/0.38.0)
 - zha-quirks to [0.0.111](https://github.com/zigpy/zha-device-handlers/releases/tag/0.0.111)
 - zigpy-deconz to [0.23.0](https://github.com/zigpy/zigpy-deconz/releases/tag/0.23.0)
 - zigpy to [0.62.2](https://github.com/zigpy/zigpy/releases/tag/0.62.2)
 - universal-silabs-flasher to [0.0.18](https://github.com/NabuCasa/universal-silabs-flasher/releases/tag/v0.0.18)

This PR fixes a bug with zigpy's handling of default responses (affecting Tuya sensors), improves reliability when communicating with Silicon Labs radios and reduces unnecessary resets, and finally fixes Conbee III compatibility issues introduced in 2024.1.6.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109519, fixes #109287
- This PR is related to issue: #107200
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
