### PR TITLE
Cleanup BLE-only controls when migrating HomeKit BLE device to Thread

### DIFF
--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_characteristic(char: Characteristic) -> bool:
-        entities: list[HomeKitButton | HomeKitEcobeeClearHoldButton] = []
+        entities: list[CharacteristicEntity] = []
         info = {"aid": char.service.accessory.aid, "iid": char.service.iid}
 
         if description := BUTTON_ENTITIES.get(char.type):
@@ -100,7 +100,11 @@ async def async_setup_entry(
     conn.add_char_factory(async_add_characteristic)
 
 
-class HomeKitButton(CharacteristicEntity, ButtonEntity):
+class BaseHomeKitButton(CharacteristicEntity, ButtonEntity):
+    """Base class for all HomeKit buttons."""
+
+
+class HomeKitButton(BaseHomeKitButton):
     """Representation of a Button control on a homekit accessory."""
 
     entity_description: HomeKitButtonEntityDescription
@@ -134,7 +138,7 @@ class HomeKitButton(CharacteristicEntity, ButtonEntity):
         await self.async_put_characteristics({key: val})
 
 
-class HomeKitEcobeeClearHoldButton(CharacteristicEntity, ButtonEntity):
+class HomeKitEcobeeClearHoldButton(BaseHomeKitButton):
     """Representation of a Button control for Ecobee clear hold request."""
 
     def get_characteristic_types(self) -> list[str]:
@@ -163,7 +167,7 @@ class HomeKitEcobeeClearHoldButton(CharacteristicEntity, ButtonEntity):
             await self.async_put_characteristics({key: val})
 
 
-class HomeKitProvisionPreferredThreadCredentials(CharacteristicEntity, ButtonEntity):
+class HomeKitProvisionPreferredThreadCredentials(BaseHomeKitButton):
     """A button users can press to migrate their HomeKit BLE device to Thread."""
 
     _attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -975,6 +975,7 @@ class HKDevice:
             raise HomeAssistantError("No thread network credentials available")
 
         await self.pairing.thread_provision(dataset)
+        self.pairing.controller.transport_type = TransportType.COAP
 
         try:
             discovery = (

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -544,7 +544,7 @@ class HKDevice:
                 current_unique_id.add((accessory.aid, service.iid, None))
 
                 for char in service.characteristics:
-                    if self.pairing.transport != TransportType.BLE:
+                    if self.pairing.transport != Transport.BLE:
                         if char.type == CharacteristicsTypes.THREAD_CONTROL_POINT:
                             continue
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -18,7 +18,7 @@ from aiohomekit.exceptions import (
     EncryptionError,
 )
 from aiohomekit.model import Accessories, Accessory, Transport
-from aiohomekit.model.characteristics import Characteristic
+from aiohomekit.model.characteristics import Characteristic, CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.thread.dataset_store import async_get_preferred_dataset
@@ -544,6 +544,10 @@ class HKDevice:
                 current_unique_id.add((accessory.aid, service.iid, None))
 
                 for char in service.characteristics:
+                    if self.pairing.transport != TransportType.BLE:
+                        if char.type == CharacteristicsTypes.THREAD_CONTROL_POINT:
+                            continue
+
                     current_unique_id.add(
                         (
                             accessory.aid,

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -975,7 +975,6 @@ class HKDevice:
             raise HomeAssistantError("No thread network credentials available")
 
         await self.pairing.thread_provision(dataset)
-        self.pairing.controller.transport_type = TransportType.COAP
 
         try:
             discovery = (

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -75,44 +75,6 @@
             'aliases': list([
             ]),
             'area_id': None,
-            'capabilities': None,
-            'config_entry_id': 'TestData',
-            'device_class': None,
-            'disabled_by': None,
-            'domain': 'button',
-            'entity_category': <EntityCategory.CONFIG: 'config'>,
-            'entity_id': 'button.airversa_ap2_1808_provision_preferred_thread_credentials',
-            'has_entity_name': False,
-            'hidden_by': None,
-            'icon': None,
-            'labels': list([
-            ]),
-            'name': None,
-            'options': dict({
-            }),
-            'original_device_class': None,
-            'original_icon': None,
-            'original_name': 'Airversa AP2 1808 Provision Preferred Thread Credentials',
-            'platform': 'homekit_controller',
-            'previous_unique_id': None,
-            'supported_features': 0,
-            'translation_key': None,
-            'unique_id': '00:00:00:00:00:00_1_112_119',
-            'unit_of_measurement': None,
-          }),
-          'state': dict({
-            'attributes': dict({
-              'friendly_name': 'Airversa AP2 1808 Provision Preferred Thread Credentials',
-            }),
-            'entity_id': 'button.airversa_ap2_1808_provision_preferred_thread_credentials',
-            'state': 'unknown',
-          }),
-        }),
-        dict({
-          'entry': dict({
-            'aliases': list([
-            ]),
-            'area_id': None,
             'capabilities': dict({
               'preset_modes': None,
             }),
@@ -14197,44 +14159,6 @@
               'friendly_name': 'Nanoleaf Strip 3B32 Identify',
             }),
             'entity_id': 'button.nanoleaf_strip_3b32_identify',
-            'state': 'unknown',
-          }),
-        }),
-        dict({
-          'entry': dict({
-            'aliases': list([
-            ]),
-            'area_id': None,
-            'capabilities': None,
-            'config_entry_id': 'TestData',
-            'device_class': None,
-            'disabled_by': None,
-            'domain': 'button',
-            'entity_category': <EntityCategory.CONFIG: 'config'>,
-            'entity_id': 'button.nanoleaf_strip_3b32_provision_preferred_thread_credentials',
-            'has_entity_name': False,
-            'hidden_by': None,
-            'icon': None,
-            'labels': list([
-            ]),
-            'name': None,
-            'options': dict({
-            }),
-            'original_device_class': None,
-            'original_icon': None,
-            'original_name': 'Nanoleaf Strip 3B32 Provision Preferred Thread Credentials',
-            'platform': 'homekit_controller',
-            'previous_unique_id': None,
-            'supported_features': 0,
-            'translation_key': None,
-            'unique_id': '00:00:00:00:00:00_1_31_119',
-            'unit_of_measurement': None,
-          }),
-          'state': dict({
-            'attributes': dict({
-              'friendly_name': 'Nanoleaf Strip 3B32 Provision Preferred Thread Credentials',
-            }),
-            'entity_id': 'button.nanoleaf_strip_3b32_provision_preferred_thread_credentials',
             'state': 'unknown',
           }),
         }),

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -234,8 +234,6 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
 
     fake_controller = await setup_platform(hass)
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
-    fake_controller.transport_type = TransportType.BLE
-
     config_entry = MockConfigEntry(
         version=1,
         domain="homekit_controller",
@@ -245,6 +243,8 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
         unique_id="00:00:00:00:00:00",
     )
     config_entry.add_to_hass(hass)
+
+    fake_controller.transport_type = TransportType.BLE
 
     # Needs a COAP transport to do migration
     fake_controller.transports = {TransportType.COAP: fake_controller}

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -234,6 +234,8 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
 
     fake_controller = await setup_platform(hass)
     await fake_controller.add_paired_device(accessories, "00:00:00:00:00:00")
+    fake_controller.transport_type = TransportType.BLE
+
     config_entry = MockConfigEntry(
         version=1,
         domain="homekit_controller",
@@ -243,8 +245,6 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
         unique_id="00:00:00:00:00:00",
     )
     config_entry.add_to_hass(hass)
-
-    fake_controller.transport_type = TransportType.BLE
 
     # Needs a COAP transport to do migration
     fake_controller.transports = {TransportType.COAP: fake_controller}

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -15,6 +15,7 @@ from homeassistant.components.thread import async_add_dataset, dataset_store
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_accessories_from_file, setup_platform, setup_test_accessories
 
@@ -216,7 +217,7 @@ async def test_thread_provision_no_creds(hass: HomeAssistant) -> None:
         )
 
 
-async def test_thread_provision(hass: HomeAssistant) -> None:
+async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
     """Test that a when a thread provision works the config entry is updated."""
     await async_add_dataset(
         hass,
@@ -256,6 +257,9 @@ async def test_thread_provision(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
+    assert hass.states.get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
+    assert entity_registry.async_get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
+
     await hass.services.async_call(
         "button",
         "press",
@@ -266,6 +270,9 @@ async def test_thread_provision(hass: HomeAssistant) -> None:
     )
 
     assert config_entry.data["Connection"] == "CoAP"
+
+    assert not hass.states.get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
+    assert not entity_registry.async_get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
 
 
 async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -14,8 +14,7 @@ from homeassistant.components.homekit_controller.const import (
 from homeassistant.components.thread import async_add_dataset, dataset_store
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import setup_accessories_from_file, setup_platform, setup_test_accessories
 
@@ -217,7 +216,9 @@ async def test_thread_provision_no_creds(hass: HomeAssistant) -> None:
         )
 
 
-async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> None:
+async def test_thread_provision(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test that a when a thread provision works the config entry is updated."""
     await async_add_dataset(
         hass,
@@ -257,8 +258,12 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
-    assert entity_registry.async_get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
+    assert hass.states.get(
+        "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+    )
+    assert entity_registry.async_get(
+        "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+    )
 
     await hass.services.async_call(
         "button",
@@ -271,8 +276,12 @@ async def test_thread_provision(hass: HomeAssistant, entity_registry: er.EntityR
 
     assert config_entry.data["Connection"] == "CoAP"
 
-    assert not hass.states.get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
-    assert not entity_registry.async_get("button.nanoleaf_strip_3b32_provision_preferred_thread_credentials")
+    assert not hass.states.get(
+        "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+    )
+    assert not entity_registry.async_get(
+        "button.nanoleaf_strip_3b32_provision_preferred_thread_credentials"
+    )
 
 
 async def test_thread_provision_migration_failed(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

We expose some config controls that don't make sense when a device migrates from BLE to COAP. Ensure they are removed from the state machine and entity registry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
