### PR TITLE
Add support for Shelly RPC devices custom TCP port

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Final
 
 from aioshelly.block_device import BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions
-from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
+from aioshelly.const import DEFAULT_COAP_PORT, DEFAULT_HTTP_PORT, RPC_GENERATIONS
 from aioshelly.exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
@@ -255,7 +255,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         device_mac=entry.unique_id,
-        port=entry.data.get(CONF_PORT, DEFAULT_HOST_PORT),
+        port=entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT),
     )
 
     ws_context = await get_ws_context(hass)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Final
 
 from aioshelly.block_device import BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions
-from aioshelly.const import DEFAULT_COAP_PORT, DEFAULT_HTTP_PORT, RPC_GENERATIONS
+from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
 from aioshelly.exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
@@ -18,13 +18,7 @@ from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-    Platform,
-)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
@@ -62,6 +56,7 @@ from .utils import (
     get_block_device_sleep_period,
     get_coap_context,
     get_device_entry_gen,
+    get_http_port,
     get_rpc_device_wakeup_period,
     get_ws_context,
 )
@@ -255,7 +250,7 @@ async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> boo
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         device_mac=entry.unique_id,
-        port=entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT),
+        port=get_http_port(entry.data),
     )
 
     ws_context = await get_ws_context(hass)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -18,7 +18,13 @@ from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import issue_registry as ir
@@ -58,7 +64,6 @@ from .utils import (
     get_device_entry_gen,
     get_rpc_device_wakeup_period,
     get_ws_context,
-    parse_host,
 )
 
 BLOCK_PLATFORMS: Final = [
@@ -245,13 +250,12 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
 async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Shelly RPC based device from a config entry."""
-    host, port = await parse_host(entry.data[CONF_HOST])
     options = ConnectionOptions(
-        host,
+        entry.data[CONF_HOST],
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         device_mac=entry.unique_id,
-        port=port,
+        port=entry.data.get(CONF_PORT, DEFAULT_HOST_PORT),
     )
 
     ws_context = await get_ws_context(hass)

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -58,6 +58,7 @@ from .utils import (
     get_device_entry_gen,
     get_rpc_device_wakeup_period,
     get_ws_context,
+    parse_host,
 )
 
 BLOCK_PLATFORMS: Final = [
@@ -244,11 +245,13 @@ async def _async_setup_block_entry(hass: HomeAssistant, entry: ConfigEntry) -> b
 
 async def _async_setup_rpc_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Shelly RPC based device from a config entry."""
+    host, port = await parse_host(entry.data[CONF_HOST])
     options = ConnectionOptions(
-        entry.data[CONF_HOST],
+        host,
         entry.data.get(CONF_USERNAME),
         entry.data.get(CONF_PASSWORD),
         device_mac=entry.unique_id,
+        port=port,
     )
 
     ws_context = await get_ws_context(hass)

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -205,7 +205,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 if device_info["model"]:
-                    host, port = await parse_host(user_input[CONF_HOST])
+                    host, port = await parse_host(self.host)
                     return self.async_create_entry(
                         title=device_info["title"],
                         data={

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -43,6 +43,7 @@ from .utils import (
     get_block_device_sleep_period,
     get_coap_context,
     get_device_entry_gen,
+    get_http_port,
     get_info_auth,
     get_info_gen,
     get_model_name,
@@ -204,8 +205,6 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "invalid_auth"
             except DeviceConnectionError:
                 errors["base"] = "cannot_connect"
-            except CustomPortNotSupported:
-                errors["base"] = "custom_port_not_supported"
             except Exception:  # pylint: disable=broad-except
                 LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -355,7 +354,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         assert self.entry is not None
         host = self.entry.data[CONF_HOST]
-        port = self.entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT)
+        port = get_http_port(self.entry.data)
 
         if user_input is not None:
             try:

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -51,7 +51,7 @@ from .utils import (
     mac_address_from_name,
 )
 
-HOST_SCHEMA: Final = vol.Schema(
+CONFIG_SCHEMA: Final = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_PORT, default=DEFAULT_HTTP_PORT): vol.Coerce(int),
@@ -77,7 +77,7 @@ async def validate_input(
 ) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
-    Data has the keys from HOST_SCHEMA with values provided by the user.
+    Data has the keys from CONFIG_SCHEMA with values provided by the user.
     """
     options = ConnectionOptions(
         ip_address=host,
@@ -161,7 +161,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 try:
                     device_info = await validate_input(
-                        self.hass, self.host, self.port, self.info, {}
+                        self.hass, host, port, self.info, {}
                     )
                 except DeviceConnectionError:
                     errors["base"] = "cannot_connect"
@@ -185,7 +185,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "firmware_not_fully_provisioned"
 
         return self.async_show_form(
-            step_id="user", data_schema=HOST_SCHEMA, errors=errors
+            step_id="user", data_schema=CONFIG_SCHEMA, errors=errors
         )
 
     async def async_step_credentials(

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -388,7 +388,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _async_get_info(self, host: str, port: int) -> dict[str, Any]:
         """Get info from shelly device."""
-        return await get_info(async_get_clientsession(self.hass), host, None, port)
+        return await get_info(async_get_clientsession(self.hass), host, port=port)
 
     @staticmethod
     @callback

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -123,6 +123,7 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Shelly."""
 
     VERSION = 1
+    MINOR_VERSION = 2
 
     host: str = ""
     port: int = 80

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -137,8 +137,8 @@ class ShellyConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            host, port = await parse_host(user_input[CONF_HOST])
             try:
+                host, port = await parse_host(user_input[CONF_HOST])
                 self.info = await self._async_get_info(host, port)
             except DeviceConnectionError:
                 errors["base"] = "cannot_connect"

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -119,7 +119,6 @@ async def validate_input(
         CONF_SLEEP_PERIOD: get_block_device_sleep_period(block_device.settings),
         "model": block_device.model,
         CONF_GEN: gen,
-        CONF_PORT: port,
     }
 
 

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -10,17 +10,12 @@ from typing import Any, Generic, TypeVar, cast
 
 from aioshelly.ble import async_ensure_ble_enabled, async_stop_scanner
 from aioshelly.block_device import BlockDevice, BlockUpdateType
-from aioshelly.const import DEFAULT_HTTP_PORT, MODEL_NAMES, MODEL_VALVE
+from aioshelly.const import MODEL_NAMES, MODEL_VALVE
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import (
-    ATTR_DEVICE_ID,
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.debounce import Debouncer
@@ -64,6 +59,7 @@ from .const import (
 )
 from .utils import (
     get_device_entry_gen,
+    get_http_port,
     get_rpc_device_wakeup_period,
     update_device_fw_info,
 )
@@ -145,7 +141,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
             model=MODEL_NAMES.get(self.model, self.model),
             sw_version=self.sw_version,
             hw_version=f"gen{get_device_entry_gen(self.entry)} ({self.model})",
-            configuration_url=f"http://{self.entry.data[CONF_HOST]}:{self.entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT)}",
+            configuration_url=f"http://{self.entry.data[CONF_HOST]}:{get_http_port(self.entry.data)}",
         )
         self.device_id = device_entry.id
 

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -10,7 +10,7 @@ from typing import Any, Generic, TypeVar, cast
 
 from aioshelly.ble import async_ensure_ble_enabled, async_stop_scanner
 from aioshelly.block_device import BlockDevice, BlockUpdateType
-from aioshelly.const import MODEL_NAMES, MODEL_VALVE
+from aioshelly.const import DEFAULT_HTTP_PORT, MODEL_NAMES, MODEL_VALVE
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError
 from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 
@@ -145,7 +145,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
             model=MODEL_NAMES.get(self.model, self.model),
             sw_version=self.sw_version,
             hw_version=f"gen{get_device_entry_gen(self.entry)} ({self.model})",
-            configuration_url=f"http://{self.entry.data[CONF_HOST]}:{self.entry.data.get(CONF_PORT, 80)}",
+            configuration_url=f"http://{self.entry.data[CONF_HOST]}:{self.entry.data.get(CONF_PORT, DEFAULT_HTTP_PORT)}",
         )
         self.device_id = device_entry.id
 

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -15,7 +15,12 @@ from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCal
 from aioshelly.rpc_device import RpcDevice, RpcUpdateType
 
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST, EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    CONF_HOST,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+)
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.debounce import Debouncer
@@ -140,7 +145,7 @@ class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):
             model=MODEL_NAMES.get(self.model, self.model),
             sw_version=self.sw_version,
             hw_version=f"gen{get_device_entry_gen(self.entry)} ({self.model})",
-            configuration_url=f"http://{self.entry.data[CONF_HOST]}",
+            configuration_url=f"http://{self.entry.data[CONF_HOST]}:{self.entry.data.get(CONF_PORT, 80)}",
         )
         self.device_id = device_entry.id
 

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -33,7 +33,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support",
-      "custom_port_not_supported": "Gen1 devices cannot be configured via range extender."
+      "custom_port_not_supported": "Gen1 device does not support custom port."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -5,7 +5,8 @@
       "user": {
         "description": "Before setup, battery-powered devices must be woken up, you can now wake the device up using a button on it.",
         "data": {
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
           "host": "The hostname or IP address of the Shelly device to connect to."

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -31,7 +31,8 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support"
+      "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support",
+      "wrong_shelly_gen": "Gen1 devices cannot be configured via range extender."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -32,7 +32,7 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "firmware_not_fully_provisioned": "Device not fully provisioned. Please contact Shelly support",
-      "wrong_shelly_gen": "Gen1 devices cannot be configured via range extender."
+      "custom_port_not_supported": "Gen1 devices cannot be configured via range extender."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -8,7 +8,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Shelly device to connect to.\nYou can also specify a port with 'ip:port' syntax."
+          "host": "The hostname or IP address of the Shelly device to connect to. You can also specify a port with 'IP:PORT' syntax."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -8,8 +8,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Shelly device to connect to.",
-          "port": "The IP port of the Shelly device to connect to (default is 80)."
+          "host": "The hostname or IP address of the Shelly device to connect to."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -8,7 +8,7 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Shelly device to connect to."
+          "host": "The hostname or IP address of the Shelly device to connect to.\nYou can also specify a port with 'ip:port' syntax."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -8,7 +8,8 @@
           "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Shelly device to connect to. You can also specify a port with 'IP:PORT' syntax."
+          "host": "The hostname or IP address of the Shelly device to connect to.",
+          "port": "The IP port of the Shelly device to connect to (default is 80)."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "host": "The hostname or IP address of the Shelly device to connect to.",
-          "port": "The IP port of the Shelly device to connect to (default is 80)."
+          "port": "The TCP port of the Shelly device (Gen2+) to connect to."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -10,7 +10,7 @@
         },
         "data_description": {
           "host": "The hostname or IP address of the Shelly device to connect to.",
-          "port": "The TCP port of the Shelly device (Gen2+) to connect to."
+          "port": "The TCP port of the Shelly device to connect to (Gen2+)."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/strings.json
+++ b/homeassistant/components/shelly/strings.json
@@ -9,7 +9,8 @@
           "port": "[%key:common::config_flow::data::port%]"
         },
         "data_description": {
-          "host": "The hostname or IP address of the Shelly device to connect to."
+          "host": "The hostname or IP address of the Shelly device to connect to.",
+          "port": "The IP port of the Shelly device to connect to (default is 80)."
         }
       },
       "credentials": {

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
+from types import MappingProxyType
 from typing import Any, cast
 
 from aiohttp.web import Request, WebSocketResponse
@@ -11,6 +12,7 @@ from aioshelly.block_device import COAP, Block, BlockDevice
 from aioshelly.const import (
     BLOCK_GENERATIONS,
     DEFAULT_COAP_PORT,
+    DEFAULT_HTTP_PORT,
     MODEL_1L,
     MODEL_DIMMER,
     MODEL_DIMMER_2,
@@ -24,7 +26,7 @@ from aioshelly.rpc_device import RpcDevice, WsServer
 from homeassistant.components import network
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir, singleton
 from homeassistant.helpers.device_registry import (
@@ -473,3 +475,8 @@ def is_rpc_wifi_stations_disabled(
         return False
 
     return True
+
+
+def get_http_port(data: MappingProxyType[str, Any]) -> int:
+    """Get port from config entry data."""
+    return cast(int, data.get(CONF_PORT, DEFAULT_HTTP_PORT))

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -26,7 +26,6 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir, singleton
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -474,20 +473,3 @@ def is_rpc_wifi_stations_disabled(
         return False
 
     return True
-
-
-async def parse_host(input_host: str) -> tuple[str, int]:
-    """Parse host to verify port."""
-
-    if ":" in input_host:
-        splited: list = input_host.split(":")
-        try:
-            host = splited[0]
-            port = int(splited[1])
-        except ValueError as ex:
-            raise HomeAssistantError("Syntax error") from ex
-    else:
-        host = input_host
-        port = 80
-
-    return (host, port)

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -465,6 +465,20 @@ def async_create_issue_unsupported_firmware(
     )
 
 
+async def parse_host(input_host: str) -> tuple[str, int]:
+    """Parse host to verify port."""
+
+    if ":" in input_host:
+        splited: list = input_host.split(":")
+        host = splited[0]
+        port = int(splited[1])
+    else:
+        host = input_host
+        port = 80
+
+    return (host, port)
+
+
 def is_rpc_wifi_stations_disabled(
     config: dict[str, Any], _status: dict[str, Any], key: str
 ) -> bool:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -465,6 +465,16 @@ def async_create_issue_unsupported_firmware(
     )
 
 
+def is_rpc_wifi_stations_disabled(
+    config: dict[str, Any], _status: dict[str, Any], key: str
+) -> bool:
+    """Return true if rpc all WiFi stations are disabled."""
+    if config[key]["sta"]["enable"] is True or config[key]["sta1"]["enable"] is True:
+        return False
+
+    return True
+
+
 async def parse_host(input_host: str) -> tuple[str, int]:
     """Parse host to verify port."""
 
@@ -477,13 +487,3 @@ async def parse_host(input_host: str) -> tuple[str, int]:
         port = 80
 
     return (host, port)
-
-
-def is_rpc_wifi_stations_disabled(
-    config: dict[str, Any], _status: dict[str, Any], key: str
-) -> bool:
-    """Return true if rpc all WiFi stations are disabled."""
-    if config[key]["sta"]["enable"] is True or config[key]["sta1"]["enable"] is True:
-        return False
-
-    return True

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -26,6 +26,7 @@ from homeassistant.components.http import HomeAssistantView
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir, singleton
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -480,8 +481,11 @@ async def parse_host(input_host: str) -> tuple[str, int]:
 
     if ":" in input_host:
         splited: list = input_host.split(":")
-        host = splited[0]
-        port = int(splited[1])
+        try:
+            host = splited[0]
+            port = int(splited[1])
+        except ValueError as ex:
+            raise HomeAssistantError("Syntax error") from ex
     else:
         host = input_host
         port = 80

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -94,7 +94,7 @@ async def test_form(
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"host": f"1.1.1.1:{port}"},
+            {"host": "1.1.1.1", "port": port},
         )
         await hass.async_block_till_done()
 
@@ -109,35 +109,6 @@ async def test_form(
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
-
-
-async def test_form_wrong_syntax(
-    hass: HomeAssistant,
-    mock_block_device: Mock,
-) -> None:
-    """Test we get the form."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.shelly.config_flow.get_info",
-        return_value={
-            "mac": "test-mac",
-            "type": MODEL_1,
-            "auth": False,
-            "gen": 1,
-            "port": 1100,
-        },
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"host": "1.1.1.1:"},
-        )
-
-    assert result2["errors"]["base"] == "unknown"
 
 
 async def test_form_gen1_custom_port(
@@ -160,7 +131,7 @@ async def test_form_gen1_custom_port(
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"host": "1.1.1.1:1100"},
+            {"host": "1.1.1.1", "port": "1100"},
         )
 
         assert result2["type"] == data_entry_flow.FlowResultType.FORM

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -126,7 +126,7 @@ async def test_form_gen1_custom_port(
         "homeassistant.components.shelly.config_flow.get_info",
         return_value={"mac": "test-mac", "type": MODEL_1, "gen": 1},
     ), patch(
-        "homeassistant.components.shelly.config_flow.validate_input",
+        "aioshelly.block_device.BlockDevice.create",
         side_effect=CustomPortNotSupported,
     ):
         result2 = await hass.config_entries.flow.async_configure(

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -406,7 +406,7 @@ async def test_entry_missing_port(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
     entry.add_to_hass(hass)
     with patch(
-        "homeassistant.components.shelly.__init__.RpcDevice.create", return_value=Mock()
+        "homeassistant.components.shelly.RpcDevice.create", return_value=Mock()
     ) as rpc_device_mock:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -428,7 +428,7 @@ async def test_rpc_entry_custom_port(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
     entry.add_to_hass(hass)
     with patch(
-        "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
+        "homeassistant.components.shelly.RpcDevice.create", return_value=Mock()
     ) as rpc_device_mock:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -4,6 +4,8 @@ from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, Mock, call, patch
 
 from aioshelly.block_device import COAP
+from aioshelly.common import ConnectionOptions
+from aioshelly.const import MODEL_PLUS_2PM
 from aioshelly.exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
@@ -16,13 +18,14 @@ from homeassistant.components.shelly.const import (
     BLOCK_EXPECTED_SLEEP_PERIOD,
     BLOCK_WRONG_SLEEP_PERIOD,
     CONF_BLE_SCANNER_MODE,
+    CONF_GEN,
     CONF_SLEEP_PERIOD,
     DOMAIN,
     MODELS_WITH_WRONG_SLEEP_PERIOD,
     BLEScannerMode,
 )
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import CONF_HOST, CONF_PORT, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
@@ -390,6 +393,49 @@ async def test_entry_missing_gen(hass: HomeAssistant, mock_block_device: Mock) -
 
     assert entry.state is ConfigEntryState.LOADED
     assert hass.states.get("switch.test_name_channel_1").state is STATE_ON
+
+
+async def test_entry_missing_port(hass: HomeAssistant) -> None:
+    """Test successful Gen2 device init when port is missing in entry data."""
+    with patch(
+        "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
+    ) as rpc_device_mock:
+        data = {
+            CONF_HOST: "192.168.1.37",
+            CONF_SLEEP_PERIOD: 0,
+            "model": MODEL_PLUS_2PM,
+            CONF_GEN: 2,
+        }
+        entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert rpc_device_mock.call_args[0][2] == ConnectionOptions(
+            ip_address="192.168.1.37", device_mac="123456789ABC", port=80
+        )
+
+
+async def test_rpc_entry_custom_port(hass: HomeAssistant) -> None:
+    """Test successful Gen2 device init using custom port."""
+    with patch(
+        "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
+    ) as rpc_device_mock:
+        data = {
+            CONF_HOST: "192.168.1.37",
+            CONF_SLEEP_PERIOD: 0,
+            "model": MODEL_PLUS_2PM,
+            CONF_GEN: 2,
+            CONF_PORT: 8001,
+        }
+        entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert rpc_device_mock.call_args[0][2] == ConnectionOptions(
+            ip_address="192.168.1.37", device_mac="123456789ABC", port=8001
+        )
 
 
 @pytest.mark.parametrize(("model"), MODELS_WITH_WRONG_SLEEP_PERIOD)

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -406,7 +406,7 @@ async def test_entry_missing_port(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
     entry.add_to_hass(hass)
     with patch(
-        "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
+        "homeassistant.components.shelly.__init__.RpcDevice.create", return_value=Mock()
     ) as rpc_device_mock:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -418,18 +418,18 @@ async def test_entry_missing_port(hass: HomeAssistant) -> None:
 
 async def test_rpc_entry_custom_port(hass: HomeAssistant) -> None:
     """Test successful Gen2 device init using custom port."""
+    data = {
+        CONF_HOST: "192.168.1.37",
+        CONF_SLEEP_PERIOD: 0,
+        "model": MODEL_PLUS_2PM,
+        CONF_GEN: 2,
+        CONF_PORT: 8001,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
     with patch(
         "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
     ) as rpc_device_mock:
-        data = {
-            CONF_HOST: "192.168.1.37",
-            CONF_SLEEP_PERIOD: 0,
-            "model": MODEL_PLUS_2PM,
-            CONF_GEN: 2,
-            CONF_PORT: 8001,
-        }
-        entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
-        entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -397,17 +397,17 @@ async def test_entry_missing_gen(hass: HomeAssistant, mock_block_device: Mock) -
 
 async def test_entry_missing_port(hass: HomeAssistant) -> None:
     """Test successful Gen2 device init when port is missing in entry data."""
+    data = {
+        CONF_HOST: "192.168.1.37",
+        CONF_SLEEP_PERIOD: 0,
+        "model": MODEL_PLUS_2PM,
+        CONF_GEN: 2,
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
+    entry.add_to_hass(hass)
     with patch(
         "aioshelly.rpc_device.RpcDevice.create", return_value=Mock()
     ) as rpc_device_mock:
-        data = {
-            CONF_HOST: "192.168.1.37",
-            CONF_SLEEP_PERIOD: 0,
-            "model": MODEL_PLUS_2PM,
-            CONF_GEN: 2,
-        }
-        entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=MOCK_MAC)
-        entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add TCP custom port support for Shelly devices.

Shelly devices that support such feature, can now be used as "range extender".
On top, Shelly Gen2/Gen3 devices behind a NAT can be configured in Home Assistant as well.

**NOTE**: Shelly range extender doesn't support CoAP port forwarding, thus Gen1 devices cannot be configured with custom ports.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109092 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31902

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
