### PR TITLE
Refactor keymitt_ble Config Flow

### DIFF
--- a/homeassistant/components/keymitt_ble/config_flow.py
+++ b/homeassistant/components/keymitt_ble/config_flow.py
@@ -120,8 +120,8 @@ class MicroBotConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Given a configured host, will ask the user to press the button to pair."""
         errors: dict[str, str] = {}
+        token = randomid(32)
         if self._client is None:
-            token = randomid(32)
             self._client = MicroBotApiClient(
                 device=self._ble_device,
                 token=token,

--- a/homeassistant/components/keymitt_ble/coordinator.py
+++ b/homeassistant/components/keymitt_ble/coordinator.py
@@ -10,14 +10,12 @@ from homeassistant.components import bluetooth
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothDataUpdateCoordinator,
 )
-from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 
 if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-PLATFORMS: list[str] = [Platform.SWITCH]
 
 
 class MicroBotDataUpdateCoordinator(PassiveBluetoothDataUpdateCoordinator):

--- a/homeassistant/components/keymitt_ble/strings.json
+++ b/homeassistant/components/keymitt_ble/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "flow_title": "{name}",
     "step": {
-      "init": {
+      "user": {
         "title": "Set up MicroBot device",
         "data": {
           "address": "Device address",

--- a/tests/components/keymitt_ble/__init__.py
+++ b/tests/components/keymitt_ble/__init__.py
@@ -60,6 +60,7 @@ class MockMicroBotApiClient:
     async def disconnect(self):
         """Mock disconnect."""
 
+    @property
     def is_connected(self):
         """Mock connected."""
         return True
@@ -77,6 +78,7 @@ class MockMicroBotApiClientFail:
     async def disconnect(self):
         """Mock disconnect."""
 
-    async def is_connected(self):
+    @property
+    def is_connected(self):
         """Mock disconnected."""
         return False

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -172,7 +172,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
 
     with patch_microbot_api(), patch(
         "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
-        MockMicroBotApiClientFail,
+        MockMicroBotApiClientFail
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -178,7 +178,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
             result["flow_id"],
             USER_INPUT,
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
     
     assert result2["type"] == FlowResultType.FORM
     assert result2["step_id"] == "link"
@@ -192,7 +192,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
             result2["flow_id"],
             USER_INPUT,
         )
-    await hass.async_block_till_done()
+        await hass.async_block_till_done()
     
     assert result3["type"] == FlowResultType.FORM
     assert result3["step_id"] == "link"

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -27,7 +27,7 @@ def patch_microbot_api():
 
 async def test_bluetooth_discovery(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
-    result = await hass.config_entries.flow.async_user(
+    result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_BLUETOOTH},
         data=SERVICE_INFO,
@@ -72,7 +72,7 @@ async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
     with patch_microbot_api():
-        result = await hass.config_entries.flow.async_user(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": SOURCE_BLUETOOTH},
             data=SERVICE_INFO,
@@ -88,7 +88,7 @@ async def test_user_setup(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_user(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.FORM
@@ -135,7 +135,7 @@ async def test_user_setup_already_configured(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_user(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.ABORT
@@ -148,7 +148,7 @@ async def test_user_no_devices(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[],
     ):
-        result = await hass.config_entries.flow.async_user(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.ABORT
@@ -162,7 +162,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_user(
+        result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.FORM

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -193,7 +193,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
             USER_INPUT,
         )
         await hass.async_block_till_done()
-    
+
     assert result3["type"] == FlowResultType.FORM
     assert result3["step_id"] == "link"
     assert result3["errors"] == {}

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -43,8 +43,22 @@ async def test_bluetooth_discovery(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "link"
+    assert result["errors"] is None
 
-    assert len(mock_setup_entry.mock_calls) == 0
+    with patch_microbot_api(), patch_async_setup_entry() as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == FlowResultType.CREATE_ENTRY
+    assert result2["result"].data == {
+        CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+        CONF_ACCESS_TOKEN: ANY,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -180,12 +180,11 @@ async def test_no_link(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
         MockMicroBotApiClientFail,
-    ), patch_async_setup_entry() as mock_setup_entry:
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             USER_INPUT,
         )
-        await hass.async_block_till_done()
 
     assert result3["type"] == FlowResultType.FORM
     assert result3["step_id"] == "link"

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -192,6 +192,3 @@ async def test_no_link(hass: HomeAssistant) -> None:
     assert result3["errors"] == {"base": "linking"}
 
     assert len(mock_setup_entry.mock_calls) == 0
-
-    assert result4["type"] == FlowResultType.ABORT
-    assert result4["reason"] == "cannot_connect"

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -187,7 +187,11 @@ async def test_no_link(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
+    assert result3["type"] == FlowResultType.FORM
+    assert result3["step_id"] == "link"
+    assert result3["errors"] == {"base": "linking"}
 
     assert len(mock_setup_entry.mock_calls) == 0
+
+    assert result4["type"] == FlowResultType.ABORT
+    assert result4["reason"] == "cannot_connect"

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -27,13 +27,13 @@ def patch_microbot_api():
 
 async def test_bluetooth_discovery(hass: HomeAssistant) -> None:
     """Test discovery via bluetooth with a valid device."""
-    result = await hass.config_entries.flow.async_init(
+    result = await hass.config_entries.flow.async_user(
         DOMAIN,
         context={"source": SOURCE_BLUETOOTH},
         data=SERVICE_INFO,
     )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "user"
 
     with patch_async_setup_entry() as mock_setup_entry, patch_microbot_api():
         result = await hass.config_entries.flow.async_configure(
@@ -72,7 +72,7 @@ async def test_bluetooth_discovery_already_setup(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
     with patch_microbot_api():
-        result = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_user(
             DOMAIN,
             context={"source": SOURCE_BLUETOOTH},
             data=SERVICE_INFO,
@@ -88,11 +88,11 @@ async def test_user_setup(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_user(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch_microbot_api():
@@ -135,7 +135,7 @@ async def test_user_setup_already_configured(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_user(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.ABORT
@@ -148,7 +148,7 @@ async def test_user_no_devices(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[],
     ):
-        result = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_user(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.ABORT
@@ -162,11 +162,11 @@ async def test_no_link(hass: HomeAssistant) -> None:
         "homeassistant.components.keymitt_ble.config_flow.async_discovered_service_info",
         return_value=[SERVICE_INFO],
     ):
-        result = await hass.config_entries.flow.async_init(
+        result = await hass.config_entries.flow.async_user(
             DOMAIN, context={"source": SOURCE_USER}
         )
     assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "init"
+    assert result["step_id"] == "user"
     assert result["errors"] == {}
 
     with patch_microbot_api():

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -186,7 +186,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
 
     with patch_microbot_api(), patch(
         "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
-        MockMicroBotApiClient,
+        MockMicroBotApiClient
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -172,7 +172,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
 
     with patch_microbot_api(), patch(
         "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
-        MockMicroBotApiClientFail
+        MockMicroBotApiClientFail,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -186,7 +186,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
 
     with patch_microbot_api(), patch(
         "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
-        MockMicroBotApiClient
+        MockMicroBotApiClient,
     ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -187,8 +187,5 @@ async def test_no_link(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.FORM
-    assert result3["step_id"] == "link"
-    assert result3["errors"] == {"base": "linking"}
-
-    assert len(mock_setup_entry.mock_calls) == 0
+    assert result3["type"] == FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -187,8 +187,20 @@ async def test_no_link(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.CREATE_ENTRY
+    assert result3["type"] == FlowResultType.FORM
     assert result3["step_id"] == "link"
     assert result3["errors"] == {"base": "linking"}
 
-    assert len(mock_setup_entry.mock_calls) == 0
+    with patch_microbot_api(), patch_async_setup_entry() as mock_setup_entry:
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
+            USER_INPUT,
+        )
+        await hass.async_block_till_done()
+
+    assert result4["type"] == FlowResultType.CREATE_ENTRY
+    assert result4["result"].data == {
+        CONF_ADDRESS: "aa:bb:cc:dd:ee:ff",
+        CONF_ACCESS_TOKEN: ANY,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -184,19 +184,19 @@ async def test_no_link(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "linking"}
 
     with patch_microbot_api():
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
             USER_INPUT,
         )
     await hass.async_block_till_done()
     
-    assert result2["type"] == FlowResultType.FORM
-    assert result2["step_id"] == "link"
-    assert result2["errors"] == {}
+    assert result3["type"] == FlowResultType.FORM
+    assert result3["step_id"] == "link"
+    assert result3["errors"] == {}
     
     with patch_microbot_api(), patch_async_setup_entry() as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result4 = await hass.config_entries.flow.async_configure(
+            result3["flow_id"],
             USER_INPUT,
         )
         await hass.async_block_till_done()

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -189,3 +189,5 @@ async def test_no_link(hass: HomeAssistant) -> None:
 
     assert result3["type"] == FlowResultType.ABORT
     assert result["reason"] == "cannot_connect"
+
+    assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -187,7 +187,7 @@ async def test_no_link(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == FlowResultType.FORM
+    assert result3["type"] == FlowResultType.CREATE_ENTRY
     assert result3["step_id"] == "link"
     assert result3["errors"] == {"base": "linking"}
 

--- a/tests/components/keymitt_ble/test_config_flow.py
+++ b/tests/components/keymitt_ble/test_config_flow.py
@@ -10,6 +10,7 @@ from . import (
     SERVICE_INFO,
     USER_INPUT,
     MockMicroBotApiClientFail,
+    MockMicroBotApiClient,
     patch_async_setup_entry,
 )
 
@@ -183,7 +184,10 @@ async def test_no_link(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "link"
     assert result2["errors"] == {"base": "linking"}
 
-    with patch_microbot_api():
+    with patch_microbot_api(), patch(
+        "homeassistant.components.keymitt_ble.config_flow.MicroBotApiClient",
+        MockMicroBotApiClient,
+    ):
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             USER_INPUT,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Fix ```FutureWarning: is_connected has been changed to a property. Calling it as an async method will be removed in a future version self._client.is_connected()``` Config Flow updated to look for what is now a property in pyMicrobot.....although there is backwards compatibility written into 0.0.17 for now.
- Address late review comments in https://github.com/home-assistant/core/pull/76575;
    - Remove unused ```PLATFORMS: list[str] = [Platform.SWITCH]``` from coordinator
    - Merge the init step and the user step of the config flow 
    - Continue all config flow tests to either a create entry, error or abort result.
    - Do not create a new client every time the link method is called

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/issues/109742
- This PR addresses review comments in : https://github.com/home-assistant/core/pull/76575

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
