### PR TITLE
Fix Motionblinds brand name consistency

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 hass.config_entries.async_update_entry(entry, data=data)
                 _LOGGER.debug(
                     (
-                        "Motion Blinds interface updated from %s to %s, "
+                        "Motionblinds interface updated from %s to %s, "
                         "this should only occur after a network change"
                     ),
                     multicast_interface,

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow to configure Motion Blinds using their WLAN API."""
+"""Config flow to configure Motionblinds using their WLAN API."""
 from __future__ import annotations
 
 from typing import Any
@@ -62,12 +62,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
 
 class MotionBlindsFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a Motion Blinds config flow."""
+    """Handle a Motionblinds config flow."""
 
     VERSION = 1
 
     def __init__(self) -> None:
-        """Initialize the Motion Blinds flow."""
+        """Initialize the Motionblinds flow."""
         self._host: str | None = None
         self._ips: list[str] = []
         self._config_settings = None

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -2,8 +2,8 @@
 from homeassistant.const import Platform
 
 DOMAIN = "motion_blinds"
-MANUFACTURER = "Motion Blinds, Coulisse B.V."
-DEFAULT_GATEWAY_NAME = "Motion Blinds Gateway"
+MANUFACTURER = "Motionblinds, Coulisse B.V."
+DEFAULT_GATEWAY_NAME = "Motionblinds Gateway"
 
 PLATFORMS = [Platform.COVER, Platform.SENSOR]
 

--- a/homeassistant/components/motion_blinds/const.py
+++ b/homeassistant/components/motion_blinds/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Motion Blinds component."""
+"""Constants for the Motionblinds component."""
 from homeassistant.const import Platform
 
 DOMAIN = "motion_blinds"

--- a/homeassistant/components/motion_blinds/coordinator.py
+++ b/homeassistant/components/motion_blinds/coordinator.py
@@ -1,4 +1,4 @@
-"""DataUpdateCoordinator for motion blinds integration."""
+"""DataUpdateCoordinator for Motionblinds integration."""
 import asyncio
 from datetime import timedelta
 import logging

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -1,4 +1,4 @@
-"""Support for Motion Blinds using their WLAN API."""
+"""Support for Motionblinds using their WLAN API."""
 from __future__ import annotations
 
 import logging

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -86,7 +86,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Motion Blind from a config entry."""
+    """Set up the Motionblind from a config entry."""
     entities = []
     motion_gateway = hass.data[DOMAIN][config_entry.entry_id][KEY_GATEWAY]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
@@ -169,7 +169,7 @@ async def async_setup_entry(
 
 
 class MotionPositionDevice(MotionCoordinatorEntity, CoverEntity):
-    """Representation of a Motion Blind Device."""
+    """Representation of a Motionblinds Device."""
 
     _attr_name = None
     _restore_tilt = False
@@ -306,7 +306,7 @@ class MotionPositionDevice(MotionCoordinatorEntity, CoverEntity):
 
 
 class MotionTiltDevice(MotionPositionDevice):
-    """Representation of a Motion Blind Device."""
+    """Representation of a Motionblinds Device."""
 
     _restore_tilt = True
 
@@ -352,7 +352,7 @@ class MotionTiltDevice(MotionPositionDevice):
 
 
 class MotionTiltOnlyDevice(MotionTiltDevice):
-    """Representation of a Motion Blind Device."""
+    """Representation of a Motionblinds Device."""
 
     _restore_tilt = False
 

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -1,4 +1,4 @@
-"""Support for Motion Blinds using their WLAN API."""
+"""Support for Motionblinds using their WLAN API."""
 from __future__ import annotations
 
 from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, MotionGateway
@@ -20,7 +20,7 @@ from .gateway import device_name
 
 
 class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlinds]):
-    """Representation of a Motion Blind entity."""
+    """Representation of a Motionblind entity."""
 
     _attr_has_entity_name = True
 

--- a/homeassistant/components/motion_blinds/gateway.py
+++ b/homeassistant/components/motion_blinds/gateway.py
@@ -100,7 +100,7 @@ class ConnectMotionGateway:
         interfaces = await self.async_get_interfaces()
         for interface in interfaces:
             _LOGGER.debug(
-                "Checking Motion Blinds interface '%s' with host %s", interface, host
+                "Checking Motionblinds interface '%s' with host %s", interface, host
             )
             # initialize multicast listener
             check_multicast = AsyncMotionMulticast(interface=interface)
@@ -126,7 +126,7 @@ class ConnectMotionGateway:
             if result:
                 # successfully received multicast
                 _LOGGER.debug(
-                    "Success using Motion Blinds interface '%s' with host %s",
+                    "Success using Motionblinds interface '%s' with host %s",
                     interface,
                     host,
                 )
@@ -134,7 +134,7 @@ class ConnectMotionGateway:
 
         _LOGGER.error(
             (
-                "Could not find working interface for Motion Blinds host %s, using"
+                "Could not find working interface for Motionblinds host %s, using"
                 " interface '%s'"
             ),
             host,

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "motion_blinds",
-  "name": "Motion Blinds",
+  "name": "Motionblinds",
   "codeowners": ["@starkillerOG"],
   "config_flow": true,
   "dependencies": ["network"],

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -1,4 +1,4 @@
-"""Support for Motion Blinds sensors."""
+"""Support for Motionblinds sensors."""
 from motionblinds import DEVICE_TYPES_WIFI
 from motionblinds.motion_blinds import DEVICE_TYPE_TDBU
 
@@ -23,7 +23,7 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Perform the setup for Motion Blinds."""
+    """Perform the setup for Motionblinds."""
     entities: list[SensorEntity] = []
     motion_gateway = hass.data[DOMAIN][config_entry.entry_id][KEY_GATEWAY]
     coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]

--- a/homeassistant/components/motion_blinds/services.yaml
+++ b/homeassistant/components/motion_blinds/services.yaml
@@ -1,4 +1,4 @@
-# Describes the format for available motion blinds services
+# Describes the format for available Motionblinds services
 
 set_absolute_position:
   target:

--- a/homeassistant/components/smart_blinds/manifest.json
+++ b/homeassistant/components/smart_blinds/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "smart_blinds",
-  "name": "Smart Blinds",
+  "name": "Smartblinds",
   "integration_type": "virtual",
   "supported_by": "motion_blinds"
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3693,7 +3693,7 @@
       "iot_class": "local_push"
     },
     "motion_blinds": {
-      "name": "Motion Blinds",
+      "name": "Motionblinds",
       "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_push"
@@ -5402,7 +5402,7 @@
       "iot_class": "cloud_polling"
     },
     "smart_blinds": {
-      "name": "Smart Blinds",
+      "name": "Smartblinds",
       "integration_type": "virtual",
       "supported_by": "motion_blinds"
     },

--- a/tests/components/motion_blinds/__init__.py
+++ b/tests/components/motion_blinds/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the Motion Blinds integration."""
+"""Tests for the Motionblinds integration."""

--- a/tests/components/motion_blinds/test_config_flow.py
+++ b/tests/components/motion_blinds/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Test the Motion Blinds config flow."""
+"""Test the Motionblinds config flow."""
 import socket
 from unittest.mock import Mock, patch
 
@@ -70,7 +70,7 @@ TEST_INTERFACES = [
 
 @pytest.fixture(name="motion_blinds_connect", autouse=True)
 def motion_blinds_connect_fixture(mock_get_source_ip):
-    """Mock motion blinds connection and entry setup."""
+    """Mock Motionblinds connection and entry setup."""
     with patch(
         "homeassistant.components.motion_blinds.gateway.MotionGateway.GetDeviceList",
         return_value=True,
@@ -362,7 +362,7 @@ async def test_dhcp_flow(hass: HomeAssistant) -> None:
 
 
 async def test_dhcp_flow_abort(hass: HomeAssistant) -> None:
-    """Test that DHCP discovery aborts if not Motion Blinds."""
+    """Test that DHCP discovery aborts if not Motionblinds."""
     dhcp_data = dhcp.DhcpServiceInfo(
         ip=TEST_HOST,
         hostname="MOTION_abcdef",

--- a/tests/components/motion_blinds/test_gateway.py
+++ b/tests/components/motion_blinds/test_gateway.py
@@ -1,4 +1,4 @@
-"""Test the Motion Blinds config flow."""
+"""Test the Motionblinds config flow."""
 from unittest.mock import Mock
 
 from motionblinds import DEVICE_TYPES_WIFI, BlindType


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to the below PR for the documentation, this PR fixes consistency in the usage of brand name **Motionblinds** in the motion_blinds integration.
https://github.com/home-assistant/home-assistant.io/pull/31353


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
