### PR TITLE
Matching duplicate named entities is now an error in Assist

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -165,11 +165,9 @@ class GetStateIntentHandler(intent.IntentHandler):
         area_id = area_slot.get("value")
         area_name = area_slot.get("text")
         area: ar.AreaEntry | None = None
-        if area_name is not None:
+        if area_id is not None:
             areas = ar.async_get(hass)
-            area = areas.async_get_area(area_id) or areas.async_get_area_by_name(
-                area_name
-            )
+            area = areas.async_get_area(area_id)
             if area is None:
                 raise intent.IntentHandleError(f"No area named {area_name}")
 

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -156,14 +156,18 @@ class GetStateIntentHandler(intent.IntentHandler):
         slots = self.async_validate_slots(intent_obj.slots)
 
         # Entity name to match
-        entity_name: str | None = slots.get("name", {}).get("value")
+        name_slot = slots.get("name", {})
+        entity_name: str | None = name_slot.get("value")
+        entity_text: str | None = name_slot.get("text")
 
         # Look up area first to fail early
-        area_name = slots.get("area", {}).get("value")
+        area_slot = slots.get("area", {})
+        area_id = area_slot.get("value")
+        area_name = area_slot.get("text")
         area: ar.AreaEntry | None = None
         if area_name is not None:
             areas = ar.async_get(hass)
-            area = areas.async_get_area(area_name) or areas.async_get_area_by_name(
+            area = areas.async_get_area(area_id) or areas.async_get_area_by_name(
                 area_name
             )
             if area is None:
@@ -204,6 +208,13 @@ class GetStateIntentHandler(intent.IntentHandler):
             device_classes,
             intent_obj.assistant,
         )
+
+        if entity_name and (len(states) > 1):
+            # Multiple entities matched for the same name
+            raise intent.DuplicateNamesMatchedError(
+                name=entity_text or entity_name,
+                area=area_name or area_id,
+            )
 
         # Create response
         response = intent_obj.create_response()

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -425,9 +425,7 @@ class ServiceIntentHandler(IntentHandler):
         area: area_registry.AreaEntry | None = None
         if area_id is not None:
             areas = area_registry.async_get(hass)
-            area = areas.async_get_area(area_id) or areas.async_get_area_by_name(
-                area_name
-            )
+            area = areas.async_get_area(area_id)
             if area is None:
                 raise IntentHandleError(f"No area named {area_name}")
 

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -155,6 +155,17 @@ class NoStatesMatchedError(IntentError):
         self.device_classes = device_classes
 
 
+class DuplicateNamesMatchedError(IntentError):
+    """Error when two or more entities with the same name matched."""
+
+    def __init__(self, name: str, area: str | None) -> None:
+        """Initialize error."""
+        super().__init__()
+
+        self.name = name
+        self.area = area
+
+
 def _is_device_class(
     state: State,
     entity: entity_registry.RegistryEntry | None,
@@ -318,8 +329,6 @@ def async_match_states(
         for state, entity in states_and_entities:
             if _has_name(state, entity, name):
                 yield state
-                break
-
     else:
         # Not filtered by name
         for state, _entity in states_and_entities:
@@ -451,6 +460,13 @@ class ServiceIntentHandler(IntentHandler):
                 area=area_name or area_id,
                 domains=domains,
                 device_classes=device_classes,
+            )
+
+        if entity_name and (len(states) > 1):
+            # Multiple entities matched for the same name
+            raise DuplicateNamesMatchedError(
+                name=entity_text or entity_name,
+                area=area_name or area_id,
             )
 
         response = await self.async_handle_states(intent_obj, states, area)

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1397,7 +1397,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'kitchen',
+            'value': 'my cool light',
           }),
         }),
         'intent': dict({
@@ -1422,7 +1422,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'kitchen',
+            'value': 'my cool light',
           }),
         }),
         'intent': dict({

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -614,6 +614,115 @@ async def test_error_no_intent(hass: HomeAssistant, init_components) -> None:
         )
 
 
+async def test_error_duplicate_names(
+    hass: HomeAssistant, init_components, entity_registry: er.EntityRegistry
+) -> None:
+    """Test error message when multiple devices have the same name (or alias)."""
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Check name and alias
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name}"
+        )
+
+        # question
+        result = await conversation.async_converse(
+            hass, f"is {name} on?", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name}"
+        )
+
+
+async def test_error_duplicate_names_in_area(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test error message when multiple devices have the same name (or alias)."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            area_id=area_kitchen.id,
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Check name and alias
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name} in the {area_kitchen.name} area"
+        )
+
+        # question
+        result = await conversation.async_converse(
+            hass, f"is {name} on in the {area_kitchen.name}?", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name} in the {area_kitchen.name} area"
+        )
+
+
 async def test_no_states_matched_default_error(
     hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
 ) -> None:
@@ -794,3 +903,112 @@ async def test_same_named_entities_in_different_areas(
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
     assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]
+
+    # Targeting a duplicate name should fail
+    result = await conversation.async_converse(
+        hass, "turn on overhead light", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # Querying a duplicate name should also fail
+    result = await conversation.async_converse(
+        hass, "is the overhead light on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # But we can still ask questions that don't rely on the name
+    result = await conversation.async_converse(
+        hass, "how many lights are on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+
+
+async def test_same_aliased_entities_in_different_areas(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities with the same alias (but different names) in different areas can be targeted."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+
+    # Both lights have the same alias, but are in different areas
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        area_id=area_kitchen.id,
+        name="kitchen overhead light",
+        aliases={"overhead light"},
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+
+    bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    bedroom_light = entity_registry.async_update_entity(
+        bedroom_light.entity_id,
+        area_id=area_bedroom.id,
+        name="bedroom overhead light",
+        aliases={"overhead light"},
+    )
+    hass.states.async_set(
+        bedroom_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: bedroom_light.name},
+    )
+
+    # Target kitchen light
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the kitchen", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
+    assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
+    assert calls[0].data.get("entity_id") == [kitchen_light.entity_id]
+
+    # Target bedroom light
+    calls.clear()
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the bedroom", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
+    assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
+    assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]
+
+    # Targeting a duplicate alias should fail
+    result = await conversation.async_converse(
+        hass, "turn on overhead light", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # Querying a duplicate alias should also fail
+    result = await conversation.async_converse(
+        hass, "is the overhead light on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # But we can still ask questions that don't rely on the alias
+    result = await conversation.async_converse(
+        hass, "how many lights are on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Targeting entities with the same name or alias is now an error in Assist, resulting in an error like "Sorry, there are multiple devices named overhead light". If the entities are in different areas, they can still be targeted ("turn on overhead light in the bedroom"). This avoids the previous behavior where one of the entities would be targeted, depending on its position in HA's state machine.

This PR also completes the fix for issue: https://github.com/home-assistant/core/issues/109868

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/home-assistant/core/issues/109868
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
