### PR TITLE
Add generic URL handler to blueprint importer

### DIFF
--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -213,6 +213,7 @@ async def test_fetch_blueprint_from_generic_url(
 
 def test_generic_importer_last() -> None:
     """Test that generic importer is always the last one."""
-    for i, func in enumerate(importer.FETCH_FUNCTIONS):
-        if func is importer.fetch_blueprint_from_generic_url:
-            assert i == (len(importer.FETCH_FUNCTIONS) - 1)
+    assert (
+        importer.FETCH_FUNCTIONS.count(importer.fetch_blueprint_from_generic_url) == 1
+    )
+    assert importer.FETCH_FUNCTIONS[-1] = importer.fetch_blueprint_from_generic_url

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -216,4 +216,4 @@ def test_generic_importer_last() -> None:
     assert (
         importer.FETCH_FUNCTIONS.count(importer.fetch_blueprint_from_generic_url) == 1
     )
-    assert importer.FETCH_FUNCTIONS[-1] = importer.fetch_blueprint_from_generic_url
+    assert importer.FETCH_FUNCTIONS[-1] == importer.fetch_blueprint_from_generic_url

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -200,7 +200,7 @@ async def test_fetch_blueprint_from_generic_url(
         "https://example.org/path/someblueprint.yaml",
         text=Path(
             hass.config.path("blueprints/automation/test_event_service.yaml")
-        ).read_text(),
+        ).read_text(encoding="utf8"),
     )
 
     url = "https://example.org/path/someblueprint.yaml"

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -192,9 +192,27 @@ async def test_fetch_blueprint_from_website_url(
     assert imported_blueprint.blueprint.metadata["source_url"] == url
 
 
-async def test_fetch_blueprint_from_unsupported_url(hass: HomeAssistant) -> None:
-    """Test fetching blueprint from an unsupported URL."""
-    url = "https://example.com/unsupported.yaml"
+async def test_fetch_blueprint_from_generic_url(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test fetching blueprint from url."""
+    aioclient_mock.get(
+        "https://example.org/path/someblueprint.yaml",
+        text=Path(
+            hass.config.path("blueprints/automation/test_event_service.yaml")
+        ).read_text(),
+    )
 
-    with pytest.raises(HomeAssistantError, match=r"^Unsupported URL$"):
-        await importer.fetch_blueprint_from_url(hass, url)
+    url = "https://example.org/path/someblueprint.yaml"
+    imported_blueprint = await importer.fetch_blueprint_from_url(hass, url)
+    assert isinstance(imported_blueprint, importer.ImportedBlueprint)
+    assert imported_blueprint.blueprint.domain == "automation"
+    assert imported_blueprint.suggested_filename == "example.org/someblueprint"
+    assert imported_blueprint.blueprint.metadata["source_url"] == url
+
+
+def test_generic_importer_last() -> None:
+    """Test that generic importer is always the last one."""
+    for i, func in enumerate(importer.FETCH_FUNCTIONS):
+        if func is importer.fetch_blueprint_from_generic_url:
+            assert i == (len(importer.FETCH_FUNCTIONS) - 1)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change extends the blueprint importer to allow imports from any generic URL.

As a blueprint author, I might not host my blueprint on GitHub or in the community 
forums but instead choose another version control service (e.g. GitLab, codeberg, sr.ht, etc.) 
or even a personal website/blog.

Because the blueprint importer currently only supports some hand-picked sources,
I'm unable to do so.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

_Note: I didn't find any documentation on the supported blueprint import URLs.
If it exists I'd appreciate a link so that I can add it, otherwise I could write an entirely
new documentation page on the matter, if necessary._

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

_Since this is my very first contribution to this codebase I didn't feel comfortable doing
a proper review. If there is a checklist for things to look out for, I could do a screening for
these things on a couple of PRs._

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
