### PR TITLE
Fix  local todo list persistence for due dates

### DIFF
--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -43,7 +43,7 @@ ICS_TODO_STATUS_MAP_INV = {
 def _migrate_calendar(calendar: Calendar) -> bool:
     """Upgrade due dates to rfc5545 format.
 
-    If rfc5545 due dates are exclusive, however we previously set the due date
+    In rfc5545 due dates are exclusive, however we previously set the due date
     as inclusive based on what the user set in the UI. A task is considered
     overdue at midnight at the start of a date so we need to shift the due date
     to the next day for old calendar versions.

--- a/homeassistant/components/local_todo/todo.py
+++ b/homeassistant/components/local_todo/todo.py
@@ -1,5 +1,6 @@
 """A Local To-do todo platform."""
 
+import datetime
 import logging
 
 from ical.calendar import Calendar
@@ -24,7 +25,8 @@ from .store import LocalTodoListStore
 _LOGGER = logging.getLogger(__name__)
 
 
-PRODID = "-//homeassistant.io//local_todo 1.0//EN"
+PRODID = "-//homeassistant.io//local_todo 2.0//EN"
+PRODID_REQUIRES_MIGRATION = "-//homeassistant.io//local_todo 1.0//EN"
 
 ICS_TODO_STATUS_MAP = {
     TodoStatus.IN_PROCESS: TodoItemStatus.NEEDS_ACTION,
@@ -38,6 +40,25 @@ ICS_TODO_STATUS_MAP_INV = {
 }
 
 
+def _migrate_calendar(calendar: Calendar) -> bool:
+    """Upgrade due dates to rfc5545 format.
+
+    If rfc5545 due dates are exclusive, however we previously set the due date
+    as inclusive based on what the user set in the UI. A task is considered
+    overdue at midnight at the start of a date so we need to shift the due date
+    to the next day for old calendar versions.
+    """
+    if calendar.prodid is None or calendar.prodid != PRODID_REQUIRES_MIGRATION:
+        return False
+    migrated = False
+    for todo in calendar.todos:
+        if todo.due is None or isinstance(todo.due, datetime.datetime):
+            continue
+        todo.due += datetime.timedelta(days=1)
+        migrated = True
+    return migrated
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
@@ -48,11 +69,15 @@ async def async_setup_entry(
     store = hass.data[DOMAIN][config_entry.entry_id]
     ics = await store.async_load()
     calendar = IcsCalendarStream.calendar_from_ics(ics)
+    migrated = _migrate_calendar(calendar)
     calendar.prodid = PRODID
 
     name = config_entry.data[CONF_TODO_LIST_NAME]
     entity = LocalTodoListEntity(store, calendar, name, unique_id=config_entry.entry_id)
     async_add_entities([entity], True)
+
+    if migrated:
+        await entity.async_save()
 
 
 def _convert_item(item: TodoItem) -> Todo:
@@ -65,6 +90,8 @@ def _convert_item(item: TodoItem) -> Todo:
     if item.status:
         todo.status = ICS_TODO_STATUS_MAP_INV[item.status]
     todo.due = item.due
+    if todo.due and not isinstance(todo.due, datetime.datetime):
+        todo.due += datetime.timedelta(days=1)
     todo.description = item.description
     return todo
 
@@ -99,31 +126,36 @@ class LocalTodoListEntity(TodoListEntity):
 
     async def async_update(self) -> None:
         """Update entity state based on the local To-do items."""
-        self._attr_todo_items = [
-            TodoItem(
-                uid=item.uid,
-                summary=item.summary or "",
-                status=ICS_TODO_STATUS_MAP.get(
-                    item.status or TodoStatus.NEEDS_ACTION, TodoItemStatus.NEEDS_ACTION
-                ),
-                due=item.due,
-                description=item.description,
+        todo_items = []
+        for item in self._calendar.todos:
+            if (due := item.due) and not isinstance(due, datetime.datetime):
+                due -= datetime.timedelta(days=1)
+            todo_items.append(
+                TodoItem(
+                    uid=item.uid,
+                    summary=item.summary or "",
+                    status=ICS_TODO_STATUS_MAP.get(
+                        item.status or TodoStatus.NEEDS_ACTION,
+                        TodoItemStatus.NEEDS_ACTION,
+                    ),
+                    due=due,
+                    description=item.description,
+                )
             )
-            for item in self._calendar.todos
-        ]
+        self._attr_todo_items = todo_items
 
     async def async_create_todo_item(self, item: TodoItem) -> None:
         """Add an item to the To-do list."""
         todo = _convert_item(item)
         TodoStore(self._calendar).add(todo)
-        await self._async_save()
+        await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
     async def async_update_todo_item(self, item: TodoItem) -> None:
         """Update an item to the To-do list."""
         todo = _convert_item(item)
         TodoStore(self._calendar).edit(todo.uid, todo)
-        await self._async_save()
+        await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
@@ -131,7 +163,7 @@ class LocalTodoListEntity(TodoListEntity):
         store = TodoStore(self._calendar)
         for uid in uids:
             store.delete(uid)
-        await self._async_save()
+        await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
     async def async_move_todo_item(
@@ -156,10 +188,10 @@ class LocalTodoListEntity(TodoListEntity):
         if dst_idx > src_idx:
             dst_idx -= 1
         todos.insert(dst_idx, src_item)
-        await self._async_save()
+        await self.async_save()
         await self.async_update_ha_state(force_refresh=True)
 
-    async def _async_save(self) -> None:
+    async def async_save(self) -> None:
         """Persist the todo list to disk."""
         content = IcsCalendarStream.calendar_to_ics(self._calendar)
         await self._store.async_store(content)

--- a/tests/components/local_todo/snapshots/test_todo.ambr
+++ b/tests/components/local_todo/snapshots/test_todo.ambr
@@ -1,0 +1,47 @@
+# serializer version: 1
+# name: test_parse_existing_ics[completed]
+  list([
+    dict({
+      'status': 'completed',
+      'summary': 'Complete Task',
+      'uid': '077cb7f2-6c89-11ee-b2a9-0242ac110002',
+    }),
+  ])
+# ---
+# name: test_parse_existing_ics[due]
+  list([
+    dict({
+      'due': '2023-10-23',
+      'status': 'needs_action',
+      'summary': 'Task',
+      'uid': '077cb7f2-6c89-11ee-b2a9-0242ac110002',
+    }),
+  ])
+# ---
+# name: test_parse_existing_ics[empty]
+  list([
+  ])
+# ---
+# name: test_parse_existing_ics[legacy_due]
+  list([
+    dict({
+      'due': '2023-10-23',
+      'status': 'needs_action',
+      'summary': 'Task',
+      'uid': '077cb7f2-6c89-11ee-b2a9-0242ac110002',
+    }),
+  ])
+# ---
+# name: test_parse_existing_ics[needs_action]
+  list([
+    dict({
+      'status': 'needs_action',
+      'summary': 'Incomplete Task',
+      'uid': '077cb7f2-6c89-11ee-b2a9-0242ac110002',
+    }),
+  ])
+# ---
+# name: test_parse_existing_ics[not_exists]
+  list([
+  ])
+# ---

--- a/tests/components/local_todo/snapshots/test_todo.ambr
+++ b/tests/components/local_todo/snapshots/test_todo.ambr
@@ -22,7 +22,7 @@
   list([
   ])
 # ---
-# name: test_parse_existing_ics[legacy_due]
+# name: test_parse_existing_ics[migrate_legacy_due]
   list([
     dict({
       'due': '2023-10-23',

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -5,6 +5,7 @@ import textwrap
 from typing import Any
 
 import pytest
+from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.todo import DOMAIN as TODO_DOMAIN
 from homeassistant.core import HomeAssistant
@@ -628,13 +629,64 @@ async def test_move_item_previous_unknown(
             ),
             "1",
         ),
+        (
+            textwrap.dedent(
+                """\
+                    BEGIN:VCALENDAR
+                    PRODID:-//homeassistant.io//local_todo 1.0//EN
+                    VERSION:2.0
+                    BEGIN:VTODO
+                    DTSTAMP:20231024T014011
+                    UID:077cb7f2-6c89-11ee-b2a9-0242ac110002
+                    CREATED:20231017T010348
+                    LAST-MODIFIED:20231024T014011
+                    SEQUENCE:1
+                    STATUS:NEEDS-ACTION
+                    SUMMARY:Task
+                    DUE:20231023
+                    END:VTODO
+                    END:VCALENDAR
+                """
+            ),
+            "1",
+        ),
+        (
+            textwrap.dedent(
+                """\
+                    BEGIN:VCALENDAR
+                    PRODID:-//homeassistant.io//local_todo 2.0//EN
+                    VERSION:2.0
+                    BEGIN:VTODO
+                    DTSTAMP:20231024T014011
+                    UID:077cb7f2-6c89-11ee-b2a9-0242ac110002
+                    CREATED:20231017T010348
+                    LAST-MODIFIED:20231024T014011
+                    SEQUENCE:1
+                    STATUS:NEEDS-ACTION
+                    SUMMARY:Task
+                    DUE:20231024
+                    END:VTODO
+                    END:VCALENDAR
+                """
+            ),
+            "1",
+        ),
     ],
-    ids=("empty", "not_exists", "completed", "needs_action"),
+    ids=(
+        "empty",
+        "not_exists",
+        "completed",
+        "needs_action",
+        "migrate_legacy_due",
+        "due",
+    ),
 )
 async def test_parse_existing_ics(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     setup_integration: None,
+    ws_get_items: Callable[[], Awaitable[dict[str, str]]],
+    snapshot: SnapshotAssertion,
     expected_state: str,
 ) -> None:
     """Test parsing ics content."""
@@ -642,6 +694,9 @@ async def test_parse_existing_ics(
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == expected_state
+
+    items = await ws_get_items()
+    assert items == snapshot
 
 
 async def test_susbcribe(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix how local todo list handles of due dates when persisted to disk. In rfc5545, the due date field is exclusive and at midnight on the due date a task is considered overdue, equivalent to end dates on a calendar event where all day events have a duration of one day. Home Assistant is using inclusive dates for due dates so a task is not considered overdue until the next day (consistent with how APIs like Google Tasks or Todoist represent a due date)

This PR has two main changes:
(1) Handle converting between the home assistant due date format (inclusive dates) and the persisted due date format 
(2) Migrate old calendar object files to the new todo format.

This is needed to prepare for handle recurring tasks correctly where only one instance of a specific task is shown at a time.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
