### PR TITLE
Avoid creating many tasks when adding hue v2 entities

### DIFF
--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -1,6 +1,7 @@
 """Support for Hue binary sensors."""
 from __future__ import annotations
 
+from functools import partial
 from typing import TypeAlias
 
 from aiohue.v2 import HueBridgeV2
@@ -58,14 +59,15 @@ async def async_setup_entry(
 
     @callback
     def register_items(controller: ControllerType, sensor_class: SensorType):
+        make_binary_sensor_entity = partial(sensor_class, bridge, controller)
+
         @callback
         def async_add_sensor(event_type: EventType, resource: SensorType) -> None:
             """Add Hue Binary Sensor."""
-            async_add_entities([sensor_class(bridge, controller, resource)])
+            async_add_entities([make_binary_sensor_entity(resource)])
 
         # add all current items in controller
-        for sensor in controller:
-            async_add_sensor(EventType.RESOURCE_ADDED, sensor)
+        async_add_entities(make_binary_sensor_entity(sensor) for sensor in controller)
 
         # register listener for new sensors
         config_entry.async_on_unload(

--- a/homeassistant/components/hue/v2/light.py
+++ b/homeassistant/components/hue/v2/light.py
@@ -1,6 +1,7 @@
 """Support for Hue lights."""
 from __future__ import annotations
 
+from functools import partial
 from typing import Any
 
 from aiohue import HueBridgeV2
@@ -51,17 +52,15 @@ async def async_setup_entry(
     bridge: HueBridge = hass.data[DOMAIN][config_entry.entry_id]
     api: HueBridgeV2 = bridge.api
     controller: LightsController = api.lights
+    make_light_entity = partial(HueLight, bridge, controller)
 
     @callback
     def async_add_light(event_type: EventType, resource: Light) -> None:
         """Add Hue Light."""
-        light = HueLight(bridge, controller, resource)
-        async_add_entities([light])
+        async_add_entities([make_light_entity(resource)])
 
     # add all current items in controller
-    for light in controller:
-        async_add_light(EventType.RESOURCE_ADDED, resource=light)
-
+    async_add_entities(make_light_entity(light) for light in controller)
     # register listener for new lights
     config_entry.async_on_unload(
         controller.subscribe(async_add_light, event_filter=EventType.RESOURCE_ADDED)

--- a/homeassistant/components/hue/v2/sensor.py
+++ b/homeassistant/components/hue/v2/sensor.py
@@ -1,6 +1,7 @@
 """Support for Hue sensors."""
 from __future__ import annotations
 
+from functools import partial
 from typing import Any, TypeAlias
 
 from aiohue.v2 import HueBridgeV2
@@ -53,14 +54,15 @@ async def async_setup_entry(
 
     @callback
     def register_items(controller: ControllerType, sensor_class: SensorType):
+        make_sensor_entity = partial(sensor_class, bridge, controller)
+
         @callback
         def async_add_sensor(event_type: EventType, resource: SensorType) -> None:
             """Add Hue Sensor."""
-            async_add_entities([sensor_class(bridge, controller, resource)])
+            async_add_entities([make_sensor_entity(resource)])
 
         # add all current items in controller
-        for sensor in controller:
-            async_add_sensor(EventType.RESOURCE_ADDED, sensor)
+        async_add_entities(make_sensor_entity(sensor) for sensor in controller)
 
         # register listener for new sensors
         config_entry.async_on_unload(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Each entity creation would call `async_add_entities` which spawned a seperate task.  When the platform is setup, we can create them in a single task.

fixes
`2024-02-12 18:06:09.819 WARNING (MainThread) [asyncio] Executing <Task pending name='config entry forward setup Philips Hue 2 hue fcb64edfc5ac2edbb656607d5193b583 light' coro=<ConfigEntries.async_forward_entry_setup() running at /usr/src/homeassistant/homeassistant/config_entries.py:1597> wait_for=<Future pending cb=[shield.<locals>._outer_done_callback() at /usr/local/lib/python3.12/asyncio/tasks.py:922, Task.task_wakeup()] created at /usr/local/lib/python3.12/asyncio/base_events.py:447> cb=[gather.<locals>._done_callback() at /usr/local/lib/python3.12/asyncio/tasks.py:767] created at /usr/local/lib/python3.12/asyncio/tasks.py:420> took 1.260 seconds`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
