### PR TITLE
Fix cast.show_lovelace_view service

### DIFF
--- a/homeassistant/components/cast/home_assistant_cast.py
+++ b/homeassistant/components/cast/home_assistant_cast.py
@@ -70,7 +70,7 @@ async def async_setup_ha_cast(
             SIGNAL_HASS_CAST_SHOW_VIEW,
             controller,
             call.data[ATTR_ENTITY_ID],
-            call.data[ATTR_VIEW_PATH],
+            call.data.get(ATTR_VIEW_PATH),
             call.data.get(ATTR_URL_PATH),
         )
 

--- a/homeassistant/components/cast/services.yaml
+++ b/homeassistant/components/cast/services.yaml
@@ -7,7 +7,6 @@ show_lovelace_view:
           integration: cast
           domain: media_player
     dashboard_path:
-      required: true
       example: lovelace-cast
       selector:
         text:

--- a/homeassistant/components/cast/strings.json
+++ b/homeassistant/components/cast/strings.json
@@ -51,12 +51,12 @@
           "description": "Media player entity to show the dashboard view on."
         },
         "dashboard_path": {
-          "name": "Dashboard path",
-          "description": "The URL path of the dashboard to show."
+          "name": "Dashboard",
+          "description": "The dashboard to show, for example 'energy' or 'lovelace'. If not specified, the default dashboard will be shown."
         },
         "view_path": {
-          "name": "View path",
-          "description": "The path of the dashboard view to show."
+          "name": "View",
+          "description": "The view to show. If not specified, the dashboard's default view will be shown."
         }
       }
     }

--- a/homeassistant/components/cast/strings.json
+++ b/homeassistant/components/cast/strings.json
@@ -56,7 +56,7 @@
         },
         "view_path": {
           "name": "View",
-          "description": "The view to show. If not specified, the dashboard's default view will be shown."
+          "description": "The view to show, for example 'home' for a view with a specified URL or '0' for view without a specified URL. If not specified, the dashboard's default view will be shown."
         }
       }
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve `cast.show_lovelace_view` service:
- Fix crash when the optional `view_path` parametter is omitted.
- Mark the `dashboard_path` parameter as optional
- Improve service description

Based on a discussion with @bramkragten it works like this:
- no urlPath and no viewPath: default dashboard and default (first) view
- no urlPath but viewPath: default dashboard and the requested view
- urlPath but no viewPath: requested dashboard and default (first) view
- urlPath and viewPath: requested dashboard and the requested view

However, testing suggests that not the case:
- If I specify neither dashboard nor view, I just see "Connected", and nothing else
- If I specify the "lovelace" dasboard without specifying a view, I just see "Connected", and nothing else
- If I specify the "energy" dashboard without specifying a view, the energy dashboard is shown
- If I specify only a view (for example test), I see "Unable to find a view with path test"

PR set to draft until confirmed how it's supposed to work

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
