### PR TITLE
Add myuplink switch platform

### DIFF
--- a/homeassistant/components/myuplink/__init__.py
+++ b/homeassistant/components/myuplink/__init__.py
@@ -20,6 +20,7 @@ from .coordinator import MyUplinkDataCoordinator
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.UPDATE,
 ]
 

--- a/homeassistant/components/myuplink/helpers.py
+++ b/homeassistant/components/myuplink/helpers.py
@@ -13,9 +13,7 @@ def find_matching_platform(device_point: DevicePoint) -> Platform:
         and device_point.enum_values[1]["value"] == "1"
     ):
         if device_point.writable:
-            # Change to Platform.SWITCH when platform is implemented
-            # return Platform.SWITCH
-            return Platform.SENSOR
+            return Platform.SWITCH
         return Platform.BINARY_SENSOR
 
     return Platform.SENSOR

--- a/homeassistant/components/myuplink/switch.py
+++ b/homeassistant/components/myuplink/switch.py
@@ -17,9 +17,9 @@ from .helpers import find_matching_platform
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, SwitchEntityDescription]] = {
     "NIBEF": {
-        "43161": SwitchEntityDescription(
-            key="elect_add",
-            icon="mdi:electric-switch",
+        "50004": SwitchEntityDescription(
+            key="temporary_lux",
+            icon="mdi:water-alert-outline",
         ),
     },
 }

--- a/homeassistant/components/myuplink/switch.py
+++ b/homeassistant/components/myuplink/switch.py
@@ -49,7 +49,7 @@ async def async_setup_entry(
     entities: list[SwitchEntity] = []
     coordinator: MyUplinkDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Setup device point sensors
+    # Setup device point switches
     for device_id, point_data in coordinator.data.points.items():
         for point_id, device_point in point_data.items():
             if find_matching_platform(device_point) == Platform.SWITCH:
@@ -69,7 +69,7 @@ async def async_setup_entry(
 
 
 class MyUplinkDevicePointSwitch(MyUplinkEntity, SwitchEntity):
-    """Representation of a myUplink device point sensor."""
+    """Representation of a myUplink device point switch."""
 
     def __init__(
         self,

--- a/homeassistant/components/myuplink/switch.py
+++ b/homeassistant/components/myuplink/switch.py
@@ -1,0 +1,115 @@
+"""Switch entity for myUplink."""
+
+from typing import Any
+
+from myuplink import DevicePoint
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import MyUplinkDataCoordinator
+from .const import DOMAIN
+from .entity import MyUplinkEntity
+from .helpers import find_matching_platform
+
+CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, SwitchEntityDescription]] = {
+    "NIBEF": {
+        "43161": SwitchEntityDescription(
+            key="elect_add",
+            icon="mdi:electric-switch",
+        ),
+    },
+}
+
+
+def get_description(device_point: DevicePoint) -> SwitchEntityDescription | None:
+    """Get description for a device point.
+
+    Priorities:
+    1. Category specific prefix e.g "NIBEF"
+    2. Default to None
+    """
+    prefix, _, _ = device_point.category.partition(" ")
+    description = CATEGORY_BASED_DESCRIPTIONS.get(prefix, {}).get(
+        device_point.parameter_id
+    )
+
+    return description
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up myUplink switch."""
+    entities: list[SwitchEntity] = []
+    coordinator: MyUplinkDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Setup device point sensors
+    for device_id, point_data in coordinator.data.points.items():
+        for point_id, device_point in point_data.items():
+            if find_matching_platform(device_point) == Platform.SWITCH:
+                description = get_description(device_point)
+
+                entities.append(
+                    MyUplinkDevicePointSwitch(
+                        coordinator=coordinator,
+                        device_id=device_id,
+                        device_point=device_point,
+                        entity_description=description,
+                        unique_id_suffix=point_id,
+                    )
+                )
+
+    async_add_entities(entities)
+
+
+class MyUplinkDevicePointSwitch(MyUplinkEntity, SwitchEntity):
+    """Representation of a myUplink device point sensor."""
+
+    def __init__(
+        self,
+        coordinator: MyUplinkDataCoordinator,
+        device_id: str,
+        device_point: DevicePoint,
+        entity_description: SwitchEntityDescription | None,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id=device_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+        # Internal properties
+        self.point_id = device_point.parameter_id
+        self._attr_name = device_point.parameter_name
+
+        if entity_description is not None:
+            self.entity_description = entity_description
+
+    @property
+    def is_on(self) -> bool:
+        """Switch state value."""
+        device_point = self.coordinator.data.points[self.device_id][self.point_id]
+        return int(device_point.value) != 0
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on switch."""
+        await self._async_turn_switch(1)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off switch."""
+        await self._async_turn_switch(0)
+
+    async def _async_turn_switch(self, mode: int) -> None:
+        """Set switch mode."""
+        await self.coordinator.api.async_set_device_points(
+            self.device_id, data={self.point_id: mode}
+        )
+        await self.coordinator.async_request_refresh()

--- a/tests/components/myuplink/__init__.py
+++ b/tests/components/myuplink/__init__.py
@@ -1,9 +1,6 @@
 """Tests for the myuplink integration."""
-from unittest.mock import patch
 
-from homeassistant.components.myuplink import DOMAIN
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -13,20 +10,3 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-
-
-async def setup_platform(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    platform: str | None = None,
-) -> MockConfigEntry:
-    """Set up one or all platforms."""
-    config_entry = mock_config_entry
-    config_entry.add_to_hass(hass)
-
-    if platform:
-        with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", [platform]):
-            assert await async_setup_component(hass, DOMAIN, {})
-        await hass.async_block_till_done()
-
-    return config_entry

--- a/tests/components/myuplink/__init__.py
+++ b/tests/components/myuplink/__init__.py
@@ -1,5 +1,9 @@
 """Tests for the myuplink integration."""
+from unittest.mock import patch
+
+from homeassistant.components.myuplink import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
@@ -9,3 +13,20 @@ async def setup_integration(hass: HomeAssistant, config_entry: MockConfigEntry) 
     config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
+
+
+async def setup_platform(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    platform: str | None = None,
+) -> MockConfigEntry:
+    """Set up one or all platforms."""
+    config_entry = mock_config_entry
+    config_entry.add_to_hass(hass)
+
+    if platform:
+        with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", [platform]):
+            assert await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+
+    return config_entry

--- a/tests/components/myuplink/conftest.py
+++ b/tests/components/myuplink/conftest.py
@@ -1,5 +1,5 @@
 """Test helpers for myuplink."""
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 import time
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -180,11 +180,10 @@ async def setup_platform(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     platforms,
-) -> MockConfigEntry:
+) -> AsyncGenerator[Any, Any]:
     """Set up one or all platforms."""
 
-    if platforms != []:
-        with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
-            assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-    return mock_config_entry
+        yield

--- a/tests/components/myuplink/conftest.py
+++ b/tests/components/myuplink/conftest.py
@@ -167,3 +167,24 @@ async def init_integration(
     await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture for platforms."""
+    return []
+
+
+@pytest.fixture
+async def setup_platform(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    platforms,
+) -> MockConfigEntry:
+    """Set up one or all platforms."""
+
+    if platforms != []:
+        with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
+            assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/myuplink/conftest.py
+++ b/tests/components/myuplink/conftest.py
@@ -180,7 +180,7 @@ async def setup_platform(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     platforms,
-) -> AsyncGenerator[Any, Any]:
+) -> AsyncGenerator[None, None]:
     """Set up one or all platforms."""
 
     with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -4,17 +4,20 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from homeassistant.components.switch import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
+    Platform,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-pytestmark = pytest.mark.parametrize("platforms", [(PLATFORM_DOMAIN,)])
+from tests.common import MockConfigEntry
+
+TEST_PLATFORM = Platform.SWITCH
+pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
 ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
 ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
@@ -25,9 +28,9 @@ async def test_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_myuplink_client: MagicMock,
-    setup_platform,
+    setup_platform: MockConfigEntry,
 ) -> None:
-    """Tests that the entities are registered in the entity registry."""
+    """Test that the entities are registered in the entity registry."""
 
     entry = entity_registry.async_get(ENTITY_ID)
     assert entry.unique_id == ENTITY_UID
@@ -56,7 +59,7 @@ async def test_switch_on(
     """Test the switch can be turned on."""
 
     await hass.services.async_call(
-        PLATFORM_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        TEST_PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
     )
     await hass.async_block_till_done()
     mock_myuplink_client.async_set_device_points.assert_called_once()
@@ -70,7 +73,7 @@ async def test_switch_off(
     """Test the switch can be turned on."""
 
     await hass.services.async_call(
-        PLATFORM_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        TEST_PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
     )
     await hass.async_block_till_done()
     mock_myuplink_client.async_set_device_points.assert_called_once()

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -19,11 +19,6 @@ pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
 ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
 ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
-ENTITY_STATE = STATE_OFF
-ENTITY_STATE_ATTRIBUTES = {
-    "friendly_name": ENTITY_FRIENDLY_NAME,
-    "icon": "mdi:water-alert-outline",
-}
 ENTITY_UID = "batman-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff-50004"
 
 
@@ -47,8 +42,11 @@ async def test_attributes(
     """Test the switch attributes are correct."""
 
     state = hass.states.get(ENTITY_ID)
-    assert state.state == ENTITY_STATE
-    assert state.attributes == ENTITY_STATE_ATTRIBUTES
+    assert state.state == STATE_OFF
+    assert state.attributes == {
+        "friendly_name": ENTITY_FRIENDLY_NAME,
+        "icon": "mdi:water-alert-outline",
+    }
 
 
 async def test_switch_on(

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -19,6 +19,11 @@ pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
 ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
 ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
+ENTITY_STATE = STATE_OFF
+ENTITY_STATE_ATTRIBUTES = {
+    "friendly_name": ENTITY_FRIENDLY_NAME,
+    "icon": "mdi:water-alert-outline",
+}
 ENTITY_UID = "batman-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff-50004"
 
 
@@ -42,11 +47,8 @@ async def test_attributes(
     """Test the switch attributes are correct."""
 
     state = hass.states.get(ENTITY_ID)
-    assert state.state == STATE_OFF
-    assert state.attributes == {
-        "friendly_name": ENTITY_FRIENDLY_NAME,
-        "icon": "mdi:water-alert-outline",
-    }
+    assert state.state == ENTITY_STATE
+    assert state.attributes == ENTITY_STATE_ATTRIBUTES
 
 
 async def test_switch_on(

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -1,0 +1,80 @@
+"""Tests for myuplink switch module."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_platform
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
+ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
+ENTITY_UID = "batman-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff-50004"
+
+
+async def test_entity_registry(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_myuplink_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Tests that the devices are registered in the entity registry."""
+    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
+
+    entry = entity_registry.async_get(ENTITY_ID)
+    assert entry.unique_id == ENTITY_UID
+
+
+async def test_attributes(
+    hass: HomeAssistant,
+    mock_myuplink_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the switch attributes are correct."""
+    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.state == STATE_OFF
+    assert state.attributes == {
+        "friendly_name": ENTITY_FRIENDLY_NAME,
+        "icon": "mdi:water-alert-outline",
+    }
+
+
+async def test_switch_on(
+    hass: HomeAssistant,
+    mock_myuplink_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the switch can be turned on."""
+    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+    mock_myuplink_client.async_set_device_points.assert_called_once()
+
+
+async def test_switch_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_myuplink_client: MagicMock,
+) -> None:
+    """Test the switch can be turned on."""
+    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+    )
+    await hass.async_block_till_done()
+    mock_myuplink_client.async_set_device_points.assert_called_once()

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -37,7 +37,7 @@ async def test_entity_registry(
 async def test_attributes(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
-    setup_platform,
+    setup_platform: None,
 ) -> None:
     """Test the switch attributes are correct."""
 
@@ -52,7 +52,7 @@ async def test_attributes(
 async def test_switch_on(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
-    setup_platform,
+    setup_platform: None,
 ) -> None:
     """Test the switch can be turned on."""
 
@@ -66,7 +66,7 @@ async def test_switch_on(
 async def test_switch_off(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
-    setup_platform,
+    setup_platform: None,
 ) -> None:
     """Test the switch can be turned on."""
 

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import MagicMock
 
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+import pytest
+
+from homeassistant.components.switch import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -12,9 +14,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from . import setup_platform
-
-from tests.common import MockConfigEntry
+pytestmark = pytest.mark.parametrize("platforms", [(PLATFORM_DOMAIN,)])
 
 ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
 ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
@@ -25,10 +25,9 @@ async def test_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_myuplink_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
+    setup_platform,
 ) -> None:
-    """Tests that the devices are registered in the entity registry."""
-    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
+    """Tests that the entities are registered in the entity registry."""
 
     entry = entity_registry.async_get(ENTITY_ID)
     assert entry.unique_id == ENTITY_UID
@@ -37,10 +36,9 @@ async def test_entity_registry(
 async def test_attributes(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
+    setup_platform,
 ) -> None:
     """Test the switch attributes are correct."""
-    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_OFF
@@ -53,13 +51,12 @@ async def test_attributes(
 async def test_switch_on(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
-    mock_config_entry: MockConfigEntry,
+    setup_platform,
 ) -> None:
     """Test the switch can be turned on."""
-    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        PLATFORM_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
     )
     await hass.async_block_till_done()
     mock_myuplink_client.async_set_device_points.assert_called_once()
@@ -67,14 +64,13 @@ async def test_switch_on(
 
 async def test_switch_off(
     hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
     mock_myuplink_client: MagicMock,
+    setup_platform,
 ) -> None:
     """Test the switch can be turned on."""
-    await setup_platform(hass, mock_config_entry, SWITCH_DOMAIN)
 
     await hass.services.async_call(
-        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        PLATFORM_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
     )
     await hass.async_block_till_done()
     mock_myuplink_client.async_set_device_points.assert_called_once()

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -14,8 +14,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from tests.common import MockConfigEntry
-
 TEST_PLATFORM = Platform.SWITCH
 pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
@@ -28,7 +26,7 @@ async def test_entity_registry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_myuplink_client: MagicMock,
-    setup_platform: MockConfigEntry,
+    setup_platform: None,
 ) -> None:
     """Test that the entities are registered in the entity registry."""
 

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -79,17 +79,25 @@ async def test_switch_off(
     mock_myuplink_client.async_set_device_points.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("service"),
+    [
+        (SERVICE_TURN_ON),
+        (SERVICE_TURN_OFF),
+    ],
+)
 async def test_api_failure(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
     setup_platform: None,
+    service: str,
 ) -> None:
     """Test handling of exception from API."""
 
     with pytest.raises(HomeAssistantError):
         mock_myuplink_client.async_set_device_points.side_effect = ClientError
         await hass.services.async_call(
-            TEST_PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+            TEST_PLATFORM, service, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
         )
         await hass.async_block_till_done()
         mock_myuplink_client.async_set_device_points.assert_called_once()

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -51,29 +51,23 @@ async def test_attributes(
     }
 
 
-async def test_switch_on(
+@pytest.mark.parametrize(
+    ("service"),
+    [
+        (SERVICE_TURN_ON),
+        (SERVICE_TURN_OFF),
+    ],
+)
+async def test_switching(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
     setup_platform: None,
+    service: str,
 ) -> None:
-    """Test the switch can be turned on."""
+    """Test the switch can be turned on/off."""
 
     await hass.services.async_call(
-        TEST_PLATFORM, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
-    )
-    await hass.async_block_till_done()
-    mock_myuplink_client.async_set_device_points.assert_called_once()
-
-
-async def test_switch_off(
-    hass: HomeAssistant,
-    mock_myuplink_client: MagicMock,
-    setup_platform: None,
-) -> None:
-    """Test the switch can be turned on."""
-
-    await hass.services.async_call(
-        TEST_PLATFORM, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
+        TEST_PLATFORM, service, {ATTR_ENTITY_ID: ENTITY_ID}, blocking=True
     )
     await hass.async_block_till_done()
     mock_myuplink_client.async_set_device_points.assert_called_once()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch platform to MyUplink integration. Switch entities are identified automatically based on metadata from the API. Not ethat the user might need a n active subscription to be able to control their equiment.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31476

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
