### PR TITLE
Avoid delaying startup in dlna_dmr

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -28,7 +28,7 @@ from homeassistant.components.media_player import (
     async_process_play_media_url,
 )
 from homeassistant.const import CONF_DEVICE_ID, CONF_MAC, CONF_TYPE, CONF_URL
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -192,7 +192,12 @@ class DlnaDmrEntity(MediaPlayerEntity):
             )
         )
 
-        if not self._device:
+        if self._device:
+            return
+
+        if self.hass.state is CoreState.running:
+            await self._async_setup()
+        else:
             self._background_setup_task = self.hass.async_create_background_task(
                 self._async_setup(), f"dlna_dmr {self.name} setup"
             )

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -91,21 +91,15 @@ async def async_setup_entry(
 
     udn = entry.data[CONF_DEVICE_ID]
     ent_reg = er.async_get(hass)
-    # If the device is offline, we need to make sure we still
-    # have the previous connections so that the entity does not
-    # get unlinked from the device when it gets added to hass.
-    previous_connections: set[tuple[str, str]] = set()
-    if (
+    has_linked_device_id = bool(
         (
             existing_entity_id := ent_reg.async_get_entity_id(
                 domain=MEDIA_PLAYER_DOMAIN, platform=DOMAIN, unique_id=udn
             )
         )
         and (existing_entry := ent_reg.async_get(existing_entity_id))
-        and (device_id := existing_entry.device_id)
-        and (device_entry := dr.async_get(hass).async_get(device_id))
-    ):
-        previous_connections = device_entry.connections
+        and existing_entry.device_id
+    )
 
     # Create our own device-wrapping entity
     entity = DlnaDmrEntity(
@@ -119,7 +113,7 @@ async def async_setup_entry(
         mac_address=entry.data.get(CONF_MAC),
         browse_unfiltered=entry.options.get(CONF_BROWSE_UNFILTERED, False),
         config_entry=entry,
-        previous_connections=previous_connections,
+        has_linked_device_id=has_linked_device_id,
     )
 
     async_add_entities([entity])
@@ -166,7 +160,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         mac_address: str | None,
         browse_unfiltered: bool,
         config_entry: config_entries.ConfigEntry,
-        previous_connections: set[tuple[str, str]],
+        has_linked_device_id: bool,
     ) -> None:
         """Initialize DLNA DMR entity."""
         self.udn = udn
@@ -181,8 +175,15 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self._background_setup_task: asyncio.Task[None] | None = None
         self._updated_registry: bool = False
         self._config_entry = config_entry
-        if previous_connections:
-            self._attr_device_info = dr.DeviceInfo(connections=previous_connections)
+        if has_linked_device_id:
+            # If the entity registry already has a device_id we want
+            # to link to in case the device is not available, we can
+            # set the device_info now. If we do not set device info
+            # the linkage to the device will be removed by the entity
+            # platform.
+            self._attr_device_info = dr.DeviceInfo(
+                connections={(dr.CONNECTION_UPNP, udn)}
+            )
 
     async def async_added_to_hass(self) -> None:
         """Handle addition."""

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -156,10 +156,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self._device_lock = asyncio.Lock()
         self._background_setup_task: asyncio.Task[None] | None = None
         self._updated_registry: bool = False
-        # Device info will be updated when the device is connected
-        self._attr_device_info = dr.DeviceInfo(
-            connections={(dr.CONNECTION_UPNP, self.udn)},
-        )
 
     async def async_added_to_hass(self) -> None:
         """Handle addition."""

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -155,6 +155,11 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self.browse_unfiltered = browse_unfiltered
         self._device_lock = asyncio.Lock()
         self._background_setup_task: asyncio.Task[None] | None = None
+        # Device info will be updated when the device is connected
+        self._attr_device_info = dr.DeviceInfo(
+            connections={(dr.CONNECTION_UPNP, self.udn)},
+            default_name=name,
+        )
 
     async def async_added_to_hass(self) -> None:
         """Handle addition."""

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -97,7 +97,9 @@ async def async_setup_entry(
     has_linked_device_id = bool(
         existing_entity_id
         and (existing_entry := ent_reg.async_get(existing_entity_id))
-        and existing_entry.device_id
+        and (device_id := existing_entry.device_id)
+        and (device_entry := dr.async_get(hass).async_get(device_id))
+        and (dr.CONNECTION_UPNP, udn) in device_entry.connections
     )
 
     # Create our own device-wrapping entity

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -91,11 +91,14 @@ async def async_setup_entry(
 
     udn = entry.data[CONF_DEVICE_ID]
     ent_reg = er.async_get(hass)
+    # If the device is offline, we need to make sure we still
+    # have the previous connections so that the entity does not
+    # get unlinked from the device when it gets added to hass.
     previous_connections: set[tuple[str, str]] = set()
     if (
         (
             existing_entity_id := ent_reg.async_get_entity_id(
-                MEDIA_PLAYER_DOMAIN, DOMAIN, udn
+                domain=MEDIA_PLAYER_DOMAIN, platform=DOMAIN, unique_id=udn
             )
         )
         and (existing_entry := ent_reg.async_get(existing_entity_id))

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -383,16 +383,19 @@ class DlnaDmrEntity(MediaPlayerEntity):
             return  # No new information
 
         self._updated_registry = True
-        connections = set()
         # Connections based on the root device's UDN, and the DMR embedded
         # device's UDN. They may be the same, if the DMR is the root device.
-        connections.add(
+        connections = {
             (
                 dr.CONNECTION_UPNP,
                 self._device.profile_device.root_device.udn,
-            )
-        )
-        connections.add((dr.CONNECTION_UPNP, self._device.udn))
+            ),
+            (dr.CONNECTION_UPNP, self._device.udn),
+            (
+                dr.CONNECTION_UPNP,
+                self.udn,
+            ),
+        }
 
         if self.mac_address:
             # Connection based on MAC address, if known

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -91,12 +91,11 @@ async def async_setup_entry(
 
     udn = entry.data[CONF_DEVICE_ID]
     ent_reg = er.async_get(hass)
+    existing_entity_id = ent_reg.async_get_entity_id(
+        domain=MEDIA_PLAYER_DOMAIN, platform=DOMAIN, unique_id=udn
+    )
     has_linked_device_id = bool(
-        (
-            existing_entity_id := ent_reg.async_get_entity_id(
-                domain=MEDIA_PLAYER_DOMAIN, platform=DOMAIN, unique_id=udn
-            )
-        )
+        existing_entity_id
         and (existing_entry := ent_reg.async_get(existing_entity_id))
         and existing_entry.device_id
     )

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -420,6 +420,13 @@ class DlnaDmrEntity(MediaPlayerEntity):
             device_id=device_entry.id,
         )
 
+        self._attr_device_info = dr.DeviceInfo(
+            connections=connections,
+            default_manufacturer=self._device.manufacturer,
+            default_model=self._device.model_name,
+            default_name=self._device.name,
+        )
+
     async def _device_disconnect(self) -> None:
         """Destroy connections to the device now that it's not available.
 

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -188,15 +188,13 @@ class DlnaDmrEntity(MediaPlayerEntity):
             )
         )
 
-        if self._device:
-            return
-
-        if self.hass.state is CoreState.running:
-            await self._async_setup()
-        else:
-            self._background_setup_task = self.hass.async_create_background_task(
-                self._async_setup(), f"dlna_dmr {self.name} setup"
-            )
+        if not self._device:
+            if self.hass.state is CoreState.running:
+                await self._async_setup()
+            else:
+                self._background_setup_task = self.hass.async_create_background_task(
+                    self._async_setup(), f"dlna_dmr {self.name} setup"
+                )
 
     async def _async_setup(self) -> None:
         # Try to connect to the last known location, but don't worry if not available

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -402,21 +402,18 @@ class DlnaDmrEntity(MediaPlayerEntity):
                 (dr.CONNECTION_NETWORK_MAC, self.mac_address)
             )
 
-        self._attr_device_info = dr.DeviceInfo(
+        device_info = dr.DeviceInfo(
             connections=connections,
             default_manufacturer=self._device.manufacturer,
             default_model=self._device.model_name,
             default_name=self._device.name,
         )
+        self._attr_device_info = device_info
 
         self._updated_registry = True
         # Create linked HA DeviceEntry now the information is known.
         device_entry = dr.async_get(self.hass).async_get_or_create(
-            config_entry_id=self._config_entry_id,
-            connections=connections,
-            default_manufacturer=self._device.manufacturer,
-            default_model=self._device.model_name,
-            default_name=self._device.name,
+            config_entry_id=self._config_entry_id, **device_info
         )
 
         # Update entity registry to link to the device

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -163,11 +163,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
     async def async_added_to_hass(self) -> None:
         """Handle addition."""
-        self._background_setup_task = self.hass.async_create_background_task(
-            self._async_setup(), f"dlna_dmr {self.name} setup"
-        )
-
-    async def _async_setup(self) -> None:
         # Update this entity when the associated config entry is modified
         if self.registry_entry and self.registry_entry.config_entry_id:
             config_entry = self.hass.config_entries.async_get_entry(
@@ -177,13 +172,6 @@ class DlnaDmrEntity(MediaPlayerEntity):
             self.async_on_remove(
                 config_entry.add_update_listener(self.async_config_update_listener)
             )
-
-        # Try to connect to the last known location, but don't worry if not available
-        if not self._device:
-            try:
-                await self._device_connect(self.location)
-            except UpnpError as err:
-                _LOGGER.debug("Couldn't connect immediately: %r", err)
 
         # Get SSDP notifications for only this device
         self.async_on_remove(
@@ -203,6 +191,18 @@ class DlnaDmrEntity(MediaPlayerEntity):
                 {"_udn": self.udn, "NTS": NotificationSubType.SSDP_BYEBYE},
             )
         )
+
+        if not self._device:
+            self._background_setup_task = self.hass.async_create_background_task(
+                self._async_setup(), f"dlna_dmr {self.name} setup"
+            )
+
+    async def _async_setup(self) -> None:
+        # Try to connect to the last known location, but don't worry if not available
+        try:
+            await self._device_connect(self.location)
+        except UpnpError as err:
+            _LOGGER.debug("Couldn't connect immediately: %r", err)
 
     async def async_will_remove_from_hass(self) -> None:
         """Handle removal."""

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -367,11 +367,14 @@ class DlnaDmrEntity(MediaPlayerEntity):
 
     def _update_device_registry(self, set_mac: bool = False) -> None:
         """Update the device registry with new information about the DMR."""
-        if not self._device:
-            return  # Can't get all the required information without a connection
-
-        if not set_mac and self._updated_registry:
-            return  # No new information
+        if (
+            # Can't get all the required information without a connection
+            not self._device
+            or
+            # No new information
+            (not set_mac and self._updated_registry)
+        ):
+            return
 
         # Connections based on the root device's UDN, and the DMR embedded
         # device's UDN. They may be the same, if the DMR is the root device.

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -100,7 +100,7 @@ async def async_setup_entry(
         location=entry.data[CONF_URL],
         mac_address=entry.data.get(CONF_MAC),
         browse_unfiltered=entry.options.get(CONF_BROWSE_UNFILTERED, False),
-        config_entry_id=entry.entry_id,
+        config_entry=entry,
     )
 
     async_add_entities([entity])
@@ -146,7 +146,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         location: str,
         mac_address: str | None,
         browse_unfiltered: bool,
-        config_entry_id: str,
+        config_entry: config_entries.ConfigEntry,
     ) -> None:
         """Initialize DLNA DMR entity."""
         self.udn = udn
@@ -160,7 +160,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self._device_lock = asyncio.Lock()
         self._background_setup_task: asyncio.Task[None] | None = None
         self._updated_registry: bool = False
-        self._config_entry_id = config_entry_id
+        self._config_entry = config_entry
 
     async def async_added_to_hass(self) -> None:
         """Handle addition."""
@@ -413,7 +413,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self._updated_registry = True
         # Create linked HA DeviceEntry now the information is known.
         device_entry = dr.async_get(self.hass).async_get_or_create(
-            config_entry_id=self._config_entry_id, **device_info
+            config_entry_id=self._config_entry.entry_id, **device_info
         )
 
         # Update entity registry to link to the device
@@ -422,6 +422,7 @@ class DlnaDmrEntity(MediaPlayerEntity):
             DOMAIN,
             self.unique_id,
             device_id=device_entry.id,
+            config_entry=self._config_entry,
         )
 
     async def _device_disconnect(self) -> None:

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -155,10 +155,10 @@ class DlnaDmrEntity(MediaPlayerEntity):
         self.browse_unfiltered = browse_unfiltered
         self._device_lock = asyncio.Lock()
         self._background_setup_task: asyncio.Task[None] | None = None
+        self._updated_registry: bool = False
         # Device info will be updated when the device is connected
         self._attr_device_info = dr.DeviceInfo(
             connections={(dr.CONNECTION_UPNP, self.udn)},
-            default_name=name,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -374,9 +374,10 @@ class DlnaDmrEntity(MediaPlayerEntity):
         if not self.registry_entry or not self.registry_entry.config_entry_id:
             return  # No config registry entry to link to
 
-        if self.registry_entry.device_id and not set_mac:
+        if self.registry_entry.device_id and not set_mac and self._updated_registry:
             return  # No new information
 
+        self._updated_registry = True
         connections = set()
         # Connections based on the root device's UDN, and the DMR embedded
         # device's UDN. They may be the same, if the DMR is the root device.

--- a/tests/components/dlna_dmr/test_init.py
+++ b/tests/components/dlna_dmr/test_init.py
@@ -6,6 +6,7 @@ from homeassistant.components import media_player
 from homeassistant.components.dlna_dmr.const import DOMAIN as DLNA_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -31,6 +32,10 @@ async def test_resource_lifecycle(
     )
     assert len(entries) == 1
     entity_id = entries[0].entity_id
+
+    await async_update_entity(hass, entity_id)
+    await hass.async_block_till_done()
+
     mock_state = hass.states.get(entity_id)
     assert mock_state is not None
     assert mock_state.state == media_player.STATE_IDLE

--- a/tests/components/dlna_dmr/test_init.py
+++ b/tests/components/dlna_dmr/test_init.py
@@ -6,7 +6,6 @@ from homeassistant.components import media_player
 from homeassistant.components.dlna_dmr.const import DOMAIN as DLNA_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -32,10 +31,6 @@ async def test_resource_lifecycle(
     )
     assert len(entries) == 1
     entity_id = entries[0].entity_id
-
-    await async_update_entity(hass, entity_id)
-    await hass.async_block_till_done()
-
     mock_state = hass.states.get(entity_id)
     assert mock_state is not None
     assert mock_state.state == media_player.STATE_IDLE

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -2299,3 +2299,111 @@ async def test_config_update_mac_address(
     )
     assert device is not None
     assert (CONNECTION_NETWORK_MAC, MOCK_MAC_ADDRESS) in device.connections
+
+
+@pytest.mark.parametrize(
+    "core_state",
+    (CoreState.not_running, CoreState.running),
+)
+async def test_connections_restored(
+    hass: HomeAssistant,
+    domain_data_mock: Mock,
+    ssdp_scanner_mock: Mock,
+    config_entry_mock: MockConfigEntry,
+    dmr_device_mock: Mock,
+    core_state: CoreState,
+) -> None:
+    """Test previous connections re restored."""
+    # Cause connection attempts to fail before adding entity
+    hass.set_state(core_state)
+    domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
+    mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    mock_state = hass.states.get(mock_entity_id)
+    assert mock_state is not None
+    assert mock_state.state == ha_const.STATE_UNAVAILABLE
+
+    # Check hass device information has not been filled in yet
+    dev_reg = async_get_dr(hass)
+    device = dev_reg.async_get_device(
+        connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
+        identifiers=set(),
+    )
+    assert device is None
+
+    # Mock device is now available.
+    domain_data_mock.upnp_factory.async_create_device.side_effect = None
+    domain_data_mock.upnp_factory.async_create_device.reset_mock()
+
+    # Send an SSDP notification from the now alive device
+    ssdp_callback = ssdp_scanner_mock.async_register_callback.call_args.args[0]
+    await ssdp_callback(
+        ssdp.SsdpServiceInfo(
+            ssdp_usn=MOCK_DEVICE_USN,
+            ssdp_location=NEW_DEVICE_LOCATION,
+            ssdp_st=MOCK_DEVICE_TYPE,
+            upnp={},
+        ),
+        ssdp.SsdpChange.ALIVE,
+    )
+    await hass.async_block_till_done()
+
+    # Check device was created from the supplied URL
+    domain_data_mock.upnp_factory.async_create_device.assert_awaited_once_with(
+        NEW_DEVICE_LOCATION
+    )
+    # Check event notifiers are acquired
+    domain_data_mock.async_get_event_notifier.assert_awaited_once_with(
+        EventListenAddr(LOCAL_IP, 0, None), hass
+    )
+    # Check UPnP services are subscribed
+    dmr_device_mock.async_subscribe_services.assert_awaited_once_with(
+        auto_resubscribe=True
+    )
+    assert dmr_device_mock.on_event is not None
+    # Quick check of the state to verify the entity has a connected DmrDevice
+    mock_state = hass.states.get(mock_entity_id)
+    assert mock_state is not None
+    assert mock_state.state == MediaPlayerState.IDLE
+    # Check hass device information is now filled in
+    dev_reg = async_get_dr(hass)
+    device = dev_reg.async_get_device(
+        connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
+        identifiers=set(),
+    )
+    assert device is not None
+    assert device.manufacturer == "device_manufacturer"
+    assert device.model == "device_model_name"
+    assert device.name == "device_name"
+
+    # Reload the config entry
+    assert await hass.config_entries.async_reload(config_entry_mock.entry_id)
+    await async_update_entity(hass, mock_entity_id)
+
+    # Confirm SSDP notifications unregistered
+    assert ssdp_scanner_mock.async_register_callback.return_value.call_count == 2
+
+    # Confirm the entity has disconnected from the device
+    domain_data_mock.async_release_event_notifier.assert_awaited_once()
+    dmr_device_mock.async_unsubscribe_services.assert_awaited_once()
+
+    # Check hass device information has not been filled in yet
+    dev_reg = async_get_dr(hass)
+    device = dev_reg.async_get_device(
+        connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
+        identifiers=set(),
+    )
+    assert device is not None
+
+    # Verify the entity remains linked to the device
+    ent_reg = async_get_er(hass)
+    entry = ent_reg.async_get(mock_entity_id)
+    assert entry is not None
+    assert entry.device_id == device.id
+
+    # Verify the entity has an idle state
+    mock_state = hass.states.get(mock_entity_id)
+    assert mock_state is not None
+    assert mock_state.state == MediaPlayerState.IDLE
+
+    # Unload config entry to clean up
+    assert await hass.config_entries.async_unload(config_entry_mock.entry_id)

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -216,9 +216,6 @@ async def test_setup_entry_no_options(
     """
     config_entry_mock.options = MappingProxyType({})
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
-
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -288,8 +285,6 @@ async def test_setup_entry_with_options(
         }
     )
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -348,9 +343,8 @@ async def test_setup_entry_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Entry with a MAC address will set up and set the device registry connection."""
-    mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
+    await setup_mock_component(hass, config_entry_mock)
+
     # Check the device registry connections for MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -369,9 +363,8 @@ async def test_setup_entry_no_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Test setting up an entry without a MAC address will succeed."""
-    mock_entity_id = await setup_mock_component(hass, config_entry_mock_no_mac)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
+    await setup_mock_component(hass, config_entry_mock_no_mac)
+
     # Check the device registry connections does not include the MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -389,8 +382,6 @@ async def test_event_subscribe_failure(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpError
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -421,8 +412,6 @@ async def test_event_subscribe_rejected(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(status=501)
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -443,8 +432,6 @@ async def test_available_device(
 ) -> None:
     """Test a DlnaDmrEntity with a connected DmrDevice."""
     # Check hass device information is filled in
-    await async_update_entity(hass, mock_entity_id)
-    await hass.async_block_till_done()
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
@@ -1349,9 +1336,7 @@ async def test_unavailable_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is not None
-    assert device.name is None
-    assert device.manufacturer is None
+    assert device is None
 
     # Unload config entry to clean up
     assert await hass.config_entries.async_remove(config_entry_mock.entry_id) == {
@@ -1391,7 +1376,7 @@ async def test_become_available(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is not None
+    assert device is None
 
     # Mock device is now available.
     domain_data_mock.upnp_factory.async_create_device.side_effect = None

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -2459,6 +2459,8 @@ async def test_udn_upnp_connection_added_if_missing(
         identifiers=set(),
     )
 
+    ent_reg.async_update_entity(mock_entity_id, device_id=device.id)
+
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
     assert await hass.config_entries.async_setup(config_entry_mock.entry_id) is True
     await hass.async_block_till_done()
@@ -2469,8 +2471,6 @@ async def test_udn_upnp_connection_added_if_missing(
 
     # Check hass device information has not been filled in yet
     dev_reg = async_get_dr(hass)
-    device = dev_reg.async_get_device(
-        connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
-    )
+    device = dev_reg.async_get(device.id)
     assert device is not None
+    assert (CONNECTION_UPNP, MOCK_DEVICE_UDN) in device.connections

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -216,6 +216,9 @@ async def test_setup_entry_no_options(
     """
     config_entry_mock.options = MappingProxyType({})
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
+
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -285,6 +288,8 @@ async def test_setup_entry_with_options(
         }
     )
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -343,8 +348,9 @@ async def test_setup_entry_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Entry with a MAC address will set up and set the device registry connection."""
-    await setup_mock_component(hass, config_entry_mock)
-
+    mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     # Check the device registry connections for MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -363,8 +369,9 @@ async def test_setup_entry_no_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Test setting up an entry without a MAC address will succeed."""
-    await setup_mock_component(hass, config_entry_mock_no_mac)
-
+    mock_entity_id = await setup_mock_component(hass, config_entry_mock_no_mac)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     # Check the device registry connections does not include the MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -382,6 +389,8 @@ async def test_event_subscribe_failure(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpError
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -412,6 +421,8 @@ async def test_event_subscribe_rejected(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(status=501)
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -432,6 +443,8 @@ async def test_available_device(
 ) -> None:
     """Test a DlnaDmrEntity with a connected DmrDevice."""
     # Check hass device information is filled in
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
@@ -1366,6 +1379,7 @@ async def test_become_available(
     # Cause connection attempts to fail before adding entity
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
     assert mock_state.state == ha_const.STATE_UNAVAILABLE

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -216,6 +216,9 @@ async def test_setup_entry_no_options(
     """
     config_entry_mock.options = MappingProxyType({})
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
+
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -291,6 +294,8 @@ async def test_setup_entry_with_options(
         }
     )
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -349,8 +354,9 @@ async def test_setup_entry_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Entry with a MAC address will set up and set the device registry connection."""
-    await setup_mock_component(hass, config_entry_mock)
-
+    mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     # Check the device registry connections for MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -369,8 +375,9 @@ async def test_setup_entry_no_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Test setting up an entry without a MAC address will succeed."""
-    await setup_mock_component(hass, config_entry_mock_no_mac)
-
+    mock_entity_id = await setup_mock_component(hass, config_entry_mock_no_mac)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     # Check the device registry connections does not include the MAC address
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
@@ -388,6 +395,8 @@ async def test_event_subscribe_failure(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpError
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -418,6 +427,8 @@ async def test_event_subscribe_rejected(
     dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(status=501)
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
 
@@ -438,6 +449,8 @@ async def test_available_device(
 ) -> None:
     """Test a DlnaDmrEntity with a connected DmrDevice."""
     # Check hass device information is filled in
+    await async_update_entity(hass, mock_entity_id)
+    await hass.async_block_till_done()
     dev_reg = async_get_dr(hass)
     device = dev_reg.async_get_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
@@ -1348,7 +1361,9 @@ async def test_unavailable_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is None
+    assert device is not None
+    assert device.name is None
+    assert device.manufacturer is None
 
     # Unload config entry to clean up
     assert await hass.config_entries.async_remove(config_entry_mock.entry_id) == {
@@ -1394,7 +1409,7 @@ async def test_become_available(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is None
+    assert device is not None
 
     # Mock device is now available.
     domain_data_mock.upnp_factory.async_create_device.side_effect = None
@@ -2313,7 +2328,7 @@ async def test_connections_restored(
     dmr_device_mock: Mock,
     core_state: CoreState,
 ) -> None:
-    """Test previous connections re restored."""
+    """Test previous connections restored."""
     # Cause connection attempts to fail before adding entity
     hass.set_state(core_state)
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
@@ -2328,7 +2343,7 @@ async def test_connections_restored(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is None
+    assert device is not None
 
     # Mock device is now available.
     domain_data_mock.upnp_factory.async_create_device.side_effect = None
@@ -2371,6 +2386,7 @@ async def test_connections_restored(
         identifiers=set(),
     )
     assert device is not None
+    previous_connections = device.connections
     assert device.manufacturer == "device_manufacturer"
     assert device.model == "device_model_name"
     assert device.name == "device_name"
@@ -2393,6 +2409,7 @@ async def test_connections_restored(
         identifiers=set(),
     )
     assert device is not None
+    assert device.connections == previous_connections
 
     # Verify the entity remains linked to the device
     ent_reg = async_get_er(hass)

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -266,17 +266,23 @@ async def test_setup_entry_no_options(
     assert mock_state.state == ha_const.STATE_UNAVAILABLE
 
 
+@pytest.mark.parametrize(
+    "core_state",
+    (CoreState.not_running, CoreState.running),
+)
 async def test_setup_entry_with_options(
     hass: HomeAssistant,
     domain_data_mock: Mock,
     ssdp_scanner_mock: Mock,
     config_entry_mock: MockConfigEntry,
     dmr_device_mock: Mock,
+    core_state: CoreState,
 ) -> None:
     """Test setting options leads to a DlnaDmrEntity with custom event_handler.
 
     Check that the device is constructed properly as part of the test.
     """
+    hass.set_state(core_state)
     config_entry_mock.options = MappingProxyType(
         {
             CONF_LISTEN_PORT: 2222,

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -1349,7 +1349,9 @@ async def test_unavailable_device(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is None
+    assert device is not None
+    assert device.name is None
+    assert device.manufacturer is None
 
     # Unload config entry to clean up
     assert await hass.config_entries.async_remove(config_entry_mock.entry_id) == {
@@ -1379,7 +1381,6 @@ async def test_become_available(
     # Cause connection attempts to fail before adding entity
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
-    await async_update_entity(hass, mock_entity_id)
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
     assert mock_state.state == ha_const.STATE_UNAVAILABLE
@@ -1390,7 +1391,7 @@ async def test_become_available(
         connections={(CONNECTION_UPNP, MOCK_DEVICE_UDN)},
         identifiers=set(),
     )
-    assert device is None
+    assert device is not None
 
     # Mock device is now available.
     domain_data_mock.upnp_factory.async_create_device.side_effect = None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Ensure the udn is always set in the device and add it if its missing
- Always set device_info in case the dlna_dmr device is offline so the entity does not get unlinked from the device
- Make the connection in a background task if hass has not yet started to avoid delaying startup

fixes #109834


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
