### PR TITLE
Don't block Supervisor entry setup with refreshing updates

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -1003,25 +1003,18 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):  # pylint: disable=has
         raise_on_entry_error: bool = False,
     ) -> None:
         """Refresh data."""
-        if not scheduled:
+        if not scheduled and not raise_on_auth_failed:
             # Force refreshing updates for non-scheduled updates
-            # It `raise_on_auth_failed` is set, it means this is
-            # the first refresh. We background the update task in
-            # that case.
-            if raise_on_auth_failed:
-                self.config_entry.async_create_background_task(
-                    self.hass, self._async_refresh_updates(), "hassio_refresh_updates"
-                )
-            else:
-                await self._async_refresh_updates()
+            # If `raise_on_auth_failed` is set, it means this is
+            # the first refresh and we do not want to delay
+            # startup or cause a timeout so we only refresh the
+            # updates if this is not a scheduled refresh and
+            # we are not doing the first refresh.
+            try:
+                await self.hassio.refresh_updates()
+            except HassioAPIError as err:
+                _LOGGER.warning("Error on Supervisor API: %s", err)
 
         await super()._async_refresh(
             log_failures, raise_on_auth_failed, scheduled, raise_on_entry_error
         )
-
-    async def _async_refresh_updates(self) -> None:
-        """Refresh updates."""
-        try:
-            await self.hassio.refresh_updates()
-        except HassioAPIError as err:
-            _LOGGER.warning("Error on Supervisor API: %s", err)

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -749,8 +749,6 @@ def async_remove_addons_from_dev_reg(
 class HassioDataUpdateCoordinator(DataUpdateCoordinator):  # pylint: disable=hass-enforce-coordinator-module
     """Class to retrieve Hass.io status."""
 
-    config_entry: ConfigEntry
-
     def __init__(
         self, hass: HomeAssistant, config_entry: ConfigEntry, dev_reg: dr.DeviceRegistry
     ) -> None:

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -459,7 +459,7 @@ class HassIO:
 
         This method returns a coroutine.
         """
-        return self.send_command("/refresh_updates", timeout=None)
+        return self.send_command("/refresh_updates", timeout=300)
 
     @api_data
     def retrieve_discovery_messages(self) -> Coroutine:

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -245,7 +245,7 @@ async def test_setup_api_ping(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert hass.components.hassio.get_core_info()["version_latest"] == "1.0.0"
     assert hass.components.hassio.is_hassio()
 
@@ -290,7 +290,7 @@ async def test_setup_api_push_api_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -309,7 +309,7 @@ async def test_setup_api_push_api_data_server_host(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert not aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -326,7 +326,7 @@ async def test_setup_api_push_api_data_default(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]["refresh_token"]
@@ -406,7 +406,7 @@ async def test_setup_api_existing_hassio_user(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     assert aioclient_mock.mock_calls[1][2]["refresh_token"] == token.token
@@ -423,7 +423,7 @@ async def test_setup_core_push_timezone(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert aioclient_mock.mock_calls[2][2]["timezone"] == "testzone"
 
     with patch("homeassistant.util.dt.set_default_time_zone"):
@@ -443,7 +443,7 @@ async def test_setup_hassio_no_additional_data(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert aioclient_mock.mock_calls[-1][3]["Authorization"] == "Bearer 123456"
 
 
@@ -525,14 +525,14 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 24
+    assert aioclient_mock.call_count == 23
     assert aioclient_mock.mock_calls[-1][2] == "test"
 
     await hass.services.async_call("hassio", "host_shutdown", {})
     await hass.services.async_call("hassio", "host_reboot", {})
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 26
+    assert aioclient_mock.call_count == 25
 
     await hass.services.async_call("hassio", "backup_full", {})
     await hass.services.async_call(
@@ -547,7 +547,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 28
+    assert aioclient_mock.call_count == 27
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "homeassistant": True,
@@ -572,7 +572,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 30
+    assert aioclient_mock.call_count == 29
     assert aioclient_mock.mock_calls[-1][2] == {
         "addons": ["test"],
         "folders": ["ssl"],
@@ -591,7 +591,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 31
+    assert aioclient_mock.call_count == 30
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "backup_name",
         "location": "backup_share",
@@ -607,7 +607,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 32
+    assert aioclient_mock.call_count == 31
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 03:48:00",
         "location": None,
@@ -625,7 +625,7 @@ async def test_service_calls(
     )
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 34
+    assert aioclient_mock.call_count == 33
     assert aioclient_mock.mock_calls[-1][2] == {
         "name": "2021-11-13 11:48:00",
         "location": None,
@@ -897,14 +897,17 @@ async def test_coordinator_updates(
         config_entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        # Initial refresh without stats
-        assert refresh_updates_mock.call_count == 1
+
+        # Initial refresh, no update refresh call
+        assert refresh_updates_mock.call_count == 0
 
     with patch(
         "homeassistant.components.hassio.HassIO.refresh_updates",
     ) as refresh_updates_mock:
         async_fire_time_changed(hass, dt_util.now() + timedelta(minutes=20))
         await hass.async_block_till_done()
+
+        # Scheduled refresh, no update refresh call
         assert refresh_updates_mock.call_count == 0
 
     with patch(
@@ -921,13 +924,14 @@ async def test_coordinator_updates(
             },
             blocking=True,
         )
-        assert refresh_updates_mock.call_count == 0
 
-    # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
-    async_fire_time_changed(
-        hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
-    )
-    await hass.async_block_till_done()
+        # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
+        assert refresh_updates_mock.call_count == 0
+        async_fire_time_changed(
+            hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
+        )
+        await hass.async_block_till_done()
+        assert refresh_updates_mock.call_count == 1
 
     with patch(
         "homeassistant.components.hassio.HassIO.refresh_updates",
@@ -968,14 +972,14 @@ async def test_coordinator_updates_stats_entities_enabled(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         # Initial refresh without stats
-        assert refresh_updates_mock.call_count == 1
+        assert refresh_updates_mock.call_count == 0
 
         # Refresh with stats once we know which ones are needed
         async_fire_time_changed(
             hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
         )
         await hass.async_block_till_done()
-        assert refresh_updates_mock.call_count == 2
+        assert refresh_updates_mock.call_count == 1
 
     with patch(
         "homeassistant.components.hassio.HassIO.refresh_updates",
@@ -1059,7 +1063,7 @@ async def test_setup_hardware_integration(
         await hass.async_block_till_done()
 
     assert result
-    assert aioclient_mock.call_count == 20
+    assert aioclient_mock.call_count == 19
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -702,12 +702,12 @@ async def test_service_calls_core(
     await hass.services.async_call("homeassistant", "stop")
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 6
+    assert aioclient_mock.call_count == 5
 
     await hass.services.async_call("homeassistant", "check_config")
     await hass.async_block_till_done()
 
-    assert aioclient_mock.call_count == 6
+    assert aioclient_mock.call_count == 5
 
     with patch(
         "homeassistant.config.async_check_ha_config_file", return_value=None
@@ -716,7 +716,7 @@ async def test_service_calls_core(
         await hass.async_block_till_done()
         assert mock_check_config.called
 
-    assert aioclient_mock.call_count == 7
+    assert aioclient_mock.call_count == 6
 
 
 async def test_entry_load_and_unload(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

On startup, the `hassio` integration will refresh all updates, which can take quite a bit of time (e.g., pulling all git repositories of add-ons). This main cause a global timeout on the first stage:

```
2024-02-05 13:13:03.763 WARNING (MainThread) [homeassistant.bootstrap] Waiting on integrations to complete setup: hassio
2024-02-05 13:14:01.155 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry Hassio for hassio
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 442, in async_setup
result = await component.async_setup_entry(hass, self)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/hassio/__init__.py", line 634, in async_setup_entry
await coordinator.async_config_entry_first_refresh()
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 278, in async_config_entry_first_refresh
await self._async_refresh(
File "/usr/src/homeassistant/homeassistant/components/hassio/__init__.py", line 1007, in _async_refresh
await self.hassio.refresh_updates()
File "/usr/src/homeassistant/homeassistant/components/hassio/handler.py", line 39, in _wrapper
data = await funct(*argv, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/hassio/handler.py", line 574, in send_command
request = await self.websession.request(
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/aiohttp/client.py", line 605, in _request
await resp.start(conn)
File "/usr/local/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 966, in start
message, payload = await protocol.read() # type: ignore[union-attr]
^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/site-packages/aiohttp/streams.py", line 622, in read
await self._waiter
asyncio.exceptions.CancelledError: Global task timeout
2024-02-05 13:14:01.184 WARNING (MainThread) [homeassistant.bootstrap] Setup timed out for stage 1 - moving forward
```

We don't have to block the setup for this; So, this PR removes this call from the startup. Information will be available a bit later (also the Supervisor does update that info on a schedule as well).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works. (already covered)

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
