### PR TITLE
Fix formatting of mac addresses from dhcp discovery mocking in broadlink

### DIFF
--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -10,7 +10,6 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.broadlink.const import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 
 from . import get_device
 
@@ -838,7 +837,7 @@ async def test_dhcp_can_finish(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress=dr.format_mac(device.mac).replace(":", ""),
+                macaddress=device.mac,
             ),
         )
         await hass.async_block_till_done()
@@ -932,7 +931,7 @@ async def test_dhcp_device_not_supported(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip=device.host,
-                macaddress=dr.format_mac(device.mac).replace(":", ""),
+                macaddress=device.mac,
             ),
         )
 

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -838,7 +838,7 @@ async def test_dhcp_can_finish(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress=dr.format_mac(device.mac),
+                macaddress=dr.format_mac(device.mac).replace(":", ""),
             ),
         )
         await hass.async_block_till_done()
@@ -872,7 +872,7 @@ async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress="34:ea:34:b4:3b:5a",
+                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
             ),
         )
         await hass.async_block_till_done()
@@ -956,7 +956,7 @@ async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress="34:ea:34:b4:3b:5a",
+                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
             ),
         )
         await hass.async_block_till_done()
@@ -981,7 +981,7 @@ async def test_dhcp_updates_host(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="4.5.6.7",
-                macaddress="34:ea:34:b4:3b:5a",
+                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
             ),
         )
         await hass.async_block_till_done()

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -872,7 +872,7 @@ async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
+                macaddress="34ea34b43b5a",
             ),
         )
         await hass.async_block_till_done()
@@ -891,7 +891,7 @@ async def test_dhcp_unreachable(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress="34:ea:34:b4:3b:5a",
+                macaddress="34ea34b43b5a",
             ),
         )
         await hass.async_block_till_done()
@@ -910,7 +910,7 @@ async def test_dhcp_connect_unknown_error(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress="34:ea:34:b4:3b:5a",
+                macaddress="34ea34b43b5a",
             ),
         )
         await hass.async_block_till_done()
@@ -932,7 +932,7 @@ async def test_dhcp_device_not_supported(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip=device.host,
-                macaddress=dr.format_mac(device.mac),
+                macaddress=dr.format_mac(device.mac).replace(":", ""),
             ),
         )
 
@@ -956,7 +956,7 @@ async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="1.2.3.4",
-                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
+                macaddress="34ea34b43b5a",
             ),
         )
         await hass.async_block_till_done()
@@ -981,7 +981,7 @@ async def test_dhcp_updates_host(hass: HomeAssistant) -> None:
             data=dhcp.DhcpServiceInfo(
                 hostname="broadlink",
                 ip="4.5.6.7",
-                macaddress=dr.format_mac("34:ea:34:b4:3b:5a").replace(":", ""),
+                macaddress="34ea34b43b5a",
             ),
         )
         await hass.async_block_till_done()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
dhcp returns addresses in lowercase without :


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
