### PR TITLE
Move Shelly thermostat check to status endpoint

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -43,7 +43,12 @@ from .const import (
 )
 from .coordinator import ShellyBlockCoordinator, ShellyRpcCoordinator, get_entry_data
 from .entity import ShellyRpcEntity
-from .utils import async_remove_shelly_entity, get_device_entry_gen, get_rpc_key_ids
+from .utils import (
+    async_remove_shelly_entity,
+    get_device_entry_gen,
+    get_rpc_key_ids,
+    is_rpc_thermostat_internal_actuator,
+)
 
 
 async def async_setup_entry(
@@ -127,7 +132,7 @@ def async_setup_rpc_entry(
     for id_ in climate_key_ids:
         climate_ids.append(id_)
 
-        if coordinator.device.shelly.get("relay_in_thermostat", False):
+        if is_rpc_thermostat_internal_actuator(coordinator.device.status):
             # Wall Display relay is used as the thermostat actuator,
             # we need to remove a switch entity
             unique_id = f"{coordinator.mac}-switch:{id_}"

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -41,6 +41,7 @@ from .utils import (
     get_rpc_key_ids,
     is_block_channel_type_light,
     is_rpc_channel_type_light,
+    is_rpc_thermostat_internal_actuator,
 )
 
 
@@ -134,7 +135,7 @@ def async_setup_rpc_entry(
             continue
 
         if coordinator.model == MODEL_WALL_DISPLAY:
-            if not coordinator.device.shelly.get("relay_in_thermostat", False):
+            if not is_rpc_thermostat_internal_actuator(coordinator.device.status):
                 # Wall Display relay is not used as the thermostat actuator,
                 # we need to remove a climate entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -367,6 +367,11 @@ def is_rpc_channel_type_light(config: dict[str, Any], channel: int) -> bool:
     return cast(str, con_types[channel]).lower().startswith("light")
 
 
+def is_rpc_thermostat_internal_actuator(status: dict[str, Any]) -> bool:
+    """Return true if the thermostat uses an internal relay."""
+    return cast(bool, status.get("relay_in_thermostat", False))
+
+
 def get_rpc_input_triggers(device: RpcDevice) -> list[tuple[str, str]]:
     """Return list of input triggers for RPC device."""
     triggers = []

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -369,7 +369,7 @@ def is_rpc_channel_type_light(config: dict[str, Any], channel: int) -> bool:
 
 def is_rpc_thermostat_internal_actuator(status: dict[str, Any]) -> bool:
     """Return true if the thermostat uses an internal relay."""
-    return cast(bool, status.get("relay_in_thermostat", False))
+    return cast(bool, status["sys"].get("relay_in_thermostat", False))
 
 
 def get_rpc_input_triggers(device: RpcDevice) -> list[tuple[str, str]]:

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -247,11 +247,11 @@ MOCK_STATUS_RPC = {
         "available_updates": {
             "beta": {"version": "some_beta_version"},
             "stable": {"version": "some_beta_version"},
-        }
+        },
+        "relay_in_thermostat": True,
     },
     "voltmeter": {"voltage": 4.321},
     "wifi": {"rssi": -63},
-    "relay_in_thermostat": True,
 }
 
 

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -201,7 +201,6 @@ MOCK_SHELLY_RPC = {
     "auth_en": False,
     "auth_domain": None,
     "profile": "cover",
-    "relay_in_thermostat": True,
 }
 
 MOCK_STATUS_COAP = {
@@ -252,6 +251,7 @@ MOCK_STATUS_RPC = {
     },
     "voltmeter": {"voltage": 4.321},
     "wifi": {"rssi": -63},
+    "relay_in_thermostat": True,
 }
 
 

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -146,7 +146,8 @@ async def test_rpc_config_entry_diagnostics(
                 "available_updates": {
                     "beta": {"version": "some_beta_version"},
                     "stable": {"version": "some_beta_version"},
-                }
+                },
+                "relay_in_thermostat": True,
             },
             "wifi": {"rssi": -63},
         },

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -328,7 +328,7 @@ async def test_wall_display_relay_mode(
     switch_entity_id = "switch.test_switch_0"
 
     new_status = deepcopy(mock_rpc_device.status)
-    new_status["relay_in_thermostat"] = False
+    new_status["sys"]["relay_in_thermostat"] = False
     monkeypatch.setattr(mock_rpc_device, "status", new_status)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -327,9 +327,9 @@ async def test_wall_display_relay_mode(
     climate_entity_id = "climate.test_name"
     switch_entity_id = "switch.test_switch_0"
 
-    new_shelly = deepcopy(mock_rpc_device.shelly)
-    new_shelly["relay_in_thermostat"] = False
-    monkeypatch.setattr(mock_rpc_device, "shelly", new_shelly)
+    new_status = deepcopy(mock_rpc_device.status)
+    new_status["relay_in_thermostat"] = False
+    monkeypatch.setattr(mock_rpc_device, "status", new_status)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the check for thermostat mode from `/shelly` to `/status`.
This change will prepare the adoption of EntityDescription.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
