### PR TITLE
2024.2.1

### DIFF
--- a/homeassistant/components/aosmith/manifest.json
+++ b/homeassistant/components/aosmith/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/aosmith",
   "iot_class": "cloud_polling",
-  "requirements": ["py-aosmith==1.0.6"]
+  "requirements": ["py-aosmith==1.0.8"]
 }

--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -1,4 +1,5 @@
 """Intents for the client integration."""
+
 from __future__ import annotations
 
 import voluptuous as vol
@@ -36,24 +37,34 @@ class GetTemperatureIntent(intent.IntentHandler):
         if not entities:
             raise intent.IntentHandleError("No climate entities")
 
-        if "area" in slots:
-            # Filter by area
-            area_name = slots["area"]["value"]
+        name_slot = slots.get("name", {})
+        entity_name: str | None = name_slot.get("value")
+        entity_text: str | None = name_slot.get("text")
+
+        area_slot = slots.get("area", {})
+        area_id = area_slot.get("value")
+
+        if area_id:
+            # Filter by area and optionally name
+            area_name = area_slot.get("text")
 
             for maybe_climate in intent.async_match_states(
-                hass, area_name=area_name, domains=[DOMAIN]
+                hass, name=entity_name, area_name=area_id, domains=[DOMAIN]
             ):
                 climate_state = maybe_climate
                 break
 
             if climate_state is None:
-                raise intent.IntentHandleError(f"No climate entity in area {area_name}")
+                raise intent.NoStatesMatchedError(
+                    name=entity_text or entity_name,
+                    area=area_name or area_id,
+                    domains={DOMAIN},
+                    device_classes=None,
+                )
 
             climate_entity = component.get_entity(climate_state.entity_id)
-        elif "name" in slots:
+        elif entity_name:
             # Filter by name
-            entity_name = slots["name"]["value"]
-
             for maybe_climate in intent.async_match_states(
                 hass, name=entity_name, domains=[DOMAIN]
             ):
@@ -61,7 +72,12 @@ class GetTemperatureIntent(intent.IntentHandler):
                 break
 
             if climate_state is None:
-                raise intent.IntentHandleError(f"No climate entity named {entity_name}")
+                raise intent.NoStatesMatchedError(
+                    name=entity_name,
+                    area=None,
+                    domains={DOMAIN},
+                    device_classes=None,
+                )
 
             climate_entity = component.get_entity(climate_state.entity_id)
         else:

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aioelectricitymaps"],
-  "requirements": ["aioelectricitymaps==0.3.1"]
+  "requirements": ["aioelectricitymaps==0.4.0"]
 }

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -223,22 +223,22 @@ class DefaultAgent(AbstractConversationAgent):
         # Check if a trigger matched
         if isinstance(result, SentenceTriggerResult):
             # Gather callback responses in parallel
-            trigger_responses = await asyncio.gather(
-                *(
-                    self._trigger_sentences[trigger_id].callback(
-                        result.sentence, trigger_result
-                    )
-                    for trigger_id, trigger_result in result.matched_triggers.items()
+            trigger_callbacks = [
+                self._trigger_sentences[trigger_id].callback(
+                    result.sentence, trigger_result
                 )
-            )
+                for trigger_id, trigger_result in result.matched_triggers.items()
+            ]
 
             # Use last non-empty result as response.
             #
             # There may be multiple copies of a trigger running when editing in
             # the UI, so it's critical that we filter out empty responses here.
             response_text: str | None = None
-            for trigger_response in trigger_responses:
-                response_text = response_text or trigger_response
+            for trigger_future in asyncio.as_completed(trigger_callbacks):
+                if trigger_response := await trigger_future:
+                    response_text = trigger_response
+                    break
 
             # Convert to conversation result
             response = intent.IntentResponse(language=language)
@@ -724,7 +724,12 @@ class DefaultAgent(AbstractConversationAgent):
             if async_should_expose(self.hass, DOMAIN, state.entity_id)
         ]
 
-        # Gather exposed entity names
+        # Gather exposed entity names.
+        #
+        # NOTE: We do not pass entity ids in here because multiple entities may
+        # have the same name. The intent matcher doesn't gather all matching
+        # values for a list, just the first. So we will need to match by name no
+        # matter what.
         entity_names = []
         for state in states:
             # Checked against "requires_context" and "excludes_context" in hassil
@@ -740,7 +745,7 @@ class DefaultAgent(AbstractConversationAgent):
 
             if not entity:
                 # Default name
-                entity_names.append((state.name, state.entity_id, context))
+                entity_names.append((state.name, state.name, context))
                 continue
 
             if entity.aliases:
@@ -748,12 +753,15 @@ class DefaultAgent(AbstractConversationAgent):
                     if not alias.strip():
                         continue
 
-                    entity_names.append((alias, state.entity_id, context))
+                    entity_names.append((alias, state.name, context))
 
             # Default name
-            entity_names.append((state.name, state.entity_id, context))
+            entity_names.append((state.name, state.name, context))
 
-        # Expose all areas
+        # Expose all areas.
+        #
+        # We pass in area id here with the expectation that no two areas will
+        # share the same name or alias.
         areas = ar.async_get(self.hass)
         area_names = []
         for area in areas.async_list_areas():

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.8", "deebot-client==5.1.0"]
+  "requirements": ["py-sucks==0.9.8", "deebot-client==5.1.1"]
 }

--- a/homeassistant/components/ecowitt/manifest.json
+++ b/homeassistant/components/ecowitt/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["webhook"],
   "documentation": "https://www.home-assistant.io/integrations/ecowitt",
   "iot_class": "local_push",
-  "requirements": ["aioecowitt==2024.2.0"]
+  "requirements": ["aioecowitt==2024.2.1"]
 }

--- a/homeassistant/components/evohome/manifest.json
+++ b/homeassistant/components/evohome/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/evohome",
   "iot_class": "cloud_polling",
   "loggers": ["evohomeasync", "evohomeasync2"],
-  "requirements": ["evohome-async==0.4.17"]
+  "requirements": ["evohome-async==0.4.18"]
 }

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -20,5 +20,5 @@
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["home-assistant-frontend==20240207.0"]
+  "requirements": ["home-assistant-frontend==20240207.1"]
 }

--- a/homeassistant/components/geonetnz_volcano/manifest.json
+++ b/homeassistant/components/geonetnz_volcano/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aio_geojson_geonetnz_volcano"],
-  "requirements": ["aio-geojson-geonetnz-volcano==0.8"]
+  "requirements": ["aio-geojson-geonetnz-volcano==0.9"]
 }

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -506,7 +506,6 @@ class HassIO:
         options = {
             "ssl": CONF_SSL_CERTIFICATE in http_config,
             "port": port,
-            "watchdog": True,
             "refresh_token": refresh_token.token,
         }
 

--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from aiohttp import ClientConnectionError
 from aiosomecomfort import (
+    APIRateLimited,
     AuthError,
     ConnectionError as AscConnectionError,
     SomeComfortError,
@@ -505,10 +506,11 @@ class HoneywellUSThermostat(ClimateEntity):
                 await self._device.refresh()
 
             except (
+                asyncio.TimeoutError,
+                AscConnectionError,
+                APIRateLimited,
                 AuthError,
                 ClientConnectionError,
-                AscConnectionError,
-                asyncio.TimeoutError,
             ):
                 self._retry += 1
                 self._attr_available = self._retry <= RETRY
@@ -524,7 +526,12 @@ class HoneywellUSThermostat(ClimateEntity):
             await _login()
             return
 
-        except (AscConnectionError, ClientConnectionError, asyncio.TimeoutError):
+        except (
+            asyncio.TimeoutError,
+            AscConnectionError,
+            APIRateLimited,
+            ClientConnectionError,
+        ):
             self._retry += 1
             self._attr_available = self._retry <= RETRY
             return

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -1,4 +1,5 @@
 """The Intent integration."""
+
 from __future__ import annotations
 
 import logging
@@ -155,7 +156,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         slots = self.async_validate_slots(intent_obj.slots)
 
         # Entity name to match
-        name: str | None = slots.get("name", {}).get("value")
+        entity_name: str | None = slots.get("name", {}).get("value")
 
         # Look up area first to fail early
         area_name = slots.get("area", {}).get("value")
@@ -186,7 +187,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         states = list(
             intent.async_match_states(
                 hass,
-                name=name,
+                name=entity_name,
                 area=area,
                 domains=domains,
                 device_classes=device_classes,
@@ -197,7 +198,7 @@ class GetStateIntentHandler(intent.IntentHandler):
         _LOGGER.debug(
             "Found %s state(s) that matched: name=%s, area=%s, domains=%s, device_classes=%s, assistant=%s",
             len(states),
-            name,
+            entity_name,
             area,
             domains,
             device_classes,

--- a/homeassistant/components/keymitt_ble/manifest.json
+++ b/homeassistant/components/keymitt_ble/manifest.json
@@ -16,5 +16,5 @@
   "integration_type": "hub",
   "iot_class": "assumed_state",
   "loggers": ["keymitt_ble"],
-  "requirements": ["PyMicroBot==0.0.10"]
+  "requirements": ["PyMicroBot==0.0.12"]
 }

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -129,6 +129,9 @@ class MatterEntity(Entity):
 
     async def async_update(self) -> None:
         """Call when the entity needs to be updated."""
+        if not self._endpoint.node.available:
+            # skip poll when the node is not (yet) available
+            return
         # manually poll/refresh the primary value
         await self.matter_client.refresh_attribute(
             self._endpoint.node.node_id,

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "iot_class": "local_push",
-  "requirements": ["python-matter-server==5.4.1"]
+  "requirements": ["python-matter-server==5.5.0"]
 }

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -186,7 +186,7 @@ BASE_STRUCT_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
             ]
         ),
         vol.Optional(CONF_STRUCTURE): cv.string,
-        vol.Optional(CONF_SCALE, default=1): cv.positive_float,
+        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
         vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
         vol.Optional(CONF_PRECISION): cv.positive_int,
         vol.Optional(

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -241,8 +241,8 @@ CLIMATE_SCHEMA = vol.All(
         {
             vol.Required(CONF_TARGET_TEMP): cv.positive_int,
             vol.Optional(CONF_TARGET_TEMP_WRITE_REGISTERS, default=False): cv.boolean,
-            vol.Optional(CONF_MAX_TEMP, default=35): cv.positive_float,
-            vol.Optional(CONF_MIN_TEMP, default=5): cv.positive_float,
+            vol.Optional(CONF_MAX_TEMP, default=35): vol.Coerce(float),
+            vol.Optional(CONF_MIN_TEMP, default=5): vol.Coerce(float),
             vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
             vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
             vol.Optional(CONF_HVAC_ONOFF_REGISTER): cv.positive_int,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -342,8 +342,8 @@ SENSOR_SCHEMA = vol.All(
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
             vol.Exclusive(CONF_VIRTUAL_COUNT, "vir_sen_count"): cv.positive_int,
             vol.Exclusive(CONF_SLAVE_COUNT, "vir_sen_count"): cv.positive_int,
-            vol.Optional(CONF_MIN_VALUE): cv.positive_float,
-            vol.Optional(CONF_MAX_VALUE): cv.positive_float,
+            vol.Optional(CONF_MIN_VALUE): vol.Coerce(float),
+            vol.Optional(CONF_MAX_VALUE): vol.Coerce(float),
             vol.Optional(CONF_NAN_VALUE): nan_validator,
             vol.Optional(CONF_ZERO_SUPPRESS): cv.positive_float,
         }

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -364,7 +364,9 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
 
             # Translate the value received
             if fan_mode is not None:
-                self._attr_fan_mode = self._fan_mode_mapping_from_modbus[int(fan_mode)]
+                self._attr_fan_mode = self._fan_mode_mapping_from_modbus.get(
+                    int(fan_mode), self._attr_fan_mode
+                )
 
         # Read the on/off register if defined. If the value in this
         # register is "OFF", it will take precedence over the value

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -7,6 +7,7 @@ from collections.abc import (
     Callable,
     Coroutine,
     Generator,
+    Hashable,
     Iterable,
     Mapping,
     ValuesView,
@@ -49,6 +50,7 @@ from .helpers.event import (
 )
 from .helpers.frame import report
 from .helpers.typing import UNDEFINED, ConfigType, DiscoveryInfoType, UndefinedType
+from .loader import async_suggest_report_issue
 from .setup import DATA_SETUP_DONE, async_process_deps_reqs, async_setup_component
 from .util import uuid as uuid_util
 from .util.decorator import Registry
@@ -1124,9 +1126,10 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
     - domain -> unique_id -> ConfigEntry
     """
 
-    def __init__(self) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the container."""
         super().__init__()
+        self._hass = hass
         self._domain_index: dict[str, list[ConfigEntry]] = {}
         self._domain_unique_id_index: dict[str, dict[str, ConfigEntry]] = {}
 
@@ -1145,8 +1148,27 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         data[entry_id] = entry
         self._domain_index.setdefault(entry.domain, []).append(entry)
         if entry.unique_id is not None:
+            unique_id_hash = entry.unique_id
+            # Guard against integrations using unhashable unique_id
+            # In HA Core 2024.9, we should remove the guard and instead fail
+            if not isinstance(entry.unique_id, Hashable):
+                unique_id_hash = str(entry.unique_id)  # type: ignore[unreachable]
+                report_issue = async_suggest_report_issue(
+                    self._hass, integration_domain=entry.domain
+                )
+                _LOGGER.error(
+                    (
+                        "Config entry '%s' from integration %s has an invalid unique_id"
+                        " '%s', please %s"
+                    ),
+                    entry.title,
+                    entry.domain,
+                    entry.unique_id,
+                    report_issue,
+                )
+
             self._domain_unique_id_index.setdefault(entry.domain, {})[
-                entry.unique_id
+                unique_id_hash
             ] = entry
 
     def _unindex_entry(self, entry_id: str) -> None:
@@ -1157,6 +1179,9 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         if not self._domain_index[domain]:
             del self._domain_index[domain]
         if (unique_id := entry.unique_id) is not None:
+            # Check type first to avoid expensive isinstance call
+            if type(unique_id) is not str and not isinstance(unique_id, Hashable):  # noqa: E721
+                unique_id = str(entry.unique_id)  # type: ignore[unreachable]
             del self._domain_unique_id_index[domain][unique_id]
             if not self._domain_unique_id_index[domain]:
                 del self._domain_unique_id_index[domain]
@@ -1174,6 +1199,9 @@ class ConfigEntryItems(UserDict[str, ConfigEntry]):
         self, domain: str, unique_id: str
     ) -> ConfigEntry | None:
         """Get entry by domain and unique id."""
+        # Check type first to avoid expensive isinstance call
+        if type(unique_id) is not str and not isinstance(unique_id, Hashable):  # noqa: E721
+            unique_id = str(unique_id)  # type: ignore[unreachable]
         return self._domain_unique_id_index.get(domain, {}).get(unique_id)
 
 
@@ -1189,7 +1217,7 @@ class ConfigEntries:
         self.flow = ConfigEntriesFlowManager(hass, self, hass_config)
         self.options = OptionsFlowManager(hass)
         self._hass_config = hass_config
-        self._entries = ConfigEntryItems()
+        self._entries = ConfigEntryItems(hass)
         self._store = storage.Store[dict[str, list[dict[str, Any]]]](
             hass, STORAGE_VERSION, STORAGE_KEY
         )
@@ -1314,10 +1342,10 @@ class ConfigEntries:
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
 
         if config is None:
-            self._entries = ConfigEntryItems()
+            self._entries = ConfigEntryItems(self.hass)
             return
 
-        entries: ConfigEntryItems = ConfigEntryItems()
+        entries: ConfigEntryItems = ConfigEntryItems(self.hass)
         for entry in config["entries"]:
             pref_disable_new_entities = entry.get("pref_disable_new_entities")
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 2
-PATCH_VERSION: Final = "0"
+PATCH_VERSION: Final = "1"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -403,11 +403,11 @@ class ServiceIntentHandler(IntentHandler):
         slots = self.async_validate_slots(intent_obj.slots)
 
         name_slot = slots.get("name", {})
-        entity_id: str | None = name_slot.get("value")
-        entity_name: str | None = name_slot.get("text")
-        if entity_id == "all":
+        entity_name: str | None = name_slot.get("value")
+        entity_text: str | None = name_slot.get("text")
+        if entity_name == "all":
             # Don't match on name if targeting all entities
-            entity_id = None
+            entity_name = None
 
         # Look up area first to fail early
         area_slot = slots.get("area", {})
@@ -436,7 +436,7 @@ class ServiceIntentHandler(IntentHandler):
         states = list(
             async_match_states(
                 hass,
-                name=entity_id,
+                name=entity_name,
                 area=area,
                 domains=domains,
                 device_classes=device_classes,
@@ -447,13 +447,16 @@ class ServiceIntentHandler(IntentHandler):
         if not states:
             # No states matched constraints
             raise NoStatesMatchedError(
-                name=entity_name or entity_id,
+                name=entity_text or entity_name,
                 area=area_name or area_id,
                 domains=domains,
                 device_classes=device_classes,
             )
 
         response = await self.async_handle_states(intent_obj, states, area)
+
+        # Make the matched states available in the response
+        response.async_set_states(matched_states=states, unmatched_states=[])
 
         return response
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -273,7 +273,13 @@ class _TranslationCache:
         for key, value in updated_resources.items():
             if key not in cached_resources:
                 continue
-            tuples = list(string.Formatter().parse(value))
+            try:
+                tuples = list(string.Formatter().parse(value))
+            except ValueError:
+                _LOGGER.error(
+                    ("Error while parsing localized (%s) string %s"), language, key
+                )
+                continue
             updated_placeholders = {tup[1] for tup in tuples if tup[1] is not None}
 
             tuples = list(string.Formatter().parse(cached_resources[key]))

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -28,7 +28,7 @@ habluetooth==2.4.0
 hass-nabucasa==0.76.0
 hassil==1.6.1
 home-assistant-bluetooth==1.12.0
-home-assistant-frontend==20240207.0
+home-assistant-frontend==20240207.1
 home-assistant-intents==2024.2.2
 httpx==0.26.0
 ifaddr==0.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.2.0"
+version     = "2024.2.1"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2238,7 +2238,7 @@ python-kasa[speedups]==0.6.2.1
 # python-lirc==1.2.3
 
 # homeassistant.components.matter
-python-matter-server==5.4.1
+python-matter-server==5.5.0
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -684,7 +684,7 @@ debugpy==1.8.0
 # decora==0.6
 
 # homeassistant.components.ecovacs
-deebot-client==5.1.0
+deebot-client==5.1.1
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1059,7 +1059,7 @@ hole==0.8.0
 holidays==0.42
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240207.0
+home-assistant-frontend==20240207.1
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -173,7 +173,7 @@ aio-geojson-generic-client==0.4
 aio-geojson-geonetnz-quakes==0.16
 
 # homeassistant.components.geonetnz_volcano
-aio-geojson-geonetnz-volcano==0.8
+aio-geojson-geonetnz-volcano==0.9
 
 # homeassistant.components.nsw_rural_fire_service_feed
 aio-geojson-nsw-rfs-incidents==0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -230,7 +230,7 @@ aioeafm==0.1.2
 aioeagle==1.1.0
 
 # homeassistant.components.ecowitt
-aioecowitt==2024.2.0
+aioecowitt==2024.2.1
 
 # homeassistant.components.co2signal
 aioelectricitymaps==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -76,7 +76,7 @@ PyMetEireann==2021.8.0
 PyMetno==0.11.0
 
 # homeassistant.components.keymitt_ble
-PyMicroBot==0.0.10
+PyMicroBot==0.0.12
 
 # homeassistant.components.nina
 PyNINA==0.3.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -233,7 +233,7 @@ aioeagle==1.1.0
 aioecowitt==2024.2.0
 
 # homeassistant.components.co2signal
-aioelectricitymaps==0.3.1
+aioelectricitymaps==0.4.0
 
 # homeassistant.components.emonitor
 aioemonitor==1.0.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -818,7 +818,7 @@ eufylife-ble-client==0.1.8
 # evdev==1.6.1
 
 # homeassistant.components.evohome
-evohome-async==0.4.17
+evohome-async==0.4.18
 
 # homeassistant.components.faa_delays
 faadelays==2023.9.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1579,7 +1579,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.6
+py-aosmith==1.0.8
 
 # homeassistant.components.canary
 py-canary==0.5.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1711,7 +1711,7 @@ python-juicenet==1.1.0
 python-kasa[speedups]==0.6.2.1
 
 # homeassistant.components.matter
-python-matter-server==5.4.1
+python-matter-server==5.5.0
 
 # homeassistant.components.xiaomi_miio
 python-miio==0.5.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -212,7 +212,7 @@ aioeagle==1.1.0
 aioecowitt==2024.2.0
 
 # homeassistant.components.co2signal
-aioelectricitymaps==0.3.1
+aioelectricitymaps==0.4.0
 
 # homeassistant.components.emonitor
 aioemonitor==1.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -209,7 +209,7 @@ aioeafm==0.1.2
 aioeagle==1.1.0
 
 # homeassistant.components.ecowitt
-aioecowitt==2024.2.0
+aioecowitt==2024.2.1
 
 # homeassistant.components.co2signal
 aioelectricitymaps==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1232,7 +1232,7 @@ pushover_complete==1.1.1
 pvo==2.1.1
 
 # homeassistant.components.aosmith
-py-aosmith==1.0.6
+py-aosmith==1.0.8
 
 # homeassistant.components.canary
 py-canary==0.5.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -559,7 +559,7 @@ dbus-fast==2.21.1
 debugpy==1.8.0
 
 # homeassistant.components.ecovacs
-deebot-client==5.1.0
+deebot-client==5.1.1
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -64,7 +64,7 @@ PyMetEireann==2021.8.0
 PyMetno==0.11.0
 
 # homeassistant.components.keymitt_ble
-PyMicroBot==0.0.10
+PyMicroBot==0.0.12
 
 # homeassistant.components.nina
 PyNINA==0.3.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -152,7 +152,7 @@ aio-geojson-generic-client==0.4
 aio-geojson-geonetnz-quakes==0.16
 
 # homeassistant.components.geonetnz_volcano
-aio-geojson-geonetnz-volcano==0.8
+aio-geojson-geonetnz-volcano==0.9
 
 # homeassistant.components.nsw_rural_fire_service_feed
 aio-geojson-nsw-rfs-incidents==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -855,7 +855,7 @@ hole==0.8.0
 holidays==0.42
 
 # homeassistant.components.frontend
-home-assistant-frontend==20240207.0
+home-assistant-frontend==20240207.1
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1397,7 +1397,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'light.kitchen',
+            'value': 'kitchen',
           }),
         }),
         'intent': dict({
@@ -1422,7 +1422,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'light.kitchen',
+            'value': 'kitchen',
           }),
         }),
         'intent': dict({
@@ -1572,7 +1572,7 @@
           'name': dict({
             'name': 'name',
             'text': 'test light',
-            'value': 'light.demo_1234',
+            'value': 'test light',
           }),
         }),
         'intent': dict({
@@ -1604,7 +1604,7 @@
           'name': dict({
             'name': 'name',
             'text': 'test light',
-            'value': 'light.demo_1234',
+            'value': 'test light',
           }),
         }),
         'intent': dict({

--- a/tests/components/conversation/snapshots/test_init.ambr
+++ b/tests/components/conversation/snapshots/test_init.ambr
@@ -1397,7 +1397,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'kitchen',
+            'value': 'my cool light',
           }),
         }),
         'intent': dict({
@@ -1422,7 +1422,7 @@
           'name': dict({
             'name': 'name',
             'text': 'my cool light',
-            'value': 'kitchen',
+            'value': 'my cool light',
           }),
         }),
         'intent': dict({

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -101,7 +101,7 @@ async def test_exposed_areas(
     device_registry.async_update_device(kitchen_device.id, area_id=area_kitchen.id)
 
     kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
-    entity_registry.async_update_entity(
+    kitchen_light = entity_registry.async_update_entity(
         kitchen_light.entity_id, device_id=kitchen_device.id
     )
     hass.states.async_set(
@@ -109,7 +109,7 @@ async def test_exposed_areas(
     )
 
     bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
-    entity_registry.async_update_entity(
+    bedroom_light = entity_registry.async_update_entity(
         bedroom_light.entity_id, area_id=area_bedroom.id
     )
     hass.states.async_set(
@@ -206,14 +206,14 @@ async def test_unexposed_entities_skipped(
 
     # Both lights are in the kitchen
     exposed_light = entity_registry.async_get_or_create("light", "demo", "1234")
-    entity_registry.async_update_entity(
+    exposed_light = entity_registry.async_update_entity(
         exposed_light.entity_id,
         area_id=area_kitchen.id,
     )
     hass.states.async_set(exposed_light.entity_id, "off")
 
     unexposed_light = entity_registry.async_get_or_create("light", "demo", "5678")
-    entity_registry.async_update_entity(
+    unexposed_light = entity_registry.async_update_entity(
         unexposed_light.entity_id,
         area_id=area_kitchen.id,
     )
@@ -336,7 +336,9 @@ async def test_device_area_context(
             light_entity = entity_registry.async_get_or_create(
                 "light", "demo", f"{area.name}-light-{i}"
             )
-            entity_registry.async_update_entity(light_entity.entity_id, area_id=area.id)
+            light_entity = entity_registry.async_update_entity(
+                light_entity.entity_id, area_id=area.id
+            )
             hass.states.async_set(
                 light_entity.entity_id,
                 "off",
@@ -692,7 +694,7 @@ async def test_empty_aliases(
 
         names = slot_lists["name"]
         assert len(names.values) == 1
-        assert names.values[0].value_out == kitchen_light.entity_id
+        assert names.values[0].value_out == kitchen_light.name
         assert names.values[0].text_in.text == kitchen_light.name
 
 
@@ -713,3 +715,82 @@ async def test_all_domains_loaded(hass: HomeAssistant, init_components) -> None:
         result.response.speech["plain"]["speech"]
         == "Sorry, I am not aware of any device called test light"
     )
+
+
+async def test_same_named_entities_in_different_areas(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities with the same name in different areas can be targeted."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+
+    # Both lights have the same name, but are in different areas
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        area_id=area_kitchen.id,
+        name="overhead light",
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+
+    bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    bedroom_light = entity_registry.async_update_entity(
+        bedroom_light.entity_id,
+        area_id=area_bedroom.id,
+        name="overhead light",
+    )
+    hass.states.async_set(
+        bedroom_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: bedroom_light.name},
+    )
+
+    # Target kitchen light
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the kitchen", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert (
+        result.response.intent.slots.get("name", {}).get("value") == kitchen_light.name
+    )
+    assert (
+        result.response.intent.slots.get("name", {}).get("text") == kitchen_light.name
+    )
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
+    assert calls[0].data.get("entity_id") == [kitchen_light.entity_id]
+
+    # Target bedroom light
+    calls.clear()
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the bedroom", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert (
+        result.response.intent.slots.get("name", {}).get("value") == bedroom_light.name
+    )
+    assert (
+        result.response.intent.slots.get("name", {}).get("text") == bedroom_light.name
+    )
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
+    assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -614,6 +614,115 @@ async def test_error_no_intent(hass: HomeAssistant, init_components) -> None:
         )
 
 
+async def test_error_duplicate_names(
+    hass: HomeAssistant, init_components, entity_registry: er.EntityRegistry
+) -> None:
+    """Test error message when multiple devices have the same name (or alias)."""
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Check name and alias
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name}"
+        )
+
+        # question
+        result = await conversation.async_converse(
+            hass, f"is {name} on?", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name}"
+        )
+
+
+async def test_error_duplicate_names_in_area(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test error message when multiple devices have the same name (or alias)."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    kitchen_light_1 = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light_2 = entity_registry.async_get_or_create("light", "demo", "5678")
+
+    # Same name and alias
+    for light in (kitchen_light_1, kitchen_light_2):
+        light = entity_registry.async_update_entity(
+            light.entity_id,
+            name="kitchen light",
+            area_id=area_kitchen.id,
+            aliases={"overhead light"},
+        )
+        hass.states.async_set(
+            light.entity_id,
+            "off",
+            attributes={ATTR_FRIENDLY_NAME: light.name},
+        )
+
+    # Check name and alias
+    for name in ("kitchen light", "overhead light"):
+        # command
+        result = await conversation.async_converse(
+            hass, f"turn on {name} in {area_kitchen.name}", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name} in the {area_kitchen.name} area"
+        )
+
+        # question
+        result = await conversation.async_converse(
+            hass, f"is {name} on in the {area_kitchen.name}?", None, Context(), None
+        )
+        assert result.response.response_type == intent.IntentResponseType.ERROR
+        assert (
+            result.response.error_code
+            == intent.IntentResponseErrorCode.NO_VALID_TARGETS
+        )
+        assert (
+            result.response.speech["plain"]["speech"]
+            == f"Sorry, there are multiple devices called {name} in the {area_kitchen.name} area"
+        )
+
+
 async def test_no_states_matched_default_error(
     hass: HomeAssistant, init_components, area_registry: ar.AreaRegistry
 ) -> None:
@@ -794,3 +903,112 @@ async def test_same_named_entities_in_different_areas(
     assert len(result.response.matched_states) == 1
     assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
     assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]
+
+    # Targeting a duplicate name should fail
+    result = await conversation.async_converse(
+        hass, "turn on overhead light", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # Querying a duplicate name should also fail
+    result = await conversation.async_converse(
+        hass, "is the overhead light on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # But we can still ask questions that don't rely on the name
+    result = await conversation.async_converse(
+        hass, "how many lights are on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER
+
+
+async def test_same_aliased_entities_in_different_areas(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that entities with the same alias (but different names) in different areas can be targeted."""
+    area_kitchen = area_registry.async_get_or_create("kitchen_id")
+    area_kitchen = area_registry.async_update(area_kitchen.id, name="kitchen")
+
+    area_bedroom = area_registry.async_get_or_create("bedroom_id")
+    area_bedroom = area_registry.async_update(area_bedroom.id, name="bedroom")
+
+    # Both lights have the same alias, but are in different areas
+    kitchen_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    kitchen_light = entity_registry.async_update_entity(
+        kitchen_light.entity_id,
+        area_id=area_kitchen.id,
+        name="kitchen overhead light",
+        aliases={"overhead light"},
+    )
+    hass.states.async_set(
+        kitchen_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: kitchen_light.name},
+    )
+
+    bedroom_light = entity_registry.async_get_or_create("light", "demo", "5678")
+    bedroom_light = entity_registry.async_update_entity(
+        bedroom_light.entity_id,
+        area_id=area_bedroom.id,
+        name="bedroom overhead light",
+        aliases={"overhead light"},
+    )
+    hass.states.async_set(
+        bedroom_light.entity_id,
+        "off",
+        attributes={ATTR_FRIENDLY_NAME: bedroom_light.name},
+    )
+
+    # Target kitchen light
+    calls = async_mock_service(hass, "light", "turn_on")
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the kitchen", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
+    assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == kitchen_light.entity_id
+    assert calls[0].data.get("entity_id") == [kitchen_light.entity_id]
+
+    # Target bedroom light
+    calls.clear()
+    result = await conversation.async_converse(
+        hass, "turn on overhead light in the bedroom", None, Context(), None
+    )
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert result.response.intent is not None
+    assert result.response.intent.slots.get("name", {}).get("value") == "overhead light"
+    assert result.response.intent.slots.get("name", {}).get("text") == "overhead light"
+    assert len(result.response.matched_states) == 1
+    assert result.response.matched_states[0].entity_id == bedroom_light.entity_id
+    assert calls[0].data.get("entity_id") == [bedroom_light.entity_id]
+
+    # Targeting a duplicate alias should fail
+    result = await conversation.async_converse(
+        hass, "turn on overhead light", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # Querying a duplicate alias should also fail
+    result = await conversation.async_converse(
+        hass, "is the overhead light on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.ERROR
+
+    # But we can still ask questions that don't rely on the alias
+    result = await conversation.async_converse(
+        hass, "how many lights are on?", None, Context(), None
+    )
+    assert result.response.response_type == intent.IntentResponseType.QUERY_ANSWER

--- a/tests/components/emulated_hue/test_init.py
+++ b/tests/components/emulated_hue/test_init.py
@@ -1,7 +1,9 @@
 """Test the Emulated Hue component."""
 from datetime import timedelta
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
+
+from aiohttp import web
 
 from homeassistant.components.emulated_hue.config import (
     DATA_KEY,
@@ -135,6 +137,9 @@ async def test_setup_works(hass: HomeAssistant) -> None:
         AsyncMock(),
     ) as mock_create_upnp_datagram_endpoint, patch(
         "homeassistant.components.emulated_hue.async_get_source_ip"
+    ), patch(
+        "homeassistant.components.emulated_hue.web.TCPSite",
+        return_value=Mock(spec_set=web.TCPSite),
     ):
         mock_create_upnp_datagram_endpoint.return_value = AsyncMock(
             spec=UPNPResponderProtocol

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -293,7 +293,7 @@ async def test_setup_api_push_api_data(
     assert aioclient_mock.call_count == 19
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
-    assert aioclient_mock.mock_calls[1][2]["watchdog"]
+    assert "watchdog" not in aioclient_mock.mock_calls[1][2]
 
 
 async def test_setup_api_push_api_data_server_host(

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -144,10 +144,10 @@ async def test_node_added_subscription(
     integration: MagicMock,
 ) -> None:
     """Test subscription to new devices work."""
-    assert matter_client.subscribe_events.call_count == 4
+    assert matter_client.subscribe_events.call_count == 5
     assert (
         matter_client.subscribe_events.call_args.kwargs["event_filter"]
-        == EventType.NODE_ADDED
+        == EventType.NODE_UPDATED
     )
 
     node_added_callback = matter_client.subscribe_events.call_args.kwargs["callback"]

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -229,6 +229,7 @@ async def test_node_diagnostics(
         mac_address="00:11:22:33:44:55",
         available=True,
         active_fabrics=[MatterFabricData(2, 4939, 1, vendor_name="Nabu Casa")],
+        active_fabric_index=0,
     )
     matter_client.node_diagnostics = AsyncMock(return_value=mock_diagnostics)
 

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -42,6 +42,8 @@ from homeassistant.components.modbus.const import (
     CONF_HVAC_MODE_REGISTER,
     CONF_HVAC_MODE_VALUES,
     CONF_HVAC_ONOFF_REGISTER,
+    CONF_MAX_TEMP,
+    CONF_MIN_TEMP,
     CONF_TARGET_TEMP,
     CONF_TARGET_TEMP_WRITE_REGISTERS,
     CONF_WRITE_REGISTERS,
@@ -167,6 +169,30 @@ ENTITY_ID = f"{CLIMATE_DOMAIN}.{TEST_ENTITY_NAME}".replace(" ", "_")
                             "state_auto": 6,
                         },
                     },
+                }
+            ],
+        },
+        {
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_TARGET_TEMP: 117,
+                    CONF_ADDRESS: 117,
+                    CONF_SLAVE: 10,
+                    CONF_MIN_TEMP: 23,
+                    CONF_MAX_TEMP: 57,
+                }
+            ],
+        },
+        {
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_TARGET_TEMP: 117,
+                    CONF_ADDRESS: 117,
+                    CONF_SLAVE: 10,
+                    CONF_MIN_TEMP: -57,
+                    CONF_MAX_TEMP: -23,
                 }
             ],
         },

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -688,6 +688,16 @@ async def test_config_wrong_struct_sensor(
             False,
             "112594",
         ),
+        (
+            {
+                CONF_DATA_TYPE: DataType.INT16,
+                CONF_SCALE: -1,
+                CONF_OFFSET: 0,
+            },
+            [0x000A],
+            False,
+            "-10",
+        ),
     ],
 )
 async def test_all_sensor(hass: HomeAssistant, mock_do_cycle, expected) -> None:

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -185,6 +185,28 @@ SLAVE_UNIQUE_ID = "ground_floor_sensor"
                 }
             ]
         },
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_DATA_TYPE: DataType.INT16,
+                    CONF_MIN_VALUE: 1,
+                    CONF_MAX_VALUE: 3,
+                }
+            ]
+        },
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_ENTITY_NAME,
+                    CONF_ADDRESS: 51,
+                    CONF_DATA_TYPE: DataType.INT16,
+                    CONF_MIN_VALUE: -3,
+                    CONF_MAX_VALUE: -1,
+                }
+            ]
+        },
     ],
 )
 async def test_config_sensor(hass: HomeAssistant, mock_modbus) -> None:


### PR DESCRIPTION
- Catch APIRateLimit in Honeywell ([@mkmer] - [#107806]) ([honeywell docs])
- Allow disabling home assistant watchdog ([@mdegat01] - [#109818]) ([hassio docs])
- Assist fixes ([@synesthesiam] - [#109889]) ([climate docs]) ([conversation docs]) ([intent docs])
- Bump Python matter server to 5.5.0 ([@marcelveldt] - [#109894]) ([matter docs]) (dependency)
- Bump aioelectricitymaps to 0.4.0 ([@jpbede] - [#109895]) ([co2signal docs]) (dependency)
- Skip polling of unavailable Matter nodes ([@marcelveldt] - [#109917]) ([matter docs])
- Bump aio-geojson-geonetnz-volcano to 0.9 ([@exxamalte] - [#109940]) ([geonetnz_volcano docs]) (dependency)
- Handle Matter nodes that become available after startup is done ([@marcelveldt] - [#109956]) ([matter docs])
- Allow modbus "scale" to be negative. ([@janiversen] - [#109965]) ([modbus docs])
- Don't blow up if config entries have unhashable unique IDs ([@emontnemery] - [#109966])
- Bump pyMicrobot to 0.0.12 ([@spycle] - [#109970]) ([keymitt_ble docs]) (dependency)
- Allow modbus min/max temperature to be negative. ([@janiversen] - [#109977]) ([modbus docs])
- Bump deebot-client to 5.1.1 ([@edenhaus] - [#109994]) ([ecovacs docs]) (dependency)
- Allow modbus negative min/max value. ([@janiversen] - [#109995]) ([modbus docs])
- Bump aioecowitt to 2024.2.1 ([@edenhaus] - [#109999]) ([ecowitt docs]) (dependency)
- Avoid key_error in modbus climate with non-defined fan_mode. ([@janiversen] - [#110017]) ([modbus docs])
- Update frontend to 20240207.1 ([@bramkragten] - [#110039]) ([frontend docs])
- Log error and continue on parsing issues of translated strings ([@mib1185] - [#110046])
- Matching duplicate named entities is now an error in Assist ([@synesthesiam] - [#110050]) ([conversation docs]) ([intent docs])
- Bump evohome-async to 0.4.18 ([@zxdavb] - [#110056]) ([evohome docs]) (dependency)
- Bump py-aosmith to 1.0.8 ([@bdr99] - [#110061]) ([aosmith docs]) (dependency)

[#107806]: https://github.com/home-assistant/core/pull/107806
[#109818]: https://github.com/home-assistant/core/pull/109818
[#109883]: https://github.com/home-assistant/core/pull/109883
[#109889]: https://github.com/home-assistant/core/pull/109889
[#109894]: https://github.com/home-assistant/core/pull/109894
[#109895]: https://github.com/home-assistant/core/pull/109895
[#109917]: https://github.com/home-assistant/core/pull/109917
[#109940]: https://github.com/home-assistant/core/pull/109940
[#109956]: https://github.com/home-assistant/core/pull/109956
[#109965]: https://github.com/home-assistant/core/pull/109965
[#109966]: https://github.com/home-assistant/core/pull/109966
[#109970]: https://github.com/home-assistant/core/pull/109970
[#109977]: https://github.com/home-assistant/core/pull/109977
[#109994]: https://github.com/home-assistant/core/pull/109994
[#109995]: https://github.com/home-assistant/core/pull/109995
[#109999]: https://github.com/home-assistant/core/pull/109999
[#110017]: https://github.com/home-assistant/core/pull/110017
[#110039]: https://github.com/home-assistant/core/pull/110039
[#110046]: https://github.com/home-assistant/core/pull/110046
[#110050]: https://github.com/home-assistant/core/pull/110050
[#110056]: https://github.com/home-assistant/core/pull/110056
[#110061]: https://github.com/home-assistant/core/pull/110061
[@bdr99]: https://github.com/bdr99
[@bramkragten]: https://github.com/bramkragten
[@edenhaus]: https://github.com/edenhaus
[@emontnemery]: https://github.com/emontnemery
[@exxamalte]: https://github.com/exxamalte
[@frenck]: https://github.com/frenck
[@janiversen]: https://github.com/janiversen
[@jpbede]: https://github.com/jpbede
[@marcelveldt]: https://github.com/marcelveldt
[@mdegat01]: https://github.com/mdegat01
[@mib1185]: https://github.com/mib1185
[@mkmer]: https://github.com/mkmer
[@spycle]: https://github.com/spycle
[@synesthesiam]: https://github.com/synesthesiam
[@zxdavb]: https://github.com/zxdavb
[abode docs]: https://www.home-assistant.io/integrations/abode/
[aosmith docs]: https://www.home-assistant.io/integrations/aosmith/
[climate docs]: https://www.home-assistant.io/integrations/climate/
[co2signal docs]: https://www.home-assistant.io/integrations/co2signal/
[conversation docs]: https://www.home-assistant.io/integrations/conversation/
[ecovacs docs]: https://www.home-assistant.io/integrations/ecovacs/
[ecowitt docs]: https://www.home-assistant.io/integrations/ecowitt/
[evohome docs]: https://www.home-assistant.io/integrations/evohome/
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[geonetnz_volcano docs]: https://www.home-assistant.io/integrations/geonetnz_volcano/
[hassio docs]: https://www.home-assistant.io/integrations/hassio/
[honeywell docs]: https://www.home-assistant.io/integrations/honeywell/
[intent docs]: https://www.home-assistant.io/integrations/intent/
[keymitt_ble docs]: https://www.home-assistant.io/integrations/keymitt_ble/
[matter docs]: https://www.home-assistant.io/integrations/matter/
[modbus docs]: https://www.home-assistant.io/integrations/modbus/

Docs PR: <https://github.com/home-assistant/home-assistant.io/pull/31332>