### PR TITLE
Add filter to translation event listeners to avoid creating tasks

### DIFF
--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -480,10 +480,9 @@ def async_setup(hass: HomeAssistant) -> None:
         return "language" in event.data
 
     async def _async_load_translations(event: Event) -> None:
-        if "language" in event.data:
-            language = hass.config.language
-            _LOGGER.debug("Loading translations for language: %s", language)
-            await _async_load_state_translations_to_cache(hass, language, None)
+        language = hass.config.language
+        _LOGGER.debug("Loading translations for language: %s", language)
+        await _async_load_state_translations_to_cache(hass, language, None)
 
     @callback
     def _async_load_translations_for_component_filter(event: Event) -> bool:

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -486,8 +486,9 @@ def async_setup(hass: HomeAssistant) -> None:
         return False
 
     async def _async_load_translations(event: Event) -> None:
-        _LOGGER.debug("Loading translations for language: %s", current_language)
-        await _async_load_state_translations_to_cache(hass, current_language, None)
+        new_language = event.data["language"]
+        _LOGGER.debug("Loading translations for language: %s", new_language)
+        await _async_load_state_translations_to_cache(hass, new_language, None)
 
     @callback
     def _async_load_translations_for_component_filter(event: Event) -> bool:

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -5,7 +5,7 @@ import asyncio
 from collections.abc import Iterable, Mapping
 import logging
 import string
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
     EVENT_COMPONENT_LOADED,
@@ -204,6 +204,11 @@ class _TranslationCache:
         self.loaded: dict[str, set[str]] = {}
         self.cache: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
         self.lock = asyncio.Lock()
+
+    @callback
+    def async_is_loaded(self, language: str, components: set[str]) -> bool:
+        """Return if the given components are loaded for the language."""
+        return components.issubset(self.loaded.get(language, set()))
 
     async def async_load(
         self,
@@ -465,20 +470,36 @@ def async_setup(hass: HomeAssistant) -> None:
 
     Listeners load translations for every loaded component and after config change.
     """
+    cache = _TranslationCache(hass)
 
-    hass.data[TRANSLATION_FLATTEN_CACHE] = _TranslationCache(hass)
+    hass.data[TRANSLATION_FLATTEN_CACHE] = cache
 
-    async def load_translations(event: Event) -> None:
+    @callback
+    def _async_load_translations_filter(event: Event) -> bool:
+        """Filter out unwanted events."""
+        return "language" in event.data
+
+    async def _async_load_translations(event: Event) -> None:
         if "language" in event.data:
             language = hass.config.language
             _LOGGER.debug("Loading translations for language: %s", language)
             await _async_load_state_translations_to_cache(hass, language, None)
 
-    async def load_translations_for_component(event: Event) -> None:
-        component = event.data.get("component")
+    @callback
+    def _async_load_translations_for_component_filter(event: Event) -> bool:
+        """Filter out unwanted events."""
+        component: str | None = event.data.get("component")
         # Platforms don't have their own translations, skip them
-        if component is None or "." in str(component):
-            return
+        return bool(
+            component
+            and "." not in component
+            and not cache.async_is_loaded(hass.config.language, {component})
+        )
+
+    async def _async_load_translations_for_component(event: Event) -> None:
+        component: str | None = event.data.get("component")
+        if TYPE_CHECKING:
+            assert component is not None
         language = hass.config.language
         _LOGGER.debug(
             "Loading translations for language: %s and component: %s",
@@ -487,8 +508,16 @@ def async_setup(hass: HomeAssistant) -> None:
         )
         await _async_load_state_translations_to_cache(hass, language, component)
 
-    hass.bus.async_listen(EVENT_COMPONENT_LOADED, load_translations_for_component)
-    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, load_translations)
+    hass.bus.async_listen(
+        EVENT_COMPONENT_LOADED,
+        _async_load_translations_for_component,
+        event_filter=_async_load_translations_for_component_filter,
+    )
+    hass.bus.async_listen(
+        EVENT_CORE_CONFIG_UPDATE,
+        _async_load_translations,
+        event_filter=_async_load_translations_filter,
+    )
 
 
 @callback

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -602,12 +602,21 @@ async def test_setup(hass: HomeAssistant):
         await hass.async_block_till_done()
         mock.assert_not_called()
 
+    # Should not be called if the language is the current language
     with patch(
         "homeassistant.helpers.translation._async_load_state_translations_to_cache",
     ) as mock:
         hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {"language": "en"})
         await hass.async_block_till_done()
-        mock.assert_called_once_with(hass, hass.config.language, None)
+        mock.assert_not_called()
+
+    # Should be called if the language is different
+    with patch(
+        "homeassistant.helpers.translation._async_load_state_translations_to_cache",
+    ) as mock:
+        hass.bus.async_fire(EVENT_CORE_CONFIG_UPDATE, {"language": "es"})
+        await hass.async_block_till_done()
+        mock.assert_called_once_with(hass, "es", None)
 
     with patch(
         "homeassistant.helpers.translation._async_load_state_translations_to_cache",


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We no longer create tasks when the the task will be a no-op

This is not so useful on its own but it supports
#110674 and was split to make the review smaller

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
