### PR TITLE
Make ConfigEntryItems responsible for updating unique ids

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1200,9 +1200,10 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
 
         This method mutates the entry with the new unique id and updates the indexes.
         """
-        self._unindex_entry(entry.entry_id)
+        entry_id = entry.entry_id
+        self._unindex_entry(entry_id)
         entry.unique_id = new_unique_id
-        self._index_entry(entry.entry_id, entry)
+        self._index_entry(entry_id, entry)
 
     def get_entries_for_domain(self, domain: str) -> list[ConfigEntry]:
         """Get entries for a domain."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1144,11 +1144,11 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
             # In the future, once we have fixed the tests, this will raise HomeAssistantError.
             _LOGGER.error("An entry with the id %s already exists", entry_id)
             self._unindex_entry(entry_id)
+        self.data[entry_id] = entry
         self._index_entry(entry_id, entry)
 
     def _index_entry(self, entry_id: str, entry: ConfigEntry) -> None:
         """Index an entry."""
-        self.data[entry_id] = entry
         self._domain_index.setdefault(entry.domain, []).append(entry)
         if entry.unique_id is not None:
             unique_id_hash = entry.unique_id

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1139,12 +1139,13 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
 
     def __setitem__(self, entry_id: str, entry: ConfigEntry) -> None:
         """Add an item."""
-        if entry_id in self.data:
+        data = self.data
+        if entry_id in data:
             # This is likely a bug in a test that is adding the same entry twice.
             # In the future, once we have fixed the tests, this will raise HomeAssistantError.
             _LOGGER.error("An entry with the id %s already exists", entry_id)
             self._unindex_entry(entry_id)
-        self.data[entry_id] = entry
+        data[entry_id] = entry
         self._index_entry(entry_id, entry)
 
     def _index_entry(self, entry_id: str, entry: ConfigEntry) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1146,9 +1146,9 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
             _LOGGER.error("An entry with the id %s already exists", entry_id)
             self._unindex_entry(entry_id)
         data[entry_id] = entry
-        self._index_entry(entry_id, entry)
+        self._index_entry(entry)
 
-    def _index_entry(self, entry_id: str, entry: ConfigEntry) -> None:
+    def _index_entry(self, entry: ConfigEntry) -> None:
         """Index an entry."""
         self._domain_index.setdefault(entry.domain, []).append(entry)
         if entry.unique_id is not None:
@@ -1203,7 +1203,7 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         entry_id = entry.entry_id
         self._unindex_entry(entry_id)
         entry.unique_id = new_unique_id
-        self._index_entry(entry_id, entry)
+        self._index_entry(entry)
 
     def get_entries_for_domain(self, domain: str) -> list[ConfigEntry]:
         """Get entries for a domain."""


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make ConfigEntryItems responsible for updating unique ids

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
