### PR TITLE
Improve performance of async_get_integration_with_requirements

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -213,7 +213,7 @@ class RequirementsManager:
                 check_domain not in done
                 and check_domain not in deps_to_check
                 # If the integration is in the cache and its an Integration
-                # its already been checked for the requirements and we should
+                # it's already been checked for the requirements and we should
                 # not check it again.
                 and (
                     not (cached_integration := cache.get(check_domain))

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -199,7 +199,7 @@ class RequirementsManager:
             dep
             for dep in integration.dependencies + integration.after_dependencies
             if dep not in done
-            # If the dep is in the cache and its an Integration
+            # If the dep is in the cache and it's an Integration
             # it's already been checked for the requirements and we should
             # not check it again.
             and (

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -155,19 +155,19 @@ class RequirementsManager:
             return integration
 
         cache = self.integrations_with_reqs
-        int_or_evt = cache.get(domain, UNDEFINED)
+        int_or_fut = cache.get(domain, UNDEFINED)
 
-        if isinstance(int_or_evt, asyncio.Future):
-            await int_or_evt
+        if isinstance(int_or_fut, asyncio.Future):
+            await int_or_fut
 
             # When we have waited and it's UNDEFINED, it doesn't exist
             # We don't cache that it doesn't exist, or else people can't fix it
             # and then restart, because their config will never be valid.
-            if (int_or_evt := cache.get(domain, UNDEFINED)) is UNDEFINED:
+            if (int_or_fut := cache.get(domain, UNDEFINED)) is UNDEFINED:
                 raise IntegrationNotFound(domain)
 
-        if int_or_evt is not UNDEFINED:
-            return cast(Integration, int_or_evt)
+        if int_or_fut is not UNDEFINED:
+            return cast(Integration, int_or_fut)
 
         event = cache[domain] = self.hass.loop.create_future()
 

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -212,7 +212,7 @@ class RequirementsManager:
             if (
                 check_domain not in done
                 and check_domain not in deps_to_check
-                # If the integration is in the cache and its an Integration
+                # If the integration is in the cache and it's an Integration
                 # it's already been checked for the requirements and we should
                 # not check it again.
                 and (

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -200,7 +200,7 @@ class RequirementsManager:
             for dep in integration.dependencies + integration.after_dependencies
             if dep not in done
             # If the dep is in the cache and its an Integration
-            # its already been checked for the requirements and we should
+            # it's already been checked for the requirements and we should
             # not check it again.
             and (
                 not (cached_integration := cache.get(dep))

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant import loader, setup
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
 from homeassistant.requirements import (
     CONSTRAINT_FILE,
     RequirementsNotFound,
@@ -153,6 +154,108 @@ async def test_get_integration_with_requirements(hass: HomeAssistant) -> None:
         "test-comp-after-dep==1.0.0",
         "test-comp-dep==1.0.0",
         "test-comp==1.0.0",
+    ]
+
+
+async def test_get_integration_with_requirements_cache(hass: HomeAssistant) -> None:
+    """Check getting an integration with loaded requirements considers cache.
+
+    We want to make sure that we do not check requirements for dependencies
+    that we have already checked.
+    """
+    hass.config.skip_pip = False
+    mock_integration(
+        hass, MockModule("test_component_dep", requirements=["test-comp-dep==1.0.0"])
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component_after_dep", requirements=["test-comp-after-dep==1.0.0"]
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            requirements=["test-comp==1.0.0"],
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component2",
+            requirements=["test-comp2==1.0.0"],
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+
+    with patch(
+        "homeassistant.util.package.is_installed", return_value=False
+    ) as mock_is_installed, patch(
+        "homeassistant.util.package.install_package", return_value=True
+    ) as mock_inst, patch(
+        "homeassistant.requirements.async_get_integration", wraps=async_get_integration
+    ) as mock_async_get_integration:
+        integration = await async_get_integration_with_requirements(
+            hass, "test_component"
+        )
+        assert integration
+        assert integration.domain == "test_component"
+
+    assert len(mock_is_installed.mock_calls) == 3
+    assert sorted(mock_call[1][0] for mock_call in mock_is_installed.mock_calls) == [
+        "test-comp-after-dep==1.0.0",
+        "test-comp-dep==1.0.0",
+        "test-comp==1.0.0",
+    ]
+
+    assert len(mock_inst.mock_calls) == 3
+    assert sorted(mock_call[1][0] for mock_call in mock_inst.mock_calls) == [
+        "test-comp-after-dep==1.0.0",
+        "test-comp-dep==1.0.0",
+        "test-comp==1.0.0",
+    ]
+
+    # The dependent integrations should be fetched since
+    assert len(mock_async_get_integration.mock_calls) == 3
+    assert sorted(
+        mock_call[1][1] for mock_call in mock_async_get_integration.mock_calls
+    ) == ["test_component", "test_component_after_dep", "test_component_dep"]
+
+    # test_component2 has the same deps as test_component and we should
+    # not check the requirements for the deps again
+    with patch(
+        "homeassistant.util.package.is_installed", return_value=False
+    ) as mock_is_installed, patch(
+        "homeassistant.util.package.install_package", return_value=True
+    ) as mock_inst, patch(
+        "homeassistant.requirements.async_get_integration", wraps=async_get_integration
+    ) as mock_async_get_integration:
+        integration = await async_get_integration_with_requirements(
+            hass, "test_component2"
+        )
+        assert integration
+        assert integration.domain == "test_component2"
+
+    assert len(mock_is_installed.mock_calls) == 1
+    assert sorted(mock_call[1][0] for mock_call in mock_is_installed.mock_calls) == [
+        "test-comp2==1.0.0",
+    ]
+
+    assert len(mock_inst.mock_calls) == 1
+    assert sorted(mock_call[1][0] for mock_call in mock_inst.mock_calls) == [
+        "test-comp2==1.0.0",
+    ]
+
+    # The dependent integrations should not be fetched again
+    assert len(mock_async_get_integration.mock_calls) == 1
+    assert sorted(
+        mock_call[1][1] for mock_call in mock_async_get_integration.mock_calls
+    ) == [
+        "test_component2",
     ]
 
 

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -207,40 +207,41 @@ async def test_get_integration_with_requirements_cache(hass: HomeAssistant) -> N
         assert integration
         assert integration.domain == "test_component"
 
-    assert len(mock_is_installed.mock_calls) == 3
-    assert sorted(mock_call[1][0] for mock_call in mock_is_installed.mock_calls) == [
-        "test-comp-after-dep==1.0.0",
-        "test-comp-dep==1.0.0",
-        "test-comp==1.0.0",
-    ]
+        assert len(mock_is_installed.mock_calls) == 3
+        assert sorted(
+            mock_call[1][0] for mock_call in mock_is_installed.mock_calls
+        ) == [
+            "test-comp-after-dep==1.0.0",
+            "test-comp-dep==1.0.0",
+            "test-comp==1.0.0",
+        ]
 
-    assert len(mock_inst.mock_calls) == 3
-    assert sorted(mock_call[1][0] for mock_call in mock_inst.mock_calls) == [
-        "test-comp-after-dep==1.0.0",
-        "test-comp-dep==1.0.0",
-        "test-comp==1.0.0",
-    ]
+        assert len(mock_inst.mock_calls) == 3
+        assert sorted(mock_call[1][0] for mock_call in mock_inst.mock_calls) == [
+            "test-comp-after-dep==1.0.0",
+            "test-comp-dep==1.0.0",
+            "test-comp==1.0.0",
+        ]
 
-    # The dependent integrations should be fetched since
-    assert len(mock_async_get_integration.mock_calls) == 3
-    assert sorted(
-        mock_call[1][1] for mock_call in mock_async_get_integration.mock_calls
-    ) == ["test_component", "test_component_after_dep", "test_component_dep"]
+        # The dependent integrations should be fetched since
+        assert len(mock_async_get_integration.mock_calls) == 3
+        assert sorted(
+            mock_call[1][1] for mock_call in mock_async_get_integration.mock_calls
+        ) == ["test_component", "test_component_after_dep", "test_component_dep"]
 
-    # test_component2 has the same deps as test_component and we should
-    # not check the requirements for the deps again
-    with patch(
-        "homeassistant.util.package.is_installed", return_value=False
-    ) as mock_is_installed, patch(
-        "homeassistant.util.package.install_package", return_value=True
-    ) as mock_inst, patch(
-        "homeassistant.requirements.async_get_integration", wraps=async_get_integration
-    ) as mock_async_get_integration:
+        # test_component2 has the same deps as test_component and we should
+        # not check the requirements for the deps again
+
+        mock_is_installed.reset_mock()
+        mock_inst.reset_mock()
+        mock_async_get_integration.reset_mock()
+
         integration = await async_get_integration_with_requirements(
             hass, "test_component2"
         )
-        assert integration
-        assert integration.domain == "test_component2"
+
+    assert integration
+    assert integration.domain == "test_component2"
 
     assert len(mock_is_installed.mock_calls) == 1
     assert sorted(mock_call[1][0] for mock_call in mock_is_installed.mock_calls) == [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Migrate to the `asyncio.Future` pattern instead of using `asyncio.Event`
- Use `set`s in a few places to avoid linear searching
- Check the cache when processing deps so we do not create tasks to process requirements for deps that have already been processed. (`websocket_api`, `http`, etc would get processed over and over again)
- add missing test coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
