### PR TITLE
Add kelvin to light profile

### DIFF
--- a/homeassistant/components/light/light_profiles.csv
+++ b/homeassistant/components/light/light_profiles.csv
@@ -1,5 +1,8 @@
-id,x,y,brightness
+id,x,y,brightness,kelvin
 relax,0.5119,0.4147,144
 concentrate,0.5119,0.4147,219
 energize,0.368,0.3686,203
 reading,0.4448,0.4066,240
+warm_white,,,255,,3000
+cool_white,,,255,,4000
+daylight,,,255,,5000

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1043,10 +1043,13 @@ async def test_profiles(hass: HomeAssistant) -> None:
     profiles = orig_Profiles(hass)
     await profiles.async_initialize()
     assert profiles.data == {
-        "concentrate": light.Profile("concentrate", 0.5119, 0.4147, 219, None),
-        "energize": light.Profile("energize", 0.368, 0.3686, 203, None),
-        "reading": light.Profile("reading", 0.4448, 0.4066, 240, None),
-        "relax": light.Profile("relax", 0.5119, 0.4147, 144, None),
+        "concentrate": light.Profile("concentrate", 0.5119, 0.4147, 219, None, None),
+        "energize": light.Profile("energize", 0.368, 0.3686, 203, None, None),
+        "reading": light.Profile("reading", 0.4448, 0.4066, 240, None, None),
+        "relax": light.Profile("relax", 0.5119, 0.4147, 144, None, None),
+        "warm_white": light.Profile("warm_white", None, None, 255, None, 3000),
+        "cool_white": light.Profile("cool_white", None, None, 255, None, 4000),
+        "daylight": light.Profile("daylight", None, None, 255, None, 5000),
     }
     assert profiles.data["concentrate"].hs_color == (35.932, 69.412)
     assert profiles.data["energize"].hs_color == (43.333, 21.176)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR adds kelvins to the light profile. 

Previously, the light profile only supported <x,y>. This is problematic for RGBCCT lights - even though it is possible to convert kelvin to x,y values, sending the x,y value could cause the light to go into RGB mode instead of using the CCT leds only (for example, if [color_interlock](https://esphome.io/components/light/rgbw.html#rgbw-color-interlock) is set on a esphome light). 

This PR adds an extra optional kelvin field at the end of the color profile. If x,y is left blank, then only kelvin will be passed, correctly enabling default "white" lights.

## Type of change
- [x] New feature (which adds functionality to an existing integration)

## Additional information
Example of new csv file:

```
id,x,y,brightness,transition,kelvin
group.all_lights.default,,,255,,2800
```

- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
