### PR TITLE
Ensure github tests add config entry before updating it

### DIFF
--- a/tests/components/github/common.py
+++ b/tests/components/github/common.py
@@ -18,6 +18,7 @@ async def setup_github_integration(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
+    add_entry_to_hass: bool = True,
 ) -> None:
     """Mock setting up the integration."""
     headers = json.loads(load_fixture("base_headers.json", DOMAIN))
@@ -41,7 +42,8 @@ async def setup_github_integration(
         json=json.loads(load_fixture("graphql.json", DOMAIN)),
         headers=headers,
     )
-    mock_config_entry.add_to_hass(hass)
+    if add_entry_to_hass:
+        mock_config_entry.add_to_hass(hass)
 
     setup_result = await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/github/test_config_flow.py
+++ b/tests/components/github/test_config_flow.py
@@ -260,13 +260,13 @@ async def test_options_flow(
     mock_setup_entry: None,
 ) -> None:
     """Test options flow."""
+    mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={
             CONF_REPOSITORIES: ["homeassistant/core", "homeassistant/architecture"]
         },
     )
-    mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/github/test_diagnostics.py
+++ b/tests/components/github/test_diagnostics.py
@@ -25,6 +25,7 @@ async def test_entry_diagnostics(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test config entry diagnostics."""
+    mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={CONF_REPOSITORIES: ["home-assistant/core"]},
@@ -43,7 +44,9 @@ async def test_entry_diagnostics(
         headers={"Content-Type": "application/json"},
     )
 
-    await setup_github_integration(hass, mock_config_entry, aioclient_mock)
+    await setup_github_integration(
+        hass, mock_config_entry, aioclient_mock, add_entry_to_hass=False
+    )
     result = await get_diagnostics_for_config_entry(
         hass,
         hass_client,

--- a/tests/components/github/test_init.py
+++ b/tests/components/github/test_init.py
@@ -21,11 +21,14 @@ async def test_device_registry_cleanup(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that we remove untracked repositories from the decvice registry."""
+    mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={CONF_REPOSITORIES: ["home-assistant/core"]},
     )
-    await setup_github_integration(hass, mock_config_entry, aioclient_mock)
+    await setup_github_integration(
+        hass, mock_config_entry, aioclient_mock, add_entry_to_hass=False
+    )
 
     devices = dr.async_entries_for_config_entry(
         registry=device_registry,
@@ -62,12 +65,15 @@ async def test_subscription_setup(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test that we setup event subscription."""
+    mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={CONF_REPOSITORIES: ["home-assistant/core"]},
         pref_disable_polling=False,
     )
-    await setup_github_integration(hass, mock_config_entry, aioclient_mock)
+    await setup_github_integration(
+        hass, mock_config_entry, aioclient_mock, add_entry_to_hass=False
+    )
     assert (
         "https://api.github.com/repos/home-assistant/core/events" in x[1]
         for x in aioclient_mock.mock_calls
@@ -82,12 +88,15 @@ async def test_subscription_setup_polling_disabled(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test that we do not setup event subscription if polling is disabled."""
+    mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={CONF_REPOSITORIES: ["home-assistant/core"]},
         pref_disable_polling=True,
     )
-    await setup_github_integration(hass, mock_config_entry, aioclient_mock)
+    await setup_github_integration(
+        hass, mock_config_entry, aioclient_mock, add_entry_to_hass=False
+    )
     assert (
         "https://api.github.com/repos/home-assistant/core/events" not in x[1]
         for x in aioclient_mock.mock_calls


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure github tests add config entry before updating it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
