### PR TITLE
Add backup created event when new HA backup finish

### DIFF
--- a/homeassistant/components/backup/const.py
+++ b/homeassistant/components/backup/const.py
@@ -4,6 +4,8 @@ from logging import getLogger
 DOMAIN = "backup"
 LOGGER = getLogger(__package__)
 
+EVENT_BACKUP_CREATED = "backup_created"
+
 EXCLUDE_FROM_BACKUP = [
     "__pycache__/*",
     ".DS_Store",

--- a/homeassistant/components/backup/manager.py
+++ b/homeassistant/components/backup/manager.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.json import save_json
 from homeassistant.util import dt as dt_util
 from homeassistant.util.json import json_loads_object
 
-from .const import DOMAIN, EXCLUDE_FROM_BACKUP, LOGGER
+from .const import DOMAIN, EVENT_BACKUP_CREATED, EXCLUDE_FROM_BACKUP, LOGGER
 
 BUF_SIZE = 2**20 * 4  # 4MB
 
@@ -204,6 +204,7 @@ class BackupManager:
             if self.loaded_backups:
                 self.backups[slug] = backup
             LOGGER.debug("Generated new backup with slug %s", slug)
+            self.hass.bus.async_fire(EVENT_BACKUP_CREATED, backup.as_dict())
             return backup
         finally:
             self.backing_up = False

--- a/tests/components/backup/test_manager.py
+++ b/tests/components/backup/test_manager.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from homeassistant.components.backup import BackupManager
+from homeassistant.components.backup.const import EVENT_BACKUP_CREATED
 from homeassistant.components.backup.manager import BackupPlatformProtocol
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -14,7 +15,7 @@ from homeassistant.setup import async_setup_component
 
 from .common import TEST_BACKUP
 
-from tests.common import MockPlatform, mock_platform
+from tests.common import MockPlatform, async_capture_events, mock_platform
 
 
 async def _mock_backup_generation(manager: BackupManager):
@@ -175,11 +176,13 @@ async def test_generate_backup(
     manager = BackupManager(hass)
     manager.loaded_backups = True
 
+    test_created_event = async_capture_events(hass, EVENT_BACKUP_CREATED)
     await _mock_backup_generation(manager)
 
     assert "Generated new backup with slug " in caplog.text
     assert "Creating backup directory" in caplog.text
     assert "Loaded 0 platforms" in caplog.text
+    assert len(test_created_event) == 1, "Created event not fired"
 
 
 async def test_loading_platforms(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Currently there is no indication after new backup is created. Only possibility is after some time (after backup.create service call)  just check if there is new backup available and then perform actions like upload it to external storage, check size, etc.
With this event we can simply trigger automation based on it. Event also includes all backup data (currently slug, name, date, path, size).
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/new-backup-feature-raise-event-on-completion/416781
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
