### PR TITLE
Properly report cover positions to prometheus

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -21,7 +21,10 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_LOW,
     HVACAction,
 )
-from homeassistant.components.cover import ATTR_POSITION, ATTR_TILT_POSITION
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+)
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.components.humidifier import ATTR_AVAILABLE_MODES, ATTR_HUMIDITY
 from homeassistant.components.light import ATTR_BRIGHTNESS
@@ -437,7 +440,7 @@ class PrometheusMetrics:
                 float(cover_state == state.state)
             )
 
-        position = state.attributes.get(ATTR_POSITION)
+        position = state.attributes.get(ATTR_CURRENT_POSITION)
         if position is not None:
             position_metric = self._metric(
                 "cover_position",
@@ -446,7 +449,7 @@ class PrometheusMetrics:
             )
             position_metric.labels(**self._labels(state)).set(float(position))
 
-        tilt_position = state.attributes.get(ATTR_TILT_POSITION)
+        tilt_position = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
         if tilt_position is not None:
             tilt_position_metric = self._metric(
                 "cover_tilt_position",

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -1352,7 +1352,7 @@ async def cover_fixture(
         suggested_object_id="position_shade",
         original_name="Position Shade",
     )
-    cover_position_attributes = {cover.ATTR_POSITION: 50}
+    cover_position_attributes = {cover.ATTR_CURRENT_POSITION: 50}
     set_state_with_entry(hass, cover_position, STATE_OPEN, cover_position_attributes)
     data["cover_position"] = cover_position
 
@@ -1363,7 +1363,7 @@ async def cover_fixture(
         suggested_object_id="tilt_position_shade",
         original_name="Tilt Position Shade",
     )
-    cover_tilt_position_attributes = {cover.ATTR_TILT_POSITION: 50}
+    cover_tilt_position_attributes = {cover.ATTR_CURRENT_TILT_POSITION: 50}
     set_state_with_entry(
         hass, cover_tilt_position, STATE_OPEN, cover_tilt_position_attributes
     )


### PR DESCRIPTION
This component was using the attributes for **setting** position and tilt instead of the attributes for **getting** them, resulting in no metrics. See https://developers.home-assistant.io/docs/core/entity/cover/#properties.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #110156

Locally tested: 

```
# HELP homeassistant_cover_state State of the cover (0/1)
# TYPE homeassistant_cover_state gauge
homeassistant_cover_state{domain="cover",entity="cover.garage_door",friendly_name="test cover",state="closed"} 0.0
homeassistant_cover_state{domain="cover",entity="cover.garage_door",friendly_name="test cover",state="closing"} 0.0
homeassistant_cover_state{domain="cover",entity="cover.garage_door",friendly_name="test cover",state="open"} 1.0
homeassistant_cover_state{domain="cover",entity="cover.garage_door",friendly_name="test cover",state="opening"} 0.0
# HELP homeassistant_cover_position Position of the cover (0-100)
# TYPE homeassistant_cover_position gauge
homeassistant_cover_position{domain="cover",entity="cover.garage_door",friendly_name="test cover"} 47.0
# HELP homeassistant_cover_tilt_position Tilt Position of the cover (0-100)
# TYPE homeassistant_cover_tilt_position gauge
homeassistant_cover_tilt_position{domain="cover",entity="cover.garage_door",friendly_name="test cover"} 32.0
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
