### PR TITLE
Cache JSON representation of ConfigEntry objects

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -70,11 +70,10 @@ class ConfigManagerEntryIndexView(HomeAssistantView):
         type_filter = None
         if "type" in request.query:
             type_filter = [request.query["type"]]
-        return self.json(
-            await _async_matching_config_entries_json_fragments(
-                hass, type_filter, domain
-            )
+        fragments = await _async_matching_config_entries_json_fragments(
+            hass, type_filter, domain
         )
+        return self.json(fragments)
 
 
 class ConfigManagerEntryResourceView(HomeAssistantView):
@@ -459,12 +458,10 @@ async def config_entries_get(
     msg: dict[str, Any],
 ) -> None:
     """Return matching config entries by type and/or domain."""
-    connection.send_result(
-        msg["id"],
-        await _async_matching_config_entries_json_fragments(
-            hass, msg.get("type_filter"), msg.get("domain")
-        ),
+    fragments = await _async_matching_config_entries_json_fragments(
+        hass, msg.get("type_filter"), msg.get("domain")
     )
+    connection.send_result(msg["id"], fragments)
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.data_entry_flow import (
     FlowManagerResourceView,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.json import json_fragment
 from homeassistant.loader import (
     Integration,
     IntegrationNotFound,
@@ -69,7 +70,11 @@ class ConfigManagerEntryIndexView(HomeAssistantView):
         type_filter = None
         if "type" in request.query:
             type_filter = [request.query["type"]]
-        return self.json(await async_matching_config_entries(hass, type_filter, domain))
+        return self.json(
+            await _async_matching_config_entries_json_fragments(
+                hass, type_filter, domain
+            )
+        )
 
 
 class ConfigManagerEntryResourceView(HomeAssistantView):
@@ -129,7 +134,8 @@ def _prepare_config_flow_result_json(
         return prepare_result_json(result)
 
     data = result.copy()
-    data["result"] = entry_json(result["result"])
+    entry: config_entries.ConfigEntry = data["result"]
+    data["result"] = entry.as_json_fragment
     data.pop("data")
     data.pop("context")
     return data
@@ -312,7 +318,7 @@ async def config_entry_get_single(
     if entry is None:
         return
 
-    result = {"config_entry": entry_json(entry)}
+    result = {"config_entry": entry.as_json_fragment}
     connection.send_result(msg["id"], result)
 
 
@@ -347,7 +353,7 @@ async def config_entry_update(
     hass.config_entries.async_update_entry(entry, **changes)
 
     result = {
-        "config_entry": entry_json(entry),
+        "config_entry": entry.as_json_fragment,
         "require_restart": False,
     }
 
@@ -455,7 +461,7 @@ async def config_entries_get(
     """Return matching config entries by type and/or domain."""
     connection.send_result(
         msg["id"],
-        await async_matching_config_entries(
+        await _async_matching_config_entries_json_fragments(
             hass, msg.get("type_filter"), msg.get("domain")
         ),
     )
@@ -491,13 +497,15 @@ async def config_entries_subscribe(
                 [
                     {
                         "type": change,
-                        "entry": entry_json(entry),
+                        "entry": entry.as_json_fragment,
                     }
                 ],
             )
         )
 
-    current_entries = await async_matching_config_entries(hass, type_filter, None)
+    current_entries = await _async_matching_config_entries_json_fragments(
+        hass, type_filter, None
+    )
     connection.subscriptions[msg["id"]] = async_dispatcher_connect(
         hass,
         config_entries.SIGNAL_CONFIG_ENTRY_CHANGED,
@@ -511,9 +519,9 @@ async def config_entries_subscribe(
     )
 
 
-async def async_matching_config_entries(
+async def _async_matching_config_entries_json_fragments(
     hass: HomeAssistant, type_filter: list[str] | None, domain: str | None
-) -> list[dict[str, Any]]:
+) -> list[json_fragment]:
     """Return matching config entries by type and/or domain."""
     if domain:
         entries = hass.config_entries.async_entries(domain)
@@ -521,7 +529,7 @@ async def async_matching_config_entries(
         entries = hass.config_entries.async_entries()
 
     if not type_filter:
-        return [entry_json(entry) for entry in entries]
+        return [entry.as_json_fragment for entry in entries]
 
     integrations: dict[str, Integration] = {}
     # Fetch all the integrations so we can check their type
@@ -541,7 +549,7 @@ async def async_matching_config_entries(
     filter_is_not_helper = type_filter != ["helper"]
     filter_set = set(type_filter)
     return [
-        entry_json(entry)
+        entry.as_json_fragment
         for entry in entries
         # If the filter is not 'helper', we still include the integration
         # even if its not returned from async_get_integrations for backwards
@@ -552,22 +560,3 @@ async def async_matching_config_entries(
         )
         or (filter_is_not_helper and entry.domain not in integrations)
     ]
-
-
-@callback
-def entry_json(entry: config_entries.ConfigEntry) -> dict[str, Any]:
-    """Return JSON value of a config entry."""
-    return {
-        "entry_id": entry.entry_id,
-        "domain": entry.domain,
-        "title": entry.title,
-        "source": entry.source,
-        "state": entry.state.value,
-        "supports_options": entry.supports_options,
-        "supports_remove_device": entry.supports_remove_device or False,
-        "supports_unload": entry.supports_unload or False,
-        "pref_disable_new_entities": entry.pref_disable_new_entities,
-        "pref_disable_polling": entry.pref_disable_polling,
-        "disabled_by": entry.disabled_by,
-        "reason": entry.reason,
-    }

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -413,24 +413,21 @@ class ConfigEntry:
     @cached_property
     def as_json_fragment(self) -> json_fragment:
         """Return JSON fragment of a config entry."""
-        return json_fragment(
-            json_bytes(
-                {
-                    "entry_id": self.entry_id,
-                    "domain": self.domain,
-                    "title": self.title,
-                    "source": self.source,
-                    "state": self.state.value,
-                    "supports_options": self.supports_options,
-                    "supports_remove_device": self.supports_remove_device or False,
-                    "supports_unload": self.supports_unload or False,
-                    "pref_disable_new_entities": self.pref_disable_new_entities,
-                    "pref_disable_polling": self.pref_disable_polling,
-                    "disabled_by": self.disabled_by,
-                    "reason": self.reason,
-                }
-            )
-        )
+        json_repr = {
+            "entry_id": self.entry_id,
+            "domain": self.domain,
+            "title": self.title,
+            "source": self.source,
+            "state": self.state.value,
+            "supports_options": self.supports_options,
+            "supports_remove_device": self.supports_remove_device or False,
+            "supports_unload": self.supports_unload or False,
+            "pref_disable_new_entities": self.pref_disable_new_entities,
+            "pref_disable_polling": self.pref_disable_polling,
+            "disabled_by": self.disabled_by,
+            "reason": self.reason,
+        }
+        return json_fragment(json_bytes(json_repr))
 
     async def async_setup(
         self,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -400,7 +400,9 @@ class ConfigEntry:
         """Return if entry supports config options."""
         if self._supports_options is None and (handler := HANDLERS.get(self.domain)):
             # work out if handler has support for options flow
-            self._supports_options = handler.async_supports_options_flow(self)
+            object.__setattr__(
+                self, "_supports_options", handler.async_supports_options_flow(self)
+            )
         return self._supports_options or False
 
     def clear_cache(self) -> None:

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1646,8 +1646,8 @@ class ConfigEntries:
             )
 
         self._async_schedule_save()
-        self._async_dispatch(ConfigEntryChange.UPDATED, entry)
         entry.clear_cache()
+        self._async_dispatch(ConfigEntryChange.UPDATED, entry)
         return True
 
     @callback

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -12,6 +12,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant import config_entries, data_entry_flow, loader
+from homeassistant.backports.functools import cached_property
 from homeassistant.components import dhcp
 from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.const import (
@@ -834,7 +835,14 @@ async def test_as_dict(snapshot: SnapshotAssertion) -> None:
 
     # Make sure the expected keys are present
     dict_repr = entry.as_dict()
-    for key in config_entries.ConfigEntry.__slots__:
+    for key in config_entries.ConfigEntry.__dict__:
+        func = getattr(config_entries.ConfigEntry, key)
+        if (
+            key.startswith("__")
+            or callable(func)
+            or type(func) in (cached_property, property)
+        ):
+            continue
         assert key in dict_repr or key in excluded_from_dict
         assert not (key in dict_repr and key in excluded_from_dict)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cache JSON representation of ConfigEntry objects

Now that we have a very limited set of paths where the config entry data can change, its possible to cache the serialized version.  We fetch the whole list of config entries many places in the UI [config, search, device info page (`config_entries/get` was the slowest call there)], and while the payload is smaller 
(only have ~750 on my big system, some users have a lot more), unlike the registries which we loaded at connection time, these get fetched every time a screen that needs them is loaded.

I didn't save the raw bytes like we do with the registries since the fragments produce cleaner code. If we ever end up with a lot more config entries, and need to squeeze more out of it, we could use the same pattern here. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
