### PR TITLE
Handle no data error in Electricity Maps config flow

### DIFF
--- a/homeassistant/components/co2signal/config_flow.py
+++ b/homeassistant/components/co2signal/config_flow.py
@@ -8,6 +8,7 @@ from aioelectricitymaps import (
     ElectricityMaps,
     ElectricityMapsError,
     ElectricityMapsInvalidTokenError,
+    ElectricityMapsNoDataError,
 )
 import voluptuous as vol
 
@@ -151,6 +152,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await fetch_latest_carbon_intensity(self.hass, em, data)
             except ElectricityMapsInvalidTokenError:
                 errors["base"] = "invalid_auth"
+            except ElectricityMapsNoDataError:
+                errors["base"] = "no_data"
             except ElectricityMapsError:
                 errors["base"] = "unknown"
             else:

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -28,7 +28,7 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "no_data": "No data is provided for the location you have selected."
+      "no_data": "No data is available for the location you have selected."
     },
     "abort": {
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"

--- a/homeassistant/components/co2signal/strings.json
+++ b/homeassistant/components/co2signal/strings.json
@@ -28,12 +28,9 @@
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "api_ratelimit": "API Ratelimit exceeded"
+      "no_data": "No data is provided for the location you have selected."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "api_ratelimit": "[%key:component::co2signal::config::error::api_ratelimit%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },

--- a/tests/components/co2signal/test_config_flow.py
+++ b/tests/components/co2signal/test_config_flow.py
@@ -5,6 +5,7 @@ from aioelectricitymaps import (
     ElectricityMapsConnectionError,
     ElectricityMapsError,
     ElectricityMapsInvalidTokenError,
+    ElectricityMapsNoDataError,
 )
 import pytest
 
@@ -139,12 +140,9 @@ async def test_form_country(hass: HomeAssistant) -> None:
         ),
         (ElectricityMapsError("Something else"), "unknown"),
         (ElectricityMapsConnectionError("Boom"), "unknown"),
+        (ElectricityMapsNoDataError("I have no data"), "no_data"),
     ],
-    ids=[
-        "invalid auth",
-        "generic error",
-        "json decode error",
-    ],
+    ids=["invalid auth", "generic error", "json decode error", "no data error"],
 )
 async def test_form_error_handling(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change
The Electricity Maps can respond with `{"status": "no-data", ...}`, which means that no data is available for the selected region. The upstream lib raises a `ElectricityMapsNoDataError` in this case. This PR deals with this in the config flow.

Also remove `api_ratelimit` from `strings.json`, which is not needed anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
