### PR TITLE
Add to/from/not_to/not_from to template trigger

### DIFF
--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -487,6 +487,181 @@ async def test_if_fires_on_change_bool(hass: HomeAssistant, start_ha, calls) -> 
                 (4, "foo", False),
             ],
         ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_to": "foo",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (0, "foo", False),
+                (1, "bar", False),
+                (1, "bar", False),
+                (2, "baz", False),
+                (2, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_to": ["foo"],
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (0, "foo", False),
+                (1, "bar", False),
+                (1, "bar", False),
+                (2, "baz", False),
+                (2, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_to": ["foo", "bar"],
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (0, "foo", False),
+                (0, "bar", False),
+                (1, "baz", False),
+                (1, "baz", False),
+                (1, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_from": "foo",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (1, "foo", False),
+                (1, "bar", False),
+                (1, "bar", False),
+                (2, "baz", False),
+                (3, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_from": ["foo"],
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (1, "foo", False),
+                (1, "bar", False),
+                (1, "bar", False),
+                (2, "baz", False),
+                (3, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_from": ["foo", "bar"],
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (1, "foo", False),
+                (1, "bar", False),
+                (1, "baz", False),
+                (1, "baz", False),
+                (2, "bar", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_to": "foo",
+                        "from": "bar",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (0, "foo", False),
+                (0, "bar", False),
+                (1, "baz", False),
+                (1, "baz", False),
+                (1, "bar", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "to": "foo",
+                        "not_from": "bar",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (1, "foo", False),
+                (1, "foo", False),
+                (1, "bar", False),
+                (1, "foo", False),
+                (1, "baz", False),
+                (2, "foo", False),
+            ],
+        ),
+        (
+            {
+                automation.DOMAIN: {
+                    "trigger": {
+                        "platform": "template",
+                        "value_template": "{{ states('test.entity') }}",
+                        "not_to": "foo",
+                        "not_from": "bar",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            },
+            [
+                (0, "foo", False),
+                (1, "bar", False),
+                (1, "baz", False),
+                (2, "beep", False),
+                (3, "baz", False),
+            ],
+        ),
     ],
 )
 async def test_general(hass: HomeAssistant, call_setup, start_ha, calls) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add to, from, not_to and not_from options to the template trigger. These behave in the sme way as the same options in the state trigger. This saves having to create a template state entity if you want to create a trigger from a template value that can't be simplified to a true/false option.

If none of to/from/not_to/not_from are specified then the template trigger behaves as before, expecting a value that can be converted to a boolean, and triggering when that switches from false to true.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31447

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
