### PR TITLE
Allow for case insensitive setting of climate modes. This is because …

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -626,10 +626,16 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         mode_type: Literal["preset", "swing", "fan"],
         mode: str,
         modes: list[str] | None,
-    ) -> None:
+    ) -> str:
         """Raise ServiceValidationError on invalid modes."""
         if modes and mode in modes:
-            return
+            return mode
+        # check if there is a case insenitive match
+        if mode and modes:
+            mode_in = mode.casefold()
+            for mode_out in modes:
+                if mode_in == mode_out.casefold():
+                    return mode_out
         modes_str: str = ", ".join(modes) if modes else ""
         if mode_type == "preset":
             translation_key = "not_valid_preset_mode"
@@ -669,7 +675,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @final
     async def async_handle_set_fan_mode_service(self, fan_mode: str) -> None:
         """Validate and set new preset mode."""
-        self._valid_mode_or_raise("fan", fan_mode, self.fan_modes)
+        fan_mode = self._valid_mode_or_raise("fan", fan_mode, self.fan_modes)
         await self.async_set_fan_mode(fan_mode)
 
     def set_fan_mode(self, fan_mode: str) -> None:
@@ -691,7 +697,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @final
     async def async_handle_set_swing_mode_service(self, swing_mode: str) -> None:
         """Validate and set new preset mode."""
-        self._valid_mode_or_raise("swing", swing_mode, self.swing_modes)
+        swing_mode = self._valid_mode_or_raise("swing", swing_mode, self.swing_modes)
         await self.async_set_swing_mode(swing_mode)
 
     def set_swing_mode(self, swing_mode: str) -> None:
@@ -705,7 +711,9 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     @final
     async def async_handle_set_preset_mode_service(self, preset_mode: str) -> None:
         """Validate and set new preset mode."""
-        self._valid_mode_or_raise("preset", preset_mode, self.preset_modes)
+        preset_mode = self._valid_mode_or_raise(
+            "preset", preset_mode, self.preset_modes
+        )
         await self.async_set_preset_mode(preset_mode)
 
     def set_preset_mode(self, preset_mode: str) -> None:

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -269,6 +269,16 @@ async def test_preset_mode_validation(
         },
         blocking=True,
     )
+    # test case insensitivity
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_PRESET_MODE,
+        {
+            "entity_id": "climate.test",
+            "preset_mode": "Away",
+        },
+        blocking=True,
+    )
     await hass.services.async_call(
         DOMAIN,
         SERVICE_SET_SWING_MODE,


### PR DESCRIPTION
…different climate intergrations may have the same name but different case.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See https://community.home-assistant.io/t/hvac-mode-case-sensitive/689394


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- related to multiple climate integrations can't be set to the same mode because they use different case for Away/away, Home/home, etc..

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
