### PR TITLE
Fix scene activation with climate entities with `None` attribute values

### DIFF
--- a/homeassistant/components/climate/reproduce_state.py
+++ b/homeassistant/components/climate/reproduce_state.py
@@ -68,13 +68,22 @@ async def _async_reproduce_states(
             [ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW],
         )
 
-    if ATTR_PRESET_MODE in state.attributes:
+    if (
+        ATTR_PRESET_MODE in state.attributes
+        and state.attributes[ATTR_PRESET_MODE] is not None
+    ):
         await call_service(SERVICE_SET_PRESET_MODE, [ATTR_PRESET_MODE])
 
-    if ATTR_SWING_MODE in state.attributes:
+    if (
+        ATTR_SWING_MODE in state.attributes
+        and state.attributes[ATTR_SWING_MODE] is not None
+    ):
         await call_service(SERVICE_SET_SWING_MODE, [ATTR_SWING_MODE])
 
-    if ATTR_FAN_MODE in state.attributes:
+    if (
+        ATTR_FAN_MODE in state.attributes
+        and state.attributes[ATTR_FAN_MODE] is not None
+    ):
         await call_service(SERVICE_SET_FAN_MODE, [ATTR_FAN_MODE])
 
     if ATTR_HUMIDITY in state.attributes:

--- a/tests/components/climate/test_reproduce_state.py
+++ b/tests/components/climate/test_reproduce_state.py
@@ -119,6 +119,25 @@ async def test_attribute(hass: HomeAssistant, service, attribute) -> None:
     assert calls_1[0].data == {"entity_id": ENTITY_1, attribute: value}
 
 
+@pytest.mark.parametrize(
+    ("service", "attribute"),
+    [
+        (SERVICE_SET_PRESET_MODE, ATTR_PRESET_MODE),
+        (SERVICE_SET_SWING_MODE, ATTR_SWING_MODE),
+        (SERVICE_SET_FAN_MODE, ATTR_FAN_MODE),
+    ],
+)
+async def test_attribute_with_none(hass: HomeAssistant, service, attribute) -> None:
+    """Test that service call is not made for attributes with None value."""
+    calls_1 = async_mock_service(hass, DOMAIN, service)
+
+    await async_reproduce_states(hass, [State(ENTITY_1, None, {attribute: None})])
+
+    await hass.async_block_till_done()
+
+    assert len(calls_1) == 0
+
+
 async def test_attribute_partial_temperature(hass: HomeAssistant) -> None:
     """Test that service call ignores null attributes."""
     calls_1 = async_mock_service(hass, DOMAIN, SERVICE_SET_TEMPERATURE)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In case there is no current mode set, `None` should be the state for this 3 mode attributes, but setting these modes requires valid modes, so we should not try to fire service calls to set these mode to `None`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #110114
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
