### PR TITLE
Avoid directly changing config entry state in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -944,6 +944,27 @@ class MockConfigEntry(config_entries.ConfigEntry):
         """Test helper to add entry to entry manager."""
         manager._entries[self.entry_id] = self
 
+    def mock_state(
+        self,
+        hass: HomeAssistant,
+        state: config_entries.ConfigEntryState,
+        reason: str | None = None,
+    ) -> None:
+        """Mock the state of a config entry to be used in tests.
+
+        Currently this is a wrapper around _async_set_state, but it may
+        change in the future.
+
+        It is preferable to get the config entry into the desired state
+        by using the normal config entry methods, and this helper
+        is only intended to be used in cases where that is not possible.
+
+        When in doubt, this helper should not be used in new code
+        and is only intended for backwards compatibility with existing
+        tests.
+        """
+        self._async_set_state(hass, state, reason)
+
 
 def patch_yaml_files(files_dict, endswith=True):
     """Patch load_yaml with a dictionary of yaml files."""

--- a/tests/components/blink/test_services.py
+++ b/tests/components/blink/test_services.py
@@ -179,7 +179,7 @@ async def test_service_pin_called_with_unloaded_entry(
     mock_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    mock_config_entry.state = ConfigEntryState.SETUP_ERROR
+    mock_config_entry.mock_state(hass, ConfigEntryState.SETUP_ERROR)
     hass.config.is_allowed_path = Mock(return_value=True)
     mock_blink_api.cameras = {CAMERA_NAME: AsyncMock()}
 
@@ -207,7 +207,7 @@ async def test_service_update_called_with_unloaded_entry(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    mock_config_entry.state = ConfigEntryState.SETUP_ERROR
+    mock_config_entry.mock_state(hass, ConfigEntryState.SETUP_ERROR)
     hass.config.is_allowed_path = Mock(return_value=True)
     mock_blink_api.cameras = {CAMERA_NAME: AsyncMock()}
 

--- a/tests/components/hue/test_light_v1.py
+++ b/tests/components/hue/test_light_v1.py
@@ -179,7 +179,7 @@ async def setup_bridge(hass, mock_bridge_v1):
     hass.config.components.add(hue.DOMAIN)
     config_entry = create_config_entry()
     config_entry.add_to_hass(hass)
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.options = {CONF_ALLOW_HUE_GROUPS: True}
     mock_bridge_v1.config_entry = config_entry
     hass.data[hue.DOMAIN] = {config_entry.entry_id: mock_bridge_v1}

--- a/tests/components/opower/test_config_flow.py
+++ b/tests/components/opower/test_config_flow.py
@@ -277,7 +277,7 @@ async def test_form_valid_reauth(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test that we can handle a valid reauth."""
-    mock_config_entry.state = ConfigEntryState.LOADED
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
     mock_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
@@ -326,7 +326,7 @@ async def test_form_valid_reauth_with_mfa(
             "utility": "Consolidated Edison (ConEd)",
         },
     )
-    mock_config_entry.state = ConfigEntryState.LOADED
+    mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
     mock_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -106,7 +106,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
         "Motion Sensor 1", [Capability.motion_sensor], {Attribute.motion: "inactive"}
     )
     config_entry = await setup_platform(hass, BINARY_SENSOR_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "binary_sensor")
     # Assert

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -243,7 +243,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
         "Garage", [Capability.garage_door_control], {Attribute.door: "open"}
     )
     config_entry = await setup_platform(hass, COVER_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, COVER_DOMAIN)
     # Assert

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -301,7 +301,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
         status={Attribute.switch: "off", Attribute.fan_speed: 0},
     )
     config_entry = await setup_platform(hass, FAN_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "fan")
     # Assert

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -319,7 +319,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
         },
     )
     config_entry = await setup_platform(hass, LIGHT_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "light")
     # Assert

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -120,7 +120,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
     # Arrange
     device = device_factory("Lock_1", [Capability.lock], {Attribute.lock: "locked"})
     config_entry = await setup_platform(hass, LOCK_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "lock")
     # Assert

--- a/tests/components/smartthings/test_scene.py
+++ b/tests/components/smartthings/test_scene.py
@@ -44,7 +44,7 @@ async def test_unload_config_entry(hass: HomeAssistant, scene) -> None:
     """Test the scene is removed when the config entry is unloaded."""
     # Arrange
     config_entry = await setup_platform(hass, SCENE_DOMAIN, scenes=[scene])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, SCENE_DOMAIN)
     # Assert

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -296,7 +296,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
     # Arrange
     device = device_factory("Sensor 1", [Capability.battery], {Attribute.battery: 100})
     config_entry = await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
     # Assert

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -106,7 +106,7 @@ async def test_unload_config_entry(hass: HomeAssistant, device_factory) -> None:
     # Arrange
     device = device_factory("Switch 1", [Capability.switch], {Attribute.switch: "on"})
     config_entry = await setup_platform(hass, SWITCH_DOMAIN, devices=[device])
-    config_entry.state = ConfigEntryState.LOADED
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     # Act
     await hass.config_entries.async_forward_entry_unload(config_entry, "switch")
     # Assert


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`ConfigEntry` is designed to control its own state by the normal entry points and is not expected to have its state changed externally. Add a helper for existing tests that are changing it externally with a note that it should not be used in new tests

https://github.com/home-assistant/core/pull/110023 is going to add some warnings when the config entry state is changed externally and this is the first step to ensure we do not do it in core.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
