### PR TITLE
Add new intents for cover, valve, vacuum, and media player

### DIFF
--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -36,11 +36,6 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             intent.INTENT_SET_POSITION,
             DOMAIN,
             SERVICE_SET_COVER_POSITION,
-            extra_slot_names={ATTR_POSITION},
-            extra_slot_schema={
-                vol.Required(ATTR_POSITION): vol.All(
-                    vol.Coerce(int), vol.Range(min=0, max=100)
-                )
-            },
+            extra_slots={ATTR_POSITION: vol.All(vol.Range(min=0, max=100))},
         ),
     )

--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -30,7 +30,6 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             INTENT_CLOSE_COVER, DOMAIN, SERVICE_CLOSE_COVER, "Closed {}"
         ),
     )
-
     intent.async_register(
         hass,
         intent.ServiceIntentHandler(

--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -10,7 +10,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
-from . import DOMAIN
+from . import ATTR_POSITION, DOMAIN
 
 INTENT_OPEN_COVER = "HassOpenCover"
 INTENT_CLOSE_COVER = "HassCloseCover"
@@ -36,9 +36,9 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             intent.INTENT_SET_POSITION,
             DOMAIN,
             SERVICE_SET_COVER_POSITION,
-            extra_slot_names={"position"},
+            extra_slot_names={ATTR_POSITION},
             extra_slot_schema={
-                vol.Required("position"): vol.All(
+                vol.Required(ATTR_POSITION): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=100)
                 )
             },

--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -1,5 +1,12 @@
 """Intents for the cover integration."""
-from homeassistant.const import SERVICE_CLOSE_COVER, SERVICE_OPEN_COVER
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    SERVICE_CLOSE_COVER,
+    SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
@@ -21,5 +28,20 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
         hass,
         intent.ServiceIntentHandler(
             INTENT_CLOSE_COVER, DOMAIN, SERVICE_CLOSE_COVER, "Closed {}"
+        ),
+    )
+
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            intent.INTENT_SET_POSITION,
+            DOMAIN,
+            SERVICE_SET_COVER_POSITION,
+            extra_slot_names={"position"},
+            extra_slot_schema={
+                vol.Required("position"): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=100)
+                )
+            },
         ),
     )

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -87,10 +87,10 @@ class IntentPlatformProtocol(Protocol):
 
 
 class OnOffIntentHandler(intent.ServiceIntentHandler):
-    """Intent handler for on/off that handles covers too."""
+    """Intent handler for on/off that also supports covers, valves, locks, etc."""
 
     async def async_call_service(self, intent_obj: intent.Intent, state: State) -> None:
-        """Call service on entity with special case for covers."""
+        """Call service on entity with handling for special cases."""
         hass = intent_obj.hass
 
         if state.domain == COVER_DOMAIN:

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -20,11 +20,6 @@ from homeassistant.components.lock import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
-from homeassistant.components.vacuum import (
-    DOMAIN as VACUUM_DOMAIN,
-    SERVICE_RETURN_TO_BASE,
-    SERVICE_START,
-)
 from homeassistant.components.valve import (
     DOMAIN as VALVE_DOMAIN,
     SERVICE_CLOSE_VALVE,
@@ -152,27 +147,6 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
                 hass.async_create_task(
                     hass.services.async_call(
                         VALVE_DOMAIN,
-                        service_name,
-                        {ATTR_ENTITY_ID: state.entity_id},
-                        context=intent_obj.context,
-                        blocking=True,
-                    )
-                )
-            )
-            return
-
-        if state.domain == VACUUM_DOMAIN:
-            # on = start
-            # off = return to base
-            if self.service == SERVICE_TURN_ON:
-                service_name = SERVICE_START
-            else:
-                service_name = SERVICE_RETURN_TO_BASE
-
-            await self._run_then_background(
-                hass.async_create_task(
-                    hass.services.async_call(
-                        VACUUM_DOMAIN,
                         service_name,
                         {ATTR_ENTITY_ID: state.entity_id},
                         context=intent_obj.context,

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -20,6 +20,11 @@ from homeassistant.components.lock import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
+from homeassistant.components.valve import (
+    DOMAIN as VALVE_DOMAIN,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TOGGLE,
@@ -121,6 +126,27 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
                 hass.async_create_task(
                     hass.services.async_call(
                         LOCK_DOMAIN,
+                        service_name,
+                        {ATTR_ENTITY_ID: state.entity_id},
+                        context=intent_obj.context,
+                        blocking=True,
+                    )
+                )
+            )
+            return
+
+        if state.domain == VALVE_DOMAIN:
+            # on = opened
+            # off = closed
+            if self.service == SERVICE_TURN_ON:
+                service_name = SERVICE_OPEN_VALVE
+            else:
+                service_name = SERVICE_CLOSE_VALVE
+
+            await self._run_then_background(
+                hass.async_create_task(
+                    hass.services.async_call(
+                        VALVE_DOMAIN,
                         service_name,
                         {ATTR_ENTITY_ID: state.entity_id},
                         context=intent_obj.context,

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -20,6 +20,11 @@ from homeassistant.components.lock import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
 )
+from homeassistant.components.vacuum import (
+    DOMAIN as VACUUM_DOMAIN,
+    SERVICE_RETURN_TO_BASE,
+    SERVICE_START,
+)
 from homeassistant.components.valve import (
     DOMAIN as VALVE_DOMAIN,
     SERVICE_CLOSE_VALVE,
@@ -147,6 +152,27 @@ class OnOffIntentHandler(intent.ServiceIntentHandler):
                 hass.async_create_task(
                     hass.services.async_call(
                         VALVE_DOMAIN,
+                        service_name,
+                        {ATTR_ENTITY_ID: state.entity_id},
+                        context=intent_obj.context,
+                        blocking=True,
+                    )
+                )
+            )
+            return
+
+        if state.domain == VACUUM_DOMAIN:
+            # on = start
+            # off = return to base
+            if self.service == SERVICE_TURN_ON:
+                service_name = SERVICE_START
+            else:
+                service_name = SERVICE_RETURN_TO_BASE
+
+            await self._run_then_background(
+                hass.async_create_task(
+                    hass.services.async_call(
+                        VACUUM_DOMAIN,
                         service_name,
                         {ATTR_ENTITY_ID: state.entity_id},
                         context=intent_obj.context,

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -10,7 +10,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
-import homeassistant.helpers.config_validation as cv
 
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
 
@@ -42,7 +41,10 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             INTENT_SET_VOLUME,
             DOMAIN,
             SERVICE_VOLUME_SET,
-            extra_slot_names={ATTR_MEDIA_VOLUME_LEVEL},
-            extra_slot_schema={vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float},
+            extra_slots={
+                ATTR_MEDIA_VOLUME_LEVEL: vol.All(
+                    vol.Range(min=0, max=100), lambda val: val / 100
+                )
+            },
         ),
     )

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -1,0 +1,48 @@
+"""Intents for the media_player integration."""
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_VOLUME_SET,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+import homeassistant.helpers.config_validation as cv
+
+from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
+
+INTENT_MEDIA_PAUSE = "HassMediaPause"
+INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
+INTENT_MEDIA_NEXT = "HassMediaNext"
+INTENT_SET_VOLUME = "HassSetVolume"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the media_player intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(INTENT_MEDIA_UNPAUSE, DOMAIN, SERVICE_MEDIA_PLAY),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(INTENT_MEDIA_PAUSE, DOMAIN, SERVICE_MEDIA_PAUSE),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_MEDIA_NEXT, DOMAIN, SERVICE_MEDIA_NEXT_TRACK
+        ),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_SET_VOLUME,
+            DOMAIN,
+            SERVICE_VOLUME_SET,
+            extra_slot_names={ATTR_MEDIA_VOLUME_LEVEL},
+            extra_slot_schema={vol.Required(ATTR_MEDIA_VOLUME_LEVEL): cv.small_float},
+        ),
+    )

--- a/homeassistant/components/vacuum/intent.py
+++ b/homeassistant/components/vacuum/intent.py
@@ -1,0 +1,24 @@
+"""Intents for the vacuum integration."""
+
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from . import DOMAIN, SERVICE_RETURN_TO_BASE, SERVICE_START
+
+INTENT_VACUUM_START = "HassVacuumStart"
+INTENT_VACUUM_RETURN_TO_BASE = "HassVacuumReturnToBase"
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the vacuum intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(INTENT_VACUUM_START, DOMAIN, SERVICE_START),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_VACUUM_RETURN_TO_BASE, DOMAIN, SERVICE_RETURN_TO_BASE
+        ),
+    )

--- a/homeassistant/components/valve/intent.py
+++ b/homeassistant/components/valve/intent.py
@@ -17,11 +17,6 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             intent.INTENT_SET_POSITION,
             DOMAIN,
             SERVICE_SET_VALVE_POSITION,
-            extra_slot_names={ATTR_POSITION},
-            extra_slot_schema={
-                vol.Required(ATTR_POSITION): vol.All(
-                    vol.Coerce(int), vol.Range(min=0, max=100)
-                )
-            },
+            extra_slots={ATTR_POSITION: vol.All(vol.Range(min=0, max=100))},
         ),
     )

--- a/homeassistant/components/valve/intent.py
+++ b/homeassistant/components/valve/intent.py
@@ -1,0 +1,27 @@
+"""Intents for the valve integration."""
+
+import voluptuous as vol
+
+from homeassistant.const import SERVICE_SET_VALVE_POSITION
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from . import DOMAIN
+
+
+async def async_setup_intents(hass: HomeAssistant) -> None:
+    """Set up the valve intents."""
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            intent.INTENT_SET_POSITION,
+            DOMAIN,
+            SERVICE_SET_VALVE_POSITION,
+            extra_slot_names={"position"},
+            extra_slot_schema={
+                vol.Required("position"): vol.All(
+                    vol.Coerce(int), vol.Range(min=0, max=100)
+                )
+            },
+        ),
+    )

--- a/homeassistant/components/valve/intent.py
+++ b/homeassistant/components/valve/intent.py
@@ -6,7 +6,7 @@ from homeassistant.const import SERVICE_SET_VALVE_POSITION
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
-from . import DOMAIN
+from . import ATTR_POSITION, DOMAIN
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
@@ -17,9 +17,9 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             intent.INTENT_SET_POSITION,
             DOMAIN,
             SERVICE_SET_VALVE_POSITION,
-            extra_slot_names={"position"},
+            extra_slot_names={ATTR_POSITION},
             extra_slot_schema={
-                vol.Required("position"): vol.All(
+                vol.Required(ATTR_POSITION): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=100)
                 )
             },

--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -367,9 +367,7 @@ class IntentHandler:
     @cached_property
     def _slot_schema(self) -> vol.Schema:
         """Create validation schema for slots."""
-        if self.slot_schema is None:
-            raise ValueError("Slot schema is not defined")
-
+        assert self.slot_schema is not None
         return vol.Schema(
             {
                 key: SLOT_SCHEMA.extend({"value": validator})

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -1,9 +1,14 @@
 """The tests for the cover platform."""
+
 from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
+    SERVICE_SET_COVER_POSITION,
     intent as cover_intent,
 )
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 
@@ -14,37 +19,66 @@ async def test_open_cover_intent(hass: HomeAssistant) -> None:
     """Test HassOpenCover intent."""
     await cover_intent.async_setup_intents(hass)
 
-    hass.states.async_set("cover.garage_door", "closed")
-    calls = async_mock_service(hass, "cover", SERVICE_OPEN_COVER)
+    hass.states.async_set(f"{DOMAIN}.garage_door", STATE_CLOSED)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_COVER)
 
     response = await intent.async_handle(
-        hass, "test", "HassOpenCover", {"name": {"value": "garage door"}}
+        hass, "test", cover_intent.INTENT_OPEN_COVER, {"name": {"value": "garage door"}}
     )
     await hass.async_block_till_done()
 
     assert response.speech["plain"]["speech"] == "Opened garage door"
     assert len(calls) == 1
     call = calls[0]
-    assert call.domain == "cover"
-    assert call.service == "open_cover"
-    assert call.data == {"entity_id": "cover.garage_door"}
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_OPEN_COVER
+    assert call.data == {"entity_id": f"{DOMAIN}.garage_door"}
 
 
 async def test_close_cover_intent(hass: HomeAssistant) -> None:
     """Test HassCloseCover intent."""
     await cover_intent.async_setup_intents(hass)
 
-    hass.states.async_set("cover.garage_door", "open")
-    calls = async_mock_service(hass, "cover", SERVICE_CLOSE_COVER)
+    hass.states.async_set(f"{DOMAIN}.garage_door", STATE_OPEN)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_COVER)
 
     response = await intent.async_handle(
-        hass, "test", "HassCloseCover", {"name": {"value": "garage door"}}
+        hass,
+        "test",
+        cover_intent.INTENT_CLOSE_COVER,
+        {"name": {"value": "garage door"}},
     )
     await hass.async_block_till_done()
 
     assert response.speech["plain"]["speech"] == "Closed garage door"
     assert len(calls) == 1
     call = calls[0]
-    assert call.domain == "cover"
-    assert call.service == "close_cover"
-    assert call.data == {"entity_id": "cover.garage_door"}
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_CLOSE_COVER
+    assert call.data == {"entity_id": f"{DOMAIN}.garage_door"}
+
+
+async def test_set_cover_position(hass: HomeAssistant) -> None:
+    """Test HassSetPosition intent for covers."""
+    await cover_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_cover"
+    hass.states.async_set(
+        entity_id, STATE_CLOSED, attributes={ATTR_CURRENT_POSITION: 0}
+    )
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_COVER_POSITION)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_POSITION,
+        {"name": {"value": "test cover"}, "position": {"value": 50}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_SET_COVER_POSITION
+    assert call.data == {"entity_id": entity_id, "position": 50}

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -99,7 +99,7 @@ async def test_volume_media_player_intent(hass: HomeAssistant) -> None:
         hass,
         "test",
         media_player_intent.INTENT_SET_VOLUME,
-        {"name": {"value": "test media player"}, "volume_level": {"value": 0.5}},
+        {"name": {"value": "test media player"}, "volume_level": {"value": 50}},
     )
     await hass.async_block_till_done()
 

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -1,0 +1,111 @@
+"""The tests for the media_player platform."""
+
+from homeassistant.components.media_player import (
+    DOMAIN,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_VOLUME_SET,
+    intent as media_player_intent,
+)
+from homeassistant.const import STATE_IDLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+
+from tests.common import async_mock_service
+
+
+async def test_pause_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaPause intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PAUSE)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_PAUSE,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_MEDIA_PAUSE
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_unpause_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaUnpause intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PLAY)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_UNPAUSE,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_MEDIA_PLAY
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_next_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaNext intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_NEXT_TRACK)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_NEXT,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_MEDIA_NEXT_TRACK
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_volume_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassSetVolume intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_VOLUME_SET)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_SET_VOLUME,
+        {"name": {"value": "test media player"}, "volume_level": {"value": 0.5}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_VOLUME_SET
+    assert call.data == {"entity_id": entity_id, "volume_level": 0.5}

--- a/tests/components/vacuum/test_intent.py
+++ b/tests/components/vacuum/test_intent.py
@@ -1,0 +1,55 @@
+"""The tests for the vacuum platform."""
+
+from homeassistant.components.vacuum import (
+    DOMAIN,
+    SERVICE_RETURN_TO_BASE,
+    SERVICE_START,
+)
+from homeassistant.const import STATE_IDLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_mock_service
+
+
+async def test_start_vacuum_intent(hass: HomeAssistant) -> None:
+    """Test HassTurnOn intent for vacuums."""
+    assert await async_setup_component(hass, "intent", {})
+
+    entity_id = f"{DOMAIN}.test_vacuum"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_START)
+
+    response = await intent.async_handle(
+        hass, "test", intent.INTENT_TURN_ON, {"name": {"value": "test vacuum"}}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_START
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_stop_vacuum_intent(hass: HomeAssistant) -> None:
+    """Test HassTurnOff intent for vacuums."""
+    assert await async_setup_component(hass, "intent", {})
+
+    entity_id = f"{DOMAIN}.test_vacuum"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_RETURN_TO_BASE)
+
+    response = await intent.async_handle(
+        hass, "test", intent.INTENT_TURN_OFF, {"name": {"value": "test vacuum"}}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_RETURN_TO_BASE
+    assert call.data == {"entity_id": entity_id}

--- a/tests/components/vacuum/test_intent.py
+++ b/tests/components/vacuum/test_intent.py
@@ -4,25 +4,28 @@ from homeassistant.components.vacuum import (
     DOMAIN,
     SERVICE_RETURN_TO_BASE,
     SERVICE_START,
+    intent as vacuum_intent,
 )
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
-from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
 
 
 async def test_start_vacuum_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOn intent for vacuums."""
-    assert await async_setup_component(hass, "intent", {})
+    await vacuum_intent.async_setup_intents(hass)
 
     entity_id = f"{DOMAIN}.test_vacuum"
     hass.states.async_set(entity_id, STATE_IDLE)
     calls = async_mock_service(hass, DOMAIN, SERVICE_START)
 
     response = await intent.async_handle(
-        hass, "test", intent.INTENT_TURN_ON, {"name": {"value": "test vacuum"}}
+        hass,
+        "test",
+        vacuum_intent.INTENT_VACUUM_START,
+        {"name": {"value": "test vacuum"}},
     )
     await hass.async_block_till_done()
 
@@ -36,14 +39,17 @@ async def test_start_vacuum_intent(hass: HomeAssistant) -> None:
 
 async def test_stop_vacuum_intent(hass: HomeAssistant) -> None:
     """Test HassTurnOff intent for vacuums."""
-    assert await async_setup_component(hass, "intent", {})
+    await vacuum_intent.async_setup_intents(hass)
 
     entity_id = f"{DOMAIN}.test_vacuum"
     hass.states.async_set(entity_id, STATE_IDLE)
     calls = async_mock_service(hass, DOMAIN, SERVICE_RETURN_TO_BASE)
 
     response = await intent.async_handle(
-        hass, "test", intent.INTENT_TURN_OFF, {"name": {"value": "test vacuum"}}
+        hass,
+        "test",
+        vacuum_intent.INTENT_VACUUM_RETURN_TO_BASE,
+        {"name": {"value": "test vacuum"}},
     )
     await hass.async_block_till_done()
 

--- a/tests/components/valve/test_intent.py
+++ b/tests/components/valve/test_intent.py
@@ -1,10 +1,14 @@
 """The tests for the valve platform."""
 
 from homeassistant.components.valve import (
+    ATTR_CURRENT_POSITION,
     DOMAIN,
     SERVICE_CLOSE_VALVE,
     SERVICE_OPEN_VALVE,
+    SERVICE_SET_VALVE_POSITION,
+    intent as valve_intent,
 )
+from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 from homeassistant.setup import async_setup_component
@@ -17,11 +21,11 @@ async def test_open_valve_intent(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "intent", {})
 
     entity_id = f"{DOMAIN}.test_valve"
-    hass.states.async_set(entity_id, "closed")
+    hass.states.async_set(entity_id, STATE_CLOSED)
     calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_VALVE)
 
     response = await intent.async_handle(
-        hass, "test", "HassTurnOn", {"name": {"value": "test valve"}}
+        hass, "test", intent.INTENT_TURN_ON, {"name": {"value": "test valve"}}
     )
     await hass.async_block_till_done()
 
@@ -38,11 +42,11 @@ async def test_close_valve_intent(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, "intent", {})
 
     entity_id = f"{DOMAIN}.test_valve"
-    hass.states.async_set(entity_id, "opened")
+    hass.states.async_set(entity_id, STATE_OPEN)
     calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_VALVE)
 
     response = await intent.async_handle(
-        hass, "test", "HassTurnOff", {"name": {"value": "test valve"}}
+        hass, "test", intent.INTENT_TURN_OFF, {"name": {"value": "test valve"}}
     )
     await hass.async_block_till_done()
 
@@ -52,3 +56,29 @@ async def test_close_valve_intent(hass: HomeAssistant) -> None:
     assert call.domain == DOMAIN
     assert call.service == SERVICE_CLOSE_VALVE
     assert call.data == {"entity_id": entity_id}
+
+
+async def test_set_valve_position(hass: HomeAssistant) -> None:
+    """Test HassSetPosition intent for valves."""
+    await valve_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_valve"
+    hass.states.async_set(
+        entity_id, STATE_CLOSED, attributes={ATTR_CURRENT_POSITION: 0}
+    )
+    calls = async_mock_service(hass, DOMAIN, SERVICE_SET_VALVE_POSITION)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_SET_POSITION,
+        {"name": {"value": "test valve"}, "position": {"value": 50}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_SET_VALVE_POSITION
+    assert call.data == {"entity_id": entity_id, "position": 50}

--- a/tests/components/valve/test_intent.py
+++ b/tests/components/valve/test_intent.py
@@ -1,0 +1,54 @@
+"""The tests for the valve platform."""
+
+from homeassistant.components.valve import (
+    DOMAIN,
+    SERVICE_CLOSE_VALVE,
+    SERVICE_OPEN_VALVE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_mock_service
+
+
+async def test_open_valve_intent(hass: HomeAssistant) -> None:
+    """Test HassTurnOn intent for valves."""
+    assert await async_setup_component(hass, "intent", {})
+
+    entity_id = f"{DOMAIN}.test_valve"
+    hass.states.async_set(entity_id, "closed")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_OPEN_VALVE)
+
+    response = await intent.async_handle(
+        hass, "test", "HassTurnOn", {"name": {"value": "test valve"}}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_OPEN_VALVE
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_close_valve_intent(hass: HomeAssistant) -> None:
+    """Test HassTurnOff intent for valves."""
+    assert await async_setup_component(hass, "intent", {})
+
+    entity_id = f"{DOMAIN}.test_valve"
+    hass.states.async_set(entity_id, "opened")
+    calls = async_mock_service(hass, DOMAIN, SERVICE_CLOSE_VALVE)
+
+    response = await intent.async_handle(
+        hass, "test", "HassTurnOff", {"name": {"value": "test valve"}}
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_CLOSE_VALVE
+    assert call.data == {"entity_id": entity_id}

--- a/tests/helpers/test_intent.py
+++ b/tests/helpers/test_intent.py
@@ -1,4 +1,5 @@
 """Tests for the intent helpers."""
+
 import asyncio
 from unittest.mock import MagicMock, patch
 
@@ -174,6 +175,14 @@ def test_async_validate_slots() -> None:
     handler1.async_validate_slots(
         {"name": {"value": "kitchen"}, "probability": {"value": "0.5"}}
     )
+
+
+def test_async_validate_slots_no_schema() -> None:
+    """Test async_validate_slots of IntentHandler with no schema."""
+    handler1 = MockIntentHandler(None)
+    assert handler1.async_validate_slots({"name": {"value": "kitchen"}}) == {
+        "name": {"value": "kitchen"}
+    }
 
 
 async def test_cant_turn_on_lock(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds several new intents and enhances some existing intents for different integrations:

* `HassTurnOn` and `HassTurnOff`
    * Open/closes valves (like covers)
* `HassSetPosition` (new)
    * Sets cover and valve positions to a number 0-100
* `HassSetVolume` (new)
    * Sets media player volume to a number 0-1
* `HassMediaPause` (new)
    * Pauses a media player
* `HassMediaUnpause` (new)
    * Unpauses a media player (see discussion)
* `HassMediaNext` (new)
    * Skips a media player to the next item
* `HassVacuumStart` (new)
    * Starts a vacuum
* `HassVacuumReturnToBase` (new)
    * Returns a vacuum to base

## Points of Discussion

Intents are an abstraction above service calls that represent common ways of interacting with devices/entities, and therefore do not need to exactly match the underlying service call nomenclature. However, deviating too much may cause confusion, so there must be a reasonable balance.

### Media Unpause

Why not `HassMediaPlay` instead of `HassMediaUnpause`? To make it very clear that the intent does not take a media URI to play.  In this case, I have purposefully avoided the confusing service call nomenclature of `media_player.media_play` vs `media_player.play_media`.
        
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
