### PR TITLE
Assist fixes

### DIFF
--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -1,4 +1,5 @@
 """Intents for the client integration."""
+
 from __future__ import annotations
 
 import voluptuous as vol
@@ -36,24 +37,34 @@ class GetTemperatureIntent(intent.IntentHandler):
         if not entities:
             raise intent.IntentHandleError("No climate entities")
 
-        if "area" in slots:
-            # Filter by area
-            area_name = slots["area"]["value"]
+        name_slot = slots.get("name", {})
+        entity_name: str | None = name_slot.get("value")
+        entity_text: str | None = name_slot.get("text")
+
+        area_slot = slots.get("area", {})
+        area_id = area_slot.get("value")
+
+        if area_id:
+            # Filter by area and optionally name
+            area_name = area_slot.get("text")
 
             for maybe_climate in intent.async_match_states(
-                hass, area_name=area_name, domains=[DOMAIN]
+                hass, name=entity_name, area_name=area_id, domains=[DOMAIN]
             ):
                 climate_state = maybe_climate
                 break
 
             if climate_state is None:
-                raise intent.IntentHandleError(f"No climate entity in area {area_name}")
+                raise intent.NoStatesMatchedError(
+                    name=entity_text or entity_name,
+                    area=area_name or area_id,
+                    domains={DOMAIN},
+                    device_classes=None,
+                )
 
             climate_entity = component.get_entity(climate_state.entity_id)
-        elif "name" in slots:
+        elif entity_name:
             # Filter by name
-            entity_name = slots["name"]["value"]
-
             for maybe_climate in intent.async_match_states(
                 hass, name=entity_name, domains=[DOMAIN]
             ):
@@ -61,7 +72,12 @@ class GetTemperatureIntent(intent.IntentHandler):
                 break
 
             if climate_state is None:
-                raise intent.IntentHandleError(f"No climate entity named {entity_name}")
+                raise intent.NoStatesMatchedError(
+                    name=entity_name,
+                    area=None,
+                    domains={DOMAIN},
+                    device_classes=None,
+                )
 
             climate_entity = component.get_entity(climate_state.entity_id)
         else:

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -724,7 +724,12 @@ class DefaultAgent(AbstractConversationAgent):
             if async_should_expose(self.hass, DOMAIN, state.entity_id)
         ]
 
-        # Gather exposed entity names
+        # Gather exposed entity names.
+        #
+        # NOTE: We do not pass entity ids in here because multiple entities may
+        # have the same name. The intent matcher doesn't gather all matching
+        # values for a list, just the first. So we will need to match by name no
+        # matter what.
         entity_names = []
         for state in states:
             # Checked against "requires_context" and "excludes_context" in hassil
@@ -740,7 +745,7 @@ class DefaultAgent(AbstractConversationAgent):
 
             if not entity:
                 # Default name
-                entity_names.append((state.name, state.entity_id, context))
+                entity_names.append((state.name, state.name, context))
                 continue
 
             if entity.aliases:
@@ -748,12 +753,15 @@ class DefaultAgent(AbstractConversationAgent):
                     if not alias.strip():
                         continue
 
-                    entity_names.append((alias, state.entity_id, context))
+                    entity_names.append((alias, state.name, context))
 
             # Default name
-            entity_names.append((state.name, state.entity_id, context))
+            entity_names.append((state.name, state.name, context))
 
-        # Expose all areas
+        # Expose all areas.
+        #
+        # We pass in area id here with the expectation that no two areas will
+        # share the same name or alias.
         areas = ar.async_get(self.hass)
         area_names = []
         for area in areas.async_list_areas():

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -1,4 +1,5 @@
 """The Intent integration."""
+
 from __future__ import annotations
 
 import logging
@@ -155,7 +156,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         slots = self.async_validate_slots(intent_obj.slots)
 
         # Entity name to match
-        name: str | None = slots.get("name", {}).get("value")
+        entity_name: str | None = slots.get("name", {}).get("value")
 
         # Look up area first to fail early
         area_name = slots.get("area", {}).get("value")
@@ -186,7 +187,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         states = list(
             intent.async_match_states(
                 hass,
-                name=name,
+                name=entity_name,
                 area=area,
                 domains=domains,
                 device_classes=device_classes,
@@ -197,7 +198,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         _LOGGER.debug(
             "Found %s state(s) that matched: name=%s, area=%s, domains=%s, device_classes=%s, assistant=%s",
             len(states),
-            name,
+            entity_name,
             area,
             domains,
             device_classes,

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -453,14 +453,10 @@ class ServiceIntentHandler(IntentHandler):
                 device_classes=device_classes,
             )
 
-        # Patch the "name" slot value with the first matched entity id.
-        #
-        # We want to use the entity id downstream in a response or automation,
-        # but we can't know it until this point.
-        if entity_name and (intent_name_slot := intent_obj.slots.get("name")):
-            intent_name_slot["value"] = states[0].entity_id
-
         response = await self.async_handle_states(intent_obj, states, area)
+
+        # Make the matched states available in the response
+        response.async_set_states(matched_states=states, unmatched_states=[])
 
         return response
 

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1397,7 +1397,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'light.kitchen',
+            'value': 'kitchen',
           }),
         }),
         'intent': dict({
@@ -1422,7 +1422,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'light.kitchen',
+            'value': 'kitchen',
           }),
         }),
         'intent': dict({
@@ -1572,7 +1572,7 @@
           'name': dict({
             'name': 'name',
             'text': 'test light',
-            'value': 'light.demo_1234',
+            'value': 'test light',
           }),
         }),
         'intent': dict({
@@ -1604,7 +1604,7 @@
           'name': dict({
             'name': 'name',
             'text': 'test light',
-            'value': 'light.demo_1234',
+            'value': 'test light',
           }),
         }),
         'intent': dict({

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -101,7 +101,7 @@ async def test_exposed_areas(
     device_registry.async_update_device(kitchen_device.id, area_id=area_kitchen.id)
 
     kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
-    entity_registry.async_update_entity(
+    kitchen_light = entity_registry.async_update_entity(
         kitchen_light.entity_id, device_id=kitchen_device.id
     )
     hass.states.async_set(
@@ -109,7 +109,7 @@ async def test_exposed_areas(
     )
 
     bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
-    entity_registry.async_update_entity(
+    bedroom_light = entity_registry.async_update_entity(
         bedroom_light.entity_id, area_id=area_bedroom.id
     )
     hass.states.async_set(
@@ -206,14 +206,14 @@ async def test_unexposed_entities_skipped(
 
     # Both lights are in the kitchen
     exposed_light = entity_registry.async_get_or_create("light", "demo", "1234")
-    entity_registry.async_update_entity(
+    exposed_light = entity_registry.async_update_entity(
         exposed_light.entity_id,
         area_id=area_kitchen.id,
     )
     hass.states.async_set(exposed_light.entity_id, "off")
 
     unexposed_light = entity_registry.async_get_or_create("light", "demo", "5678")
-    entity_registry.async_update_entity(
+    unexposed_light = entity_registry.async_update_entity(
         unexposed_light.entity_id,
         area_id=area_kitchen.id,
     )
@@ -336,7 +336,9 @@ async def test_device_area_context(
             light_entity = entity_registry.async_get_or_create(
                 "light", "demo", f"{area.name}-light-{i}"
             )
-            entity_registry.async_update_entity(light_entity.entity_id, area_id=area.id)
+            light_entity = entity_registry.async_update_entity(
+                light_entity.entity_id, area_id=area.id
+            )
             hass.states.async_set(
                 light_entity.entity_id,
                 "off",
@@ -692,7 +694,7 @@ async def test_empty_aliases(
 
         names = slot_lists["name"]
         assert len(names.values) == 1
-        assert names.values[0].value_out == kitchen_light.entity_id
+        assert names.values[0].value_out == kitchen_light.name
         assert names.values[0].text_in.text == kitchen_light.name
 
 
@@ -713,3 +715,80 @@ async def test_all_domains_loaded(hass: HomeAssistant, init_components) -> None:
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called test light"
     )
+
+
+async def test_same_named_entities_in_different_areas(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities with the same name in different areas can be targeted."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+
+    # Both lights have the same name, but are in different areas
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        area_id=area_kitchen.id,
+        name="overhead light",
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+
+    bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    bedroom_light = entity_registry.async_update_entity(
+        bedroom_light.entity_id,
+        area_id=area_bedroom.id,
+        name="overhead light",
+    )
+    hass.states.async_set(
+        bedroom_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: bedroom_light.name},
+    )
+
+    # Target kitchen light
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the kitchen", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert (
+        result.response.intent.slots.get("name", {}).get("value")
+        == kitchen_light.entity_id
+    )
+    assert (
+        result.response.intent.slots.get("name", {}).get("text") == kitchen_light.name
+    )
+    assert calls[0].data.get("entity_id") == [kitchen_light.entity_id]
+
+    # Target bedroom light
+    calls.clear()
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the bedroom", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert (
+        result.response.intent.slots.get("name", {}).get("value")
+        == bedroom_light.entity_id
+    )
+    assert (
+        result.response.intent.slots.get("name", {}).get("text") == bedroom_light.name
+    )
+    assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -766,12 +766,13 @@ async def test_same_named_entities_in_different_areas(
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
-        result.response.intent.slots.get("name", {}).get("value")
-        == kitchen_light.entity_id
+        result.response.intent.slots.get("name", {}).get("value") == kitchen_light.name
     )
     assert (
         result.response.intent.slots.get("name", {}).get("text") == kitchen_light.name
     )
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
     assert calls[0].data.get("entity_id") == [kitchen_light.entity_id]
 
     # Target bedroom light
@@ -785,10 +786,11 @@ async def test_same_named_entities_in_different_areas(
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
     assert result.response.intent is not None
     assert (
-        result.response.intent.slots.get("name", {}).get("value")
-        == bedroom_light.entity_id
+        result.response.intent.slots.get("name", {}).get("value") == bedroom_light.name
     )
     assert (
         result.response.intent.slots.get("name", {}).get("text") == bedroom_light.name
     )
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
     assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR includes several fixes for bugs found in the 2024.2 beta:

1. Name/area not being properly linked: https://github.com/home-assistant/core/issues/109868
2. Missing climate entities cause intent handling error: https://github.com/home-assistant/core/issues/109792
3. Race condition between sentence trigger responses in automations

For (1), we cannot thread entity ids through the intent matcher (hassil) like we do with area ids. If we have two entities with the same name, hassil will pick the first match from its internal list. When matching entities in areas, there is no guarantee that this entity is the one in the requested area -- we won't know this until inside the intent handler. The solution is to revert to using the entity name alone.

The fix for (2) is to raise the recently added `NoStatesMatchError` to get better error messages rather than raising a generic intent handling error.

Bug (3) is an edge case where a user has multiple automations with the same sentence. The previous behavior was to wait for all of the automations to complete and use the last non-empty response. This would unnecessarily block the pipeline waiting on all automations even if a response was already known. Now, we simply wait for the first non-empty response and return. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/109868 https://github.com/home-assistant/core/issues/109792
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
