### PR TITLE
Fix derivative integration sample leave time window

### DIFF
--- a/homeassistant/components/derivative/sensor.py
+++ b/homeassistant/components/derivative/sensor.py
@@ -1,8 +1,9 @@
 """Numeric derivative of data coming from a source sensor over time."""
 from __future__ import annotations
 
+from collections import deque
 from datetime import datetime, timedelta
-from decimal import Decimal, DecimalException
+from decimal import Decimal
 import logging
 from typing import TYPE_CHECKING
 
@@ -14,11 +15,9 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
     CONF_SOURCE,
-    STATE_UNAVAILABLE,
-    STATE_UNKNOWN,
     UnitOfTime,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -28,9 +27,12 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import (
     EventStateChangedData,
+    async_track_point_in_utc_time,
     async_track_state_change_event,
 )
+from homeassistant.helpers.start import async_at_start
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, EventType
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_ROUND_DIGITS,
@@ -45,7 +47,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_SOURCE_ID = "source"
 
 # SI Metric prefixes
-UNIT_PREFIXES = {
+UNIT_PREFIXES: dict[str | None, float] = {
     None: 1,
     "n": 1e-9,
     "µ": 1e-6,
@@ -57,7 +59,7 @@ UNIT_PREFIXES = {
 }
 
 # SI Time prefixes
-UNIT_TIME = {
+UNIT_TIME: dict[UnitOfTime, int] = {
     UnitOfTime.SECONDS: 1,
     UnitOfTime.MINUTES: 60,
     UnitOfTime.HOURS: 60 * 60,
@@ -155,7 +157,26 @@ async def async_setup_platform(
 
 
 class DerivativeSensor(RestoreSensor, SensorEntity):
-    """Representation of a derivative sensor."""
+    """Representation of a derivative sensor.
+
+    Design of the class:
+    - If time_window is given, the derivative is at all times equal to the difference between the values at the "ends" of the
+      time_window divided by the number of seconds in time_window, and then scaled by unit_time and unit_prefix. This value changes
+      when the state at either of those ends change:
+      - When a new state change happens, the value of the new state is the value at the "young" end of the time_window, and thus the derivative value changes.
+      - When a state becomes older than time_window, the the value of this state is now the value at the "old" end of the time_window, and thus the derivative value changes.
+      Thus, the derivative changes twice per state change of the source sensor; once when the new state enter time_window, and once
+      when it leaves it. To accommodate triggering on the "leave" event, a queue of states is kept. This queue contains all states
+      with a last_changed datetime which are inside time_window from now, and 1 older state, which represents the value at the "old"
+      end of time_window. Therefore, after at least one state change occurred, the queue will always contain at least 1 state.
+    - How the queue is filled, popped and how the relevant callbacks are created is taken directly from the Statistics integration.
+    - If time_window is not given (or is 0 seconds), then this sensor post-calculates the derivative, meaning a state change from
+      (old_datetime, old_value) to (new_datetime, new_value) will set the state
+        (new_datetime, (new_value - old_value)/(new_datetime - old_datetime))
+      This means that the average derivative value in the interval [old_datetime, new_datetime] is calculated and put as sensor
+      state on timestamp new_datetime. This does not coincide with graph plotting of HA, which may be counterintuitive.
+      - This is facilitated by bounding the length of the queue to 2.
+    """
 
     _attr_translation_key = "derivative"
     _attr_should_poll = False
@@ -179,8 +200,6 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
         self._sensor_source_id = source_entity
         self._round_digits = round_digits
         self._state: float | int | Decimal = 0
-        # List of tuples with (timestamp_start, timestamp_end, derivative)
-        self._state_list: list[tuple[datetime, datetime, Decimal]] = []
 
         self._attr_name = name if name is not None else f"{source_entity} derivative"
         self._attr_extra_state_attributes = {ATTR_SOURCE_ID: source_entity}
@@ -195,7 +214,13 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
 
         self._unit_prefix = UNIT_PREFIXES[unit_prefix]
         self._unit_time = UNIT_TIME[unit_time]
-        self._time_window = time_window.total_seconds()
+
+        self._time_window = time_window
+
+        max_queue_len = None if time_window else 2
+        self._states: deque[tuple[float, datetime]] = deque(maxlen=max_queue_len)
+
+        self._update_listener: CALLBACK_TYPE | None = None
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""
@@ -211,14 +236,12 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                 _LOGGER.warning("Could not restore last state: %s", err)
 
         @callback
-        def calc_derivative(event: EventType[EventStateChangedData]) -> None:
+        def async_sensor_state_listener(
+            event: EventType[EventStateChangedData],
+        ) -> None:
             """Handle the sensor state changes."""
-            if (
-                (old_state := event.data["old_state"]) is None
-                or old_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-                or (new_state := event.data["new_state"]) is None
-                or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-            ):
+            new_state = event.data["new_state"]
+            if new_state is None:
                 return
 
             if self.native_unit_of_measurement is None:
@@ -227,67 +250,131 @@ class DerivativeSensor(RestoreSensor, SensorEntity):
                     "" if unit is None else unit
                 )
 
-            # filter out all derivatives older than `time_window` from our window list
-            self._state_list = [
-                (time_start, time_end, state)
-                for time_start, time_end, state in self._state_list
-                if (new_state.last_updated - time_end).total_seconds()
-                < self._time_window
-            ]
+            self._add_state_to_queue(new_state)
+            self.async_schedule_update_ha_state(True)
 
-            try:
-                elapsed_time = (
-                    new_state.last_updated - old_state.last_updated
-                ).total_seconds()
-                delta_value = Decimal(new_state.state) - Decimal(old_state.state)
-                new_derivative = (
-                    delta_value
-                    / Decimal(elapsed_time)
-                    / Decimal(self._unit_prefix)
-                    * Decimal(self._unit_time)
-                )
-
-            except ValueError as err:
-                _LOGGER.warning("While calculating derivative: %s", err)
-            except DecimalException as err:
-                _LOGGER.warning(
-                    "Invalid state (%s > %s): %s", old_state.state, new_state.state, err
-                )
-            except AssertionError as err:
-                _LOGGER.error("Could not calculate derivative: %s", err)
-
-            # add latest derivative to the window list
-            self._state_list.append(
-                (old_state.last_updated, new_state.last_updated, new_derivative)
+        async def async_sensor_startup(_: HomeAssistant) -> None:
+            """Add listener."""
+            _LOGGER.debug(
+                "Startup for %s with source %s", self.entity_id, self._sensor_source_id
             )
 
-            def calculate_weight(
-                start: datetime, end: datetime, now: datetime
-            ) -> float:
-                window_start = now - timedelta(seconds=self._time_window)
-                if start < window_start:
-                    weight = (end - window_start).total_seconds() / self._time_window
-                else:
-                    weight = (end - start).total_seconds() / self._time_window
-                return weight
-
-            # If outside of time window just report derivative (is the same as modeling it in the window),
-            # otherwise take the weighted average with the previous derivatives
-            if elapsed_time > self._time_window:
-                derivative = new_derivative
-            else:
-                derivative = Decimal(0)
-                for start, end, value in self._state_list:
-                    weight = calculate_weight(start, end, new_state.last_updated)
-                    derivative = derivative + (value * Decimal(weight))
-
-            self._state = derivative
-            self.async_write_ha_state()
-
-        self.async_on_remove(
-            async_track_state_change_event(
-                self.hass, self._sensor_source_id, calc_derivative
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self._sensor_source_id],
+                    async_sensor_state_listener,
+                )
             )
+
+        self.async_on_remove(async_at_start(self.hass, async_sensor_startup))
+
+    def _add_state_to_queue(self, new_state: State) -> None:
+        """Add the state to the queue."""
+
+        try:
+            self._states.append((float(new_state.state), new_state.last_updated))
+        except ValueError:
+            _LOGGER.error(
+                "%s: parsing error. Expected number, but received '%s'",
+                self.entity_id,
+                new_state.state,
+            )
+
+    def _purge_old_states(self) -> None:
+        """Remove all states except 1 which are older than the time window."""
+        now = dt_util.utcnow()
+
+        _LOGGER.debug(
+            "%s: purging records older than %s(%s)",
+            self.entity_id,
+            dt_util.as_local(now - self._time_window),
+            self._time_window,
+        )
+
+        while len(self._states) > 1 and (now - self._states[1][1]) > self._time_window:
+            _LOGGER.debug(
+                "%s: purging record with datetime %s(age: %s, UTC: %s) and value %s",
+                self.entity_id,
+                dt_util.as_local(self._states[0][1]),
+                (now - self._states[0][1]),
+                dt_util.as_utc(self._states[0][1]),
+                self._states[0][0],
+            )
+            self._states.popleft()
+
+    def _next_to_purge_timestamp(self) -> datetime | None:
+        """Find the timestamp when the next purge would occur."""
+        if len(self._states) > 1 and self._time_window:
+            # Take the oldest entry from the states list that is within the time_window
+            # and add the configured time_window length.
+            # If executed after purging old states, the result is the next timestamp
+            # in the future when the oldest state will expire.
+            return self._states[1][1] + self._time_window
+        return None
+
+    async def async_update(self) -> None:
+        """Get the latest data and updates the states."""
+        _LOGGER.debug("%s: updating derivative", self.entity_id)
+        if self._time_window:
+            self._purge_old_states()
+
+        self._update_value()
+
+        # If time_window is set, ensure to update again after the defined interval.
+        if timestamp := self._next_to_purge_timestamp():
+            _LOGGER.debug("%s: scheduling update at %s", self.entity_id, timestamp)
+            if self._update_listener:
+                self._update_listener()
+                self._update_listener = None
+
+            @callback
+            def _scheduled_update(now: datetime) -> None:
+                """Timer callback for sensor update."""
+                _LOGGER.debug(
+                    "%s: executing scheduled update at time %s", self.entity_id, now
+                )
+                self.async_schedule_update_ha_state(True)
+                self._update_listener = None
+
+            self._update_listener = async_track_point_in_utc_time(
+                self.hass, _scheduled_update, timestamp
+            )
+
+    def _update_value(self) -> None:
+        """Front to calculate the derivative value."""
+
+        if len(self._states) == 0:
+            self._state = 0
+
+        # If there is only 1 value, the states are equal
+        old_state: tuple[float, datetime] = self._states[0]
+        new_state: tuple[float, datetime] = self._states[-1]
+        value_difference: float = new_state[0] - old_state[0]
+
+        time_difference: float = 1.0
+        if self._time_window:
+            time_difference = self._time_window.total_seconds()
+        elif len(self._states) == 1:
+            # It doesn't matter what time_difference is as in this case value_difference == 0.0, as long as it is not 0.0 because that results in ZeroDivisionError instead of the desired 0.0
+            time_difference = 1.0
+        else:
+            time_difference = (new_state[1] - old_state[1]).total_seconds()
+
+        self._state = (
+            value_difference / time_difference / self._unit_prefix * self._unit_time
+        )
+
+        _LOGGER.debug(
+            "%s: Calculate derivative: %s -> %s: %.12f / %.12f / %.12f * %.12f = %.12f",
+            self.entity_id,
+            old_state,
+            new_state,
+            value_difference,
+            time_difference,
+            self._unit_prefix,
+            self._unit_time,
+            self._state,
         )
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change fixes a bug where the Derivative integration with Simple-Moving-Average behaviour would not reset the value to 0 after there are no more state changes within the averaging window: If there are no state _changes_ in the window, then a single state (value) encompasses the entire window and thus the averaged derivative is 0.

However, more generally, this change updates the Derivative integration sensor every time a state change that has entered the window leaves the window.

The code is mostly copied from Statistics integration, but adapted to the requirements of the Derivative integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #83496 , but it does not fully fix it because the "other" behaviour option (linear derivative instead of SMA-derivative) is not yet fixed.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
