### PR TITLE
Remove store from google_assistant AbstractConfig

### DIFF
--- a/homeassistant/components/cloud/const.py
+++ b/homeassistant/components/cloud/const.py
@@ -30,6 +30,7 @@ PREF_GOOGLE_DEFAULT_EXPOSE = "google_default_expose"
 PREF_ALEXA_SETTINGS_VERSION = "alexa_settings_version"
 PREF_GOOGLE_SETTINGS_VERSION = "google_settings_version"
 PREF_TTS_DEFAULT_VOICE = "tts_default_voice"
+PREF_GOOGLE_CONNECTED = "google_connected"
 DEFAULT_TTS_DEFAULT_VOICE = ("en-US", "female")
 DEFAULT_DISABLE_2FA = False
 DEFAULT_ALEXA_REPORT_STATE = True

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -65,7 +65,7 @@ class ImportGoogleConfigStore(GoogleConfigStore):
     when migrating to store version 1.3.
 
     Before version 1.3 of the cloud store, the gogle_assistant store was shared between
-    the cloud integration and manually configures Google assistant.
+    the cloud integration and manually configured Google assistant.
     """
 
     # pylint: disable-next=super-init-not-called

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -59,7 +59,14 @@ class ReadOnlyStore(Store):
 
 
 class ImportGoogleConfigStore(GoogleConfigStore):
-    """A read only configuration store for google assistant."""
+    """A read only configuration store for google assistant.
+
+    This class is used to import settings from the google_assistant store
+    when migrating to store version 1.3.
+
+    Before version 1.3 of the cloud store, the gogle_assistant store was shared between
+    the cloud integration and manually configures Google assistant.
+    """
 
     # pylint: disable-next=super-init-not-called
     def __init__(self, hass: HomeAssistant) -> None:
@@ -82,7 +89,7 @@ class CloudPreferencesStore(Store):
         """Migrate to the new version."""
 
         async def google_connected() -> bool:
-            """Return True if connected to Google."""
+            """Return True if our user is preset in the google_assistant store."""
             # If we don't have a user, we can't be connected to Google
             if not (cur_username := old_data.get(PREF_USERNAME)):
                 return False
@@ -98,7 +105,9 @@ class CloudPreferencesStore(Store):
                 old_data.setdefault(PREF_ALEXA_SETTINGS_VERSION, 1)
                 old_data.setdefault(PREF_GOOGLE_SETTINGS_VERSION, 1)
             if old_minor_version < 3:
-                # Import settings from the google_assistant store.
+                # Import settings from the google_assistant store which was previously
+                # shared between the cloud integration and manually configured Google
+                # assistant.
                 # In HA Core 2024.9, remove the import and also remove the Google
                 # assistant store if it's not been migrated by manual Google assistant
                 old_data.setdefault(PREF_GOOGLE_CONNECTED, await google_connected())

--- a/homeassistant/components/cloud/prefs.py
+++ b/homeassistant/components/cloud/prefs.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
+import os
 from typing import Any
 import uuid
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.auth.models import User
 from homeassistant.components import webhook
+from homeassistant.components.google_assistant.http import GoogleConfigStore
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
@@ -28,6 +30,7 @@ from .const import (
     PREF_ENABLE_ALEXA,
     PREF_ENABLE_GOOGLE,
     PREF_ENABLE_REMOTE,
+    PREF_GOOGLE_CONNECTED,
     PREF_GOOGLE_DEFAULT_EXPOSE,
     PREF_GOOGLE_ENTITY_CONFIGS,
     PREF_GOOGLE_LOCAL_WEBHOOK_ID,
@@ -42,7 +45,7 @@ from .const import (
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 1
-STORAGE_VERSION_MINOR = 2
+STORAGE_VERSION_MINOR = 3
 
 ALEXA_SETTINGS_VERSION = 3
 GOOGLE_SETTINGS_VERSION = 3
@@ -55,10 +58,33 @@ class CloudPreferencesStore(Store):
         self, old_major_version: int, old_minor_version: int, old_data: dict[str, Any]
     ) -> dict[str, Any]:
         """Migrate to the new version."""
+
+        async def google_connected() -> bool:
+            """Return True if connected to Google."""
+            # If we don't have a user, we can't be connected to Google
+            if not (cur_username := old_data.get(PREF_USERNAME)):
+                return False
+
+            google_store = GoogleConfigStore(self.hass)
+            # If the Google store does not exist, we can't be connected to Google
+            if not await self.hass.async_add_executor_job(
+                os.path.exists,
+                # pylint: disable-next=protected-access
+                google_store._store.path,
+            ):
+                return False
+
+            await google_store.async_initialize()
+            # If our user is in the Google store, we're connected
+            return cur_username in google_store.agent_user_ids
+
         if old_major_version == 1:
             if old_minor_version < 2:
                 old_data.setdefault(PREF_ALEXA_SETTINGS_VERSION, 1)
                 old_data.setdefault(PREF_GOOGLE_SETTINGS_VERSION, 1)
+            if old_minor_version < 3:
+                # Import settings from the google_assistant store
+                old_data.setdefault(PREF_GOOGLE_CONNECTED, await google_connected())
 
         return old_data
 
@@ -131,6 +157,7 @@ class CloudPreferences:
         remote_domain: str | None | UndefinedType = UNDEFINED,
         alexa_settings_version: int | UndefinedType = UNDEFINED,
         google_settings_version: int | UndefinedType = UNDEFINED,
+        google_connected: bool | UndefinedType = UNDEFINED,
     ) -> None:
         """Update user preferences."""
         prefs = {**self._prefs}
@@ -148,6 +175,7 @@ class CloudPreferences:
             (PREF_GOOGLE_SETTINGS_VERSION, google_settings_version),
             (PREF_TTS_DEFAULT_VOICE, tts_default_voice),
             (PREF_REMOTE_DOMAIN, remote_domain),
+            (PREF_GOOGLE_CONNECTED, google_connected),
         ):
             if value is not UNDEFINED:
                 prefs[key] = value
@@ -240,6 +268,12 @@ class CloudPreferences:
         """Return if Google is enabled."""
         google_enabled: bool = self._prefs[PREF_ENABLE_GOOGLE]
         return google_enabled
+
+    @property
+    def google_connected(self) -> bool:
+        """Return if Google is connected."""
+        google_connected: bool = self._prefs[PREF_GOOGLE_CONNECTED]
+        return google_connected
 
     @property
     def google_report_state(self) -> bool:
@@ -338,6 +372,7 @@ class CloudPreferences:
             PREF_ENABLE_ALEXA: True,
             PREF_ENABLE_GOOGLE: True,
             PREF_ENABLE_REMOTE: False,
+            PREF_GOOGLE_CONNECTED: False,
             PREF_GOOGLE_DEFAULT_EXPOSE: DEFAULT_EXPOSED_DOMAINS,
             PREF_GOOGLE_ENTITY_CONFIGS: {},
             PREF_GOOGLE_SETTINGS_VERSION: GOOGLE_SETTINGS_VERSION,

--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from asyncio import gather
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Collection, Mapping
 from datetime import datetime, timedelta
 from functools import lru_cache
 from http import HTTPStatus
@@ -33,7 +33,6 @@ from homeassistant.helpers import (
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.redact import partial_redact
-from homeassistant.helpers.storage import Store
 from homeassistant.util.dt import utcnow
 
 from . import trait
@@ -46,8 +45,6 @@ from .const import (
     ERR_FUNCTION_NOT_SUPPORTED,
     NOT_EXPOSE_LOCAL,
     SOURCE_LOCAL,
-    STORE_AGENT_USER_IDS,
-    STORE_GOOGLE_LOCAL_WEBHOOK_ID,
 )
 from .data_redaction import async_redact_request_msg, async_redact_response_msg
 from .error import SmartHomeError
@@ -94,7 +91,6 @@ def _get_registry_entries(
 class AbstractConfig(ABC):
     """Hold the configuration for Google Assistant."""
 
-    _store: GoogleConfigStore
     _unsub_report_state: Callable[[], None] | None = None
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -109,9 +105,6 @@ class AbstractConfig(ABC):
 
     async def async_initialize(self) -> None:
         """Perform async initialization of config."""
-        self._store = GoogleConfigStore(self.hass)
-        await self._store.async_initialize()
-
         if not self.enabled:
             return
 
@@ -203,7 +196,7 @@ class AbstractConfig(ABC):
         """Send a state report to Google for all previously synced users."""
         jobs = [
             self.async_report_state(message, agent_user_id)
-            for agent_user_id in self._store.agent_user_ids
+            for agent_user_id in self.async_get_agent_users()
         ]
         await gather(*jobs)
 
@@ -235,13 +228,13 @@ class AbstractConfig(ABC):
 
     async def async_sync_entities_all(self) -> int:
         """Sync all entities to Google for all registered agents."""
-        if not self._store.agent_user_ids:
+        if not self.async_get_agent_users():
             return 204
 
         res = await gather(
             *(
                 self.async_sync_entities(agent_user_id)
-                for agent_user_id in self._store.agent_user_ids
+                for agent_user_id in self.async_get_agent_users()
             )
         )
         return max(res, default=204)
@@ -262,13 +255,13 @@ class AbstractConfig(ABC):
         self, event_id: str, payload: dict[str, Any]
     ) -> HTTPStatus:
         """Sync notification to Google for all registered agents."""
-        if not self._store.agent_user_ids:
+        if not self.async_get_agent_users():
             return HTTPStatus.NO_CONTENT
 
         res = await gather(
             *(
                 self.async_sync_notification(agent_user_id, event_id, payload)
-                for agent_user_id in self._store.agent_user_ids
+                for agent_user_id in self.async_get_agent_users()
             )
         )
         return max(res, default=HTTPStatus.NO_CONTENT)
@@ -291,7 +284,7 @@ class AbstractConfig(ABC):
     @callback
     def async_schedule_google_sync_all(self) -> None:
         """Schedule a sync for all registered agents."""
-        for agent_user_id in self._store.agent_user_ids:
+        for agent_user_id in self.async_get_agent_users():
             self.async_schedule_google_sync(agent_user_id)
 
     async def _async_request_sync_devices(self, agent_user_id: str) -> int:
@@ -301,13 +294,14 @@ class AbstractConfig(ABC):
         """
         raise NotImplementedError
 
+    @abstractmethod
     async def async_connect_agent_user(self, agent_user_id: str):
         """Add a synced and known agent_user_id.
 
         Called before sending a sync response to Google.
         """
-        self._store.add_agent_user_id(agent_user_id)
 
+    @abstractmethod
     async def async_disconnect_agent_user(self, agent_user_id: str):
         """Turn off report state and disable further state reporting.
 
@@ -316,7 +310,11 @@ class AbstractConfig(ABC):
          - When the cloud configuration is initialized
          - When sync entities fails with 404
         """
-        self._store.pop_agent_user_id(agent_user_id)
+
+    @callback
+    @abstractmethod
+    def async_get_agent_users(self) -> Collection[str]:
+        """Return known agent users."""
 
     @callback
     def async_enable_local_sdk(self) -> None:
@@ -330,7 +328,7 @@ class AbstractConfig(ABC):
             self._local_sdk_active = False
             return
 
-        for user_agent_id in self._store.agent_user_ids:
+        for user_agent_id in self.async_get_agent_users():
             if (webhook_id := self.get_local_webhook_id(user_agent_id)) is None:
                 setup_successful = False
                 break
@@ -375,7 +373,7 @@ class AbstractConfig(ABC):
         if not self._local_sdk_active:
             return
 
-        for agent_user_id in self._store.agent_user_ids:
+        for agent_user_id in self.async_get_agent_users():
             webhook_id = self.get_local_webhook_id(agent_user_id)
             _LOGGER.debug(
                 "Unregister webhook handler %s for agent user id %s",
@@ -452,65 +450,6 @@ class AbstractConfig(ABC):
             )
 
         return json_response(result)
-
-
-class GoogleConfigStore:
-    """A configuration store for google assistant."""
-
-    _STORAGE_VERSION = 1
-    _STORAGE_KEY = DOMAIN
-
-    def __init__(self, hass):
-        """Initialize a configuration store."""
-        self._hass = hass
-        self._store = Store(hass, self._STORAGE_VERSION, self._STORAGE_KEY)
-        self._data = None
-
-    async def async_initialize(self):
-        """Finish initializing the ConfigStore."""
-        should_save_data = False
-        if (data := await self._store.async_load()) is None:
-            # if the store is not found create an empty one
-            # Note that the first request is always a cloud request,
-            # and that will store the correct agent user id to be used for local requests
-            data = {
-                STORE_AGENT_USER_IDS: {},
-            }
-            should_save_data = True
-
-        for agent_user_id, agent_user_data in data[STORE_AGENT_USER_IDS].items():
-            if STORE_GOOGLE_LOCAL_WEBHOOK_ID not in agent_user_data:
-                data[STORE_AGENT_USER_IDS][agent_user_id] = {
-                    **agent_user_data,
-                    STORE_GOOGLE_LOCAL_WEBHOOK_ID: webhook.async_generate_id(),
-                }
-                should_save_data = True
-
-        if should_save_data:
-            await self._store.async_save(data)
-
-        self._data = data
-
-    @property
-    def agent_user_ids(self):
-        """Return a list of connected agent user_ids."""
-        return self._data[STORE_AGENT_USER_IDS]
-
-    @callback
-    def add_agent_user_id(self, agent_user_id):
-        """Add an agent user id to store."""
-        if agent_user_id not in self._data[STORE_AGENT_USER_IDS]:
-            self._data[STORE_AGENT_USER_IDS][agent_user_id] = {
-                STORE_GOOGLE_LOCAL_WEBHOOK_ID: webhook.async_generate_id(),
-            }
-            self._store.async_delay_save(lambda: self._data, 1.0)
-
-    @callback
-    def pop_agent_user_id(self, agent_user_id):
-        """Remove agent user id from store."""
-        if agent_user_id in self._data[STORE_AGENT_USER_IDS]:
-            self._data[STORE_AGENT_USER_IDS].pop(agent_user_id, None)
-            self._store.async_delay_save(lambda: self._data, 1.0)
 
 
 class RequestData:

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -394,7 +394,7 @@ async def async_get_users(hass: HomeAssistant) -> list[str]:
         not isinstance(store_data, dict)
         or not (data := store_data.get("data"))
         or not isinstance(data, dict)
-        or not (agent_user_ids := store_data.get("agent_user_ids"))
+        or not (agent_user_ids := data.get("agent_user_ids"))
         or not isinstance(agent_user_ids, dict)
     ):
         return []

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -292,6 +292,7 @@ class GoogleConfigStore:
     """A configuration store for google assistant."""
 
     _STORAGE_VERSION = 1
+    _STORAGE_VERSION_MINOR = 2
     _STORAGE_KEY = DOMAIN
     _data: dict[str, Any]
 
@@ -299,7 +300,10 @@ class GoogleConfigStore:
         """Initialize a configuration store."""
         self._hass = hass
         self._store: Store[dict[str, Any]] = Store(
-            hass, self._STORAGE_VERSION, self._STORAGE_KEY
+            hass,
+            self._STORAGE_VERSION,
+            self._STORAGE_KEY,
+            minor_version=self._STORAGE_VERSION_MINOR,
         )
 
     async def async_initialize(self) -> None:

--- a/homeassistant/components/google_assistant/http.py
+++ b/homeassistant/components/google_assistant/http.py
@@ -398,4 +398,4 @@ async def async_get_users(hass: HomeAssistant) -> list[str]:
         or not isinstance(agent_user_ids, dict)
     ):
         return []
-    return list(agent_user_ids.keys())
+    return list(agent_user_ids)

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -42,7 +42,7 @@ def mock_conf(hass, cloud_prefs):
         GACTIONS_SCHEMA({}),
         "mock-user-id",
         cloud_prefs,
-        Mock(claims={"cognito:username": "abcdefghjkl"}),
+        Mock(username="abcdefghjkl"),
     )
 
 
@@ -104,9 +104,11 @@ async def test_sync_entities(mock_conf, hass: HomeAssistant, cloud_prefs) -> Non
     assert await async_setup_component(hass, "homeassistant", {})
 
     await mock_conf.async_initialize()
+    assert len(mock_conf.async_get_agent_users()) == 0
+
     await mock_conf.async_connect_agent_user("mock-user-id")
 
-    assert len(mock_conf._store.agent_user_ids) == 1
+    assert len(mock_conf.async_get_agent_users()) == 1
 
     with patch(
         "hass_nabucasa.cloud_api.async_google_actions_request_sync",
@@ -115,7 +117,7 @@ async def test_sync_entities(mock_conf, hass: HomeAssistant, cloud_prefs) -> Non
         assert (
             await mock_conf.async_sync_entities("mock-user-id") == HTTPStatus.NOT_FOUND
         )
-        assert len(mock_conf._store.agent_user_ids) == 0
+        assert len(mock_conf.async_get_agent_users()) == 0
         assert len(mock_request_sync.mock_calls) == 1
 
 
@@ -144,7 +146,7 @@ async def test_google_update_expose_trigger_sync(
             GACTIONS_SCHEMA({}),
             "mock-user-id",
             cloud_prefs,
-            Mock(claims={"cognito:username": "abcdefghjkl"}),
+            Mock(username="abcdefghjkl"),
         )
         await config.async_initialize()
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -270,7 +272,8 @@ async def test_google_device_registry_sync(
     with patch.object(config, "async_sync_entities_all"):
         await config.async_initialize()
         await hass.async_block_till_done()
-    await config.async_connect_agent_user("mock-user-id")
+        await config.async_connect_agent_user("mock-user-id")
+        await hass.async_block_till_done()
 
     with patch.object(config, "async_schedule_google_sync_all") as mock_sync:
         # Device registry updated with non-relevant changes
@@ -326,7 +329,6 @@ async def test_sync_google_when_started(
     )
     with patch.object(config, "async_sync_entities_all") as mock_sync:
         await config.async_initialize()
-        await config.async_connect_agent_user("mock-user-id")
         await hass.async_block_till_done()
         assert len(mock_sync.mock_calls) == 1
 
@@ -341,7 +343,6 @@ async def test_sync_google_on_home_assistant_start(
     hass.set_state(CoreState.starting)
     with patch.object(config, "async_sync_entities_all") as mock_sync:
         await config.async_initialize()
-        await config.async_connect_agent_user("mock-user-id")
         assert len(mock_sync.mock_calls) == 0
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.components.google_assistant import helpers, http
 
 def mock_google_config_store(agent_user_ids=None):
     """Fake a storage for google assistant."""
-    store = MagicMock(spec=helpers.GoogleConfigStore)
+    store = MagicMock(spec=http.GoogleConfigStore)
     if agent_user_ids is not None:
         store.agent_user_ids = agent_user_ids
     else:

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -1,7 +1,6 @@
 """Test Google Assistant helpers."""
 from datetime import timedelta
 from http import HTTPStatus
-from typing import Any
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -23,12 +22,7 @@ from homeassistant.util import dt as dt_util
 
 from . import MockConfig
 
-from tests.common import (
-    MockConfigEntry,
-    async_capture_events,
-    async_fire_time_changed,
-    async_mock_service,
-)
+from tests.common import MockConfigEntry, async_capture_events, async_mock_service
 from tests.typing import ClientSessionGenerator
 
 
@@ -272,72 +266,6 @@ async def test_config_local_sdk_if_ssl_enabled(
     resp = await client.post("/api/webhook/mock-webhook-id")
     assert resp.status == HTTPStatus.OK
     assert await resp.read() == b""
-
-
-async def test_agent_user_id_storage(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
-    """Test a disconnect message."""
-
-    hass_storage["google_assistant"] = {
-        "version": 1,
-        "minor_version": 1,
-        "key": "google_assistant",
-        "data": {
-            "agent_user_ids": {
-                "agent_1": {
-                    "local_webhook_id": "test_webhook",
-                }
-            },
-        },
-    }
-
-    store = helpers.GoogleConfigStore(hass)
-    await store.async_initialize()
-
-    assert hass_storage["google_assistant"] == {
-        "version": 1,
-        "minor_version": 1,
-        "key": "google_assistant",
-        "data": {
-            "agent_user_ids": {
-                "agent_1": {
-                    "local_webhook_id": "test_webhook",
-                }
-            },
-        },
-    }
-
-    async def _check_after_delay(data):
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
-        await hass.async_block_till_done()
-
-        assert (
-            list(hass_storage["google_assistant"]["data"]["agent_user_ids"].keys())
-            == data
-        )
-
-    store.add_agent_user_id("agent_2")
-    await _check_after_delay(["agent_1", "agent_2"])
-
-    store.pop_agent_user_id("agent_1")
-    await _check_after_delay(["agent_2"])
-
-    hass_storage["google_assistant"] = {
-        "version": 1,
-        "minor_version": 1,
-        "key": "google_assistant",
-        "data": {
-            "agent_user_ids": {"agent_1": {}},
-        },
-    }
-    store = helpers.GoogleConfigStore(hass)
-    await store.async_initialize()
-
-    assert (
-        STORE_GOOGLE_LOCAL_WEBHOOK_ID
-        in hass_storage["google_assistant"]["data"]["agent_user_ids"]["agent_1"]
-    )
 
 
 async def test_agent_user_id_connect() -> None:

--- a/tests/components/google_assistant/test_http.py
+++ b/tests/components/google_assistant/test_http.py
@@ -500,7 +500,7 @@ async def test_agent_user_id_storage(
 
     assert hass_storage["google_assistant"] == {
         "version": 1,
-        "minor_version": 1,
+        "minor_version": 2,
         "key": "google_assistant",
         "data": {
             "agent_user_ids": {
@@ -528,7 +528,7 @@ async def test_agent_user_id_storage(
 
     hass_storage["google_assistant"] = {
         "version": 1,
-        "minor_version": 1,
+        "minor_version": 2,
         "key": "google_assistant",
         "data": {
             "agent_user_ids": {"agent_1": {}},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move store from `google_assistant.helpers.AbstractConfig` to `google_assistant.http.GoogleConfig`

The `cloud` integration was depending on the now moved store to keep track of if it was connected to Google or not, the PR adds a new flag to the cloud store, indicating if the user is connected to Google or now and checks the users in the store once to set the new flag.

Rationale:
The store supports storing multiple users, which is needed by manually setup Google Assistant but not by Home Assistant Cloud enabled Google Assistant. The store also stores a webhook ID for each user, which is used by manually setup Google Assistant, while the Home Assistant Cloud enabled Google Assistant keeps track of the webhook ID separately.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
