### PR TITLE
Remove homekit_controller entity registry entries when backing char or service is gone

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -514,6 +514,55 @@ class HKDevice:
             device_registry.async_update_device(device.id, new_identifiers=identifiers)
 
     @callback
+    def async_reap_stale_entity_registry_entries(self) -> None:
+        """Delete entity registry entities for removed characteristics, services and accessories."""
+        _LOGGER.debug(
+            "Removing stale entity registry entries for pairing %s",
+            self.unique_id,
+        )
+
+        reg = er.async_get(self.hass)
+
+        # For the current config entry only, visit all registry entity entries
+        # Build a set of (unique_id, aid, sid, iid)
+        # For services, (unique_id, aid, sid, None)
+        # For accessories, (unique_id, aid, None, None)
+        entries = er.async_entries_for_config_entry(reg, self.config_entry.entry_id)
+        exisiting_entities = {}
+        for entry in entries:
+            parts = tuple(int(id) for id in entry.unique_id.split("_")[1:])
+            parts += (None,) * (3 - len(parts))
+            exisiting_entities[parts] = entry.entity_id
+        existing_unique_id = set(exisiting_entities.keys())
+
+        # Process current entity map and produce a similar set
+        current_unique_id = set()
+        for accessory in self.entity_map.accessories:
+            current_unique_id.add((self.unique_id, accessory.aid, None, None))
+
+            for service in accessory.services:
+                current_unique_id.add((accessory.aid, service.iid, None))
+
+                for char in service.characteristics:
+                    current_unique_id.add(
+                        (
+                            accessory.aid,
+                            service.iid,
+                            char.iid,
+                        )
+                    )
+
+        # Remove the difference
+        if stale := existing_unique_id - current_unique_id:
+            for parts in stale:
+                _LOGGER.debug(
+                    "Removing stale entity registry entry %s for pairing %s",
+                    exisiting_entities[parts],
+                    self.unique_id,
+                )
+                reg.async_remove(exisiting_entities[parts])
+
+    @callback
     def async_migrate_ble_unique_id(self) -> None:
         """Config entries from step_bluetooth used incorrect identifier for unique_id."""
         unique_id = normalize_hkid(self.unique_id)
@@ -614,6 +663,8 @@ class HKDevice:
         self.async_remove_legacy_device_serial_numbers()
 
         self.async_migrate_ble_unique_id()
+
+        self.async_reap_stale_entity_registry_entries()
 
         self.async_create_devices()
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -553,7 +553,7 @@ class HKDevice:
                     )
 
         # Remove the difference
-        if stale := existing_unique_id - current_unique_id:
+        if stale := existing_entities.keys() - current_unique_id:
             for parts in stale:
                 _LOGGER.debug(
                     "Removing stale entity registry entry %s for pairing %s",

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -529,11 +529,11 @@ class HKDevice:
         # For services, (unique_id, aid, sid, None)
         # For accessories, (unique_id, aid, None, None)
         entries = er.async_entries_for_config_entry(reg, self.config_entry.entry_id)
-        exisiting_entities = {}
-        for entry in entries:
-            if iids := unique_id_to_iids(entry.unique_id):
-                exisiting_entities[iids] = entry.entity_id
-        existing_unique_id = set(exisiting_entities.keys())
+        existing_entities = {
+            iids: entry.entity_id
+            for entry in entries
+            if (iids := unique_id_to_iids(entry.unique_id))
+        }
 
         # Process current entity map and produce a similar set
         current_unique_id: set[IidTuple] = set()

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -21,10 +21,6 @@ from aiohomekit.model import Accessories, Accessory, Transport
 from aiohomekit.model.characteristics import Characteristic
 from aiohomekit.model.services import Service, ServicesTypes
 
-from homeassistant.components.homekit_controller.utils import (
-    IidTuple,
-    unique_id_to_iids,
-)
 from homeassistant.components.thread.dataset_store import async_get_preferred_dataset
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_VIA_DEVICE, EVENT_HOMEASSISTANT_STARTED
@@ -50,6 +46,7 @@ from .const import (
     SUBSCRIBE_COOLDOWN,
 )
 from .device_trigger import async_fire_triggers, async_setup_triggers_for_entry
+from .utils import IidTuple, unique_id_to_iids
 
 RETRY_INTERVAL = 60  # seconds
 MAX_POLL_FAILURES_TO_DECLARE_UNAVAILABLE = 3

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -557,10 +557,10 @@ class HKDevice:
             for parts in stale:
                 _LOGGER.debug(
                     "Removing stale entity registry entry %s for pairing %s",
-                    exisiting_entities[parts],
+                    existing_entities[parts],
                     self.unique_id,
                 )
-                reg.async_remove(exisiting_entities[parts])
+                reg.async_remove(existing_entities[parts])
 
     @callback
     def async_migrate_ble_unique_id(self) -> None:

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -11,6 +11,31 @@ from homeassistant.core import Event, HomeAssistant
 from .const import CONTROLLER
 from .storage import async_get_entity_storage
 
+IidTuple = tuple[int, int | None, int | None]
+
+
+def unique_id_to_iids(unique_id: str) -> IidTuple | None:
+    """Convert a unique_id to a tuple of accessory id, service iid and characteristic iid.
+
+    Depending on the field in the accessory map that is referenced, some of these may be None.
+
+    Returns None if this unique_id doesn't follow the homekit_controller scheme and is invalid.
+    """
+    try:
+        match unique_id.split("_"):
+            case (unique_id, aid, sid, cid):
+                return (int(aid), int(sid), int(cid))
+            case (unique_id, aid, sid):
+                return (int(aid), int(sid), None)
+            case (unique_id, aid):
+                return (int(aid), None, None)
+    except ValueError:
+        # One of the int conversions failed - this can't be a valid homekit_controller unique id
+        # Fall through and return None
+        pass
+
+    return None
+
 
 @lru_cache
 def folded_name(name: str) -> str:

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -343,9 +343,11 @@ async def test_ecobee3_services_and_chars_removed(
 
     # Make sure the climate entity is still there
     assert hass.states.get("climate.homew") is not None
+    assert entity_registry.async_get("climate.homew") is not None
 
     # Make sure the basement temperature sensor is gone
     assert hass.states.get("sensor.basement_temperature") is None
+    assert entity_registry.async_get("select.basement_temperature") is None
 
     # Make sure the current mode select and clear hold button are gone
     assert hass.states.get("select.homew_current_mode") is None

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -339,4 +339,7 @@ async def test_ecobee3_services_and_chars_removed(
 
     # Make sure the current mode select and clear hold button are gone
     assert hass.states.get("select.homew_current_mode") is None
+    assert entity_registry.async_get("select.homew_current_mode") is None
+
     assert hass.states.get("button.homew_clear_hold") is None
+    assert entity_registry.async_get("button.homew_clear_hold") is None

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -284,8 +284,13 @@ async def test_ecobee3_remove_sensors_at_runtime(
     await device_config_changed(hass, accessories)
 
     assert hass.states.get("binary_sensor.kitchen") is None
+    assert entity_registry.async_get("binary_sensor.kitchen") is None
+
     assert hass.states.get("binary_sensor.porch") is None
+    assert entity_registry.async_get("binary_sensor.porch") is None
+
     assert hass.states.get("binary_sensor.basement") is None
+    assert entity_registry.async_get("binary_sensor.basement") is None
 
     # Now add the sensors back
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
@@ -302,8 +307,13 @@ async def test_ecobee3_remove_sensors_at_runtime(
 
     # Ensure the sensors are back
     assert hass.states.get("binary_sensor.kitchen") is not None
+    assert occ1.id == entity_registry.async_get("binary_sensor.kitchen").id
+
     assert hass.states.get("binary_sensor.porch") is not None
+    assert occ2.id == entity_registry.async_get("binary_sensor.porch").id
+
     assert hass.states.get("binary_sensor.basement") is not None
+    assert occ3.id == entity_registry.async_get("binary_sensor.basement").id
 
 
 async def test_ecobee3_services_and_chars_removed(

--- a/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
+++ b/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
@@ -136,6 +136,7 @@ async def test_bridge_with_two_fans_one_removed(
 
     # Verify the first fan is still there
     fan_state = hass.states.get("fan.living_room_fan")
+    assert entity_registry.async_get("fan.living_room_fan") is not None
     assert (
         fan_state.attributes[ATTR_SUPPORTED_FEATURES]
         is FanEntityFeature.SET_SPEED

--- a/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
+++ b/tests/components/homekit_controller/specific_devices/test_fan_that_changes_features.py
@@ -144,3 +144,4 @@ async def test_bridge_with_two_fans_one_removed(
     )
     # The second fan should have been removed
     assert not hass.states.get("fan.ceiling_fan")
+    assert not entity_registry.async_get("fan.ceiling_fan")

--- a/tests/components/homekit_controller/test_utils.py
+++ b/tests/components/homekit_controller/test_utils.py
@@ -1,0 +1,15 @@
+"""Checks for basic helper utils."""
+from homeassistant.components.homekit_controller.utils import unique_id_to_iids
+
+
+def test_unique_id_to_iids():
+    """Check that unique_id_to_iids is safe against different invalid ids."""
+    assert unique_id_to_iids("pairingid_1_2_3") == (1, 2, 3)
+    assert unique_id_to_iids("pairingid_1_2") == (1, 2, None)
+    assert unique_id_to_iids("pairingid_1") == (1, None, None)
+
+    assert unique_id_to_iids("pairingid") is None
+    assert unique_id_to_iids("pairingid_1_2_3_4") is None
+    assert unique_id_to_iids("pairingid_a") is None
+    assert unique_id_to_iids("pairingid_1_a") is None
+    assert unique_id_to_iids("pairingid_1_2_a") is None


### PR DESCRIPTION
## Proposed change

When an entity is moved from a bridge (like a Hue or Aqara bridge) stale entity registry entities are left behind. Find them and clean them when ever we get a new entity map from the device.

Will handle the BLE -> Thread edge cases (signal strength and thread provision UI) in a follow up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
