### PR TITLE
Wait for client to be created in wyoming tests

### DIFF
--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -620,8 +620,6 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
         "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
     ) as mock_run_pipeline:
         await setup_config_entry(hass)
-        await hass.async_block_till_done()
-
         async with asyncio.timeout(1):
             await client_created_event.wait()
             await mock_client.connect_event.wait()
@@ -684,7 +682,6 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
         _stream_tts,
     ):
         entry = await setup_config_entry(hass)
-
         async with asyncio.timeout(1):
             await client_created_event.wait()
             await mock_client.connect_event.wait()

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -613,6 +613,7 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
         "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
     ) as mock_run_pipeline:
         await setup_config_entry(hass)
+        await hass.async_block_till_done()
 
         async with asyncio.timeout(1):
             await mock_client.connect_event.wait()
@@ -668,6 +669,8 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
         _stream_tts,
     ):
         entry = await setup_config_entry(hass)
+        await hass.async_block_till_done()
+
         async with asyncio.timeout(1):
             await mock_client.connect_event.wait()
             await mock_client.run_satellite_event.wait()

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -684,7 +684,6 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
         _stream_tts,
     ):
         entry = await setup_config_entry(hass)
-        await hass.async_block_till_done()
 
         async with asyncio.timeout(1):
             await client_created_event.wait()

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -606,7 +606,7 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
     client_created_event = asyncio.Event()
     mock_client = SatelliteAsyncTcpClient(events)
 
-    def _make_async_tcp_client(*args: Any, **kwargs: Any) -> SatelliteAsyncTcpClient:
+    def _async_make_tcp_client(*args: Any, **kwargs: Any) -> SatelliteAsyncTcpClient:
         client_created_event.set()
         return mock_client
 
@@ -615,7 +615,7 @@ async def test_satellite_error_during_pipeline(hass: HomeAssistant) -> None:
         return_value=SATELLITE_INFO,
     ), patch(
         "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        _make_async_tcp_client,
+        _async_make_tcp_client,
     ), patch(
         "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
     ) as mock_run_pipeline:
@@ -662,7 +662,7 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
     client_created_event = asyncio.Event()
     mock_client = SatelliteAsyncTcpClient(events)
 
-    def _make_async_tcp_client(*args: Any, **kwargs: Any) -> SatelliteAsyncTcpClient:
+    def _async_make_tcp_client(*args: Any, **kwargs: Any) -> SatelliteAsyncTcpClient:
         client_created_event.set()
         return mock_client
 
@@ -671,7 +671,7 @@ async def test_tts_not_wav(hass: HomeAssistant) -> None:
         return_value=SATELLITE_INFO,
     ), patch(
         "homeassistant.components.wyoming.satellite.AsyncTcpClient",
-        _make_async_tcp_client,
+        _async_make_tcp_client,
     ), patch(
         "homeassistant.components.wyoming.satellite.assist_pipeline.async_pipeline_from_audio_stream",
     ) as mock_run_pipeline, patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wait for client to be created in wyoming tests

These tests were relying on other tasks running and making everything slow enough for the test to pass.  https://github.com/home-assistant/core/pull/110743 will get rid of the extra tasks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
