### PR TITLE
Improve handling mqtt command template exceptions

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -348,21 +348,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 return
 
         if payload_template is not None:
-            try:
-                payload = MqttCommandTemplate(
-                    template.Template(payload_template), hass=hass
-                ).async_render()
-            except TEMPLATE_ERRORS as exc:
-                _LOGGER.error(
-                    (
-                        "Unable to publish to %s: rendering payload template of "
-                        "%s failed because %s"
-                    ),
-                    msg_topic,
-                    payload_template,
-                    exc,
-                )
-                return
+            payload = MqttCommandTemplate(
+                template.Template(payload_template), hass=hass
+            ).async_render()
 
         if TYPE_CHECKING:
             assert msg_topic is not None

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -320,32 +320,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         qos: int = call.data[ATTR_QOS]
         retain: bool = call.data[ATTR_RETAIN]
         if msg_topic_template is not None:
+            rendered_topic: Any = MqttCommandTemplate(
+                template.Template(msg_topic_template),
+                hass=hass,
+            ).async_render()
             try:
-                rendered_topic: Any = template.Template(
-                    msg_topic_template, hass
-                ).async_render(parse_result=False)
                 msg_topic = valid_publish_topic(rendered_topic)
-            except TEMPLATE_ERRORS as exc:
-                _LOGGER.error(
-                    (
-                        "Unable to publish: rendering topic template of %s "
-                        "failed because %s"
-                    ),
-                    msg_topic_template,
-                    exc,
-                )
-                return
             except vol.Invalid as err:
-                _LOGGER.error(
-                    (
-                        "Unable to publish: topic template '%s' produced an "
-                        "invalid topic '%s' after rendering (%s)"
-                    ),
-                    msg_topic_template,
-                    rendered_topic,
-                    err,
-                )
-                return
+                err_str = str(err)
+                raise ServiceValidationError(
+                    f"Unable to publish: topic template '{msg_topic_template}' produced an "
+                    f"invalid topic '{rendered_topic}' after rendering ({err_str})",
+                    translation_domain=DOMAIN,
+                    translation_key="invalid_publish_topic",
+                    translation_placeholders={
+                        "error": err_str,
+                        "topic": str(rendered_topic),
+                        "topic_template": str(msg_topic_template),
+                    },
+                ) from err
 
         if payload_template is not None:
             payload = MqttCommandTemplate(

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -15,6 +15,7 @@ import voluptuous as vol
 
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError, TemplateError
 from homeassistant.helpers import template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.service_info.mqtt import ReceivePayloadType
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
     from .discovery import MQTTDiscoveryPayload
     from .tag import MQTTTagScanner
 
-from .const import TEMPLATE_ERRORS
+from .const import DOMAIN, TEMPLATE_ERRORS
 
 
 class PayloadSentinel(StrEnum):
@@ -111,6 +112,38 @@ class MqttOriginInfo(TypedDict, total=False):
     support_url: str
 
 
+class MqttCommandTemplateException(ServiceValidationError):
+    """Handle MqttCommandTemplate exceptions."""
+
+    def __init__(
+        self,
+        *args: object,
+        base_exception: Exception,
+        command_template: str,
+        value: PublishPayloadType,
+        entity_id: str | None = None,
+    ) -> None:
+        """Initialize exception."""
+        super().__init__(base_exception, *args)
+        value_log = str(value)
+        self.translation_domain = DOMAIN
+        self.translation_key = "command_template_error"
+        self.translation_placeholders = {
+            "error": str(base_exception),
+            "entity_id": str(entity_id),
+            "command_template": command_template,
+        }
+        entity_id_log = "" if entity_id is None else f" for entity '{entity_id}'"
+        self._message = (
+            f"{type(base_exception).__name__}: {base_exception} rendering template{entity_id_log}"
+            f", template: '{command_template}' and payload: {value_log}"
+        )
+
+    def __str__(self) -> str:
+        """Return exception message string."""
+        return self._message
+
+
 class MqttCommandTemplate:
     """Class for rendering MQTT payload with command templates."""
 
@@ -177,9 +210,17 @@ class MqttCommandTemplate:
             values,
             self._command_template,
         )
-        return _convert_outgoing_payload(
-            self._command_template.async_render(values, parse_result=False)
-        )
+        try:
+            return _convert_outgoing_payload(
+                self._command_template.async_render(values, parse_result=False)
+            )
+        except TemplateError as exc:
+            raise MqttCommandTemplateException(
+                base_exception=exc,
+                command_template=self._command_template.template,
+                value=value,
+                entity_id=self._entity.entity_id if self._entity is not None else None,
+            ) from exc
 
 
 class MqttValueTemplate:

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -246,6 +246,9 @@
     }
   },
   "exceptions": {
+    "command_template_error": {
+      "message": "Parsing template `{command_template}` for entity `{entity_id}` failed with error: {error}."
+    },
     "invalid_platform_config": {
       "message": "Reloading YAML config for manually configured MQTT `{domain}` item failed. See logs for more details."
     },

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -252,6 +252,9 @@
     "invalid_platform_config": {
       "message": "Reloading YAML config for manually configured MQTT `{domain}` item failed. See logs for more details."
     },
+    "invalid_publish_topic": {
+      "message": "Unable to publish: topic template `{topic_template}` produced an invalid topic `{topic}` after rendering ({error})"
+    },
     "mqtt_not_setup_cannot_subscribe": {
       "message": "Cannot subscribe to topic '{topic}', make sure MQTT is set up correctly."
     },

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -34,7 +34,7 @@ from homeassistant.const import (
 )
 import homeassistant.core as ha
 from homeassistant.core import CoreState, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er, template
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import async_get_platforms
@@ -510,14 +510,20 @@ async def test_service_call_with_invalid_topic_template_does_not_publish(
 ) -> None:
     """Test the service call with a problematic topic template."""
     mqtt_mock = await mqtt_mock_entry()
-    await hass.services.async_call(
-        mqtt.DOMAIN,
-        mqtt.SERVICE_PUBLISH,
-        {
-            mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ 1 | no_such_filter }}",
-            mqtt.ATTR_PAYLOAD: "payload",
-        },
-        blocking=True,
+    with pytest.raises(MqttCommandTemplateException) as exc:
+        await hass.services.async_call(
+            mqtt.DOMAIN,
+            mqtt.SERVICE_PUBLISH,
+            {
+                mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ 1 | no_such_filter }}",
+                mqtt.ATTR_PAYLOAD: "payload",
+            },
+            blocking=True,
+        )
+    assert str(exc.value) == (
+        "TemplateError: TemplateAssertionError: No filter named 'no_such_filter'. "
+        "rendering template, template: "
+        "'test/{{ 1 | no_such_filter }}' and payload: None"
     )
     assert not mqtt_mock.async_publish.called
 
@@ -551,14 +557,20 @@ async def test_service_call_with_template_topic_renders_invalid_topic(
     If a wildcard topic is rendered, then fail.
     """
     mqtt_mock = await mqtt_mock_entry()
-    await hass.services.async_call(
-        mqtt.DOMAIN,
-        mqtt.SERVICE_PUBLISH,
-        {
-            mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ '+' if True else 'topic' }}/topic",
-            mqtt.ATTR_PAYLOAD: "payload",
-        },
-        blocking=True,
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            mqtt.DOMAIN,
+            mqtt.SERVICE_PUBLISH,
+            {
+                mqtt.ATTR_TOPIC_TEMPLATE: "test/{{ '+' if True else 'topic' }}/topic",
+                mqtt.ATTR_PAYLOAD: "payload",
+            },
+            blocking=True,
+        )
+    assert str(exc.value) == (
+        "Unable to publish: topic template 'test/{{ '+' if True else 'topic' }}/topic' "
+        "produced an invalid topic 'test/+/topic' after rendering "
+        "(Wildcards cannot be used in topic names)"
     )
     assert not mqtt_mock.async_publish.called
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve handling `mqtt` command template exceptions. When an exception is triggered directly through the UI a translated message is displayed. Template errors are re-raised to a `ServiceValidationError` based exception to avoid not warranted stack traces.

### Example

A mqtt button with an bad template:

```yaml
mqtt:
  - button:
      name: "Errornous button"
      command_template: "{{ 2 * None }}"
      command_topic: test/button
```
... before this PR would log on `PRESS`:

```log
Logger: homeassistant.components.websocket_api.http.connection
Source: components/websocket_api/commands.py:240
Integration: Home Assistant WebSocket API (documentation, issues)
First occurred: 09:38:00 (1 occurrences)
Last logged: 09:38:00

[546598848448] TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/template.py", line 572, in async_render
    render_result = _render_with_context(self.template, compiled, **kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/template.py", line 2332, in _render_with_context
    return template.render(**kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.12/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 1, in top-level template code
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 240, in handle_call_service
    response = await hass.services.async_call(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2279, in async_call
    response_data = await coro
                    ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/core.py", line 2316, in _execute_service
    return await target(service_call)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 892, in entity_service_call
    single_response = await _handle_entity_call(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 962, in _handle_entity_call
    result = await task
             ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/button/__init__.py", line 139, in _async_press_action
    await self.async_press()
  File "/usr/src/homeassistant/homeassistant/components/mqtt/button.py", line 95, in async_press
    payload = self._command_template(self._config[CONF_PAYLOAD_PRESS])
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/mqtt/models.py", line 179, in async_render
    self._command_template.async_render(values, parse_result=False)
  File "/usr/src/homeassistant/homeassistant/helpers/template.py", line 574, in async_render
    raise TemplateError(err) from err
homeassistant.exceptions.TemplateError: TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```
After this PR it will just log log:

```log
2024-02-26 08:41:45.085 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [139677813318592] TemplateError: TypeError: unsupported operand type(s) for *: 'int' and 'NoneType' rendering template for entity 'button.errornous_button', template: '{{ 2 * None }}' and payload: PRESS
```

Also changes the the behavior or `async_publish_service`, which throws a `ServiceValidationError` now in all cases if the topic or payload template has errors, instead of just logging and error.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
