### PR TITLE
Bump datapoint to 0.9.9 + re-enable Met Office Integration

### DIFF
--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import re
 import sys
+import datapoint
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -33,9 +34,6 @@ from .const import (
 )
 from .data import MetOfficeData
 from .helpers import fetch_data, fetch_site
-
-if sys.version_info < (3, 12):
-    import datapoint
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
-import sys
 from typing import Any
 
 import datapoint
@@ -18,7 +17,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import TimestampDataUpdateCoordinator

--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -5,8 +5,9 @@ import asyncio
 import logging
 import re
 import sys
-import datapoint
 from typing import Any
+
+import datapoint
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (

--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -43,10 +43,6 @@ PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a Met Office entry."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "Met Office is not supported on Python 3.12. Please use Python 3.11."
-        )
 
     latitude = entry.data[CONF_LATITUDE]
     longitude = entry.data[CONF_LONGITUDE]

--- a/homeassistant/components/metoffice/data.py
+++ b/homeassistant/components/metoffice/data.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import sys
 
 from datapoint.Forecast import Forecast
 from datapoint.Site import Site

--- a/homeassistant/components/metoffice/data.py
+++ b/homeassistant/components/metoffice/data.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 import sys
 
-if sys.version_info < (3, 12):
-    from datapoint.Forecast import Forecast
-    from datapoint.Site import Site
-    from datapoint.Timestep import Timestep
+from datapoint.Forecast import Forecast
+from datapoint.Site import Site
+from datapoint.Timestep import Timestep
 
 
 @dataclass

--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import logging
-import sys
-
-from homeassistant.helpers.update_coordinator import UpdateFailed
-from homeassistant.util.dt import utcnow
 
 import datapoint
 from datapoint.Site import Site
+
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util.dt import utcnow
 
 from .const import MODE_3HOURLY
 from .data import MetOfficeData

--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -7,13 +7,11 @@ import sys
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util.dt import utcnow
 
+import datapoint
+from datapoint.Site import Site
+
 from .const import MODE_3HOURLY
 from .data import MetOfficeData
-
-if sys.version_info < (3, 12):
-    import datapoint
-    from datapoint.Site import Site
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/metoffice/helpers.py
+++ b/homeassistant/components/metoffice/helpers.py
@@ -34,7 +34,7 @@ def fetch_site(
 def fetch_data(connection: datapoint.Manager, site: Site, mode: str) -> MetOfficeData:
     """Fetch weather and forecast from Datapoint API."""
     try:
-        forecast = connection.get_forecast_for_site(site.id, mode)
+        forecast = connection.get_forecast_for_site(site.location_id, mode)
     except (ValueError, datapoint.exceptions.APIException) as err:
         _LOGGER.error("Check Met Office connection: %s", err.args)
         raise UpdateFailed from err

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -3,7 +3,6 @@
   "name": "Met Office",
   "codeowners": ["@MrHarcombe", "@avee87"],
   "config_flow": true,
-  "disabled": "Integration library not compatible with Python 3.12",
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "iot_class": "cloud_polling",
   "loggers": ["datapoint"],

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "iot_class": "cloud_polling",
   "loggers": ["datapoint"],
-  "requirements": ["datapoint==0.9.8;python_version<'3.12'"]
+  "requirements": ["datapoint==0.9.9;python_version<'3.12'"]
 }

--- a/homeassistant/components/metoffice/manifest.json
+++ b/homeassistant/components/metoffice/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/metoffice",
   "iot_class": "cloud_polling",
   "loggers": ["datapoint"],
-  "requirements": ["datapoint==0.9.9;python_version<'3.12'"]
+  "requirements": ["datapoint==0.9.9"]
 }

--- a/homeassistant/components/metoffice/sensor.py
+++ b/homeassistant/components/metoffice/sensor.py
@@ -251,6 +251,6 @@ class MetOfficeCurrentSensor(
         return {
             ATTR_LAST_UPDATE: self.coordinator.data.now.date,
             ATTR_SENSOR_ID: self.entity_description.key,
-            ATTR_SITE_ID: self.coordinator.data.site.id,
+            ATTR_SITE_ID: self.coordinator.data.site.location_id,
             ATTR_SITE_NAME: self.coordinator.data.site.name,
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -71,6 +71,8 @@ PyMVGLive==1.1.4
 # homeassistant.components.met_eireann
 PyMetEireann==2021.8.0
 
+# homeassistant.components.met
+
 # homeassistant.components.metoffice
 datapoint==0.9.9
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -71,7 +71,9 @@ PyMVGLive==1.1.4
 # homeassistant.components.met_eireann
 PyMetEireann==2021.8.0
 
-# homeassistant.components.met
+# homeassistant.components.metoffice
+datapoint==0.9.9
+
 # homeassistant.components.norway_air
 PyMetno==0.11.0
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -72,10 +72,6 @@ PyMVGLive==1.1.4
 PyMetEireann==2021.8.0
 
 # homeassistant.components.met
-
-# homeassistant.components.metoffice
-datapoint==0.9.9
-
 # homeassistant.components.norway_air
 PyMetno==0.11.0
 
@@ -683,6 +679,9 @@ crownstone-uart==2.1.0
 
 # homeassistant.components.datadog
 datadog==0.15.0
+
+# homeassistant.components.metoffice
+datapoint==0.9.9
 
 # homeassistant.components.bluetooth
 dbus-fast==2.21.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -561,6 +561,9 @@ crownstone-uart==2.1.0
 # homeassistant.components.datadog
 datadog==0.15.0
 
+# homeassistant.components.metoffice
+datapoint==0.9.9
+
 # homeassistant.components.bluetooth
 dbus-fast==2.21.1
 

--- a/tests/components/metoffice/conftest.py
+++ b/tests/components/metoffice/conftest.py
@@ -1,13 +1,9 @@
 """Fixtures for Met Office weather integration tests."""
 from unittest.mock import patch
 
+from datapoint.exceptions import APIException
 import pytest
 
-# All tests are marked as disabled, as the integration is disabled in the
-# integration manifest. `datapoint` isn't compatible with Python 3.12
-#
-# from datapoint.exceptions import APIException
-APIException = Exception
 collect_ignore_glob = ["test_*.py"]
 
 

--- a/tests/components/metoffice/conftest.py
+++ b/tests/components/metoffice/conftest.py
@@ -4,8 +4,6 @@ from unittest.mock import patch
 from datapoint.exceptions import APIException
 import pytest
 
-collect_ignore_glob = ["test_*.py"]
-
 
 @pytest.fixture
 def mock_simple_manager_fail():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The change is to bump the datapoint dependency and update two files that still use `site.id` and bring them in-line with `datapoint-python` 0.9.9 to allow functionality to continue if the integration is re-enabled on a temporary basis until the new API wrapper can be developed.

Datapoint CHANGELOG (incl. all prior): https://github.com/EJEP/datapoint-python/blob/migrate_to_datahub/CHANGELOG.md

Datapoint PRIMARY DIFF: https://github.com/EJEP/datapoint-python/commit/c07b274a87895bb67bc297947fc8957da92d6bec

Further files have been changed and can be seen here: https://github.com/EJEP/datapoint-python/commits/master/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #108163
- This PR is related to issue: https://github.com/home-assistant/core/issues/109301
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
