### PR TITLE
Allow unix timestamp values for DATE and TIMESTAMP device classes in MQTT

### DIFF
--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -239,13 +239,16 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 self._attr_native_value = new_value
                 return
             try:
-                if (dt_util.parse_datetime(new_value)) is None and (
-                    string_datetime := datetime.fromtimestamp(
-                        float(payload), tz=UTC
-                    ).isoformat()
-                ) is not None:
-                    new_value = string_datetime
-                if (payload_datetime := dt_util.parse_datetime(new_value)) is None:
+                try:
+                    new_value_float = float(payload)
+                except ValueError:
+                    new_value_float = None
+
+                if (payload_datetime := dt_util.parse_datetime(new_value)) is None and (
+                    payload_datetime := datetime.fromtimestamp(new_value_float, tz=UTC)
+                    if new_value_float is not None
+                    else None
+                ) is None:
                     raise ValueError
             except ValueError:
                 _LOGGER.warning(

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import logging
 from typing import Any
 
@@ -239,6 +239,12 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 self._attr_native_value = new_value
                 return
             try:
+                if (payload_datetime := dt_util.parse_datetime(new_value)) is None and (
+                    string_datetime := datetime.fromtimestamp(
+                        float(payload), tz=UTC
+                    ).isoformat()
+                ) is not None:
+                    new_value = string_datetime
                 if (payload_datetime := dt_util.parse_datetime(new_value)) is None:
                     raise ValueError
             except ValueError:

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -239,7 +239,7 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 self._attr_native_value = new_value
                 return
             try:
-                if (payload_datetime := dt_util.parse_datetime(new_value)) is None and (
+                if (dt_util.parse_datetime(new_value)) is None and (
                     string_datetime := datetime.fromtimestamp(
                         float(payload), tz=UTC
                     ).isoformat()

--- a/homeassistant/components/mqtt/sensor.py
+++ b/homeassistant/components/mqtt/sensor.py
@@ -239,15 +239,8 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 self._attr_native_value = new_value
                 return
             try:
-                try:
-                    new_value_float = float(payload)
-                except ValueError:
-                    new_value_float = None
-
                 if (payload_datetime := dt_util.parse_datetime(new_value)) is None and (
-                    payload_datetime := datetime.fromtimestamp(new_value_float, tz=UTC)
-                    if new_value_float is not None
-                    else None
+                    payload_datetime := datetime.fromtimestamp(float(payload), tz=UTC)
                 ) is None:
                     raise ValueError
             except ValueError:
@@ -256,7 +249,10 @@ class MqttSensor(MqttEntity, RestoreSensor):
                 )
                 self._attr_native_value = None
                 return
-            if self.device_class == SensorDeviceClass.DATE:
+            if (
+                self.device_class == SensorDeviceClass.DATE
+                and payload_datetime is not None
+            ):
                 self._attr_native_value = payload_datetime.date()
                 return
             self._attr_native_value = payload_datetime

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -243,12 +243,23 @@ async def test_setting_sensor_value_via_mqtt_message(
             help_custom_config(
                 sensor.DOMAIN,
                 DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "1707265443.323565",
+            "2024-02-07T00:24:03+00:00",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
                 ({"device_class": sensor.SensorDeviceClass.DATE},),
             ),
             sensor.SensorDeviceClass.DATE,
-            "invalid",
-            STATE_UNKNOWN,
-            True,
+            "1707265443.323565",
+            "2024-02-07",
+            False,
         ),
     ],
 )

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -239,6 +239,17 @@ async def test_setting_sensor_value_via_mqtt_message(
             "2024-02-06",
             False,
         ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.DATE},),
+            ),
+            sensor.SensorDeviceClass.DATE,
+            "invalid",
+            STATE_UNKNOWN,
+            True,
+        ),
     ],
 )
 async def test_setting_sensor_native_value_handling_via_mqtt_message(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -261,6 +261,72 @@ async def test_setting_sensor_value_via_mqtt_message(
             "2024-02-07",
             False,
         ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "",
+            STATE_UNKNOWN,
+            True,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.DATE},),
+            ),
+            sensor.SensorDeviceClass.DATE,
+            "",
+            STATE_UNKNOWN,
+            True,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.DATE},),
+            ),
+            sensor.SensorDeviceClass.DATE,
+            "0",
+            "1970-01-01",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "0",
+            "1970-01-01T00:00:00+00:00",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.DATE},),
+            ),
+            sensor.SensorDeviceClass.DATE,
+            "-1234",
+            "1969-12-31",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "-1234",
+            "1969-12-31T23:39:26+00:00",
+            False,
+        ),
     ],
 )
 async def test_setting_sensor_native_value_handling_via_mqtt_message(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -239,17 +239,6 @@ async def test_setting_sensor_value_via_mqtt_message(
             "2024-02-06",
             False,
         ),
-        (
-            help_custom_config(
-                sensor.DOMAIN,
-                DEFAULT_CONFIG,
-                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
-            ),
-            sensor.SensorDeviceClass.TIMESTAMP,
-            "some_value",
-            STATE_UNKNOWN,
-            True,
-        ),
     ],
 )
 async def test_setting_sensor_native_value_handling_via_mqtt_message(

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -217,6 +217,39 @@ async def test_setting_sensor_value_via_mqtt_message(
             "some_value",
             False,
         ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "1707181599",
+            "2024-02-06T01:06:39+00:00",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.DATE},),
+            ),
+            sensor.SensorDeviceClass.DATE,
+            "1707181599",
+            "2024-02-06",
+            False,
+        ),
+        (
+            help_custom_config(
+                sensor.DOMAIN,
+                DEFAULT_CONFIG,
+                ({"device_class": sensor.SensorDeviceClass.TIMESTAMP},),
+            ),
+            sensor.SensorDeviceClass.TIMESTAMP,
+            "some_value",
+            STATE_UNKNOWN,
+            True,
+        ),
     ],
 )
 async def test_setting_sensor_native_value_handling_via_mqtt_message(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support for sensors with TIMESTAMP or DATE device class to receive topics with UNIX TIMESTAMP values.

As it is widely used in DIY projects, listing all the use cases is not an easy task.
One use case is in ESPHome (via MQTT, through the API this use is now possible), where we can send the time that a certain event occurred on the device, for example the ESPHome code below:
```
[...]

time:
  - platform: sntp
    id: sntp_time

sensor:
  - platform: template
    id: timestamp_pump_on
    name: Last activation
    device_class: timestamp

binary_sensor:
  - platform: gpio
    id: pump_status
    pin: GPIO5
    name: Pump
    on_press:
      - lambda: id(timestamp_pump_on).publish_state(id(sntp_time).now().timestamp);
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31282

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
