### PR TITLE
Add myuplink binary_sensor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1692,6 +1692,7 @@ omit =
     homeassistant/components/myuplink/__init__.py
     homeassistant/components/myuplink/api.py
     homeassistant/components/myuplink/application_credentials.py
+    homeassistant/components/myuplink/binary_sensor.py
     homeassistant/components/myuplink/coordinator.py
     homeassistant/components/myuplink/entity.py
     homeassistant/components/myuplink/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1695,6 +1695,7 @@ omit =
     homeassistant/components/myuplink/binary_sensor.py
     homeassistant/components/myuplink/coordinator.py
     homeassistant/components/myuplink/entity.py
+    homeassistant/components/myuplink/helpers.py
     homeassistant/components/myuplink/sensor.py
 
 

--- a/homeassistant/components/myuplink/__init__.py
+++ b/homeassistant/components/myuplink/__init__.py
@@ -16,7 +16,11 @@ from .api import AsyncConfigEntryAuth
 from .const import DOMAIN
 from .coordinator import MyUplinkDataCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.UPDATE]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.SENSOR,
+    Platform.UPDATE,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -33,7 +33,6 @@ def get_description(device_point: DevicePoint) -> BinarySensorEntityDescription 
     1. Category specific prefix e.g "NIBEF"
     2. Default to None
     """
-    description = None
     prefix, _, _ = device_point.category.partition(" ")
     description = CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(
         device_point.parameter_id
@@ -56,10 +55,9 @@ async def async_setup_entry(
         for point_id, device_point in point_data.items():
             if find_matching_platform(device_point) == Platform.BINARY_SENSOR:
                 description = get_description(device_point)
-                entity_class = MyUplinkDevicePointBinarySensor
 
                 entities.append(
-                    entity_class(
+                    MyUplinkDevicePointBinarySensor(
                         coordinator=coordinator,
                         device_id=device_id,
                         device_point=device_point,

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -1,0 +1,102 @@
+"""Binary sensors for myUplink."""
+
+from myuplink import DevicePoint
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import MyUplinkDataCoordinator
+from .const import DOMAIN
+from .entity import MyUplinkEntity
+from .helpers import find_matching_platform
+
+CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, BinarySensorEntityDescription]] = {
+    "NIBEF": {
+        "43161": BinarySensorEntityDescription(
+            key="elect_add",
+            icon="mdi:electric-switch",
+        ),
+    },
+}
+
+
+def get_description(device_point: DevicePoint) -> BinarySensorEntityDescription | None:
+    """Get description for a device point.
+
+    Priorities:
+    1. Category specific prefix e.g "NIBEF"
+    2. Default to None
+    """
+    description = None
+    prefix, _, _ = device_point.category.partition(" ")
+    description = CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(
+        device_point.parameter_id
+    )
+
+    return description
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up myUplink binary_sensor."""
+    entities: list[BinarySensorEntity] = []
+    coordinator: MyUplinkDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Setup device point sensors
+    for device_id, point_data in coordinator.data.points.items():
+        for point_id, device_point in point_data.items():
+            if find_matching_platform(device_point) == Platform.BINARY_SENSOR:
+                description = get_description(device_point)
+                entity_class = MyUplinkDevicePointBinarySensor
+
+                entities.append(
+                    entity_class(
+                        coordinator=coordinator,
+                        device_id=device_id,
+                        device_point=device_point,
+                        entity_description=description,
+                        unique_id_suffix=point_id,
+                    )
+                )
+    async_add_entities(entities)
+
+
+class MyUplinkDevicePointBinarySensor(MyUplinkEntity, BinarySensorEntity):
+    """Representation of a myUplink device point binary sensor."""
+
+    def __init__(
+        self,
+        coordinator: MyUplinkDataCoordinator,
+        device_id: str,
+        device_point: DevicePoint,
+        entity_description: BinarySensorEntityDescription | None,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the binary_sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id=device_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+        # Internal properties
+        self.point_id = device_point.parameter_id
+        self._attr_name = device_point.parameter_name
+
+        if entity_description is not None:
+            self.entity_description = entity_description
+
+    @property
+    def is_on(self) -> bool:
+        """Binary sensor state value."""
+        device_point = self.coordinator.data.points[self.device_id][self.point_id]
+        return int(device_point.value) != 0

--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -1,0 +1,21 @@
+"""Helper collection for myuplink."""
+
+from myuplink import DevicePoint
+
+from homeassistant.const import Platform
+
+
+def find_matching_platform(device_point: DevicePoint) -> Platform:
+    """Find entity platform for a DevicePoint."""
+    if (
+        len(device_point.enum_values) == 2
+        and device_point.enum_values[0]["value"] == "0"
+        and device_point.enum_values[1]["value"] == "1"
+    ):
+        if device_point.writable:
+            # Change to Platform.SWITCH when platform is implemented
+            # return Platform.SWITCH
+            return Platform.SENSOR
+        return Platform.BINARY_SENSOR
+
+    return Platform.SENSOR

--- a/homeassistant/components/myuplink/sensor.py
+++ b/homeassistant/components/myuplink/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    Platform,
     UnitOfElectricCurrent,
     UnitOfFrequency,
     UnitOfTemperature,
@@ -21,6 +22,7 @@ from homeassistant.helpers.typing import StateType
 from . import MyUplinkDataCoordinator
 from .const import DOMAIN
 from .entity import MyUplinkEntity
+from .helpers import find_matching_platform
 
 DEVICE_POINT_UNIT_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
     "°C": SensorEntityDescription(
@@ -103,32 +105,33 @@ async def async_setup_entry(
     # Setup device point sensors
     for device_id, point_data in coordinator.data.points.items():
         for point_id, device_point in point_data.items():
-            description = get_description(device_point)
-            entity_class = MyUplinkDevicePointSensor
-            if (
-                description is not None
-                and description.device_class == SensorDeviceClass.ENUM
-            ):
+            if find_matching_platform(device_point) == Platform.SENSOR:
+                description = get_description(device_point)
+                entity_class = MyUplinkDevicePointSensor
+                if (
+                    description is not None
+                    and description.device_class == SensorDeviceClass.ENUM
+                ):
+                    entities.append(
+                        MyUplinkEnumRawSensor(
+                            coordinator=coordinator,
+                            device_id=device_id,
+                            device_point=device_point,
+                            entity_description=description,
+                            unique_id_suffix=f"{point_id}-raw",
+                        )
+                    )
+                    entity_class = MyUplinkEnumSensor
+
                 entities.append(
-                    MyUplinkEnumRawSensor(
+                    entity_class(
                         coordinator=coordinator,
                         device_id=device_id,
                         device_point=device_point,
                         entity_description=description,
-                        unique_id_suffix=f"{point_id}-raw",
+                        unique_id_suffix=point_id,
                     )
                 )
-                entity_class = MyUplinkEnumSensor
-
-            entities.append(
-                entity_class(
-                    coordinator=coordinator,
-                    device_id=device_id,
-                    device_point=device_point,
-                    entity_description=description,
-                    unique_id_suffix=point_id,
-                )
-            )
 
     async_add_entities(entities)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some device_points should be added as binary sensors instead of as ordinary sensors.
This PR will analyze the meta-data from API and if a device_point can have exactly two values (0 or 1) a binary sensor will be created.

Side-effect: The new binary sensors will be accompanied by stale sensors with same name after first run of this version. The user can delete these stale sensors manually from the UI but a better solution would be to delete them automatically. 

This is no problem for the platforms that are included in HA 2024.3. After that, there can be stale entities when new platforms are merged or the filtering criteria are changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31394

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
