### PR TITLE
Update ruff to 0.2.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.15
+    rev: v0.2.1
     hooks:
       - id: ruff
         args:

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -96,7 +96,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
                         if history_task:
                             data[device.id].history = history_task.result()
                     except ExceptionGroup as eg:
-                        raise eg.exceptions[0]
+                        raise eg.exceptions[0]  # noqa: B904
 
         return data
 

--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -148,7 +148,8 @@ def _equivalent_units(units: set[str | None]) -> bool:
     if len(units) == 1:
         return True
     units = {
-        EQUIVALENT_UNITS[unit] if unit in EQUIVALENT_UNITS else unit for unit in units
+        EQUIVALENT_UNITS[unit] if unit in EQUIVALENT_UNITS else unit  # noqa: SIM401
+        for unit in units
     }
     return len(units) == 1
 

--- a/pylint/ruff.toml
+++ b/pylint/ruff.toml
@@ -1,7 +1,7 @@
 # This extend our general Ruff rules specifically for tests
 extend = "../pyproject.toml"
 
-[isort]
+[lint.isort]
 known-third-party = [
     "pylint",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -569,7 +569,7 @@ filterwarnings = [
     "ignore:pkg_resources is deprecated as an API:DeprecationWarning:webrtcvad",
 ]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
     "B002", # Python does not support the unary prefix increment
     "B007", # Loop control variable {name} not used within loop body
@@ -681,7 +681,7 @@ ignore = [
     "PLE0605",
 ]
 
-[tool.ruff.flake8-import-conventions.extend-aliases]
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
 voluptuous = "vol"
 "homeassistant.helpers.area_registry" = "ar"
 "homeassistant.helpers.config_validation" = "cv"
@@ -690,14 +690,14 @@ voluptuous = "vol"
 "homeassistant.helpers.issue_registry" = "ir"
 "homeassistant.util.dt" = "dt_util"
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 
-[tool.ruff.flake8-tidy-imports.banned-api]
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
 "async_timeout".msg = "use asyncio.timeout instead"
 "pytz".msg = "use zoneinfo instead"
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-sort-within-sections = true
 known-first-party = [
     "homeassistant",
@@ -705,12 +705,12 @@ known-first-party = [
 combine-as-imports = true
 split-on-trailing-comma = false
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 
 # Allow for main entry & scripts to write to stdout
 "homeassistant/__main__.py" = ["T201"]
 "homeassistant/scripts/*" = ["T201"]
 "script/*" = ["T20"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,7 @@ disable = [
     "duplicate-key", # F601
     "duplicate-string-formatting-argument", # F
     "duplicate-value", # F
-    "eval-used", # PGH001
+    "eval-used", # S307
     "exec-used", # S102
     # "expression-not-assigned", # B018, ruff catches new occurrences, needs more work
     "f-string-without-interpolation", # F541
@@ -241,7 +241,7 @@ disable = [
     "named-expr-without-context", # PLW0131
     "nested-min-max", # PLW3301
     # "pointless-statement", # B018, ruff catches new occurrences, needs more work
-    "raise-missing-from", # TRY200
+    "raise-missing-from", # B904
     # "redefined-builtin", # A001, ruff is way more stricter, needs work
     "try-except-raise", # TRY302
     "unused-argument", # ARG001, we don't use it
@@ -576,6 +576,7 @@ select = [
     "B014", # Exception handler with duplicate exception
     "B023", # Function definition does not bind loop variable {name}
     "B026", # Star-arg unpacking after a keyword argument is strongly discouraged
+    "B904", # Use raise from to specify exception cause
     "C",  # complexity
     "COM818", # Trailing comma on bare tuple prohibited
     "D",  # docstrings
@@ -589,7 +590,6 @@ select = [
     "N804", # First argument of a class method should be named cls
     "N805", # First argument of a method should be named self
     "N815", # Variable {name} in class scope should not be mixedCase
-    "PGH001", # No builtin eval() allowed
     "PGH004",  # Use specific rule codes when using noqa
     "PLC0414", # Useless import alias. Import alias does not rename original package.
     "PLC", # pylint
@@ -628,7 +628,6 @@ select = [
     "T20",  # flake8-print
     "TID251", # Banned imports
     "TRY004", # Prefer TypeError exception for invalid type
-    "TRY200", # Use raise from to specify exception cause
     "TRY302", # Remove exception handler; error is immediately re-raised
     "UP",  # pyupgrade
     "W",  # pycodestyle

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -1,5 +1,5 @@
 # Automatically generated from .pre-commit-config.yaml by gen_requirements_all.py, do not edit
 
 codespell==2.2.2
-ruff==0.1.15
+ruff==0.2.1
 yamllint==1.32.0

--- a/script/ruff.toml
+++ b/script/ruff.toml
@@ -1,7 +1,7 @@
 # This extend our general Ruff rules specifically for tests
 extend = "../pyproject.toml"
 
-[isort]
+[lint.isort]
 forced-separate = [
     "tests",
 ]

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -1,6 +1,7 @@
 # This extend our general Ruff rules specifically for tests
 extend = "../pyproject.toml"
 
+[lint]
 extend-select = [
     "PT001", # Use @pytest.fixture without parentheses
     "PT002", # Configuration for fixture specified via positional args, use kwargs
@@ -20,7 +21,7 @@ extend-ignore = [
     "N815", # Variable {name} in class scope should not be mixedCase
 ]
 
-[isort]
+[lint.isort]
 known-first-party = [
     "homeassistant",
     "tests",

--- a/tests/ruff.toml
+++ b/tests/ruff.toml
@@ -18,6 +18,7 @@ extend-ignore = [
     "PLE", # pylint
     "PLR", # pylint
     "PLW", # pylint
+    "B904", # Use raise from to specify exception cause
     "N815", # Variable {name} in class scope should not be mixedCase
 ]
 


### PR DESCRIPTION
## Proposed change
https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#021
https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#020

For the `0.2.0` update some rules have been remapped:
- [raise-without-from-inside-except](https://docs.astral.sh/ruff/rules/raise-without-from-inside-except/): TRY200 to B904
- [suspicious-eval-usage](https://docs.astral.sh/ruff/rules/suspicious-eval-usage/): PGH001 to S307

Furthermore, I've disabled `B904` for the `tests` subdirectory as I don't think it makes much sense there to enforce it.

Lastly, most config sections have been moved / renamed. They now use the `[ruff.lint...]` prefix instead of just `[ruff....]`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
