### PR TITLE
Reset log level in script tests

### DIFF
--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -1,4 +1,5 @@
 """Test the auth script to manage local users."""
+import logging
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -9,6 +10,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.scripts import auth as script_auth
 
 from tests.common import register_auth_provider
+
+
+@pytest.fixture(autouse=True)
+def reset_log_level():
+    """Reset log level after each test case."""
+    logger = logging.getLogger("homeassistant.core")
+    orig_level = logger.level
+    yield
+    logger.setLevel(orig_level)
 
 
 @pytest.fixture

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,4 +1,5 @@
 """Test check_config script."""
+import logging
 from unittest.mock import patch
 
 import pytest
@@ -20,6 +21,15 @@ BASE_CONFIG = (
 )
 
 BAD_CORE_CONFIG = "homeassistant:\n  unit_system: bad\n\n\n"
+
+
+@pytest.fixture(autouse=True)
+def reset_log_level():
+    """Reset log level after each test case."""
+    logger = logging.getLogger("homeassistant.loader")
+    orig_level = logger.level
+    yield
+    logger.setLevel(orig_level)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Proposed change
Add fixtures to reset log level from `scripts`.
Depending on the test execution order, some tests specifically in `test_core.py` and `test_loader.py` could fail.

Ref:
- #109876

--
https://github.com/home-assistant/core/blob/aea81a180c21bf5dd7d5de17a35046811f0d85b3/homeassistant/scripts/auth.py#L61-L62

https://github.com/home-assistant/core/blob/aea81a180c21bf5dd7d5de17a35046811f0d85b3/homeassistant/scripts/check_config.py#L172

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
