### PR TITLE
Test unique IDs for Shelly entities

### DIFF
--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -119,6 +119,7 @@ MOCK_BLOCKS = [
         colorTemp=mock_light_set_state()["temp"],
         **mock_light_set_state(),
         type="light",
+        description="light_0",
         set_state=AsyncMock(side_effect=mock_light_set_state),
     ),
     Mock(

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -104,6 +104,7 @@ MOCK_BLOCKS = [
         sensor_ids={"roller": "stop", "rollerPos": 0},
         channel="1",
         type="roller",
+        description="roller_0",
         set_state=AsyncMock(
             side_effect=lambda go, roller_pos=0: {
                 "current_pos": roller_pos,

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAI
 from homeassistant.components.shelly.const import SLEEP_PERIOD_MULTIPLIER
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers.entity_registry import async_get
 
 from . import (
     init_integration,
@@ -23,7 +22,7 @@ SENSOR_BLOCK_ID = 3
 
 
 async def test_block_binary_sensor(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, monkeypatch, entity_registry
 ) -> None:
     """Test block binary sensor."""
     entity_id = f"{BINARY_SENSOR_DOMAIN}.test_name_channel_1_overpowering"
@@ -36,9 +35,13 @@ async def test_block_binary_sensor(
 
     assert hass.states.get(entity_id).state == STATE_ON
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-relay_0-overpower"
+
 
 async def test_block_binary_sensor_extra_state_attr(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, monkeypatch, entity_registry
 ) -> None:
     """Test block binary sensor extra state attributes."""
     entity_id = f"{BINARY_SENSOR_DOMAIN}.test_name_gas"
@@ -55,9 +58,17 @@ async def test_block_binary_sensor_extra_state_attr(
     assert state.state == STATE_OFF
     assert state.attributes.get("detected") == "none"
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sensor_0-gas"
+
 
 async def test_block_rest_binary_sensor(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_block_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_block_device,
+    monkeypatch,
+    entity_registry,
 ) -> None:
     """Test block REST binary sensor."""
     entity_id = register_entity(hass, BINARY_SENSOR_DOMAIN, "test_name_cloud", "cloud")
@@ -71,9 +82,17 @@ async def test_block_rest_binary_sensor(
 
     assert hass.states.get(entity_id).state == STATE_ON
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-cloud"
+
 
 async def test_block_rest_binary_sensor_connected_battery_devices(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_block_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_block_device,
+    monkeypatch,
+    entity_registry,
 ) -> None:
     """Test block REST binary sensor for connected battery devices."""
     entity_id = register_entity(hass, BINARY_SENSOR_DOMAIN, "test_name_cloud", "cloud")
@@ -94,9 +113,13 @@ async def test_block_rest_binary_sensor_connected_battery_devices(
     await mock_rest_update(hass, freezer, seconds=SLEEP_PERIOD_MULTIPLIER * 3600)
     assert hass.states.get(entity_id).state == STATE_ON
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-cloud"
+
 
 async def test_block_sleeping_binary_sensor(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, monkeypatch, entity_registry
 ) -> None:
     """Test block sleeping binary sensor."""
     entity_id = f"{BINARY_SENSOR_DOMAIN}.test_name_motion"
@@ -115,6 +138,10 @@ async def test_block_sleeping_binary_sensor(
     mock_block_device.mock_update()
 
     assert hass.states.get(entity_id).state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sensor_0-motion"
 
 
 async def test_block_restored_sleeping_binary_sensor(
@@ -165,7 +192,7 @@ async def test_block_restored_sleeping_binary_sensor_no_last_state(
 
 
 async def test_rpc_binary_sensor(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, entity_registry
 ) -> None:
     """Test RPC binary sensor."""
     entity_id = f"{BINARY_SENSOR_DOMAIN}.test_cover_0_overpowering"
@@ -180,12 +207,15 @@ async def test_rpc_binary_sensor(
 
     assert hass.states.get(entity_id).state == STATE_ON
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-cover:0-overpower"
+
 
 async def test_rpc_binary_sensor_removal(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, entity_registry
 ) -> None:
     """Test RPC binary sensor is removed due to removal_condition."""
-    entity_registry = async_get(hass)
     entity_id = register_entity(
         hass, BINARY_SENSOR_DOMAIN, "test_cover_0_input", "input:0-input"
     )
@@ -199,7 +229,7 @@ async def test_rpc_binary_sensor_removal(
 
 
 async def test_rpc_sleeping_binary_sensor(
-    hass: HomeAssistant, mock_rpc_device, device_reg, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, monkeypatch, entity_registry
 ) -> None:
     """Test RPC online sleeping binary sensor."""
     entity_id = f"{BINARY_SENSOR_DOMAIN}.test_name_cloud"
@@ -225,6 +255,10 @@ async def test_rpc_sleeping_binary_sensor(
     state = hass.states.get("binary_sensor.test_name_external_power")
     assert state
     assert state.state == STATE_ON
+
+    entry = entity_registry.async_get("binary_sensor.test_name_external_power")
+    assert entry
+    assert entry.unique_id == "123456789ABC-devicepower:0-external_power"
 
 
 async def test_rpc_restored_sleeping_binary_sensor(

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -12,33 +12,49 @@ from homeassistant.helpers import entity_registry as er
 from . import init_integration
 
 
-async def test_block_button(hass: HomeAssistant, mock_block_device) -> None:
+async def test_block_button(
+    hass: HomeAssistant, mock_block_device, entity_registry
+) -> None:
     """Test block device reboot button."""
     await init_integration(hass, 1)
 
+    entity_id = "button.test_name_reboot"
+
     # reboot button
-    assert hass.states.get("button.test_name_reboot").state == STATE_UNKNOWN
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC_reboot"
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.test_name_reboot"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert mock_block_device.trigger_reboot.call_count == 1
 
 
-async def test_rpc_button(hass: HomeAssistant, mock_rpc_device) -> None:
+async def test_rpc_button(
+    hass: HomeAssistant, mock_rpc_device, entity_registry
+) -> None:
     """Test rpc device OTA button."""
     await init_integration(hass, 2)
 
+    entity_id = "button.test_name_reboot"
+
     # reboot button
-    assert hass.states.get("button.test_name_reboot").state == STATE_UNKNOWN
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC_reboot"
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
         SERVICE_PRESS,
-        {ATTR_ENTITY_ID: "button.test_name_reboot"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert mock_rpc_device.trigger_reboot.call_count == 1
@@ -56,6 +72,7 @@ async def test_migrate_unique_id(
     hass: HomeAssistant,
     mock_block_device,
     mock_rpc_device,
+    entity_registry,
     caplog: pytest.LogCaptureFixture,
     gen: int,
     old_unique_id: str,
@@ -65,7 +82,6 @@ async def test_migrate_unique_id(
     """Test migration of unique_id."""
     entry = await init_integration(hass, gen, skip_setup=True)
 
-    entity_registry = er.async_get(hass)
     entity: er.RegistryEntry = entity_registry.async_get_or_create(
         suggested_object_id="test_name_reboot",
         disabled_by=None,

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -43,7 +43,7 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.test_name"
 
 
 async def test_climate_hvac_mode(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, monkeypatch, entity_registry
 ) -> None:
     """Test climate hvac mode service."""
     monkeypatch.delattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "targetTemp")
@@ -64,6 +64,10 @@ async def test_climate_hvac_mode(
     # Test initial hvac mode - off
     state = hass.states.get(ENTITY_ID)
     assert state.state == HVACMode.OFF
+
+    entry = entity_registry.async_get(ENTITY_ID)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sensor_0"
 
     # Test set hvac mode heat
     await hass.services.async_call(

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -25,44 +25,49 @@ ROLLER_BLOCK_ID = 1
 
 
 async def test_block_device_services(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, monkeypatch, entity_registry
 ) -> None:
     """Test block device cover services."""
+    entity_id = "cover.test_name"
     monkeypatch.setitem(mock_block_device.settings, "mode", "roller")
     await init_integration(hass, 1)
 
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_SET_COVER_POSITION,
-        {ATTR_ENTITY_ID: "cover.test_name", ATTR_POSITION: 50},
+        {ATTR_ENTITY_ID: entity_id, ATTR_POSITION: 50},
         blocking=True,
     )
-    state = hass.states.get("cover.test_name")
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
-        {ATTR_ENTITY_ID: "cover.test_name"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get("cover.test_name").state == STATE_OPENING
+    assert hass.states.get(entity_id).state == STATE_OPENING
 
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER,
-        {ATTR_ENTITY_ID: "cover.test_name"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get("cover.test_name").state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == STATE_CLOSING
 
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_STOP_COVER,
-        {ATTR_ENTITY_ID: "cover.test_name"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get("cover.test_name").state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == STATE_CLOSED
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-roller_0"
 
 
 async def test_block_device_update(
@@ -89,18 +94,22 @@ async def test_block_device_no_roller_blocks(
 
 
 async def test_rpc_device_services(
-    hass: HomeAssistant, mock_rpc_device: Mock, monkeypatch: pytest.MonkeyPatch
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    monkeypatch: pytest.MonkeyPatch,
+    entity_registry,
 ) -> None:
     """Test RPC device cover services."""
+    entity_id = "cover.test_cover_0"
     await init_integration(hass, 2)
 
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_SET_COVER_POSITION,
-        {ATTR_ENTITY_ID: "cover.test_cover_0", ATTR_POSITION: 50},
+        {ATTR_ENTITY_ID: entity_id, ATTR_POSITION: 50},
         blocking=True,
     )
-    state = hass.states.get("cover.test_cover_0")
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_CURRENT_POSITION] == 50
 
     mutate_rpc_device_status(
@@ -109,11 +118,11 @@ async def test_rpc_device_services(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_OPEN_COVER,
-        {ATTR_ENTITY_ID: "cover.test_cover_0"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get("cover.test_cover_0").state == STATE_OPENING
+    assert hass.states.get(entity_id).state == STATE_OPENING
 
     mutate_rpc_device_status(
         monkeypatch, mock_rpc_device, "cover:0", "state", "closing"
@@ -121,21 +130,25 @@ async def test_rpc_device_services(
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_CLOSE_COVER,
-        {ATTR_ENTITY_ID: "cover.test_cover_0"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get("cover.test_cover_0").state == STATE_CLOSING
+    assert hass.states.get(entity_id).state == STATE_CLOSING
 
     mutate_rpc_device_status(monkeypatch, mock_rpc_device, "cover:0", "state", "closed")
     await hass.services.async_call(
         COVER_DOMAIN,
         SERVICE_STOP_COVER,
-        {ATTR_ENTITY_ID: "cover.test_cover_0"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get("cover.test_cover_0").state == STATE_CLOSED
+    assert hass.states.get(entity_id).state == STATE_CLOSED
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-cover:0"
 
 
 async def test_rpc_device_no_cover_keys(

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -12,18 +12,18 @@ from homeassistant.components.event import (
 )
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_registry import async_get
 
 from . import init_integration, inject_rpc_device_event, register_entity
 
 DEVICE_BLOCK_ID = 4
 
 
-async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
+async def test_rpc_button(
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
+) -> None:
     """Test RPC device event."""
     await init_integration(hass, 2)
     entity_id = "event.test_name_input_0"
-    registry = async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state
@@ -34,7 +34,7 @@ async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
     assert state.attributes.get(ATTR_EVENT_TYPE) is None
     assert state.attributes.get(ATTR_DEVICE_CLASS) == EventDeviceClass.BUTTON
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-input:0"
 
@@ -59,25 +59,25 @@ async def test_rpc_button(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
 
 
 async def test_rpc_event_removal(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
 ) -> None:
     """Test RPC event entity is removed due to removal_condition."""
-    registry = async_get(hass)
     entity_id = register_entity(hass, EVENT_DOMAIN, "test_name_input_0", "input:0")
 
-    assert registry.async_get(entity_id) is not None
+    assert entity_registry.async_get(entity_id) is not None
 
     monkeypatch.setitem(mock_rpc_device.config, "input:0", {"id": 0, "type": "switch"})
     await init_integration(hass, 2)
 
-    assert registry.async_get(entity_id) is None
+    assert entity_registry.async_get(entity_id) is None
 
 
-async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) -> None:
+async def test_block_event(
+    hass: HomeAssistant, monkeypatch, mock_block_device, entity_registry
+) -> None:
     """Test block device event."""
     await init_integration(hass, 1)
     entity_id = "event.test_name_channel_1"
-    registry = async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state
@@ -86,7 +86,7 @@ async def test_block_event(hass: HomeAssistant, monkeypatch, mock_block_device) 
     assert state.attributes.get(ATTR_EVENT_TYPE) is None
     assert state.attributes.get(ATTR_DEVICE_CLASS) == EventDeviceClass.BUTTON
 
-    entry = registry.async_get(entity_id)
+    entry = entity_registry.async_get(entity_id)
     assert entry
     assert entry.unique_id == "123456789ABC-relay_0-1"
 

--- a/tests/components/shelly/test_light.py
+++ b/tests/components/shelly/test_light.py
@@ -248,9 +248,7 @@ async def test_block_device_white_bulb(
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "colorTemp")
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "effect")
     monkeypatch.setattr(
-        mock_block_device.blocks[LIGHT_BLOCK_ID],
-        "description",
-        "light_1"
+        mock_block_device.blocks[LIGHT_BLOCK_ID], "description", "light_1"
     )
     monkeypatch.setattr(
         mock_block_device.blocks[LIGHT_BLOCK_ID],

--- a/tests/components/shelly/test_light.py
+++ b/tests/components/shelly/test_light.py
@@ -43,12 +43,15 @@ RELAY_BLOCK_ID = 0
 LIGHT_BLOCK_ID = 2
 
 
-async def test_block_device_rgbw_bulb(hass: HomeAssistant, mock_block_device) -> None:
+async def test_block_device_rgbw_bulb(
+    hass: HomeAssistant, mock_block_device, entity_registry
+) -> None:
     """Test block device RGBW bulb."""
+    entity_id = "light.test_name_channel_1"
     await init_integration(hass, 1, model=MODEL_BULB)
 
     # Test initial
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_RGBW_COLOR] == (45, 55, 65, 70)
@@ -66,13 +69,13 @@ async def test_block_device_rgbw_bulb(hass: HomeAssistant, mock_block_device) ->
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="off"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
     # Turn on, RGBW = [70, 80, 90, 20], brightness = 33, effect = Flash
@@ -81,7 +84,7 @@ async def test_block_device_rgbw_bulb(hass: HomeAssistant, mock_block_device) ->
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_name_channel_1",
+            ATTR_ENTITY_ID: entity_id,
             ATTR_RGBW_COLOR: [70, 80, 90, 30],
             ATTR_BRIGHTNESS: 33,
             ATTR_EFFECT: "Flash",
@@ -91,7 +94,7 @@ async def test_block_device_rgbw_bulb(hass: HomeAssistant, mock_block_device) ->
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", gain=13, brightness=13, red=70, green=80, blue=90, white=30, effect=3
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_COLOR_MODE] == ColorMode.RGBW
@@ -104,31 +107,40 @@ async def test_block_device_rgbw_bulb(hass: HomeAssistant, mock_block_device) ->
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_COLOR_TEMP_KELVIN: 3500},
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 3500},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", temp=3500, mode="white"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
     assert attributes[ATTR_COLOR_TEMP_KELVIN] == 3500
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-light_0"
 
 
 async def test_block_device_rgb_bulb(
     hass: HomeAssistant,
     mock_block_device,
     monkeypatch,
+    entity_registry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test block device RGB bulb."""
+    entity_id = "light.test_name_channel_1"
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "mode")
+    monkeypatch.setattr(
+        mock_block_device.blocks[LIGHT_BLOCK_ID], "description", "light_1"
+    )
     await init_integration(hass, 1, model=MODEL_BULB_RGBW)
 
     # Test initial
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_RGB_COLOR] == (45, 55, 65)
@@ -149,13 +161,13 @@ async def test_block_device_rgb_bulb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="off"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
     # Turn on, RGB = [70, 80, 90], brightness = 33, effect = Flash
@@ -164,7 +176,7 @@ async def test_block_device_rgb_bulb(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
         {
-            ATTR_ENTITY_ID: "light.test_name_channel_1",
+            ATTR_ENTITY_ID: entity_id,
             ATTR_RGB_COLOR: [70, 80, 90],
             ATTR_BRIGHTNESS: 33,
             ATTR_EFFECT: "Flash",
@@ -174,7 +186,7 @@ async def test_block_device_rgb_bulb(
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", gain=13, brightness=13, red=70, green=80, blue=90, effect=3
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_COLOR_MODE] == ColorMode.RGB
@@ -187,13 +199,13 @@ async def test_block_device_rgb_bulb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_COLOR_TEMP_KELVIN: 3500},
+        {ATTR_ENTITY_ID: entity_id, ATTR_COLOR_TEMP_KELVIN: 3500},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", temp=3500, mode="white"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
@@ -204,26 +216,31 @@ async def test_block_device_rgb_bulb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_EFFECT: "Breath"},
+        {ATTR_ENTITY_ID: entity_id, ATTR_EFFECT: "Breath"},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", mode="color"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_EFFECT] == "Off"
     assert "Effect 'Breath' not supported" in caplog.text
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-light_1"
+
 
 async def test_block_device_white_bulb(
     hass: HomeAssistant,
     mock_block_device,
+    entity_registry,
     monkeypatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test block device white bulb."""
+    entity_id = "light.test_name_channel_1"
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "red")
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "green")
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "blue")
@@ -232,13 +249,18 @@ async def test_block_device_white_bulb(
     monkeypatch.delattr(mock_block_device.blocks[LIGHT_BLOCK_ID], "effect")
     monkeypatch.setattr(
         mock_block_device.blocks[LIGHT_BLOCK_ID],
+        "description",
+        "light_1"
+    )
+    monkeypatch.setattr(
+        mock_block_device.blocks[LIGHT_BLOCK_ID],
         "set_state",
         AsyncMock(side_effect=mock_white_light_set_state),
     )
     await init_integration(hass, 1, model=MODEL_VINTAGE_V2)
 
     # Test initial
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_BRIGHTNESS] == 128
@@ -250,13 +272,13 @@ async def test_block_device_white_bulb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="off"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
     # Turn on, brightness = 33
@@ -264,16 +286,20 @@ async def test_block_device_white_bulb(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_BRIGHTNESS: 33},
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 33},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", gain=13, brightness=13
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_BRIGHTNESS] == 33
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-light_1"
 
 
 @pytest.mark.parametrize(
@@ -288,16 +314,20 @@ async def test_block_device_white_bulb(
     ],
 )
 async def test_block_device_support_transition(
-    hass: HomeAssistant, mock_block_device, model, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, model, monkeypatch
 ) -> None:
     """Test block device supports transition."""
+    entity_id = "light.test_name_channel_1"
     monkeypatch.setitem(
         mock_block_device.settings, "fw", "20220809-122808/v1.12-g99f7e0b"
+    )
+    monkeypatch.setattr(
+        mock_block_device.blocks[LIGHT_BLOCK_ID], "description", "light_1"
     )
     await init_integration(hass, 1, model=model)
 
     # Test initial
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert attributes[ATTR_SUPPORTED_FEATURES] & LightEntityFeature.TRANSITION
 
@@ -306,13 +336,13 @@ async def test_block_device_support_transition(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_TRANSITION: 4},
+        {ATTR_ENTITY_ID: entity_id, ATTR_TRANSITION: 4},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="on", transition=4000
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
     # Turn off, TRANSITION = 6, limit to 5000ms
@@ -320,20 +350,25 @@ async def test_block_device_support_transition(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1", ATTR_TRANSITION: 6},
+        {ATTR_ENTITY_ID: entity_id, ATTR_TRANSITION: 6},
         blocking=True,
     )
     mock_block_device.blocks[LIGHT_BLOCK_ID].set_state.assert_called_once_with(
         turn="off", transition=5000
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-light_1"
 
 
 async def test_block_device_relay_app_type_light(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block device relay in app type set to light mode."""
+    entity_id = "light.test_name_channel_1"
     monkeypatch.delattr(mock_block_device.blocks[RELAY_BLOCK_ID], "red")
     monkeypatch.delattr(mock_block_device.blocks[RELAY_BLOCK_ID], "green")
     monkeypatch.delattr(mock_block_device.blocks[RELAY_BLOCK_ID], "blue")
@@ -345,11 +380,14 @@ async def test_block_device_relay_app_type_light(
     monkeypatch.setitem(
         mock_block_device.settings["relays"][RELAY_BLOCK_ID], "appliance_type", "light"
     )
+    monkeypatch.setattr(
+        mock_block_device.blocks[RELAY_BLOCK_ID], "description", "relay_1"
+    )
     await init_integration(hass, 1)
     assert hass.states.get("switch.test_name_channel_1") is None
 
     # Test initial
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     attributes = state.attributes
     assert state.state == STATE_ON
     assert attributes[ATTR_SUPPORTED_COLOR_MODES] == [ColorMode.ONOFF]
@@ -360,13 +398,13 @@ async def test_block_device_relay_app_type_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_block_device.blocks[RELAY_BLOCK_ID].set_state.assert_called_once_with(
         turn="off"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
 
     # Turn on
@@ -374,14 +412,18 @@ async def test_block_device_relay_app_type_light(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_name_channel_1"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_block_device.blocks[RELAY_BLOCK_ID].set_state.assert_called_once_with(
         turn="on"
     )
-    state = hass.states.get("light.test_name_channel_1")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-relay_1"
 
 
 async def test_block_device_no_light_blocks(
@@ -394,9 +436,10 @@ async def test_block_device_no_light_blocks(
 
 
 async def test_rpc_device_switch_type_lights_mode(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
 ) -> None:
     """Test RPC device with switch in consumption type lights mode."""
+    entity_id = "light.test_switch_0"
     monkeypatch.setitem(
         mock_rpc_device.config["sys"]["ui_data"], "consumption_types", ["lights"]
     )
@@ -405,23 +448,29 @@ async def test_rpc_device_switch_type_lights_mode(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: "light.test_switch_0"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
-    assert hass.states.get("light.test_switch_0").state == STATE_ON
+    assert hass.states.get(entity_id).state == STATE_ON
 
     mutate_rpc_device_status(monkeypatch, mock_rpc_device, "switch:0", "output", False)
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.test_switch_0"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     mock_rpc_device.mock_update()
-    assert hass.states.get("light.test_switch_0").state == STATE_OFF
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-switch:0"
 
 
-async def test_rpc_light(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
+async def test_rpc_light(
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
+) -> None:
     """Test RPC light."""
     entity_id = f"{LIGHT_DOMAIN}.test_light_0"
     monkeypatch.delitem(mock_rpc_device.status, "switch:0")
@@ -476,3 +525,7 @@ async def test_rpc_light(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> N
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_BRIGHTNESS] == 33
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-light:0"

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -23,23 +23,28 @@ DEVICE_BLOCK_ID = 4
 
 
 async def test_block_number_update(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block device number update."""
+    entity_id = "number.test_name_valve_position"
     await init_integration(hass, 1, sleep_period=1000)
 
-    assert hass.states.get("number.test_name_valve_position") is None
+    assert hass.states.get(entity_id) is None
 
     # Make device online
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert hass.states.get("number.test_name_valve_position").state == "50"
+    assert hass.states.get(entity_id).state == "50"
 
     monkeypatch.setattr(mock_block_device.blocks[DEVICE_BLOCK_ID], "valvePos", 30)
     mock_block_device.mock_update()
 
-    assert hass.states.get("number.test_name_valve_position").state == "30"
+    assert hass.states.get(entity_id).state == "30"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-device_0-valvePos"
 
 
 async def test_block_restored_number(

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -237,10 +237,9 @@ async def test_block_sensor_error(
 
 
 async def test_block_sensor_removal(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block sensor is removed due to removal_condition."""
-    entity_registry = async_get(hass)
     entity_id = register_entity(
         hass, SENSOR_DOMAIN, "test_name_battery", "device_0-battery"
     )

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -43,7 +43,7 @@ DEVICE_BLOCK_ID = 4
 
 
 async def test_block_sensor(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block sensor."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_channel_1_power"
@@ -56,8 +56,14 @@ async def test_block_sensor(
 
     assert hass.states.get(entity_id).state == "60.1"
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-relay_0-power"
 
-async def test_energy_sensor(hass: HomeAssistant, mock_block_device) -> None:
+
+async def test_energy_sensor(
+    hass: HomeAssistant, mock_block_device, entity_registry
+) -> None:
     """Test energy sensor."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_channel_1_energy"
     await init_integration(hass, 1)
@@ -68,13 +74,16 @@ async def test_energy_sensor(hass: HomeAssistant, mock_block_device) -> None:
     # suggested unit is KWh
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfEnergy.KILO_WATT_HOUR
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-relay_0-energy"
+
 
 async def test_power_factory_unit_migration(
-    hass: HomeAssistant, mock_block_device
+    hass: HomeAssistant, mock_block_device, entity_registry
 ) -> None:
     """Test migration unit of the power factory sensor."""
-    registry = async_get(hass)
-    registry.async_get_or_create(
+    entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DOMAIN,
         "123456789ABC-emeter_0-powerFactor",
@@ -90,9 +99,13 @@ async def test_power_factory_unit_migration(
     assert state.state == "98.0"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-emeter_0-powerFactor"
+
 
 async def test_power_factory_without_unit_migration(
-    hass: HomeAssistant, mock_block_device
+    hass: HomeAssistant, mock_block_device, entity_registry
 ) -> None:
     """Test unit and value of the power factory sensor without unit migration."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_power_factor"
@@ -101,6 +114,10 @@ async def test_power_factory_without_unit_migration(
     state = hass.states.get(entity_id)
     assert state.state == "0.98"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) is None
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-emeter_0-powerFactor"
 
 
 async def test_block_rest_sensor(
@@ -119,7 +136,7 @@ async def test_block_rest_sensor(
 
 
 async def test_block_sleeping_sensor(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block sleeping sensor."""
     monkeypatch.setattr(
@@ -141,6 +158,10 @@ async def test_block_sleeping_sensor(
     mock_block_device.mock_update()
 
     assert hass.states.get(entity_id).state == "23.4"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sensor_0-temp"
 
 
 async def test_block_restored_sleeping_sensor(
@@ -197,7 +218,7 @@ async def test_block_restored_sleeping_sensor_no_last_state(
 
 
 async def test_block_sensor_error(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant, mock_block_device, entity_registry, monkeypatch
 ) -> None:
     """Test block sensor unavailable on sensor error."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_battery"
@@ -209,6 +230,10 @@ async def test_block_sensor_error(
     mock_block_device.mock_update()
 
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-device_0-battery"
 
 
 async def test_block_sensor_removal(
@@ -300,7 +325,7 @@ async def test_rpc_sensor(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
 
 
 async def test_rpc_illuminance_sensor(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
 ) -> None:
     """Test RPC illuminacne sensor."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_illuminance"
@@ -308,9 +333,13 @@ async def test_rpc_illuminance_sensor(
 
     assert hass.states.get(entity_id).state == "345"
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-illuminance:0-illuminance"
+
 
 async def test_rpc_sensor_error(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
 ) -> None:
     """Test RPC sensor unavailable on sensor error."""
     entity_id = f"{SENSOR_DOMAIN}.test_name_voltmeter"
@@ -323,9 +352,17 @@ async def test_rpc_sensor_error(
 
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-voltmeter-voltmeter"
+
 
 async def test_rpc_polling_sensor(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_rpc_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_rpc_device,
+    entity_registry,
+    monkeypatch,
 ) -> None:
     """Test RPC polling sensor."""
     entity_id = register_entity(hass, SENSOR_DOMAIN, "test_name_rssi", "wifi-rssi")
@@ -337,6 +374,10 @@ async def test_rpc_polling_sensor(
     await mock_polling_rpc_update(hass, freezer)
 
     assert hass.states.get(entity_id).state == "-70"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-wifi-rssi"
 
 
 async def test_rpc_sleeping_sensor(
@@ -470,7 +511,10 @@ async def test_rpc_em1_sensors(
 
 
 async def test_rpc_sleeping_update_entity_service(
-    hass: HomeAssistant, mock_rpc_device, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    mock_rpc_device,
+    entity_registry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test RPC sleeping device when the update_entity service is used."""
     await async_setup_component(hass, "homeassistant", {})
@@ -500,6 +544,10 @@ async def test_rpc_sleeping_update_entity_service(
     state = hass.states.get(entity_id)
     assert state.state == "22.9"
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-temperature:0-temperature_0"
+
     assert (
         "Entity sensor.test_name_temperature comes from a sleeping device"
         in caplog.text
@@ -507,7 +555,10 @@ async def test_rpc_sleeping_update_entity_service(
 
 
 async def test_block_sleeping_update_entity_service(
-    hass: HomeAssistant, mock_block_device, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    mock_block_device,
+    entity_registry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test block sleeping device when the update_entity service is used."""
     await async_setup_component(hass, "homeassistant", {})
@@ -535,6 +586,10 @@ async def test_block_sleeping_update_entity_service(
     # Entity should be available after update_entity service call
     state = hass.states.get(entity_id)
     assert state.state == "22.1"
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sensor_0-temp"
 
     assert (
         "Entity sensor.test_name_temperature comes from a sleeping device"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -54,12 +54,13 @@ async def test_block_device_services(hass: HomeAssistant, mock_block_device) -> 
     assert hass.states.get("switch.test_name_channel_1").state == STATE_OFF
 
 
-async def test_block_device_unique_ids(hass: HomeAssistant, mock_block_device) -> None:
+async def test_block_device_unique_ids(
+    hass: HomeAssistant, entity_registry, mock_block_device
+) -> None:
     """Test block device unique_ids."""
     await init_integration(hass, 1)
 
-    registry = er.async_get(hass)
-    entry = registry.async_get("switch.test_name_channel_1")
+    entry = entity_registry.async_get("switch.test_name_channel_1")
     assert entry
     assert entry.unique_id == "123456789ABC-relay_0"
 
@@ -187,13 +188,12 @@ async def test_rpc_device_services(
 
 
 async def test_rpc_device_unique_ids(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry
 ) -> None:
     """Test RPC device unique_ids."""
     await init_integration(hass, 2)
 
-    registry = er.async_get(hass)
-    entry = registry.async_get("switch.test_switch_0")
+    entry = entity_registry.async_get("switch.test_switch_0")
     assert entry
     assert entry.unique_id == "123456789ABC-switch:0"
 

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -44,10 +44,13 @@ from tests.common import mock_restore_cache
 
 
 async def test_block_update(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_block_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_block_device,
+    entity_registry,
+    monkeypatch,
 ) -> None:
     """Test block device update entity."""
-    entity_registry = async_get(hass)
     entity_registry.async_get_or_create(
         UPDATE_DOMAIN,
         DOMAIN,
@@ -55,11 +58,12 @@ async def test_block_update(
         suggested_object_id="test_name_firmware_update",
         disabled_by=None,
     )
+    entity_id = "update.test_name_firmware_update"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
     await init_integration(hass, 1)
 
-    state = hass.states.get("update.test_name_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
@@ -70,12 +74,12 @@ async def test_block_update(
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.test_name_firmware_update"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert mock_block_device.trigger_ota_update.call_count == 1
 
-    state = hass.states.get("update.test_name_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
@@ -85,18 +89,25 @@ async def test_block_update(
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "2")
     await mock_rest_update(hass, freezer)
 
-    state = hass.states.get("update.test_name_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_INSTALLED_VERSION] == "2"
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is False
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-fwupdate"
+
 
 async def test_block_beta_update(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_block_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_block_device,
+    entity_registry,
+    monkeypatch,
 ) -> None:
     """Test block device beta update entity."""
-    entity_registry = async_get(hass)
     entity_registry.async_get_or_create(
         UPDATE_DOMAIN,
         DOMAIN,
@@ -104,12 +115,13 @@ async def test_block_beta_update(
         suggested_object_id="test_name_beta_firmware_update",
         disabled_by=None,
     )
+    entity_id = "update.test_name_beta_firmware_update"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
     monkeypatch.setitem(mock_block_device.status["update"], "beta_version", "")
     await init_integration(hass, 1)
 
-    state = hass.states.get("update.test_name_beta_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "1"
@@ -118,7 +130,7 @@ async def test_block_beta_update(
     monkeypatch.setitem(mock_block_device.status["update"], "beta_version", "2b")
     await mock_rest_update(hass, freezer)
 
-    state = hass.states.get("update.test_name_beta_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2b"
@@ -128,12 +140,12 @@ async def test_block_beta_update(
     await hass.services.async_call(
         UPDATE_DOMAIN,
         SERVICE_INSTALL,
-        {ATTR_ENTITY_ID: "update.test_name_beta_firmware_update"},
+        {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
     assert mock_block_device.trigger_ota_update.call_count == 1
 
-    state = hass.states.get("update.test_name_beta_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
     assert state.attributes[ATTR_LATEST_VERSION] == "2b"
@@ -142,11 +154,15 @@ async def test_block_beta_update(
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "2b")
     await mock_rest_update(hass, freezer)
 
-    state = hass.states.get("update.test_name_beta_firmware_update")
+    state = hass.states.get(entity_id)
     assert state.state == STATE_OFF
     assert state.attributes[ATTR_INSTALLED_VERSION] == "2b"
     assert state.attributes[ATTR_LATEST_VERSION] == "2b"
     assert state.attributes[ATTR_IN_PROGRESS] is False
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-fwupdate_beta"
 
 
 async def test_block_update_connection_error(
@@ -228,7 +244,9 @@ async def test_block_update_auth_error(
     assert flow["context"].get("entry_id") == entry.entry_id
 
 
-async def test_rpc_update(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> None:
+async def test_rpc_update(
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
+) -> None:
     """Test RPC device update entity."""
     entity_id = "update.test_name_firmware_update"
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
@@ -320,9 +338,13 @@ async def test_rpc_update(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is False
 
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sys-fwupdate"
+
 
 async def test_rpc_sleeping_update(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch
+    hass: HomeAssistant, mock_rpc_device, entity_registry, monkeypatch
 ) -> None:
     """Test RPC sleeping device update entity."""
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
@@ -360,6 +382,10 @@ async def test_rpc_sleeping_update(
     assert state.attributes[ATTR_LATEST_VERSION] == "2"
     assert state.attributes[ATTR_IN_PROGRESS] is False
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == UpdateEntityFeature(0)
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sys-fwupdate"
 
 
 async def test_rpc_restored_sleeping_update(
@@ -448,10 +474,13 @@ async def test_rpc_restored_sleeping_update_no_last_state(
 
 
 async def test_rpc_beta_update(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_rpc_device, monkeypatch
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_rpc_device,
+    entity_registry,
+    monkeypatch,
 ) -> None:
     """Test RPC device beta update entity."""
-    entity_registry = async_get(hass)
     entity_registry.async_get_or_create(
         UPDATE_DOMAIN,
         DOMAIN,
@@ -563,6 +592,10 @@ async def test_rpc_beta_update(
     assert state.attributes[ATTR_INSTALLED_VERSION] == "2b"
     assert state.attributes[ATTR_LATEST_VERSION] == "2b"
     assert state.attributes[ATTR_IN_PROGRESS] is False
+
+    entry = entity_registry.async_get(entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-sys-fwupdate_beta"
 
 
 @pytest.mark.parametrize(

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -29,10 +29,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.entity_registry import async_get
 
 from . import (
-    MOCK_MAC,
     init_integration,
     inject_rpc_device_event,
     mock_rest_update,
@@ -49,18 +47,13 @@ async def test_block_update(
     mock_block_device,
     entity_registry,
     monkeypatch,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update entity."""
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-fwupdate",
-        suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
-    )
     entity_id = "update.test_name_firmware_update"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
+    monkeypatch.setitem(mock_block_device.status, "cloud", {"connected": False})
     await init_integration(hass, 1)
 
     state = hass.states.get(entity_id)
@@ -106,19 +99,14 @@ async def test_block_beta_update(
     mock_block_device,
     entity_registry,
     monkeypatch,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device beta update entity."""
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-fwupdate_beta",
-        suggested_object_id="test_name_beta_firmware_update",
-        disabled_by=None,
-    )
     entity_id = "update.test_name_beta_firmware_update"
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
     monkeypatch.setitem(mock_block_device.status["update"], "beta_version", "")
+    monkeypatch.setitem(mock_block_device.status, "cloud", {"connected": False})
     await init_integration(hass, 1)
 
     state = hass.states.get(entity_id)
@@ -170,16 +158,9 @@ async def test_block_update_connection_error(
     mock_block_device,
     monkeypatch,
     caplog: pytest.LogCaptureFixture,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update connection error."""
-    entity_registry = async_get(hass)
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-fwupdate",
-        suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
-    )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
     monkeypatch.setattr(
@@ -200,17 +181,12 @@ async def test_block_update_connection_error(
 
 
 async def test_block_update_auth_error(
-    hass: HomeAssistant, mock_block_device, monkeypatch
+    hass: HomeAssistant,
+    mock_block_device,
+    monkeypatch,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test block device update authentication error."""
-    entity_registry = async_get(hass)
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-fwupdate",
-        suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
-    )
     monkeypatch.setitem(mock_block_device.status["update"], "old_version", "1")
     monkeypatch.setitem(mock_block_device.status["update"], "new_version", "2")
     monkeypatch.setattr(
@@ -479,15 +455,9 @@ async def test_rpc_beta_update(
     mock_rpc_device,
     entity_registry,
     monkeypatch,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device beta update entity."""
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-sys-fwupdate_beta",
-        suggested_object_id="test_name_beta_firmware_update",
-        disabled_by=None,
-    )
     entity_id = "update.test_name_beta_firmware_update"
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
@@ -605,23 +575,16 @@ async def test_rpc_beta_update(
         (RpcCallError(-1, "error"), "OTA update request error"),
     ],
 )
-async def test_rpc_update__errors(
+async def test_rpc_update_errors(
     hass: HomeAssistant,
     exc,
     error,
     mock_rpc_device,
     monkeypatch,
     caplog: pytest.LogCaptureFixture,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device update connection/call errors."""
-    entity_registry = async_get(hass)
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-sys-fwupdate",
-        suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
-    )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
         mock_rpc_device.status["sys"],
@@ -647,17 +610,13 @@ async def test_rpc_update__errors(
 
 
 async def test_rpc_update_auth_error(
-    hass: HomeAssistant, mock_rpc_device, monkeypatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    mock_rpc_device,
+    entity_registry,
+    monkeypatch,
+    entity_registry_enabled_by_default: None,
 ) -> None:
     """Test RPC device update authentication error."""
-    entity_registry = async_get(hass)
-    entity_registry.async_get_or_create(
-        UPDATE_DOMAIN,
-        DOMAIN,
-        f"{MOCK_MAC}-sys-fwupdate",
-        suggested_object_id="test_name_firmware_update",
-        disabled_by=None,
-    )
     monkeypatch.setitem(mock_rpc_device.shelly, "ver", "1")
     monkeypatch.setitem(
         mock_rpc_device.status["sys"],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we only check `unique_id` for part of the entities. This may result in us not detecting `unique_id` changes in tests.

This PR:
- adds `unique_id` checking for entities
- fixes some minor mocking issues
- uses `entity_registry_enabled_by_default` and `entity_registry` fixtures

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
