### PR TITLE
Fix cpu percentage in System Monitor

### DIFF
--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinators for the System monitor integration."""
+
 from __future__ import annotations
 
 from abc import abstractmethod
@@ -43,7 +44,8 @@ dataT = TypeVar(
     | sswap
     | VirtualMemory
     | tuple[float, float, float]
-    | sdiskusage,
+    | sdiskusage
+    | None,
 )
 
 
@@ -130,12 +132,15 @@ class SystemMonitorLoadCoordinator(MonitorCoordinator[tuple[float, float, float]
         return os.getloadavg()
 
 
-class SystemMonitorProcessorCoordinator(MonitorCoordinator[float]):
+class SystemMonitorProcessorCoordinator(MonitorCoordinator[float | None]):
     """A System monitor Processor Data Update Coordinator."""
 
-    def update_data(self) -> float:
+    def update_data(self) -> float | None:
         """Fetch data."""
-        return psutil.cpu_percent(interval=None)
+        cpu_percent = psutil.cpu_percent(interval=None)
+        if cpu_percent > 0.0:
+            return cpu_percent
+        return None
 
 
 class SystemMonitorBootTimeCoordinator(MonitorCoordinator[datetime]):

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -346,7 +346,9 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription[Any]] = {
         native_unit_of_measurement=PERCENTAGE,
         icon=get_cpu_icon(),
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda entity: round(entity.coordinator.data),
+        value_fn=lambda entity: (
+            round(entity.coordinator.data) if entity.coordinator.data else None
+        ),
     ),
     "processor_temperature": SysMonitorSensorEntityDescription[
         dict[str, list[shwtemp]]

--- a/tests/components/systemmonitor/test_sensor.py
+++ b/tests/components/systemmonitor/test_sensor.py
@@ -1,4 +1,5 @@
 """Test System Monitor sensor."""
+
 from datetime import timedelta
 import socket
 from unittest.mock import Mock, patch
@@ -529,3 +530,37 @@ async def test_exception_handling_disk_sensor(
     assert disk_sensor is not None
     assert disk_sensor.state == "70.0"
     assert disk_sensor.attributes["unit_of_measurement"] == "%"
+
+
+async def test_cpu_percentage_is_zero_returns_unknown(
+    hass: HomeAssistant,
+    entity_registry_enabled_by_default: None,
+    mock_psutil: Mock,
+    mock_added_config_entry: ConfigEntry,
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the sensor."""
+    cpu_sensor = hass.states.get("sensor.system_monitor_processor_use")
+    assert cpu_sensor is not None
+    assert cpu_sensor.state == "10"
+
+    mock_psutil.cpu_percent.return_value = 0.0
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    cpu_sensor = hass.states.get("sensor.system_monitor_processor_use")
+    assert cpu_sensor is not None
+    assert cpu_sensor.state == STATE_UNKNOWN
+
+    mock_psutil.cpu_percent.return_value = 15.0
+
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    cpu_sensor = hass.states.get("sensor.system_monitor_processor_use")
+    assert cpu_sensor is not None
+    assert cpu_sensor.state == "15"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix cpu temperature in System Monitor.
A return of 0 is a false value so we should return `None` on such to declare unknown
https://psutil.readthedocs.io/en/latest/#psutil.cpu_percent

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109503
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
