### PR TITLE
Migrate zwave_js to use async_update_entry to alter config entries

### DIFF
--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1705,7 +1705,7 @@ async def test_install_addon_failure(
 async def test_options_manual(hass: HomeAssistant, client, integration) -> None:
     """Test manual settings in options flow."""
     entry = integration
-    entry.unique_id = "1234"
+    hass.config_entries.async_update_entry(entry, unique_id="1234")
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
@@ -1733,7 +1733,7 @@ async def test_options_manual_different_device(
 ) -> None:
     """Test options flow manual step connecting to different device."""
     entry = integration
-    entry.unique_id = 5678
+    hass.config_entries.async_update_entry(entry, unique_id="5678")
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
@@ -1754,7 +1754,7 @@ async def test_options_not_addon(
 ) -> None:
     """Test options flow and opting out of add-on on Supervisor."""
     entry = integration
-    entry.unique_id = "1234"
+    hass.config_entries.async_update_entry(entry, unique_id="1234")
 
     assert client.connect.call_count == 1
     assert client.disconnect.call_count == 0
@@ -1861,9 +1861,8 @@ async def test_options_addon_running(
     """Test options flow and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 
@@ -1971,9 +1970,8 @@ async def test_options_addon_running_no_changes(
     """Test options flow without changes, and add-on already running on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 
@@ -2115,9 +2113,8 @@ async def test_options_different_device(
     """Test options flow and configuring a different device."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 
@@ -2274,9 +2271,8 @@ async def test_options_addon_restart_failed(
     """Test options flow and add-on restart failure."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 
@@ -2402,9 +2398,8 @@ async def test_options_addon_running_server_info_failure(
     """Test options flow and add-on already running with server info failure."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 
@@ -2511,9 +2506,8 @@ async def test_options_addon_not_installed(
     """Test options flow and add-on not installed on Supervisor."""
     addon_options.update(old_addon_options)
     entry = integration
-    entry.unique_id = "1234"
     data = {**entry.data, **entry_data}
-    hass.config_entries.async_update_entry(entry, data=data)
+    hass.config_entries.async_update_entry(entry, data=data, unique_id="1234")
 
     assert entry.data["url"] == "ws://test.org"
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate zwave_js to use async_update_entry to alter config entries

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
