### PR TITLE
Small performance improvements to collecting analytics

### DIFF
--- a/homeassistant/components/analytics/analytics.py
+++ b/homeassistant/components/analytics/analytics.py
@@ -173,6 +173,7 @@ class Analytics:
 
     async def send_analytics(self, _: datetime | None = None) -> None:
         """Send analytics."""
+        hass = self.hass
         supervisor_info = None
         operating_system_info: dict[str, Any] = {}
 
@@ -185,10 +186,10 @@ class Analytics:
             await self._store.async_save(dataclass_asdict(self._data))
 
         if self.supervisor:
-            supervisor_info = hassio.get_supervisor_info(self.hass)
-            operating_system_info = hassio.get_os_info(self.hass) or {}
+            supervisor_info = hassio.get_supervisor_info(hass)
+            operating_system_info = hassio.get_os_info(hass) or {}
 
-        system_info = await async_get_system_info(self.hass)
+        system_info = await async_get_system_info(hass)
         integrations = []
         custom_integrations = []
         addons = []
@@ -214,10 +215,10 @@ class Analytics:
         if self.preferences.get(ATTR_USAGE, False) or self.preferences.get(
             ATTR_STATISTICS, False
         ):
-            ent_reg = er.async_get(self.hass)
+            ent_reg = er.async_get(hass)
 
             try:
-                yaml_configuration = await conf_util.async_hass_config_yaml(self.hass)
+                yaml_configuration = await conf_util.async_hass_config_yaml(hass)
             except HomeAssistantError as err:
                 LOGGER.error(err)
                 return
@@ -229,8 +230,8 @@ class Analytics:
                 if not entity.disabled
             }
 
-            domains = async_get_loaded_integrations(self.hass)
-            configured_integrations = await async_get_integrations(self.hass, domains)
+            domains = async_get_loaded_integrations(hass)
+            configured_integrations = await async_get_integrations(hass, domains)
             enabled_domains = set(configured_integrations)
 
             for integration in configured_integrations.values():
@@ -261,7 +262,7 @@ class Analytics:
             if supervisor_info is not None:
                 installed_addons = await asyncio.gather(
                     *(
-                        hassio.async_get_addon_info(self.hass, addon[ATTR_SLUG])
+                        hassio.async_get_addon_info(hass, addon[ATTR_SLUG])
                         for addon in supervisor_info[ATTR_ADDONS]
                     )
                 )
@@ -276,7 +277,7 @@ class Analytics:
                     )
 
         if self.preferences.get(ATTR_USAGE, False):
-            payload[ATTR_CERTIFICATE] = self.hass.http.ssl_certificate is not None
+            payload[ATTR_CERTIFICATE] = hass.http.ssl_certificate is not None
             payload[ATTR_INTEGRATIONS] = integrations
             payload[ATTR_CUSTOM_INTEGRATIONS] = custom_integrations
             if supervisor_info is not None:
@@ -284,11 +285,11 @@ class Analytics:
 
             if ENERGY_DOMAIN in enabled_domains:
                 payload[ATTR_ENERGY] = {
-                    ATTR_CONFIGURED: await energy_is_configured(self.hass)
+                    ATTR_CONFIGURED: await energy_is_configured(hass)
                 }
 
             if RECORDER_DOMAIN in enabled_domains:
-                instance = get_recorder_instance(self.hass)
+                instance = get_recorder_instance(hass)
                 engine = instance.database_engine
                 if engine and engine.version is not None:
                     payload[ATTR_RECORDER] = {
@@ -297,9 +298,9 @@ class Analytics:
                     }
 
         if self.preferences.get(ATTR_STATISTICS, False):
-            payload[ATTR_STATE_COUNT] = len(self.hass.states.async_all())
-            payload[ATTR_AUTOMATION_COUNT] = len(
-                self.hass.states.async_all(AUTOMATION_DOMAIN)
+            payload[ATTR_STATE_COUNT] = hass.states.async_entity_ids_count()
+            payload[ATTR_AUTOMATION_COUNT] = hass.states.async_entity_ids_count(
+                AUTOMATION_DOMAIN
             )
             payload[ATTR_INTEGRATION_COUNT] = len(integrations)
             if supervisor_info is not None:
@@ -307,7 +308,7 @@ class Analytics:
             payload[ATTR_USER_COUNT] = len(
                 [
                     user
-                    for user in await self.hass.auth.async_get_users()
+                    for user in await hass.auth.async_get_users()
                     if not user.system_generated
                 ]
             )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Use async_entity_ids_count instead of async_all

I also tried to make the code wrap a bit less but I didn't want to refactor it to much in this PR

This one blocks the event loop for just a bit so there are probably some more parts that could be optimized

`2024-02-15 07:17:30.034 WARNING (MainThread) [asyncio] Executing <Task pending name='analytics schedule' coro=<Analytics.send_analytics() running at
/usr/src/homeassistant/homeassistant/components/analytics/analytics.py:220> wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.12/asyncio/futures.py:387, Task.task_wakeup()] created at /usr/local/lib/python3.12/asyncio/base_events.py:447> cb=[set.remove()] created at
/usr/src/homeassistant/homeassistant/core.py:598> took 0.335 seconds`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
