### PR TITLE
Support Bring! recently list

### DIFF
--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -20,7 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 class BringData(BringList):
     """Coordinator data class."""
 
-    items: list[BringItemsResponse]
+    purchase_items: list[BringItemsResponse]
+    recently_items: list[BringItemsResponse]
 
 
 class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
@@ -56,7 +57,8 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
                 ) from e
             except BringParseException as e:
                 raise UpdateFailed("Unable to parse response from bring") from e
-            lst["items"] = items["purchase"]
+            lst["purchase_items"] = items["purchase"]
+            lst["recently_items"] = items["recently"]
             list_dict[lst["listUuid"]] = lst
 
         return list_dict

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -130,12 +130,12 @@ class BringTodoListEntity(
         bring_list = self.bring_list
 
         bring_purchase_item = next(
-            (i for i in bring_list["purchase_items"] if i["name"] == item.uid),
+            (i for i in bring_list["purchase_items"] if i["itemId"] == item.uid),
             None,
         )
 
         bring_recently_item = next(
-            (i for i in bring_list["recently_items"] if i["name"] == item.uid),
+            (i for i in bring_list["recently_items"] if i["itemId"] == item.uid),
             None,
         )
 

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -74,13 +74,24 @@ class BringTodoListEntity(
     def todo_items(self) -> list[TodoItem]:
         """Return the todo items."""
         return [
-            TodoItem(
-                uid=item["itemId"],
-                summary=item["itemId"],
-                description=item["specification"] or "",
-                status=TodoItemStatus.NEEDS_ACTION,
-            )
-            for item in self.bring_list["items"]
+            *(
+                TodoItem(
+                    uid=item["itemId"],
+                    summary=item["itemId"],
+                    description=item["specification"] or "",
+                    status=TodoItemStatus.NEEDS_ACTION,
+                )
+                for item in self.bring_list["purchase_items"]
+            ),
+            *(
+                TodoItem(
+                    uid=item["itemId"],
+                    summary=item["itemId"],
+                    description=item["specification"] or "",
+                    status=TodoItemStatus.COMPLETED,
+                )
+                for item in self.bring_list["recently_items"]
+            ),
         ]
 
     @property
@@ -103,27 +114,42 @@ class BringTodoListEntity(
         """Update an item to the To-do list.
 
         Bring has an internal 'recent' list which we want to use instead of a todo list
-        status, therefore completed todo list items will directly be deleted
+        status, therefore completed todo list items are matched to the recent list and pending items to the purchase list
 
         This results in following behaviour:
 
         - Completed items will move to the "completed" section in home assistant todo
-            list and get deleted in bring, which will remove them from the home
-            assistant todo list completely after a short delay
+            list and get moved to the recently list in bring
         - Bring items do not have unique identifiers and are using the
             name/summery/title. Therefore the name is not to be changed! Should a name
             be changed anyway, a new item will be created instead and no update for
             this item is performed and on the next cloud pull update, it will get
-            cleared
+            cleared and replaced seamlessly
         """
 
         bring_list = self.bring_list
 
+        bring_purchase_item = next(
+            (i for i in bring_list["purchase_items"] if i["name"] == item.uid),
+            None,
+        )
+
+        bring_recently_item = next(
+            (i for i in bring_list["recently_items"] if i["name"] == item.uid),
+            None,
+        )
+
         if TYPE_CHECKING:
             assert item.uid
 
-        if item.status == TodoItemStatus.COMPLETED:
-            await self.coordinator.bring.remove_item(
+        if item.status == TodoItemStatus.COMPLETED and bring_purchase_item:
+            await self.coordinator.bring.complete_item(
+                bring_list["listUuid"],
+                item.uid,
+            )
+
+        elif item.status == TodoItemStatus.NEEDS_ACTION and bring_recently_item:
+            await self.coordinator.bring.save_item(
                 bring_list["listUuid"],
                 item.uid,
             )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since version `2.1.0` (and as we are currently on `3.0.0`), the bring api supports a method called `complete` and `completeAsync`, which allows to check off items instead of just deleting them. In addition to the `purchase` list available in the `getItems` and `getItemsAsync`, a `recently` list is now available to, letting us perform following mapping `purchase->NEEDS_ACTION` and `recently->COMPLETED` and use the full functionality of the todo lists. A small detail, the bring api does not at all support any `uncomplete` method and basic create method can be used instead, resulting in the removal from the item from the `recently` list and getting moved to `purchase` list.

**DISCLAIMER**: In the meantime we switched the lib to `bring-api@0.1.1` which is essentially the same as `3.0.0`. Have a look at #110355 for more details about it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
