### PR TITLE
Ensure dlna_dmr tests add config entry before updating it

### DIFF
--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -79,7 +79,6 @@ pytestmark = pytest.mark.usefixtures("domain_data_mock")
 
 async def setup_mock_component(hass: HomeAssistant, mock_entry: MockConfigEntry) -> str:
     """Set up a mock DlnaDmrEntity with the given configuration."""
-    mock_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_entry.entry_id) is True
     await hass.async_block_till_done()
 
@@ -112,6 +111,7 @@ async def mock_entity_id(
 
     Yields the entity ID. Cleans up the entity after the test is complete.
     """
+    config_entry_mock.add_to_hass(hass)
     entity_id = await setup_mock_component(hass, config_entry_mock)
 
     # Check the entity has registered all needed listeners
@@ -163,7 +163,7 @@ async def mock_disconnected_entity_id(
     """
     # Cause the connection attempt to fail
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
-
+    config_entry_mock.add_to_hass(hass)
     entity_id = await setup_mock_component(hass, config_entry_mock)
 
     # Check the entity has registered all needed listeners
@@ -214,6 +214,7 @@ async def test_setup_entry_no_options(
 
     Check that the device is constructed properly as part of the test.
     """
+    config_entry_mock.add_to_hass(hass)
     hass.config_entries.async_update_entry(config_entry_mock, options={})
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     await async_update_entity(hass, mock_entity_id)
@@ -286,6 +287,7 @@ async def test_setup_entry_with_options(
     Check that the device is constructed properly as part of the test.
     """
     hass.set_state(core_state)
+    config_entry_mock.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         config_entry_mock,
         options={
@@ -355,6 +357,7 @@ async def test_setup_entry_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Entry with a MAC address will set up and set the device registry connection."""
+    config_entry_mock.add_to_hass(hass)
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
@@ -376,6 +379,7 @@ async def test_setup_entry_no_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Test setting up an entry without a MAC address will succeed."""
+    config_entry_mock_no_mac.add_to_hass(hass)
     mock_entity_id = await setup_mock_component(hass, config_entry_mock_no_mac)
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
@@ -394,7 +398,7 @@ async def test_event_subscribe_failure(
 ) -> None:
     """Test _device_connect aborts when async_subscribe_services fails."""
     dmr_device_mock.async_subscribe_services.side_effect = UpnpError
-
+    config_entry_mock.add_to_hass(hass)
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
@@ -426,6 +430,7 @@ async def test_event_subscribe_rejected(
     Device state will instead be obtained via polling in async_update.
     """
     dmr_device_mock.async_subscribe_services.side_effect = UpnpResponseError(status=501)
+    config_entry_mock.add_to_hass(hass)
 
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     await async_update_entity(hass, mock_entity_id)
@@ -1270,6 +1275,7 @@ async def test_unavailable_device(
     # Cause connection attempts to fail
     hass.set_state(core_state)
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
+    config_entry_mock.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.dlna_dmr.media_player.DmrDevice", autospec=True
@@ -1399,6 +1405,7 @@ async def test_become_available(
     # Cause connection attempts to fail before adding entity
     hass.set_state(core_state)
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
+    config_entry_mock.add_to_hass(hass)
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None
@@ -2021,6 +2028,7 @@ async def test_poll_availability(
     """Test device becomes available and noticed via poll_availability."""
     # Start with a disconnected device and poll_availability=True
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
+    config_entry_mock.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         config_entry_mock,
         options={
@@ -2284,6 +2292,7 @@ async def test_config_update_mac_address(
     dmr_device_mock: Mock,
 ) -> None:
     """Test discovering the MAC address post-setup will update the device registry."""
+    config_entry_mock_no_mac.add_to_hass(hass)
     await setup_mock_component(hass, config_entry_mock_no_mac)
 
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
@@ -2334,6 +2343,7 @@ async def test_connections_restored(
     # Cause connection attempts to fail before adding entity
     hass.set_state(core_state)
     domain_data_mock.upnp_factory.async_create_device.side_effect = UpnpConnectionError
+    config_entry_mock.add_to_hass(hass)
     mock_entity_id = await setup_mock_component(hass, config_entry_mock)
     mock_state = hass.states.get(mock_entity_id)
     assert mock_state is not None


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure dlna_dmr tests add config entry before updating it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
