### PR TITLE
Update `denonavr` to `0.11.6`

### DIFF
--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
   "iot_class": "local_push",
   "loggers": ["denonavr"],
-  "requirements": ["denonavr==0.11.4"],
+  "requirements": ["denonavr==0.11.5"],
   "ssdp": [
     {
       "manufacturer": "Denon",

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
   "iot_class": "local_push",
   "loggers": ["denonavr"],
-  "requirements": ["denonavr==0.11.5"],
+  "requirements": ["denonavr==0.11.6"],
   "ssdp": [
     {
       "manufacturer": "Denon",

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -21,6 +21,7 @@ from denonavr.exceptions import (
     AvrCommandError,
     AvrForbiddenError,
     AvrNetworkError,
+    AvrProcessingError,
     AvrTimoutError,
     DenonAvrError,
 )
@@ -201,6 +202,16 @@ def async_log_errors(
                     self._receiver.host,
                 )
                 self._attr_available = False
+        except AvrProcessingError:
+            available = True
+            if self.available:
+                _LOGGER.warning(
+                    (
+                        "Update of Denon AVR receiver at host %s not complete. "
+                        "Device is still available"
+                    ),
+                    self._receiver.host,
+                )
         except AvrForbiddenError:
             available = False
             if self.available:

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -285,8 +285,6 @@ class DenonDevice(MediaPlayerEntity):
             and MediaPlayerEntityFeature.SELECT_SOUND_MODE
         )
 
-        self._telnet_was_healthy: bool | None = None
-
     async def _telnet_callback(self, zone: str, event: str, parameter: str) -> None:
         """Process a telnet command callback."""
         # There are multiple checks implemented which reduce unnecessary updates of the ha state machine
@@ -317,23 +315,12 @@ class DenonDevice(MediaPlayerEntity):
         """Get the latest status information from device."""
         receiver = self._receiver
 
-        # We can only skip the update if telnet was healthy after
-        # the last update and is still healthy now to ensure that
-        # we don't miss any state changes while telnet is down
-        # or reconnecting.
-        if (
-            telnet_is_healthy := receiver.telnet_connected and receiver.telnet_healthy
-        ) and self._telnet_was_healthy:
+        # We skip the update if telnet is healthy.
+        # When telnet recovers it automatically updates all properties.
+        if receiver.telnet_connected and receiver.telnet_healthy:
             return
 
-        # if async_update raises an exception, we don't want to skip the next update
-        # so we set _telnet_was_healthy to None here and only set it to the value
-        # before the update if the update was successful
-        self._telnet_was_healthy = None
-
         await receiver.async_update()
-
-        self._telnet_was_healthy = telnet_is_healthy
 
         if self._update_audyssey:
             await receiver.async_update_audyssey()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -704,7 +704,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.4
+denonavr==0.11.5
 
 # homeassistant.components.devialet
 devialet==1.4.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -704,7 +704,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.5
+denonavr==0.11.6
 
 # homeassistant.components.devialet
 devialet==1.4.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -579,7 +579,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.4
+denonavr==0.11.5
 
 # homeassistant.components.devialet
 devialet==1.4.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -579,7 +579,7 @@ deluge-client==1.7.1
 demetriek==0.4.0
 
 # homeassistant.components.denonavr
-denonavr==0.11.5
+denonavr==0.11.6
 
 # homeassistant.components.devialet
 devialet==1.4.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR updates denonavr library to 0.11.6 ([changelog 0.11.5](https://github.com/ol-iver/denonavr/releases/tag/0.11.5), [changelog 0.11.6](https://github.com/ol-iver/denonavr/releases/tag/0.11.6)).
Additionally, it adds handling for `AvrProcessingError` exceptions and removes code which is obsolete since version `0.11.5`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issues: 
  - fixes #105514
  - fixes #106484 
  - fixes #107412 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
