### PR TITLE
Add time based integration trigger to Riemann sum integral helper sensor

### DIFF
--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .const import (
-    CONF_MAX_DT,
+    CONF_MAX_AGE,
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
     CONF_UNIT_PREFIX,
@@ -101,7 +101,7 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
-        vol.Optional(CONF_MAX_DT, default=0): selector.NumberSelector(
+        vol.Optional(CONF_MAX_AGE, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
                 max=1000000000,

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -26,6 +26,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .const import (
+    CONF_MAX_DT,
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
     CONF_UNIT_PREFIX,
@@ -99,6 +100,14 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
             selector.NumberSelectorConfig(
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
+        ),
+        vol.Optional(CONF_MAX_DT, default=60): selector.NumberSelector(
+            selector.NumberSelectorConfig(
+                min=1,
+                max=1000000000,
+                mode=selector.NumberSelectorMode.BOX,
+                unit_of_measurement="seconds",
+            )
         ),
     }
 

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -101,13 +101,7 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
-        vol.Optional(CONF_MAX_AGE, default=0): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0,
-                mode=selector.NumberSelectorMode.BOX,
-                unit_of_measurement="seconds",
-            )
-        ),
+        vol.Optional(CONF_MAX_AGE): selector.DurationSelector(),
     }
 
 

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .const import (
-    CONF_MAX_AGE,
+    CONF_MAX_SUB_INTERVAL,
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
     CONF_UNIT_PREFIX,
@@ -101,7 +101,7 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
-        vol.Optional(CONF_MAX_AGE): selector.DurationSelector(),
+        vol.Optional(CONF_MAX_SUB_INTERVAL): selector.DurationSelector(),
     }
 
 

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -103,7 +103,7 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
         ),
         vol.Optional(CONF_MAX_DT, default=60): selector.NumberSelector(
             selector.NumberSelectorConfig(
-                min=1,
+                min=0,
                 max=1000000000,
                 mode=selector.NumberSelectorMode.BOX,
                 unit_of_measurement="seconds",

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -101,7 +101,7 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
-        vol.Optional(CONF_MAX_DT, default=60): selector.NumberSelector(
+        vol.Optional(CONF_MAX_DT, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
                 max=1000000000,

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -104,7 +104,6 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
         vol.Optional(CONF_MAX_AGE, default=0): selector.NumberSelector(
             selector.NumberSelectorConfig(
                 min=0,
-                max=1000000000,
                 mode=selector.NumberSelectorMode.BOX,
                 unit_of_measurement="seconds",
             )

--- a/homeassistant/components/integration/config_flow.py
+++ b/homeassistant/components/integration/config_flow.py
@@ -101,7 +101,9 @@ async def _get_options_dict(handler: SchemaCommonFlowHandler | None) -> dict:
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
-        vol.Optional(CONF_MAX_SUB_INTERVAL): selector.DurationSelector(),
+        vol.Optional(CONF_MAX_SUB_INTERVAL): selector.DurationSelector(
+            selector.DurationSelectorConfig(allow_negative=False)
+        ),
     }
 
 

--- a/homeassistant/components/integration/const.py
+++ b/homeassistant/components/integration/const.py
@@ -7,7 +7,7 @@ CONF_SOURCE_SENSOR = "source"
 CONF_UNIT_OF_MEASUREMENT = "unit"
 CONF_UNIT_PREFIX = "unit_prefix"
 CONF_UNIT_TIME = "unit_time"
-CONF_MAX_AGE = "max_age"
+CONF_MAX_SUB_INTERVAL = "max_sub_interval"
 
 METHOD_TRAPEZOIDAL = "trapezoidal"
 METHOD_LEFT = "left"

--- a/homeassistant/components/integration/const.py
+++ b/homeassistant/components/integration/const.py
@@ -7,6 +7,7 @@ CONF_SOURCE_SENSOR = "source"
 CONF_UNIT_OF_MEASUREMENT = "unit"
 CONF_UNIT_PREFIX = "unit_prefix"
 CONF_UNIT_TIME = "unit_time"
+CONF_MAX_DT = "max_dt"
 
 METHOD_TRAPEZOIDAL = "trapezoidal"
 METHOD_LEFT = "left"

--- a/homeassistant/components/integration/const.py
+++ b/homeassistant/components/integration/const.py
@@ -7,7 +7,7 @@ CONF_SOURCE_SENSOR = "source"
 CONF_UNIT_OF_MEASUREMENT = "unit"
 CONF_UNIT_PREFIX = "unit_prefix"
 CONF_UNIT_TIME = "unit_time"
-CONF_MAX_DT = "max_dt"
+CONF_MAX_AGE = "max_age"
 
 METHOD_TRAPEZOIDAL = "trapezoidal"
 METHOD_LEFT = "left"

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -272,12 +272,10 @@ async def async_setup_entry(
         # Before we had support for optional selectors, "none" was used for selecting nothing
         unit_prefix = None
 
-    max_age_seconds = config_entry.options.get(CONF_MAX_AGE, None)
-    max_age = (
-        timedelta(seconds=max_age_seconds)
-        if max_age_seconds is not None and max_age_seconds != 0
-        else None
-    )
+    if max_age_duration_dict := config_entry.options.get(CONF_MAX_AGE, None):
+        max_age = cv.time_period(max_age_duration_dict)
+    else:
+        max_age = None
 
     round_digits = config_entry.options.get(CONF_ROUND_DIGITS)
     if round_digits:
@@ -355,7 +353,9 @@ class IntegrationSensor(RestoreSensor):
         self._source_entity: str = source_entity
         self._last_valid_state: Decimal | None = None
         self._attr_device_info = device_info
-        self._max_age: timedelta | None = max_age
+        self._max_age: timedelta | None = (
+            max_age if max_age is not None and max_age.total_seconds() > 0 else None
+        )
         self._max_age_exceeded_callback: CALLBACK_TYPE = lambda *args: None
         self._last_integration_time: datetime = datetime.now(tz=UTC)
         self._last_integration_trigger = _IntegrationTrigger.StateChange

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -452,14 +452,15 @@ class IntegrationSensor(RestoreSensor):
             source_state = self.hass.states.get(self._sensor_source_id)
             self._schedule_max_sub_interval_exceeded_if_state_is_numeric(source_state)
             self.async_on_remove(self._cancel_max_sub_interval_exceeded_callback)
+            handle_state_change = self._integrate_on_state_change_and_max_sub_interval
+        else:
+            handle_state_change = self._integrate_on_state_change_callback
 
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass,
                 [self._sensor_source_id],
-                self._integrate_on_state_change_and_max_sub_interval
-                if self._max_sub_interval is not None
-                else self._integrate_on_state_change_callback,
+                handle_state_change,
             )
         )
 

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -558,7 +558,7 @@ class IntegrationSensor(RestoreSensor):
             )
 
     def _cancel_max_sub_interval_exceeded_callback(self) -> None:
-        return self._max_sub_interval_exceeded_callback()
+        self._max_sub_interval_exceeded_callback()
 
     @property
     def native_value(self) -> Decimal | None:

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -112,10 +112,6 @@ class _IntegrationMethod(ABC):
         """Check state requirements for integration."""
 
     @abstractmethod
-    def validate_states(self, left: State, right: State) -> bool:
-        pass
-
-    @abstractmethod
     def calculate_area_with_two_states(
         self, elapsed_time: Decimal, left: Decimal, right: Decimal
     ) -> Decimal:

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -50,7 +50,7 @@ from homeassistant.helpers.event import async_call_later, async_track_state_chan
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
-    CONF_MAX_DT,
+    CONF_MAX_AGE,
     CONF_ROUND_DIGITS,
     CONF_SOURCE_SENSOR,
     CONF_UNIT_OF_MEASUREMENT,
@@ -92,7 +92,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_UNIT_PREFIX): vol.In(UNIT_PREFIXES),
             vol.Optional(CONF_UNIT_TIME, default=UnitOfTime.HOURS): vol.In(UNIT_TIME),
             vol.Remove(CONF_UNIT_OF_MEASUREMENT): cv.string,
-            vol.Optional(CONF_MAX_DT): cv.time_period,
+            vol.Optional(CONF_MAX_AGE): cv.time_period,
             vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
                 INTEGRATION_METHODS
             ),
@@ -272,10 +272,10 @@ async def async_setup_entry(
         # Before we had support for optional selectors, "none" was used for selecting nothing
         unit_prefix = None
 
-    max_dt_seconds = config_entry.options.get(CONF_MAX_DT, None)
-    max_dt = (
-        timedelta(seconds=max_dt_seconds)
-        if max_dt_seconds is not None and max_dt_seconds != 0
+    max_age_seconds = config_entry.options.get(CONF_MAX_AGE, None)
+    max_age = (
+        timedelta(seconds=max_age_seconds)
+        if max_age_seconds is not None and max_age_seconds != 0
         else None
     )
 
@@ -292,7 +292,7 @@ async def async_setup_entry(
         unit_prefix=unit_prefix,
         unit_time=config_entry.options[CONF_UNIT_TIME],
         device_info=device_info,
-        max_dt=max_dt,
+        max_age=max_age,
     )
 
     async_add_entities([integral])
@@ -313,7 +313,7 @@ async def async_setup_platform(
         unique_id=config.get(CONF_UNIQUE_ID),
         unit_prefix=config.get(CONF_UNIT_PREFIX),
         unit_time=config[CONF_UNIT_TIME],
-        max_dt=config.get(CONF_MAX_DT),
+        max_age=config.get(CONF_MAX_AGE),
     )
 
     async_add_entities([integral])
@@ -335,7 +335,7 @@ class IntegrationSensor(RestoreSensor):
         unique_id: str | None,
         unit_prefix: str | None,
         unit_time: UnitOfTime,
-        max_dt: timedelta | None,
+        max_age: timedelta | None,
         device_info: DeviceInfo | None = None,
     ) -> None:
         """Initialize the integration sensor."""
@@ -355,8 +355,8 @@ class IntegrationSensor(RestoreSensor):
         self._source_entity: str = source_entity
         self._last_valid_state: Decimal | None = None
         self._attr_device_info = device_info
-        self._max_dt: timedelta | None = max_dt
-        self._max_dt_exceeded_callback: CALLBACK_TYPE = lambda *args: None
+        self._max_age: timedelta | None = max_age
+        self._max_age_exceeded_callback: CALLBACK_TYPE = lambda *args: None
         self._last_integration_time: datetime = datetime.now(tz=UTC)
         self._last_integration_trigger = _IntegrationTrigger.StateChange
         self._attr_suggested_display_precision = round_digits or 2
@@ -446,26 +446,26 @@ class IntegrationSensor(RestoreSensor):
             self._attr_device_class = state.attributes.get(ATTR_DEVICE_CLASS)
             self._unit_of_measurement = state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
 
-        if self._max_dt is not None:
+        if self._max_age is not None:
             source_state = self.hass.states.get(self._sensor_source_id)
-            self._schedule_max_dt_exceeded_if_state_is_numeric(source_state)
-            self.async_on_remove(self._cancel_max_dt_exceeded_callback)
+            self._schedule_max_age_exceeded_if_state_is_numeric(source_state)
+            self.async_on_remove(self._cancel_max_age_exceeded_callback)
 
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass,
                 [self._sensor_source_id],
-                self._integrate_on_state_change_and_max_dt
-                if self._max_dt is not None
+                self._integrate_on_state_change_and_max_age
+                if self._max_age is not None
                 else self._integrate_on_state_change_callback,
             )
         )
 
     @callback
-    def _integrate_on_state_change_and_max_dt(
+    def _integrate_on_state_change_and_max_age(
         self, event: Event[EventStateChangedData]
     ) -> None:
-        self._cancel_max_dt_exceeded_callback()
+        self._cancel_max_age_exceeded_callback()
         old_state = event.data["old_state"]
         new_state = event.data["new_state"]
         try:
@@ -473,8 +473,8 @@ class IntegrationSensor(RestoreSensor):
             self._last_integration_trigger = _IntegrationTrigger.StateChange
             self._last_integration_time = datetime.now(tz=UTC)
         finally:
-            # if max_dt exceeds, by construction there was no state change, the source is assumed constant new_state over max_dt
-            self._schedule_max_dt_exceeded_if_state_is_numeric(new_state)
+            # if max_age exceeds, by construction there was no state change, the source is assumed constant new_state over max_age
+            self._schedule_max_age_exceeded_if_state_is_numeric(new_state)
 
     @callback
     def _integrate_on_state_change_callback(
@@ -514,13 +514,13 @@ class IntegrationSensor(RestoreSensor):
         self._update_integral(area)
         self.async_write_ha_state()
 
-    def _create_on_max_dt_exceeded_callback(
+    def _create_on_max_age_exceeded_callback(
         self,
         source_state: State,
         source_state_dec: Decimal,
     ) -> Callable[[datetime], None]:
         @callback
-        def _integrate_on_max_dt_exceeded_callback(now: datetime) -> None:
+        def _integrate_on_max_age_exceeded_callback(now: datetime) -> None:
             elapsed_seconds = Decimal(
                 (now - self._last_integration_time).total_seconds()
             )
@@ -534,28 +534,28 @@ class IntegrationSensor(RestoreSensor):
             self._last_integration_time = datetime.now(tz=UTC)
             self._last_integration_trigger = _IntegrationTrigger.TimeElapsed
 
-            self._schedule_max_dt_exceeded_if_state_is_numeric(source_state)
+            self._schedule_max_age_exceeded_if_state_is_numeric(source_state)
 
-        return _integrate_on_max_dt_exceeded_callback
+        return _integrate_on_max_age_exceeded_callback
 
-    def _schedule_max_dt_exceeded_if_state_is_numeric(
+    def _schedule_max_age_exceeded_if_state_is_numeric(
         self, source_state: State | None
     ) -> None:
         if (
-            self._max_dt is not None
+            self._max_age is not None
             and source_state is not None
             and (source_state_dec := _decimal_state(source_state.state))
         ):
-            self._max_dt_exceeded_callback = async_call_later(
+            self._max_age_exceeded_callback = async_call_later(
                 self.hass,
-                self._max_dt,
-                self._create_on_max_dt_exceeded_callback(
+                self._max_age,
+                self._create_on_max_age_exceeded_callback(
                     source_state, source_state_dec
                 ),
             )
 
-    def _cancel_max_dt_exceeded_callback(self) -> None:
-        return self._max_dt_exceeded_callback()
+    def _cancel_max_age_exceeded_callback(self) -> None:
+        return self._max_age_exceeded_callback()
 
     @property
     def native_value(self) -> Decimal | None:

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -353,9 +353,9 @@ class IntegrationSensor(RestoreSensor):
         self._last_valid_state: Decimal | None = None
         self._attr_device_info = device_info
         self._max_sub_interval: timedelta | None = (
-            max_sub_interval
-            if max_sub_interval is not None and max_sub_interval.total_seconds() > 0
-            else None
+            None  # disable time based integration
+            if max_sub_interval is None or max_sub_interval.total_seconds() == 0
+            else max_sub_interval
         )
         self._max_sub_interval_exceeded_callback: CALLBACK_TYPE = lambda *args: None
         self._last_integration_time: datetime = datetime.now(tz=UTC)

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -352,7 +352,7 @@ class IntegrationSensor(RestoreSensor):
         self._last_valid_state: Decimal | None = None
         self._attr_device_info = device_info
         self._max_dt: timedelta | None = (
-            timedelta(seconds=max_dt) if max_dt is not None else None
+            timedelta(seconds=max_dt) if max_dt is not None and max_dt != 0 else None
         )
         self._max_dt_exceeded_callback: CALLBACK_TYPE = lambda *args: None
         self._last_integration_time: datetime = datetime.now(tz=UTC)

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -112,6 +112,10 @@ class _IntegrationMethod(ABC):
         """Check state requirements for integration."""
 
     @abstractmethod
+    def validate_states(self, left: State, right: State) -> bool:
+        pass
+
+    @abstractmethod
     def calculate_area_with_two_states(
         self, elapsed_time: Decimal, left: Decimal, right: Decimal
     ) -> Decimal:

--- a/homeassistant/components/integration/sensor.py
+++ b/homeassistant/components/integration/sensor.py
@@ -92,7 +92,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_UNIT_PREFIX): vol.In(UNIT_PREFIXES),
             vol.Optional(CONF_UNIT_TIME, default=UnitOfTime.HOURS): vol.In(UNIT_TIME),
             vol.Remove(CONF_UNIT_OF_MEASUREMENT): cv.string,
-            vol.Optional(CONF_MAX_SUB_INTERVAL): cv.time_period,
+            vol.Optional(CONF_MAX_SUB_INTERVAL): cv.positive_time_period,
             vol.Optional(CONF_METHOD, default=METHOD_TRAPEZOIDAL): vol.In(
                 INTEGRATION_METHODS
             ),

--- a/homeassistant/components/integration/strings.json
+++ b/homeassistant/components/integration/strings.json
@@ -18,7 +18,7 @@
           "round": "Controls the number of decimal digits in the output.",
           "unit_prefix": "The output will be scaled according to the selected metric prefix.",
           "unit_time": "The output will be scaled according to the selected time unit.",
-          "max_age": "If the source sensor is constant this duration will be used for time based updates. Use 0 for no time based updates."
+          "max_age": "Applies time based integration if the source did not change for this duration. Use 0 for no time based updates."
         }
       }
     }

--- a/homeassistant/components/integration/strings.json
+++ b/homeassistant/components/integration/strings.json
@@ -11,12 +11,14 @@
           "round": "Precision",
           "source": "Input sensor",
           "unit_prefix": "Metric prefix",
-          "unit_time": "Time unit"
+          "unit_time": "Time unit",
+          "max_dt": "Max update duration."
         },
         "data_description": {
           "round": "Controls the number of decimal digits in the output.",
           "unit_prefix": "The output will be scaled according to the selected metric prefix.",
-          "unit_time": "The output will be scaled according to the selected time unit."
+          "unit_time": "The output will be scaled according to the selected time unit.",
+          "max_dt": "If the source sensor is constant this duration will be used for time based updates."
         }
       }
     }

--- a/homeassistant/components/integration/strings.json
+++ b/homeassistant/components/integration/strings.json
@@ -12,13 +12,13 @@
           "source": "Input sensor",
           "unit_prefix": "Metric prefix",
           "unit_time": "Time unit",
-          "max_dt": "Max update duration."
+          "max_age": "Max update duration."
         },
         "data_description": {
           "round": "Controls the number of decimal digits in the output.",
           "unit_prefix": "The output will be scaled according to the selected metric prefix.",
           "unit_time": "The output will be scaled according to the selected time unit.",
-          "max_dt": "If the source sensor is constant this duration will be used for time based updates. Use 0 for no time based updates."
+          "max_age": "If the source sensor is constant this duration will be used for time based updates. Use 0 for no time based updates."
         }
       }
     }

--- a/homeassistant/components/integration/strings.json
+++ b/homeassistant/components/integration/strings.json
@@ -12,13 +12,13 @@
           "source": "Input sensor",
           "unit_prefix": "Metric prefix",
           "unit_time": "Time unit",
-          "max_age": "Max update duration."
+          "max_sub_interval": "Max sub-interval"
         },
         "data_description": {
           "round": "Controls the number of decimal digits in the output.",
           "unit_prefix": "The output will be scaled according to the selected metric prefix.",
           "unit_time": "The output will be scaled according to the selected time unit.",
-          "max_age": "Applies time based integration if the source did not change for this duration. Use 0 for no time based updates."
+          "max_sub_interval": "Applies time based integration if the source did not change for this duration. Use 0 for no time based updates."
         }
       }
     }

--- a/homeassistant/components/integration/strings.json
+++ b/homeassistant/components/integration/strings.json
@@ -18,7 +18,7 @@
           "round": "Controls the number of decimal digits in the output.",
           "unit_prefix": "The output will be scaled according to the selected metric prefix.",
           "unit_time": "The output will be scaled according to the selected time unit.",
-          "max_dt": "If the source sensor is constant this duration will be used for time based updates."
+          "max_dt": "If the source sensor is constant this duration will be used for time based updates. Use 0 for no time based updates."
         }
       }
     }

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -441,7 +441,7 @@ class TimestampValidator:
         # is not flagged by one stream, it should just get flagged by the other
         # stream. Either value should result in a value which is much less than
         # a 32 bit INT_MAX, which helps avoid the assertion error from FFmpeg.
-        self._max_dts_gap = MAX_TIMESTAMP_GAP * max(
+        self._max_ages_gap = MAX_TIMESTAMP_GAP * max(
             inv_video_time_base, inv_audio_time_base
         )
 
@@ -458,7 +458,7 @@ class TimestampValidator:
         self._missing_dts = 0
         # Discard when dts is not monotonic. Terminate if gap is too wide.
         prev_dts = self._last_dts[packet.stream]
-        if abs(prev_dts - packet.dts) > self._max_dts_gap and prev_dts != NEGATIVE_INF:
+        if abs(prev_dts - packet.dts) > self._max_ages_gap and prev_dts != NEGATIVE_INF:
             raise StreamWorkerError(
                 f"Timestamp discontinuity detected: last dts = {prev_dts}, dts ="
                 f" {packet.dts}"

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -441,7 +441,7 @@ class TimestampValidator:
         # is not flagged by one stream, it should just get flagged by the other
         # stream. Either value should result in a value which is much less than
         # a 32 bit INT_MAX, which helps avoid the assertion error from FFmpeg.
-        self._max_ages_gap = MAX_TIMESTAMP_GAP * max(
+        self._max_dts_gap = MAX_TIMESTAMP_GAP * max(
             inv_video_time_base, inv_audio_time_base
         )
 
@@ -458,7 +458,7 @@ class TimestampValidator:
         self._missing_dts = 0
         # Discard when dts is not monotonic. Terminate if gap is too wide.
         prev_dts = self._last_dts[packet.stream]
-        if abs(prev_dts - packet.dts) > self._max_ages_gap and prev_dts != NEGATIVE_INF:
+        if abs(prev_dts - packet.dts) > self._max_dts_gap and prev_dts != NEGATIVE_INF:
             raise StreamWorkerError(
                 f"Timestamp discontinuity detected: last dts = {prev_dts}, dts ="
                 f" {packet.dts}"

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
                 "round": 1,
                 "source": input_sensor_entity_id,
                 "unit_time": "min",
-                "max_age": {"seconds": 0},
+                "max_sub_interval": {"seconds": 0},
             },
         )
         await hass.async_block_till_done()
@@ -50,7 +50,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_age": {"seconds": 0},
+        "max_sub_interval": {"seconds": 0},
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -62,7 +62,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_age": {"seconds": 0},
+        "max_sub_interval": {"seconds": 0},
     }
     assert config_entry.title == "My integration"
 
@@ -92,7 +92,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_age": {"minutes": 1},
+            "max_sub_interval": {"minutes": 1},
         },
         title="My integration",
     )
@@ -133,7 +133,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_age": {"minutes": 1},
+        "max_sub_interval": {"minutes": 1},
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -143,7 +143,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_age": {"minutes": 1},
+        "max_sub_interval": {"minutes": 1},
     }
     assert config_entry.title == "My integration"
 

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -36,6 +36,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
                 "round": 1,
                 "source": input_sensor_entity_id,
                 "unit_time": "min",
+                "max_dt": 60,
             },
         )
         await hass.async_block_till_done()
@@ -49,6 +50,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
+        "max_dt": 60,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -60,6 +62,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
+        "max_dt": 60,
     }
     assert config_entry.title == "My integration"
 
@@ -89,6 +92,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
+            "max_dt": 60,
         },
         title="My integration",
     )
@@ -129,6 +133,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
+        "max_dt": 60,
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -138,6 +143,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
+        "max_dt": 60,
     }
     assert config_entry.title == "My integration"
 

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
                 "round": 1,
                 "source": input_sensor_entity_id,
                 "unit_time": "min",
-                "max_age": 0,
+                "max_age": {"seconds": 0},
             },
         )
         await hass.async_block_till_done()
@@ -50,7 +50,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_age": 0,
+        "max_age": {"seconds": 0},
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -62,7 +62,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_age": 0,
+        "max_age": {"seconds": 0},
     }
     assert config_entry.title == "My integration"
 
@@ -92,7 +92,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_age": 60,
+            "max_age": {"minutes": 1},
         },
         title="My integration",
     )
@@ -133,7 +133,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_age": 60,
+        "max_age": {"minutes": 1},
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -143,7 +143,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_age": 60,
+        "max_age": {"minutes": 1},
     }
     assert config_entry.title == "My integration"
 

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -123,6 +123,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "method": "right",
             "round": 2.0,
             "source": "sensor.input",
+            "max_sub_interval": {"minutes": 1},
         },
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -36,7 +36,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
                 "round": 1,
                 "source": input_sensor_entity_id,
                 "unit_time": "min",
-                "max_dt": 60,
+                "max_age": 0,
             },
         )
         await hass.async_block_till_done()
@@ -50,7 +50,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_dt": 60,
+        "max_age": 0,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -62,7 +62,7 @@ async def test_config_flow(hass: HomeAssistant, platform) -> None:
         "round": 1.0,
         "source": "sensor.input",
         "unit_time": "min",
-        "max_dt": 60,
+        "max_age": 0,
     }
     assert config_entry.title == "My integration"
 
@@ -92,7 +92,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_dt": 60,
+            "max_age": 60,
         },
         title="My integration",
     )
@@ -133,7 +133,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_dt": 60,
+        "max_age": 60,
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -143,7 +143,7 @@ async def test_options(hass: HomeAssistant, platform) -> None:
         "source": "sensor.input",
         "unit_prefix": "k",
         "unit_time": "min",
-        "max_dt": 60,
+        "max_age": 60,
     }
     assert config_entry.title == "My integration"
 

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -30,7 +30,7 @@ async def test_setup_and_remove_config_entry(
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_dt": 60,
+            "max_age": 60,
         },
         title="My integration",
     )

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -30,7 +30,7 @@ async def test_setup_and_remove_config_entry(
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_dt": None,
+            "max_dt": 60,
         },
         title="My integration",
     )

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -30,6 +30,7 @@ async def test_setup_and_remove_config_entry(
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
+            "max_dt": None,
         },
         title="My integration",
     )

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -30,7 +30,7 @@ async def test_setup_and_remove_config_entry(
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_age": 60,
+            "max_age": {"minutes": 1},
         },
         title="My integration",
     )

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -30,7 +30,7 @@ async def test_setup_and_remove_config_entry(
             "source": "sensor.input",
             "unit_prefix": "k",
             "unit_time": "min",
-            "max_age": {"minutes": 1},
+            "max_sub_interval": {"minutes": 1},
         },
         title="My integration",
     )

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -752,7 +752,7 @@ async def test_device_id(
     assert integration_entity.device_id == source_entity.device_id
 
 
-def _integral_sensor_config(max_age: int | None = 60):
+def _integral_sensor_config(max_age: dict[str, int] | None = {"minutes": 1}):
     sensor = {
         "platform": "integration",
         "name": "integration",
@@ -764,7 +764,9 @@ def _integral_sensor_config(max_age: int | None = 60):
     return {"sensor": sensor}
 
 
-async def _setup_integral_sensor(hass: HomeAssistant, max_age: int | None = 60) -> None:
+async def _setup_integral_sensor(
+    hass: HomeAssistant, max_age: dict[str, int] | None = {"minutes": 1}
+) -> None:
     await async_setup_component(
         hass, "sensor", _integral_sensor_config(max_age=max_age)
     )

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -752,23 +752,23 @@ async def test_device_id(
     assert integration_entity.device_id == source_entity.device_id
 
 
-def _integral_sensor_config(max_age: dict[str, int] | None = {"minutes": 1}):
+def _integral_sensor_config(max_sub_interval: dict[str, int] | None = {"minutes": 1}):
     sensor = {
         "platform": "integration",
         "name": "integration",
         "source": "sensor.power",
         "method": "right",
     }
-    if max_age is not None:
-        sensor["max_age"] = max_age
+    if max_sub_interval is not None:
+        sensor["max_sub_interval"] = max_sub_interval
     return {"sensor": sensor}
 
 
 async def _setup_integral_sensor(
-    hass: HomeAssistant, max_age: dict[str, int] | None = {"minutes": 1}
+    hass: HomeAssistant, max_sub_interval: dict[str, int] | None = {"minutes": 1}
 ) -> None:
     await async_setup_component(
-        hass, "sensor", _integral_sensor_config(max_age=max_age)
+        hass, "sensor", _integral_sensor_config(max_sub_interval=max_sub_interval)
     )
     await hass.async_block_till_done()
 
@@ -792,7 +792,7 @@ async def test_on_valid_source_expect_update_on_time(
     with freeze_time(start_time) as freezer:
         await _setup_integral_sensor(hass)
         await _update_source_sensor(hass, 100)
-        state_before_max_age_exceeded = hass.states.get("sensor.integration")
+        state_before_max_sub_interval_exceeded = hass.states.get("sensor.integration")
 
         freezer.tick(61)
         async_fire_time_changed(hass, dt_util.now())
@@ -800,9 +800,10 @@ async def test_on_valid_source_expect_update_on_time(
 
         state = hass.states.get("sensor.integration")
         assert (
-            condition.async_numeric_state(hass, state_before_max_age_exceeded) is False
+            condition.async_numeric_state(hass, state_before_max_sub_interval_exceeded)
+            is False
         )
-        assert state_before_max_age_exceeded.state != state.state
+        assert state_before_max_sub_interval_exceeded.state != state.state
         assert condition.async_numeric_state(hass, state) is True
         assert float(state.state) > 1.69  # approximately 100 * 61 / 3600
         assert float(state.state) < 1.8
@@ -868,14 +869,14 @@ async def test_on_statechanges_source_expect_no_update_on_time(
         assert float(state_after_105s.state) > float(state_after_65s.state)
 
 
-async def test_on_no_max_age_expect_no_timebased_updates(
+async def test_on_no_max_sub_interval_expect_no_timebased_updates(
     hass: HomeAssistant,
 ) -> None:
-    """Test whether integratal is not updated by time when max_age is not configured."""
+    """Test whether integratal is not updated by time when max_sub_interval is not configured."""
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass, max_age=None)
+        await _setup_integral_sensor(hass, max_sub_interval=None)
         await _update_source_sensor(hass, 100)
         await hass.async_block_till_done()
         await _update_source_sensor(hass, 101)

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -102,7 +102,7 @@ async def test_state(hass: HomeAssistant, method) -> None:
     state = hass.states.get("sensor.integration")
     assert state.state == STATE_UNAVAILABLE
 
-    # 1 hour after last update, power sensor is back to normal at 2 KiloWatts and stays for 1 hour += 2kWh
+    # 1 hour after last update, power sensor is back to normal at 2 KiloWatts and stays for 1 hour
     now += timedelta(seconds=3600)
     with freeze_time(now):
         hass.states.async_set(
@@ -116,11 +116,8 @@ async def test_state(hass: HomeAssistant, method) -> None:
         )
         await hass.async_block_till_done()
     state = hass.states.get("sensor.integration")
-    assert (
-        round(float(state.state), config["sensor"]["round"]) == 3.0
-        if method == "right"
-        else 1.0
-    )
+
+    assert state.state == STATE_UNAVAILABLE
 
     now += timedelta(seconds=3600)
     with freeze_time(now):
@@ -135,11 +132,7 @@ async def test_state(hass: HomeAssistant, method) -> None:
         )
         await hass.async_block_till_done()
     state = hass.states.get("sensor.integration")
-    assert (
-        round(float(state.state), config["sensor"]["round"]) == 5.0
-        if method == "right"
-        else 3.0
-    )
+    assert round(float(state.state), config["sensor"]["round"]) == 3.0
 
 
 async def test_restore_state(hass: HomeAssistant) -> None:
@@ -670,7 +663,7 @@ async def test_calc_errors(
     assert state.state == STATE_UNKNOWN
 
     # Moving from an unknown state to a value is a calc error and should
-    # not change the value of the Reimann sensor, unless the method used is "right".
+    # not change the value of the Riemann sensor.
     now += timedelta(seconds=3600)
     with freeze_time(now):
         hass.states.async_set(entity_id, 0, {"device_class": None})
@@ -681,7 +674,7 @@ async def test_calc_errors(
     assert state is not None
     assert state.state == expected_states[0]
 
-    # With the source sensor updated successfully, the Reimann sensor
+    # With the source sensor updated successfully, the Riemann sensor
     # should have a zero (known) value.
     now += timedelta(seconds=3600)
     with freeze_time(now):

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -18,12 +18,17 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, State
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    condition,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     mock_restore_cache,
     mock_restore_cache_with_extra_data,
 )
@@ -745,3 +750,114 @@ async def test_device_id(
     integration_entity = entity_registry.async_get("sensor.integration")
     assert integration_entity is not None
     assert integration_entity.device_id == source_entity.device_id
+
+
+integral_sensor_config = {
+    "sensor": {
+        "platform": "integration",
+        "name": "integration",
+        "source": "sensor.power",
+        "method": "right",
+        "max_dt": 60,
+    }
+}
+
+
+async def _setup_integral_sensor(hass: HomeAssistant) -> None:
+    await async_setup_component(hass, "sensor", integral_sensor_config)
+    await hass.async_block_till_done()
+
+
+async def _update_source_sensor(hass: HomeAssistant, value: int | str) -> None:
+    hass.states.async_set(
+        integral_sensor_config["sensor"]["source"],
+        value,
+        {ATTR_UNIT_OF_MEASUREMENT: UnitOfPower.KILO_WATT},
+        force_update=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_on_valid_source_expect_update_on_time(
+    hass: HomeAssistant,
+) -> None:
+    """Test whether time based integration updates the integral on a valid source."""
+    start_time = dt_util.utcnow()
+
+    with freeze_time(start_time) as freezer:
+        await _setup_integral_sensor(hass)
+        await _update_source_sensor(hass, 100)
+        state_before_max_dt_exceeded = hass.states.get("sensor.integration")
+
+        freezer.tick(61)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+        assert (
+            condition.async_numeric_state(hass, state_before_max_dt_exceeded) is False
+        )
+        assert state_before_max_dt_exceeded.state != state.state
+        assert condition.async_numeric_state(hass, state) is True
+        assert float(state.state) > 1.69  # approximately 100 * 61 / 3600
+        assert float(state.state) < 1.8
+
+
+async def test_on_unvailable_source_expect_no_update_on_time(
+    hass: HomeAssistant,
+) -> None:
+    """Test whether time based integration handles unavailability of the source properly."""
+
+    start_time = dt_util.utcnow()
+    with freeze_time(start_time) as freezer:
+        await _setup_integral_sensor(hass)
+        await _update_source_sensor(hass, 100)
+        freezer.tick(61)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+        assert condition.async_numeric_state(hass, state) is True
+
+        await _update_source_sensor(hass, STATE_UNAVAILABLE)
+        await hass.async_block_till_done()
+
+        freezer.tick(61)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.integration")
+        assert condition.state(hass, state, STATE_UNAVAILABLE) is True
+
+
+async def test_on_statechanges_source_expect_no_update_on_time(
+    hass: HomeAssistant,
+) -> None:
+    """Test whether state changes cancel time based integration."""
+
+    start_time = dt_util.utcnow()
+    with freeze_time(start_time) as freezer:
+        await _setup_integral_sensor(hass)
+        await _update_source_sensor(hass, 100)
+
+        freezer.tick(30)
+        await hass.async_block_till_done()
+        await _update_source_sensor(hass, 101)
+
+        state_after_30s = hass.states.get("sensor.integration")
+        assert condition.async_numeric_state(hass, state_after_30s) is True
+
+        freezer.tick(35)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+        state_after_65s = hass.states.get("sensor.integration")
+        assert (dt_util.now() - start_time).total_seconds() > 60
+        # No state change because the timer was cancelled because of an update after 30s
+        assert state_after_65s == state_after_30s
+
+        freezer.tick(35)
+        async_fire_time_changed(hass, dt_util.now())
+        await hass.async_block_till_done()
+        state_after_105s = hass.states.get("sensor.integration")
+        # Update based on time
+        assert float(state_after_105s.state) > float(state_after_65s.state)

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -864,14 +864,16 @@ async def test_on_statechanges_source_expect_no_update_on_time(
         assert float(state_after_105s.state) > float(state_after_65s.state)
 
 
+@pytest.mark.parametrize("max_dt", [None, 0])
 async def test_on_no_max_dt_expect_no_timebased_updates(
     hass: HomeAssistant,
+    max_dt: int | None,
 ) -> None:
     """Test whether integratal is not updated by time when max_dt is not configured."""
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass, max_dt=None)
+        await _setup_integral_sensor(hass, max_dt=max_dt)
         await _update_source_sensor(hass, 100)
         await hass.async_block_till_done()
         await _update_source_sensor(hass, 101)

--- a/tests/components/integration/test_sensor.py
+++ b/tests/components/integration/test_sensor.py
@@ -753,15 +753,15 @@ async def test_device_id(
 
 
 def _integral_sensor_config(max_dt: int | None = 60):
-    return {
-        "sensor": {
-            "platform": "integration",
-            "name": "integration",
-            "source": "sensor.power",
-            "method": "right",
-            "max_dt": max_dt,
-        }
+    sensor = {
+        "platform": "integration",
+        "name": "integration",
+        "source": "sensor.power",
+        "method": "right",
     }
+    if max_dt is not None:
+        sensor["max_dt"] = max_dt
+    return {"sensor": sensor}
 
 
 async def _setup_integral_sensor(hass: HomeAssistant, max_dt: int | None = 60) -> None:
@@ -864,16 +864,14 @@ async def test_on_statechanges_source_expect_no_update_on_time(
         assert float(state_after_105s.state) > float(state_after_65s.state)
 
 
-@pytest.mark.parametrize("max_dt", [None, 0])
 async def test_on_no_max_dt_expect_no_timebased_updates(
     hass: HomeAssistant,
-    max_dt: int | None,
 ) -> None:
     """Test whether integratal is not updated by time when max_dt is not configured."""
 
     start_time = dt_util.utcnow()
     with freeze_time(start_time) as freezer:
-        await _setup_integral_sensor(hass, max_dt=max_dt)
+        await _setup_integral_sensor(hass, max_dt=None)
         await _update_source_sensor(hass, 100)
         await hass.async_block_till_done()
         await _update_source_sensor(hass, 101)


### PR DESCRIPTION
## Proposed change
### Summary of what has changed and how users can benefit from this
The Riemann sum integral sensor has a new config `max_sub_interval` which allows the integral sensor to also change over time when the source stays constant. Arguably an important feature of an integral. Workarounds like sampling fake changes of the source sensor or reloading the source sensor to trigger integral updates for constant periods are not necessary anymore with this new config.

### More detail
A drawback of the current implementation is that it only changes based on changes of the source sensor (also see linked issues). With this PR the integral sensor can change if the source has a constant valid numeric value for a duration of `max_sub_interval`, allowing for both integration based on _state changes_ and _elapsed time_. 

The idea is that after every calculation a timer will be scheduled to trigger after `max_sub_interval`. If before the time elapses a state change of the source occurs, the timer will be cancelled and integration will be done based on state change. If the timer is not cancelled, meaning there was no state change, meaning the source is constant, integration will be triggered based on time. Allowing for both fine grained state change based integration and integration during constant periods of the source. Also credits to @hberntsen for the approach. See picture of this new functionality in action (_speed_ is source, _distance_ is integral): 

<img width="1311" alt="riemann_edit" src="https://github.com/home-assistant/core/assets/15732230/4f74e1e6-131a-448f-8b29-9e003d86cca2">

Here the red rectangles update the distance during constant speed. Effectively the `max_sub_interval` config enforces a max width of the Riemann 'rectangles' in the integration approximation. I expect that with this change the integral helper sensor will be more usable. The documentation simplifies because the implicit disclaimer about accurateness-when-the-source-updates-often can be removed, see related documentation PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information


- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/88940 , https://github.com/home-assistant/core/issues/102057
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31453

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
