### PR TITLE
Fix docstring length in ZHA sensor class

### DIFF
--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -849,9 +849,10 @@ class SmartEnergySummationReceived(PolledSmartEnergySummation):
         """Entity Factory.
 
         This attribute only started to be initialized in HA 2024.2.0,
-        so the entity would still be created on the first HA start after the upgrade for existing devices,
-        as the initialization to see if an attribute is unsupported happens later in the background.
-        To avoid creating a lot of unnecessary entities for existing devices,
+        so the entity would be created on the first HA start after the
+        upgrade for existing devices, as the initialization to see if
+        an attribute is unsupported happens later in the background.
+        To avoid creating unnecessary entities for existing devices,
         wait until the attribute was properly initialized once for now.
         """
         if cluster_handlers[0].cluster.get(cls._attribute_name) is None:


### PR DESCRIPTION
## Proposed change
This correctly limits the line to 72 characters for a (ZHA sensor) docstring.
Review comment: https://github.com/home-assistant/core/pull/109268#discussion_r1479115507

(I was under the impression that pre-commit/ruff would catch something like this, but it doesn't seem to be enforced atm.)

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
