### PR TITLE
Switch to new Bring! lib

### DIFF
--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant_bring_api.bring import Bring
-from homeassistant_bring_api.exceptions import (
+from bring_api.bring import Bring
+from bring_api.exceptions import (
     BringAuthException,
     BringParseException,
     BringRequestException,

--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import logging
 
-from python_bring_api.bring import Bring
-from python_bring_api.exceptions import (
+from homeassistant_bring_api.bring import Bring
+from homeassistant_bring_api.exceptions import (
     BringAuthException,
     BringParseException,
     BringRequestException,
@@ -31,11 +31,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     password = entry.data[CONF_PASSWORD]
 
     session = async_get_clientsession(hass)
-    bring = Bring(email, password, sessionAsync=session)
+    bring = Bring(session, email, password)
 
     try:
-        await bring.loginAsync()
-        await bring.loadListsAsync()
+        await bring.login()
+        await bring.loadLists()
     except BringRequestException as e:
         raise ConfigEntryNotReady(
             f"Timeout while connecting for email '{email}'"

--- a/homeassistant/components/bring/config_flow.py
+++ b/homeassistant/components/bring/config_flow.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from python_bring_api.bring import Bring
-from python_bring_api.exceptions import BringAuthException, BringRequestException
+from homeassistant_bring_api.bring import Bring
+from homeassistant_bring_api.exceptions import BringAuthException, BringRequestException
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -50,13 +50,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input is not None:
             session = async_get_clientsession(self.hass)
-            bring = Bring(
-                user_input[CONF_EMAIL], user_input[CONF_PASSWORD], sessionAsync=session
-            )
+            bring = Bring(session, user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
 
             try:
-                await bring.loginAsync()
-                await bring.loadListsAsync()
+                await bring.login()
+                await bring.loadLists()
             except BringRequestException:
                 errors["base"] = "cannot_connect"
             except BringAuthException:

--- a/homeassistant/components/bring/config_flow.py
+++ b/homeassistant/components/bring/config_flow.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant_bring_api.bring import Bring
-from homeassistant_bring_api.exceptions import BringAuthException, BringRequestException
+from bring_api.bring import Bring
+from bring_api.exceptions import BringAuthException, BringRequestException
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -4,12 +4,9 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from homeassistant_bring_api.bring import Bring
-from homeassistant_bring_api.exceptions import (
-    BringParseException,
-    BringRequestException,
-)
-from homeassistant_bring_api.types import BringItemsResponse, BringList
+from bring_api.bring import Bring
+from bring_api.exceptions import BringParseException, BringRequestException
+from bring_api.types import BringItemsResponse, BringList
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from python_bring_api.bring import Bring
-from python_bring_api.exceptions import BringParseException, BringRequestException
-from python_bring_api.types import BringItemsResponse, BringList
+from homeassistant_bring_api.bring import Bring
+from homeassistant_bring_api.exceptions import (
+    BringParseException,
+    BringRequestException,
+)
+from homeassistant_bring_api.types import BringItemsResponse, BringList
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -40,7 +43,7 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
 
     async def _async_update_data(self) -> dict[str, BringData]:
         try:
-            lists_response = await self.bring.loadListsAsync()
+            lists_response = await self.bring.loadLists()
         except BringRequestException as e:
             raise UpdateFailed("Unable to connect and retrieve data from bring") from e
         except BringParseException as e:
@@ -49,7 +52,7 @@ class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):
         list_dict = {}
         for lst in lists_response["lists"]:
             try:
-                items = await self.bring.getItemsAsync(lst["listUuid"])
+                items = await self.bring.getItems(lst["listUuid"])
             except BringRequestException as e:
                 raise UpdateFailed(
                     "Unable to connect and retrieve data from bring"

--- a/homeassistant/components/bring/manifest.json
+++ b/homeassistant/components/bring/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bring",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["python-bring-api==3.0.0"]
+  "requirements": ["homeassistant-bring-api==0.1.0"]
 }

--- a/homeassistant/components/bring/manifest.json
+++ b/homeassistant/components/bring/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bring",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["homeassistant-bring-api==0.1.0"]
+  "requirements": ["bring-api==0.1.1"]
 }

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from python_bring_api.exceptions import BringRequestException
+from homeassistant_bring_api.exceptions import BringRequestException
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -75,8 +75,8 @@ class BringTodoListEntity(
         """Return the todo items."""
         return [
             TodoItem(
-                uid=item["name"],
-                summary=item["name"],
+                uid=item["itemId"],
+                summary=item["itemId"],
                 description=item["specification"] or "",
                 status=TodoItemStatus.NEEDS_ACTION,
             )
@@ -91,7 +91,7 @@ class BringTodoListEntity(
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add an item to the To-do list."""
         try:
-            await self.coordinator.bring.saveItemAsync(
+            await self.coordinator.bring.saveItem(
                 self.bring_list["listUuid"], item.summary, item.description or ""
             )
         except BringRequestException as e:
@@ -123,14 +123,14 @@ class BringTodoListEntity(
             assert item.uid
 
         if item.status == TodoItemStatus.COMPLETED:
-            await self.coordinator.bring.removeItemAsync(
+            await self.coordinator.bring.removeItem(
                 bring_list["listUuid"],
                 item.uid,
             )
 
         elif item.summary == item.uid:
             try:
-                await self.coordinator.bring.updateItemAsync(
+                await self.coordinator.bring.updateItem(
                     bring_list["listUuid"],
                     item.uid,
                     item.description or "",
@@ -139,11 +139,11 @@ class BringTodoListEntity(
                 raise HomeAssistantError("Unable to update todo item for bring") from e
         else:
             try:
-                await self.coordinator.bring.removeItemAsync(
+                await self.coordinator.bring.removeItem(
                     bring_list["listUuid"],
                     item.uid,
                 )
-                await self.coordinator.bring.saveItemAsync(
+                await self.coordinator.bring.saveItem(
                     bring_list["listUuid"],
                     item.summary,
                     item.description or "",
@@ -157,7 +157,7 @@ class BringTodoListEntity(
         """Delete an item from the To-do list."""
         for uid in uids:
             try:
-                await self.coordinator.bring.removeItemAsync(
+                await self.coordinator.bring.removeItem(
                     self.bring_list["listUuid"], uid
                 )
             except BringRequestException as e:

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from homeassistant_bring_api.exceptions import BringRequestException
+from bring_api.exceptions import BringRequestException
 
 from homeassistant.components.todo import (
     TodoItem,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -593,6 +593,9 @@ boschshcpy==0.2.75
 # homeassistant.components.route53
 boto3==1.33.13
 
+# homeassistant.components.bring
+bring-api==0.1.1
+
 # homeassistant.components.broadlink
 broadlink==0.18.3
 
@@ -1063,9 +1066,6 @@ home-assistant-frontend==20240205.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2
-
-# homeassistant.components.bring
-homeassistant-bring-api==0.1.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1064,6 +1064,9 @@ home-assistant-frontend==20240205.0
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2
 
+# homeassistant.components.bring
+homeassistant-bring-api==0.1.0
+
 # homeassistant.components.home_connect
 homeconnect==0.7.2
 
@@ -2179,9 +2182,6 @@ python-awair==0.2.4
 
 # homeassistant.components.blockchain
 python-blockchain-api==0.0.2
-
-# homeassistant.components.bring
-python-bring-api==3.0.0
 
 # homeassistant.components.bsblan
 python-bsblan==0.5.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -860,6 +860,9 @@ home-assistant-frontend==20240205.0
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2
 
+# homeassistant.components.bring
+homeassistant-bring-api==0.1.0
+
 # homeassistant.components.home_connect
 homeconnect==0.7.2
 
@@ -1682,9 +1685,6 @@ python-MotionMount==0.3.1
 
 # homeassistant.components.awair
 python-awair==0.2.4
-
-# homeassistant.components.bring
-python-bring-api==3.0.0
 
 # homeassistant.components.bsblan
 python-bsblan==0.5.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -501,6 +501,9 @@ bond-async==0.2.1
 # homeassistant.components.bosch_shc
 boschshcpy==0.2.75
 
+# homeassistant.components.bring
+bring-api==0.1.1
+
 # homeassistant.components.broadlink
 broadlink==0.18.3
 
@@ -859,9 +862,6 @@ home-assistant-frontend==20240205.0
 
 # homeassistant.components.conversation
 home-assistant-intents==2024.2.2
-
-# homeassistant.components.bring
-homeassistant-bring-api==0.1.0
 
 # homeassistant.components.home_connect
 homeconnect==0.7.2

--- a/tests/components/bring/conftest.py
+++ b/tests/components/bring/conftest.py
@@ -36,8 +36,8 @@ def mock_bring_client() -> Generator[AsyncMock, None, None]:
     ):
         client = mock_client.return_value
         client.uuid = UUID
-        client.loginAsync.return_value = True
-        client.loadListsAsync.return_value = {"lists": []}
+        client.login.return_value = True
+        client.loadLists.return_value = {"lists": []}
         yield client
 
 

--- a/tests/components/bring/test_config_flow.py
+++ b/tests/components/bring/test_config_flow.py
@@ -1,12 +1,12 @@
 """Test the Bring! config flow."""
 from unittest.mock import AsyncMock
 
-import pytest
-from python_bring_api.exceptions import (
+from homeassistant_bring_api.exceptions import (
     BringAuthException,
     BringParseException,
     BringRequestException,
 )
+import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.bring.const import DOMAIN
@@ -62,7 +62,7 @@ async def test_flow_user_init_data_unknown_error_and_recover(
     hass: HomeAssistant, mock_bring_client: AsyncMock, raise_error, text_error
 ) -> None:
     """Test unknown errors."""
-    mock_bring_client.loginAsync.side_effect = raise_error
+    mock_bring_client.login.side_effect = raise_error
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
@@ -76,7 +76,7 @@ async def test_flow_user_init_data_unknown_error_and_recover(
     assert result["errors"]["base"] == text_error
 
     # Recover
-    mock_bring_client.loginAsync.side_effect = None
+    mock_bring_client.login.side_effect = None
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )

--- a/tests/components/bring/test_config_flow.py
+++ b/tests/components/bring/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the Bring! config flow."""
 from unittest.mock import AsyncMock
 
-from homeassistant_bring_api.exceptions import (
+from bring_api.exceptions import (
     BringAuthException,
     BringParseException,
     BringRequestException,

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -58,6 +58,6 @@ async def test_init_failure(
     bring_config_entry: MockConfigEntry | None,
 ) -> None:
     """Test an initialization error on integration load."""
-    mock_bring_client.loginAsync.side_effect = exception
+    mock_bring_client.login.side_effect = exception
     await setup_integration(hass, bring_config_entry)
     assert bring_config_entry.state == status


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR switches to a new library in the backend. This change has been done as until now, the integration was based on a generic `python-bring-api` library which was also used for other purposes and contained a good chunk on legacy code. Further it was using the _legacy_ mode of the v2 api of bring and not under the control of the codeowners of the integration. The new library is dedicated to home assistant `bring-api`, based on a fork of the previous lib, and can therefore get rid of this legacy code. For example, this will allow for the usage of `uuid` instead of `todo item summary` as primary identifier.
The library has been set to version `0.1.0` for now, as there is still a good list of missing features until the Bring! integration can show its full potential. Just to name some: _Push Notifications via Bring App, Proper Translation based on list settings, better errors during authentication, etc._

[CHANGELOG](https://github.com/miaucl/homeassistant-bring-api/compare/8043562b22be1f6421a8771774868b105b6ca375..main)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
