### PR TITLE
Improve tests for Shelly WallDisplay

### DIFF
--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -5,7 +5,13 @@ from dataclasses import dataclass
 from typing import Any, cast
 
 from aioshelly.block_device import Block
-from aioshelly.const import MODEL_2, MODEL_25, MODEL_GAS, RPC_GENERATIONS
+from aioshelly.const import (
+    MODEL_2,
+    MODEL_25,
+    MODEL_GAS,
+    MODEL_WALL_DISPLAY,
+    RPC_GENERATIONS,
+)
 
 from homeassistant.components.automation import automations_with_entity
 from homeassistant.components.script import scripts_with_entity
@@ -20,7 +26,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
-from .const import DOMAIN, GAS_VALVE_OPEN_STATES, MODEL_WALL_DISPLAY
+from .const import DOMAIN, GAS_VALVE_OPEN_STATES
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import (
     BlockEntityDescription,

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -697,10 +697,11 @@ async def test_wall_display_thermostat_mode(
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
-    # the climate entity should not be created, only the climate entity
+    # the switch entity should be removed
     assert hass.states.get(switch_entity_id) is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
+    # the climate entity should be created
     state = hass.states.get(climate_entity_id)
     assert state
     assert state.state == HVACMode.HEAT

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 from unittest.mock import AsyncMock, Mock, PropertyMock
 
-from aioshelly.const import MODEL_VALVE
+from aioshelly.const import MODEL_VALVE, MODEL_WALL_DISPLAY
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError
 import pytest
 
@@ -21,7 +21,8 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.components.shelly.const import DOMAIN, MODEL_WALL_DISPLAY
+from homeassistant.components.shelly.const import DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
@@ -682,3 +683,29 @@ async def test_rpc_climate_hvac_mode_cool(
     state = hass.states.get(ENTITY_ID)
     assert state.state == HVACMode.COOL
     assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
+
+
+async def test_wall_display_thermostat_mode(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test Wall Display in thermostat mode."""
+    climate_entity_id = "climate.test_name"
+    switch_entity_id = "switch.test_switch_0"
+
+    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
+
+    # the climate entity should not be created, only the climate entity
+    assert hass.states.get(switch_entity_id) is None
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
+
+    state = hass.states.get(climate_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+
+    entry = entity_registry.async_get(climate_entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-thermostat:0"

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -337,6 +337,7 @@ async def test_wall_display_relay_mode(
     assert hass.states.get(climate_entity_id) is None
     assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 0
 
+    # the switch entity should be created
     state = hass.states.get(switch_entity_id)
     assert state
     assert state.state == STATE_ON

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -317,30 +317,15 @@ async def test_block_device_gas_valve(
     assert state.state == STATE_ON  # valve is open
 
 
-async def test_wall_display_thermostat_mode(
-    hass: HomeAssistant,
-    mock_rpc_device: Mock,
-) -> None:
-    """Test Wall Display in thermostat mode."""
-    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
-
-    # the switch entity should not be created, only the climate entity
-    assert hass.states.get("switch.test_name") is None
-    assert hass.states.get("climate.test_name")
-
-
 async def test_wall_display_relay_mode(
     hass: HomeAssistant,
     mock_rpc_device: Mock,
+    entity_registry: EntityRegistry,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Test Wall Display in thermostat mode."""
-    entity_id = register_entity(
-        hass,
-        CLIMATE_DOMAIN,
-        "test_name",
-        "thermostat:0",
-    )
+    """Test Wall Display in relay mode."""
+    climate_entity_id = "climate.test_name"
+    switch_entity_id = "switch.test_switch_0"
 
     new_shelly = deepcopy(mock_rpc_device.shelly)
     new_shelly["relay_in_thermostat"] = False
@@ -349,7 +334,17 @@ async def test_wall_display_relay_mode(
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 
     # the climate entity should be removed
-    assert hass.states.get(entity_id) is None
+    assert hass.states.get(climate_entity_id) is None
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 0
+
+    state = hass.states.get(switch_entity_id)
+    assert state
+    assert state.state == STATE_ON
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
+
+    entry = entity_registry.async_get(switch_entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-switch:0"
 
 
 async def test_create_issue_valve_switch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I checked once again whether the `switch` and `climate` entities are correctly added/removed for WallDisplay with the latest firmware, depending on whether it works in relay or thermostat mode.

Tests for WallDisplay have been tidied up and improved.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
