### PR TITLE
Avoid creating tasks for checking integrations platforms

### DIFF
--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -60,7 +60,7 @@ def _get_platform(
 
 
 @callback
-def _async_process_integration_platform_for_component(
+def _async_process_integration_platforms_for_component(
     hass: HomeAssistant, integration_platforms: list[IntegrationPlatform], event: Event
 ) -> None:
     """Process integration platforms for a component."""
@@ -101,7 +101,7 @@ async def async_process_integration_platforms(
         hass.bus.async_listen(
             EVENT_COMPONENT_LOADED,
             partial(
-                _async_process_integration_platform_for_component,
+                _async_process_integration_platforms_for_component,
                 hass,
                 integration_platforms,
             ),

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -110,7 +110,7 @@ async def async_process_integration_platforms(
     hass: HomeAssistant,
     platform_name: str,
     # Any = platform.
-    process_platform: Callable[[HomeAssistant, str, Any], Awaitable[None]],
+    process_platform: Callable[[HomeAssistant, str, Any], Awaitable[None] | None],
 ) -> None:
     """Process a specific platform for all current and future loaded integrations."""
     if DATA_INTEGRATION_PLATFORMS not in hass.data:

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -123,8 +123,6 @@ async def async_process_integration_platforms(
     top_level_components = {comp for comp in hass.config.components if "." not in comp}
     if not top_level_components:
         return
-
-    integrations = await async_get_integrations(hass, top_level_components)
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS
     ]
@@ -132,6 +130,8 @@ async def async_process_integration_platforms(
         platform_name, HassJob(process_platform), top_level_components
     )
     integration_platforms.append(integration_platform)
+
+    integrations = await async_get_integrations(hass, top_level_components)
     if futures := [
         future
         for comp in top_level_components

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -119,20 +119,16 @@ async def async_process_integration_platforms(
             partial(_async_process_integration_platform_for_component, hass),
         )
 
-    if not (
-        top_level_components := [
-            comp for comp in hass.config.components if "." not in comp
-        ]
-    ):
+    top_level_components = {comp for comp in hass.config.components if "." not in comp}
+    if not top_level_components:
         return
 
     integrations = await async_get_integrations(hass, top_level_components)
-    seen_components: set[str] = set(top_level_components)
     integration_platforms: list[IntegrationPlatform] = hass.data[
         DATA_INTEGRATION_PLATFORMS
     ]
     integration_platform = IntegrationPlatform(
-        platform_name, HassJob(process_platform), seen_components
+        platform_name, HassJob(process_platform), top_level_components
     )
     integration_platforms.append(integration_platform)
     if futures := [

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -39,9 +39,6 @@ async def _async_process_single_integration_platform_component(
     integration_platform: IntegrationPlatform,
 ) -> None:
     """Process a single integration platform."""
-    if component_name in integration_platform.seen_components:
-        return
-    integration_platform.seen_components.add(component_name)
     try:
         await integration_platform.process_platform(hass, component_name, platform)
     except Exception:  # pylint: disable=broad-except
@@ -97,6 +94,7 @@ def _async_process_integration_platform_for_component(
             )
         ):
             continue
+        integration_platform.seen_components.add(component_name)
         hass.async_create_task(
             _async_process_single_integration_platform_component(
                 hass, component_name, platform, integration_platform

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -40,8 +40,9 @@ def _async_process_single_integration_platform_component(
     integration_platform: IntegrationPlatform,
 ) -> asyncio.Future[None] | None:
     """Process a single integration platform."""
+    future: asyncio.Future[None] | None = None
     try:
-        return hass.async_run_hass_job(
+        future = hass.async_run_hass_job(
             integration_platform.process_platform, hass, component_name, platform
         )
     except Exception:  # pylint: disable=broad-except
@@ -50,7 +51,7 @@ def _async_process_single_integration_platform_component(
             component_name,
             integration_platform.platform_name,
         )
-    return None
+    return future
 
 
 def _get_platform_from_integration(

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -33,11 +33,6 @@ class IntegrationPlatform:
     seen_components: set[str]
 
 
-def _format_err(name: str, platform_name: str, *args: Any) -> str:
-    """Format error message."""
-    return f"Exception in {name} when processing platform '{platform_name}': {args}"
-
-
 def _get_platform_from_integration(
     integration: Integration | Exception, component_name: str, platform_name: str
 ) -> ModuleType | None:
@@ -84,6 +79,11 @@ def _async_process_integration_platform_for_component(
         hass.async_run_hass_job(
             integration_platform.process_platform, hass, component_name, platform
         )
+
+
+def _format_err(name: str, platform_name: str, *args: Any) -> str:
+    """Format error message."""
+    return f"Exception in {name} when processing platform '{platform_name}': {args}"
 
 
 @bind_hass

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -33,10 +33,8 @@ class IntegrationPlatform:
     seen_components: set[str]
 
 
-def _format_err(target: Callable, platform_name: str, *args: Any) -> str:
+def _format_err(name: str, platform_name: str, *args: Any) -> str:
     """Format error message."""
-    # Functions wrapped in partial do not have a __name__
-    name = getattr(target, "__name__", None) or str(target)
     return f"Exception in {name} when processing platform '{platform_name}': {args}"
 
 
@@ -115,7 +113,8 @@ async def async_process_integration_platforms(
         platform_name,
         HassJob(
             catch_log_exception(
-                process_platform, partial(_format_err, process_platform, platform_name)
+                process_platform,
+                partial(_format_err, str(process_platform), platform_name),
             ),
             f"process_platform {platform_name}",
         ),

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -18,6 +18,7 @@ from homeassistant.loader import (
     bind_hass,
 )
 from homeassistant.setup import ATTR_COMPONENT
+from homeassistant.util.logging import catch_log_exception
 
 _LOGGER = logging.getLogger(__name__)
 DATA_INTEGRATION_PLATFORMS = "integration_platforms"
@@ -32,26 +33,11 @@ class IntegrationPlatform:
     seen_components: set[str]
 
 
-@callback
-def _async_process_single_integration_platform_component(
-    hass: HomeAssistant,
-    component_name: str,
-    platform: ModuleType,
-    integration_platform: IntegrationPlatform,
-) -> asyncio.Future[None] | None:
-    """Process a single integration platform."""
-    future: asyncio.Future[None] | None = None
-    try:
-        future = hass.async_run_hass_job(
-            integration_platform.process_platform, hass, component_name, platform
-        )
-    except Exception:  # pylint: disable=broad-except
-        _LOGGER.exception(
-            "Error processing platform %s.%s",
-            component_name,
-            integration_platform.platform_name,
-        )
-    return future
+def _format_err(target: Callable, platform_name: str, *args: Any) -> str:
+    """Format error message."""
+    # Functions wrapped in partial do not have a __name__
+    name = getattr(target, "__name__", None) or str(target)
+    return f"Exception in {name} when processing platform '{platform_name}': {args}"
 
 
 def _get_platform_from_integration(
@@ -97,8 +83,8 @@ def _async_process_integration_platform_for_component(
         ):
             continue
         integration_platform.seen_components.add(component_name)
-        _async_process_single_integration_platform_component(
-            hass, component_name, platform, integration_platform
+        hass.async_run_hass_job(
+            integration_platform.process_platform, hass, component_name, platform
         )
 
 
@@ -126,7 +112,14 @@ async def async_process_integration_platforms(
 
     top_level_components = {comp for comp in hass.config.components if "." not in comp}
     integration_platform = IntegrationPlatform(
-        platform_name, HassJob(process_platform), top_level_components
+        platform_name,
+        HassJob(
+            catch_log_exception(
+                process_platform, partial(_format_err, process_platform, platform_name)
+            ),
+            f"process_platform {platform_name}",
+        ),
+        top_level_components,
     )
     integration_platforms.append(integration_platform)
 
@@ -143,8 +136,8 @@ async def async_process_integration_platforms(
             )
         )
         and (
-            future := _async_process_single_integration_platform_component(
-                hass, comp, platform, integration_platform
+            future := hass.async_run_hass_job(
+                integration_platform.process_platform, hass, comp, platform
             )
         )
     ]:

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -2015,6 +2015,7 @@ async def test_entry_setup_no_config(hass: HomeAssistant) -> None:
     assert not hass.config_entries.async_entries("cast")
 
 
+@pytest.mark.no_fail_on_log_exception
 async def test_invalid_cast_platform(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -463,6 +463,7 @@ async def test_delete_issue(
     }
 
 
+@pytest.mark.no_fail_on_log_exception
 async def test_non_compliant_platform(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -42,6 +42,12 @@ async def test_process_integration_platforms(hass: HomeAssistant) -> None:
     assert processed[1][0] == "event"
     assert processed[1][1] == event_platform
 
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: "event"})
+    await hass.async_block_till_done()
+
+    # Firing again should not check again
+    assert len(processed) == 2
+
 
 async def test_broken_integration(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
@@ -65,3 +71,23 @@ async def test_broken_integration(
 
     assert len(processed) == 0
     assert "Error importing integration loaded for platform_to_check" in caplog.text
+
+
+async def test_process_integration_platforms_no_integrations(
+    hass: HomeAssistant,
+) -> None:
+    """Test processing integrations when no integrations are loaded."""
+    event_platform = Mock()
+    mock_platform(hass, "event.platform_to_check", event_platform)
+
+    processed = []
+
+    async def _process_platform(hass, domain, platform):
+        """Process platform."""
+        processed.append((domain, platform))
+
+    await async_process_integration_platforms(
+        hass, "platform_to_check", _process_platform
+    )
+
+    assert len(processed) == 0

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -1,9 +1,12 @@
 """Test integration platform helpers."""
+from collections.abc import Callable
+from types import ModuleType
 from unittest.mock import Mock
 
 import pytest
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.integration_platform import (
     async_process_integration_platforms,
 )
@@ -47,6 +50,60 @@ async def test_process_integration_platforms(hass: HomeAssistant) -> None:
 
     # Firing again should not check again
     assert len(processed) == 2
+
+
+@callback
+def _process_platform_callback(
+    hass: HomeAssistant, domain: str, platform: ModuleType
+) -> None:
+    """Process platform."""
+    raise HomeAssistantError("Non-compliant platform")
+
+
+async def _process_platform_coro(
+    hass: HomeAssistant, domain: str, platform: ModuleType
+) -> None:
+    """Process platform."""
+    raise HomeAssistantError("Non-compliant platform")
+
+
+@pytest.mark.no_fail_on_log_exception
+@pytest.mark.parametrize(
+    "process_platform", (_process_platform_callback, _process_platform_coro)
+)
+async def test_process_integration_platforms_non_compliant(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, process_platform: Callable
+) -> None:
+    """Test processing integrations using with a non-compliant platform."""
+    loaded_platform = Mock()
+    mock_platform(hass, "loaded_unique_880.platform_to_check", loaded_platform)
+    hass.config.components.add("loaded_unique_880")
+
+    event_platform = Mock()
+    mock_platform(hass, "event_unique_990.platform_to_check", event_platform)
+
+    processed = []
+
+    await async_process_integration_platforms(
+        hass, "platform_to_check", process_platform
+    )
+
+    assert len(processed) == 0
+    assert "Exception in " in caplog.text
+    assert "platform_to_check" in caplog.text
+    assert "Non-compliant platform" in caplog.text
+    assert "loaded_unique_880" in caplog.text
+    caplog.clear()
+
+    hass.bus.async_fire(EVENT_COMPONENT_LOADED, {ATTR_COMPONENT: "event_unique_990"})
+    await hass.async_block_till_done()
+
+    assert "Exception in " in caplog.text
+    assert "platform_to_check" in caplog.text
+    assert "Non-compliant platform" in caplog.text
+    assert "event_unique_990" in caplog.text
+
+    assert len(processed) == 0
 
 
 async def test_broken_integration(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a followup to #110743 to avoid creating a task to check if the integration platform exists. We created tasks because we needed to await `async_get_integrations` but since its always called from `EVENT_COMPONENT_LOADED` firing, we can use the `async_get_loaded_integration` version which does not need to be awaited. This eliminates one task for every loaded component.

`process_platform` is now a `HassJob` which will allow future PRs to convert some more of the functions to callbacks since nearly all of them don't await anything which will eliminate even more tasks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
