### PR TITLE
Fix races in ESPHome manager tests

### DIFF
--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1,4 +1,5 @@
 """Test ESPHome manager."""
+import asyncio
 from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, call
 
@@ -354,7 +355,12 @@ async def test_unique_id_updated_to_mac(
         unique_id="mock-config-name",
     )
     entry.add_to_hass(hass)
+    subscribe_done = hass.loop.create_future()
 
+    async def async_subscribe_states(*args, **kwargs) -> None:
+        subscribe_done.set_result(None)
+
+    mock_client.subscribe_states = async_subscribe_states
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(
             mac_address="1122334455aa",
@@ -363,6 +369,8 @@ async def test_unique_id_updated_to_mac(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await subscribe_done
 
     assert entry.unique_id == "11:22:33:44:55:aa"
 
@@ -382,13 +390,20 @@ async def test_unique_id_not_updated_if_name_same_and_already_mac(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    disconnect_done = hass.loop.create_future()
 
+    async def async_disconnect(*args, **kwargs) -> None:
+        disconnect_done.set_result(None)
+
+    mock_client.disconnect = async_disconnect
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455ab", name="test")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await disconnect_done
 
     # Mac should never update
     assert entry.unique_id == "11:22:33:44:55:aa"
@@ -404,13 +419,20 @@ async def test_unique_id_updated_if_name_unset_and_already_mac(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    disconnect_done = hass.loop.create_future()
 
+    async def async_disconnect(*args, **kwargs) -> None:
+        disconnect_done.set_result(None)
+
+    mock_client.disconnect = async_disconnect
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455ab", name="test")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await disconnect_done
 
     # Mac should never update
     assert entry.unique_id == "11:22:33:44:55:aa"
@@ -431,13 +453,20 @@ async def test_unique_id_not_updated_if_name_different_and_already_mac(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    disconnect_done = hass.loop.create_future()
 
+    async def async_disconnect(*args, **kwargs) -> None:
+        disconnect_done.set_result(None)
+
+    mock_client.disconnect = async_disconnect
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455ab", name="different")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await disconnect_done
 
     # Mac should not be updated because name is different
     assert entry.unique_id == "11:22:33:44:55:aa"
@@ -460,13 +489,20 @@ async def test_name_updated_only_if_mac_matches(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    subscribe_done = hass.loop.create_future()
 
+    async def async_subscribe_states(*args, **kwargs) -> None:
+        subscribe_done.set_result(None)
+
+    mock_client.subscribe_states = async_subscribe_states
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455aa", name="new")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await subscribe_done
 
     assert entry.unique_id == "11:22:33:44:55:aa"
     assert entry.data[CONF_DEVICE_NAME] == "new"
@@ -487,13 +523,20 @@ async def test_name_updated_only_if_mac_was_unset(
         unique_id="notamac",
     )
     entry.add_to_hass(hass)
+    subscribe_done = hass.loop.create_future()
 
+    async def async_subscribe_states(*args, **kwargs) -> None:
+        subscribe_done.set_result(None)
+
+    mock_client.subscribe_states = async_subscribe_states
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455aa", name="new")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await subscribe_done
 
     assert entry.unique_id == "11:22:33:44:55:aa"
     assert entry.data[CONF_DEVICE_NAME] == "new"
@@ -517,13 +560,20 @@ async def test_connection_aborted_wrong_device(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    disconnect_done = hass.loop.create_future()
 
+    async def async_disconnect(*args, **kwargs) -> None:
+        disconnect_done.set_result(None)
+
+    mock_client.disconnect = async_disconnect
     mock_client.device_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455ab", name="different")
     )
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await disconnect_done
 
     assert (
         "Unexpected device found at 192.168.43.183; expected `test` "
@@ -532,8 +582,7 @@ async def test_connection_aborted_wrong_device(
     )
 
     assert "Error getting setting up connection for" not in caplog.text
-    assert len(mock_client.disconnect.mock_calls) == 1
-    mock_client.disconnect.reset_mock()
+    mock_client.disconnect = AsyncMock()
     caplog.clear()
     # Make sure discovery triggers a reconnect
     service_info = dhcp.DhcpServiceInfo(
@@ -575,15 +624,20 @@ async def test_failure_during_connect(
         unique_id="11:22:33:44:55:aa",
     )
     entry.add_to_hass(hass)
+    disconnect_done = hass.loop.create_future()
 
+    async def async_disconnect(*args, **kwargs) -> None:
+        disconnect_done.set_result(None)
+
+    mock_client.disconnect = async_disconnect
     mock_client.device_info = AsyncMock(side_effect=APIConnectionError("fail"))
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    async with asyncio.timeout(1):
+        await disconnect_done
 
     assert "Error getting setting up connection for" in caplog.text
-    # Ensure we disconnect so that the reconnect logic is triggered
-    assert len(mock_client.disconnect.mock_calls) == 1
 
 
 async def test_state_subscription(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These tests currently rely on event loop overhead to finish in time

That overhead will go away in #110828 so we need to fix this test before merging #110828

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
