### PR TITLE
Fix zone radius calculation when radius is not 0

### DIFF
--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -135,7 +135,7 @@ def async_active_zone(
             is None
             # Skip zone that are outside the radius aka the
             # lat/long is outside the zone
-            or not (zone_dist - (radius := zone_attrs[ATTR_RADIUS]) < radius)
+            or not (zone_dist - (zone_radius := zone_attrs[ATTR_RADIUS]) < radius)
         ):
             continue
 
@@ -144,7 +144,7 @@ def async_active_zone(
             zone_dist < min_dist
             or (
                 # If same distance, prefer smaller zone
-                zone_dist == min_dist and radius < closest.attributes[ATTR_RADIUS]
+                zone_dist == min_dist and zone_radius < closest.attributes[ATTR_RADIUS]
             )
         ):
             continue

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -228,6 +228,46 @@ async def test_in_zone_works_for_passive_zones(hass: HomeAssistant) -> None:
     assert zone.in_zone(hass.states.get("zone.passive_zone"), latitude, longitude)
 
 
+async def test_async_active_zone_with_non_zero_radius(
+    hass: HomeAssistant,
+) -> None:
+    """Test async_active_zone with a non-zero radius."""
+    latitude = 32.880600
+    longitude = -117.237561
+
+    assert await setup.async_setup_component(
+        hass,
+        zone.DOMAIN,
+        {
+            "zone": [
+                {
+                    "name": "Small Zone",
+                    "latitude": 32.980600,
+                    "longitude": -117.137561,
+                    "radius": 50000,
+                },
+                {
+                    "name": "Big Zone",
+                    "latitude": 32.980600,
+                    "longitude": -117.137561,
+                    "radius": 100000,
+                },
+            ]
+        },
+    )
+
+    home_state = hass.states.get("zone.home")
+    assert home_state.attributes["radius"] == 100
+    assert home_state.attributes["latitude"] == 32.87336
+    assert home_state.attributes["longitude"] == -117.22743
+
+    active = zone.async_active_zone(hass, latitude, longitude, 5000)
+    assert active.entity_id == "zone.home"
+
+    active = zone.async_active_zone(hass, latitude, longitude, 0)
+    assert active.entity_id == "zone.small_zone"
+
+
 async def test_core_config_update(hass: HomeAssistant) -> None:
     """Test updating core config will update home zone."""
     assert await setup.async_setup_component(hass, "zone", {})


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
regressed in #108629

We had no coverage for a non-zero radius so I added a test.

fixes #110027

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
