### PR TITLE
Add reformatting commits to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# Black
+4de97abc3aa83188666336ce0a015a5bab75bc8f
+
+# Switch formatting from black to ruff-format (#102893)
+706add4a57120a93d7b7fe40e722b00d634c76c2
+
+# Prettify json (component test fixtures) (#68892)
+053c4428a933c3c04c22642f93c93fccba3e8bfd
+
+# Prettify json (tests) (#68888)
+496d90bf00429d9d924caeb0155edc0bf54e86b9


### PR DESCRIPTION
## Proposed change

This PR adds a [`.git-blame-ignore-revs`](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/) file seeded with some of the large reformatting commits in the repository, to skip them while `blame`ing contents.

You may locally need to enable this with `git config blame.ignoreRevsFile .git-blame-ignore-revs` in your working copy, but GitHub will heed this well-known filename automatically.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
  - There is indeed no code in this PR. 
- [x] I have followed the dev checklist
- [x] I have followed the perfect PR recommendations
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - Every single added line of code was formatted to perfection. 😁  
- [x] Tests have been added to verify that the new code works.
