### PR TITLE
Fix misaligned mac formatting in goalzero

### DIFF
--- a/homeassistant/components/goalzero/__init__.py
+++ b/homeassistant/components/goalzero/__init__.py
@@ -1,6 +1,8 @@
 """The Goal Zero Yeti integration."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from goalzero import Yeti, exceptions
 
 from homeassistant.config_entries import ConfigEntry
@@ -8,6 +10,7 @@ from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import DOMAIN
 from .coordinator import GoalZeroDataUpdateCoordinator
@@ -17,6 +20,17 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Goal Zero Yeti from a config entry."""
+
+    mac = entry.unique_id
+
+    if TYPE_CHECKING:
+        assert mac is not None
+
+    if (formatted_mac := format_mac(mac)) != mac:
+        # The DHCP discovery path did not format the MAC address
+        # so we need to update the config entry if it's different
+        hass.config_entries.async_update_entry(entry, unique_id=formatted_mac)
+
     api = Yeti(entry.data[CONF_HOST], async_get_clientsession(hass))
     try:
         await api.init_connect()

--- a/homeassistant/components/goalzero/config_flow.py
+++ b/homeassistant/components/goalzero/config_flow.py
@@ -32,7 +32,7 @@ class GoalZeroFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle dhcp discovery."""
         self.ip_address = discovery_info.ip
 
-        await self.async_set_unique_id(discovery_info.macaddress)
+        await self.async_set_unique_id(format_mac(discovery_info.macaddress))
         self._abort_if_unique_id_configured(updates={CONF_HOST: self.ip_address})
         self._async_abort_entries_match({CONF_HOST: self.ip_address})
 

--- a/tests/components/goalzero/__init__.py
+++ b/tests/components/goalzero/__init__.py
@@ -21,7 +21,7 @@ CONF_DATA = {
 
 CONF_DHCP_FLOW = dhcp.DhcpServiceInfo(
     ip=HOST,
-    macaddress=format_mac("AA:BB:CC:DD:EE:FF"),
+    macaddress=format_mac("AA:BB:CC:DD:EE:FF").replace(":", ""),
     hostname="yeti",
 )
 

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -35,6 +35,26 @@ async def test_setup_config_and_unload(hass: HomeAssistant) -> None:
     assert not hass.data.get(DOMAIN)
 
 
+async def test_setup_config_entry_incorrectly_formatted_mac(
+    hass: HomeAssistant,
+) -> None:
+    """Test the mac address formatting is corrected."""
+    entry = create_entry(hass)
+    hass.config_entries.async_update_entry(entry, unique_id="AABBCCDDEEFF")
+    mocked_yeti = await create_mocked_yeti()
+    with patch("homeassistant.components.goalzero.Yeti", return_value=mocked_yeti):
+        await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state == ConfigEntryState.LOADED
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+    assert entry.data == CONF_DATA
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff"
+
+
 async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = create_entry(hass)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The DHCP mac address was being set as `aabbcceeddff` but the user step was setting it as `aa:bb:cc:dd:ee:ff`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
