### PR TITLE
Extend blebox shutterbox tilt support

### DIFF
--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from enum import IntEnum
 from typing import Any
 
 from blebox_uniapi.box import Box
@@ -16,14 +15,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_JAMMED,
-    STATE_OPEN,
-    STATE_OPENING,
-    STATE_PROBLEM,
-)
+from homeassistant.const import STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -36,40 +28,18 @@ BLEBOX_TO_COVER_DEVICE_CLASSES = {
     "shutter": CoverDeviceClass.SHUTTER,
 }
 
-
-class BleboxCoverState(IntEnum):
-    """Internal cover state as reported by switchbox devices and blebox_uniapi."""
-
-    MOVING_DOWN = 0
-    MOVING_UP = 1
-    MANUALLY_STOPPED = 2
-    LOWER_LIMIT_REACHED = 3
-    UPPER_LIMIT_REACHED = 4
-    OVERLOAD = 5
-    MOTOR_FAILURE = 6
-    UNUSED = 7
-    SAFETY_STOP = 8
-
-
 BLEBOX_TO_HASS_COVER_STATES = {
     None: None,
-    # === switchBox states ===
-    BleboxCoverState.MOVING_DOWN: STATE_CLOSING,
-    BleboxCoverState.MOVING_UP: STATE_OPENING,
-    # note: MANUALLY_STOPPED means either "stopped during opening" or "stopped during
-    #       closing" but never fully closed or fully opened. However, CoverEntity does
-    #       not distinguish between such states. This may result in seemingly strange
-    #       state transitions in the event log like "Is closing" -> "Was opened".
-    #       This is fine as something that is "partially" opened isn't really closed.
-    #       Such presentation of the state is thus safer for users relying on it.
-    BleboxCoverState.MANUALLY_STOPPED: STATE_OPEN,
-    BleboxCoverState.LOWER_LIMIT_REACHED: STATE_CLOSED,
-    BleboxCoverState.UPPER_LIMIT_REACHED: STATE_OPEN,
-    # === switchBox + gateController states ===
-    BleboxCoverState.OVERLOAD: STATE_PROBLEM,
-    BleboxCoverState.MOTOR_FAILURE: STATE_PROBLEM,
-    BleboxCoverState.UNUSED: None,  # never used
-    BleboxCoverState.SAFETY_STOP: STATE_JAMMED,
+    0: STATE_CLOSING,  # moving down
+    1: STATE_OPENING,  # moving up
+    2: STATE_OPEN,  # manually stopped
+    3: STATE_CLOSED,  # lower limit
+    4: STATE_OPEN,  # upper limit / open
+    # gateController
+    5: STATE_OPEN,  # overload
+    6: STATE_OPEN,  # motor failure
+    # 7 is not used
+    8: STATE_OPEN,  # safety stop
 }
 
 

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -140,7 +140,7 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
         return self._is_state(STATE_CLOSED)
 
     async def async_open_cover(self, **kwargs: Any) -> None:
-        """Fully cpen the cover position."""
+        """Fully open the cover position."""
         await self._feature.async_open()
 
     async def async_close_cover(self, **kwargs: Any) -> None:

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -149,21 +149,12 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
 
     async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Fully open the cover tilt."""
-        # note: dedicated API coming in blebox_uniapi>=2.3.0
-        if hasattr(self._feature, "async_open_tilt"):
-            await self._feature.async_open_tilt()
-        else:
-            # note: values are reversed
-            await self._feature.async_set_tilt_position(0)
+        await self._feature.async_set_tilt_position(0)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Fully close the cover tilt."""
-        # note: dedicated API coming in blebox_uniapi>=2.3.0
-        if hasattr(self._feature, "async_close_tilt"):
-            await self._feature.async_close_tilt()
-        else:
-            # note: values are reversed
-            await self._feature.async_set_tilt_position(100)
+        # note: values are reversed
+        await self._feature.async_set_tilt_position(100)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Set the cover position."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `CoverEntityFeature.OPEN_TILT` and `CoverEntityFeature.CLOSE_TILT` to `BleBoxCoverEntity`. 
The intermediary `blebox_uniapi` does not provide API for open/close tilt but it does have an API for setting specific tilt position. It means that open/close tilt can be achieved through set position. New API will come in future `blebox_uniapi` version so this change implements the feature in future-compatible way.

This PR also improves mapping of internal switchbox cover states into homeassistant states mainly by introducing proper failure states.
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
