### PR TITLE
Speed up registry config websocket api calls with list comps

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -47,19 +47,14 @@ def websocket_list_devices(
         f'"success":true,"result": ['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = b"".join(
-        (
-            msg_json_prefix,
-            b",".join(
-                [
-                    entry.json_repr
-                    for entry in registry.devices.values()
-                    if entry.json_repr is not None
-                ]
-            ),
-            b"]}",
-        )
+    inner = b",".join(
+        [
+            entry.json_repr
+            for entry in registry.devices.values()
+            if entry.json_repr is not None
+        ]
     )
+    msg_json = b"".join((msg_json_prefix, inner, b"]}"))
     connection.send_message(msg_json)
 
 

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -47,14 +47,18 @@ def websocket_list_devices(
         f'"success":true,"result": ['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = (
-        msg_json_prefix
-        + b",".join(
-            entry.json_repr
-            for entry in registry.devices.values()
-            if entry.json_repr is not None
+    msg_json = b"".join(
+        (
+            msg_json_prefix,
+            b",".join(
+                [
+                    entry.json_repr
+                    for entry in registry.devices.values()
+                    if entry.json_repr is not None
+                ]
+            ),
+            b"]}",
         )
-        + b"]}"
     )
     connection.send_message(msg_json)
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -45,19 +45,14 @@ def websocket_list_entities(
         '"success":true,"result": ['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = b"".join(
-        (
-            msg_json_prefix,
-            b",".join(
-                [
-                    entry.partial_json_repr
-                    for entry in registry.entities.values()
-                    if entry.partial_json_repr is not None
-                ]
-            ),
-            b"]}",
-        )
+    inner = b",".join(
+        [
+            entry.partial_json_repr
+            for entry in registry.entities.values()
+            if entry.partial_json_repr is not None
+        ]
     )
+    msg_json = b"".join((msg_json_prefix, inner, b"]}"))
     connection.send_message(msg_json)
 
 
@@ -81,19 +76,14 @@ def websocket_list_entities_for_display(
         f'"result":{{"entity_categories":{_ENTITY_CATEGORIES_JSON},"entities":['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = b"".join(
-        (
-            msg_json_prefix,
-            b",".join(
-                [
-                    entry.display_json_repr
-                    for entry in registry.entities.values()
-                    if entry.disabled_by is None and entry.display_json_repr is not None
-                ]
-            ),
-            b"]}}",
-        )
+    inner = b",".join(
+        [
+            entry.display_json_repr
+            for entry in registry.entities.values()
+            if entry.disabled_by is None and entry.display_json_repr is not None
+        ]
     )
+    msg_json = b"".join((msg_json_prefix, inner, b"]}}"))
     connection.send_message(msg_json)
 
 

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -45,14 +45,18 @@ def websocket_list_entities(
         '"success":true,"result": ['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = (
-        msg_json_prefix
-        + b",".join(
-            entry.partial_json_repr
-            for entry in registry.entities.values()
-            if entry.partial_json_repr is not None
+    msg_json = b"".join(
+        (
+            msg_json_prefix,
+            b",".join(
+                [
+                    entry.partial_json_repr
+                    for entry in registry.entities.values()
+                    if entry.partial_json_repr is not None
+                ]
+            ),
+            b"]}",
         )
-        + b"]}"
     )
     connection.send_message(msg_json)
 
@@ -77,14 +81,18 @@ def websocket_list_entities_for_display(
         f'"result":{{"entity_categories":{_ENTITY_CATEGORIES_JSON},"entities":['
     ).encode()
     # Concatenate cached entity registry item JSON serializations
-    msg_json = (
-        msg_json_prefix
-        + b",".join(
-            entry.display_json_repr
-            for entry in registry.entities.values()
-            if entry.disabled_by is None and entry.display_json_repr is not None
+    msg_json = b"".join(
+        (
+            msg_json_prefix,
+            b",".join(
+                [
+                    entry.display_json_repr
+                    for entry in registry.entities.values()
+                    if entry.disabled_by is None and entry.display_json_repr is not None
+                ]
+            ),
+            b"]}}",
         )
-        + b"]}}"
     )
     connection.send_message(msg_json)
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

list comps are faster than generator expressions, even more so in python 3.12 since https://peps.python.org/pep-0709/, and since we have to hold the whole result in memory anyways, a list comp makes more sense here.

https://stackoverflow.com/questions/47789/generator-expressions-vs-list-comprehensions/62709748#62709748


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
