### PR TITLE
Improve mqtt value template error logging

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -91,6 +91,7 @@ from .models import (  # noqa: F401
     MqttCommandTemplate,
     MqttData,
     MqttValueTemplate,
+    MqttValueTemplateException,
     PayloadSentinel,
     PublishPayloadType,
     ReceiveMessage,

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -91,7 +91,6 @@ from .models import (  # noqa: F401
     MqttCommandTemplate,
     MqttData,
     MqttValueTemplate,
-    MqttValueTemplateException,
     PayloadSentinel,
     PublishPayloadType,
     ReceiveMessage,

--- a/homeassistant/components/mqtt/event.py
+++ b/homeassistant/components/mqtt/event.py
@@ -29,7 +29,6 @@ from .const import (
     CONF_STATE_TOPIC,
     PAYLOAD_EMPTY_JSON,
     PAYLOAD_NONE,
-    TEMPLATE_ERRORS,
 )
 from .debug_info import log_messages
 from .mixins import (
@@ -39,6 +38,7 @@ from .mixins import (
 )
 from .models import (
     MqttValueTemplate,
+    MqttValueTemplateException,
     PayloadSentinel,
     ReceiveMessage,
     ReceivePayloadType,
@@ -134,7 +134,8 @@ class MqttEvent(MqttEntity, EventEntity):
             event_type: str
             try:
                 payload = self._template(msg.payload, PayloadSentinel.DEFAULT)
-            except TEMPLATE_ERRORS:
+            except MqttValueTemplateException as exc:
+                _LOGGER.warning(exc)
                 return
             if (
                 not payload

--- a/homeassistant/components/mqtt/image.py
+++ b/homeassistant/components/mqtt/image.py
@@ -24,14 +24,19 @@ from homeassistant.util import dt as dt_util
 
 from . import subscription
 from .config import MQTT_BASE_SCHEMA
-from .const import CONF_ENCODING, CONF_QOS, TEMPLATE_ERRORS
+from .const import CONF_ENCODING, CONF_QOS
 from .debug_info import log_messages
 from .mixins import (
     MQTT_ENTITY_COMMON_SCHEMA,
     MqttEntity,
     async_setup_entity_entry_helper,
 )
-from .models import MessageCallbackType, MqttValueTemplate, ReceiveMessage
+from .models import (
+    MessageCallbackType,
+    MqttValueTemplate,
+    MqttValueTemplateException,
+    ReceiveMessage,
+)
 from .util import get_mqtt_data, valid_subscribe_topic
 
 _LOGGER = logging.getLogger(__name__)
@@ -191,7 +196,8 @@ class MqttImage(MqttEntity, ImageEntity):
             try:
                 url = cv.url(self._url_template(msg.payload))
                 self._attr_image_url = url
-            except TEMPLATE_ERRORS:
+            except MqttValueTemplateException as exc:
+                _LOGGER.warning(exc)
                 return
             except vol.Invalid:
                 _LOGGER.error(

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -94,7 +94,6 @@ from .const import (
     DOMAIN,
     MQTT_CONNECTED,
     MQTT_DISCONNECTED,
-    TEMPLATE_ERRORS,
 )
 from .debug_info import log_message, log_messages
 from .discovery import (
@@ -109,6 +108,7 @@ from .discovery import (
 from .models import (
     MessageCallbackType,
     MqttValueTemplate,
+    MqttValueTemplateException,
     PublishPayloadType,
     ReceiveMessage,
 )
@@ -482,7 +482,8 @@ def write_state_on_attr_change(
             }
             try:
                 msg_callback(msg)
-            except TEMPLATE_ERRORS:
+            except MqttValueTemplateException as exc:
+                _LOGGER.warning(exc)
                 return
             if not _attrs_have_changed(tracked_attrs):
                 return

--- a/homeassistant/components/mqtt/tag.py
+++ b/homeassistant/components/mqtt/tag.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import functools
+import logging
 
 import voluptuous as vol
 
@@ -15,7 +16,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import subscription
 from .config import MQTT_BASE_SCHEMA
-from .const import ATTR_DISCOVERY_HASH, CONF_QOS, CONF_TOPIC, TEMPLATE_ERRORS
+from .const import ATTR_DISCOVERY_HASH, CONF_QOS, CONF_TOPIC
 from .discovery import MQTTDiscoveryPayload
 from .mixins import (
     MQTT_ENTITY_DEVICE_INFO_SCHEMA,
@@ -25,9 +26,16 @@ from .mixins import (
     send_discovery_done,
     update_device,
 )
-from .models import MqttValueTemplate, ReceiveMessage, ReceivePayloadType
+from .models import (
+    MqttValueTemplate,
+    MqttValueTemplateException,
+    ReceiveMessage,
+    ReceivePayloadType,
+)
 from .subscription import EntitySubscription
 from .util import get_mqtt_data, valid_subscribe_topic
+
+_LOGGER = logging.getLogger(__name__)
 
 LOG_NAME = "Tag"
 
@@ -138,7 +146,8 @@ class MQTTTagScanner(MqttDiscoveryDeviceUpdate):
         async def tag_scanned(msg: ReceiveMessage) -> None:
             try:
                 tag_id = str(self._value_template(msg.payload, "")).strip()
-            except TEMPLATE_ERRORS:
+            except MqttValueTemplateException as exc:
+                _LOGGER.warning(exc)
                 return
             if not tag_id:  # No output from template, ignore
                 return

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.mqtt.mixins import MQTT_ENTITY_DEVICE_INFO_SCHEMA
 from homeassistant.components.mqtt.models import (
     MessageCallbackType,
     MqttCommandTemplateException,
+    MqttValueTemplateException,
     ReceiveMessage,
 )
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
@@ -433,37 +434,30 @@ async def test_value_template_value(hass: HomeAssistant) -> None:
         assert template_state_calls.call_count == 1
 
 
-async def test_value_template_fails(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
-) -> None:
+async def test_value_template_fails(hass: HomeAssistant) -> None:
     """Test the rendering of MQTT value template fails."""
-
-    # test rendering a value fails
     entity = MockEntity(entity_id="sensor.test")
     entity.hass = hass
     tpl = template.Template("{{ value_json.some_var * 2 }}")
     val_tpl = mqtt.MqttValueTemplate(tpl, hass=hass, entity=entity)
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(MqttValueTemplateException) as exc:
         val_tpl.async_render_with_possible_json_value('{"some_var": null }')
-    assert str(exc.value) == "unsupported operand type(s) for *: 'NoneType' and 'int'"
-    assert (
+    assert str(exc.value) == (
         "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
         "rendering template for entity 'sensor.test', "
-        "template: '{{ value_json.some_var * 2 }}'"
-    ) in caplog.text
-    caplog.clear()
-    with pytest.raises(TypeError) as exc:
+        "template: '{{ value_json.some_var * 2 }}' "
+        'and payload: {"some_var": null }'
+    )
+    with pytest.raises(MqttValueTemplateException) as exc:
         val_tpl.async_render_with_possible_json_value(
             '{"some_var": null }', default=100
         )
-    assert str(exc.value) == "unsupported operand type(s) for *: 'NoneType' and 'int'"
-    assert (
+    assert str(exc.value) == (
         "TypeError: unsupported operand type(s) for *: 'NoneType' and 'int' "
         "rendering template for entity 'sensor.test', "
         "template: '{{ value_json.some_var * 2 }}', default value: 100 and payload: "
         '{"some_var": null }'
-    ) in caplog.text
-    await hass.async_block_till_done()
+    )
 
 
 async def test_service_call_without_topic_does_not_publish(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor the logging of MQTT value template exceptions. When an exception occurs we should both log and raise.

With an example sensor:

```yaml
mqtt:
  -sensor:
      name: "Errornous sensor"
      value_template: "{{ 2 * None }}"
      state_topic: test/sensor
```

Without this PR, when receiving an invalid value `test` at topic `test/sensor` we log:

```log
Logger: homeassistant.util.logging
Source: util/logging.py:102
First occurred: 20:18:48 (1 occurrences)
Last logged: 20:18:48

Exception in message_received when handling msg on 'test/sensor': 'test' Traceback (most recent call last): File "/usr/src/homeassistant/homeassistant/components/mqtt/mixins.py", line 483, in wrapper msg_callback(msg) File "/usr/src/homeassistant/homeassistant/components/mqtt/debug_info.py", line 43, in wrapper msg_callback(msg) File "/usr/src/homeassistant/homeassistant/components/mqtt/sensor.py", line 278, in message_received _update_state(msg) File "/usr/src/homeassistant/homeassistant/components/mqtt/sensor.py", line 226, in _update_state payload = self._template(msg.payload, PayloadSentinel.DEFAULT) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/src/homeassistant/homeassistant/components/mqtt/models.py", line 288, in async_render_with_possible_json_value raise ex File "/usr/src/homeassistant/homeassistant/components/mqtt/models.py", line 273, in async_render_with_possible_json_value self._value_template.async_render_with_possible_json_value( File "/usr/src/homeassistant/homeassistant/helpers/template.py", line 752, in async_render_with_possible_json_value render_result = _render_with_context( ^^^^^^^^^^^^^^^^^^^^^ File "/usr/src/homeassistant/homeassistant/helpers/template.py", line 2332, in _render_with_context return template.render(**kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^ File "/usr/local/lib/python3.12/site-packages/jinja2/environment.py", line 1301, in render self.environment.handle_exception() File "/usr/local/lib/python3.12/site-packages/jinja2/environment.py", line 936, in handle_exception raise rewrite_traceback_stack(source=source) File "<template>", line 1, in top-level template code TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```

With this PR we no longer log a stack trace:
```log
2024-02-26 19:30:05.271 WARNING (MainThread) [homeassistant.components.mqtt.mixins] TypeError: unsupported operand type(s) for *: 'int' and 'NoneType' rendering template for entity 'sensor.errornous_sensor', template: '{{ 2 * None }}', default value: default and payload: test
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
