### PR TITLE
Allow loading of more then 1 defined Apprise URL

### DIFF
--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -52,9 +52,15 @@ def get_service(
             return None
 
     # Ordered list of URLs
-    if config.get(CONF_URL) and not a_obj.add(config[CONF_URL]):
-        _LOGGER.error("Invalid Apprise URL(s) supplied")
-        return None
+    if config.get(CONF_URL):
+        has_error = False
+        for entry in config[CONF_URL]:
+            if not a_obj.add(entry):
+                has_error = True
+
+        if has_error:
+            _LOGGER.error("One or more specified Apprise URL(s) are invalid")
+            return None
 
     return AppriseNotificationService(a_obj)
 

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -52,15 +52,11 @@ def get_service(
             return None
 
     # Ordered list of URLs
-    if config.get(CONF_URL):
-        has_error = False
-        for entry in config[CONF_URL]:
+    if urls := config.get(CONF_URL):
+        for entry in urls:
             if not a_obj.add(entry):
-                has_error = True
-
-        if has_error:
-            _LOGGER.error("One or more specified Apprise URL(s) are invalid")
-            return None
+                _LOGGER.error("One or more specified Apprise URL(s) are invalid")
+                return None
 
     return AppriseNotificationService(a_obj)
 

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -118,7 +118,48 @@ async def test_apprise_notification(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # Validate calls were made under the hood correctly
-        obj.add.assert_called_once_with([config[BASE_COMPONENT]["url"]])
+        obj.add.assert_called_once_with(config[BASE_COMPONENT]["url"])
+        obj.notify.assert_called_once_with(
+            **{"body": data["message"], "title": data["title"], "tag": None}
+        )
+
+
+async def test_apprise_multiple_notification(hass: HomeAssistant) -> None:
+    """Test apprise notification."""
+
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "url": [
+                "mailto://user:pass@example.com, mailto://user:pass@gmail.com",
+                "json://user:pass@gmail.com",
+            ],
+        }
+    }
+
+    # Our Message
+    data = {"title": "Test Title", "message": "Test Message"}
+
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise"
+    ) as mock_apprise:
+        obj = MagicMock()
+        obj.add.return_value = True
+        obj.notify.return_value = True
+        mock_apprise.return_value = obj
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
+
+        # Test the existence of our service
+        assert hass.services.has_service(BASE_COMPONENT, "test")
+
+        # Test the call to our underlining notify() call
+        await hass.services.async_call(BASE_COMPONENT, "test", data)
+        await hass.async_block_till_done()
+
+        # Validate 2 calls were made under the hood
+        assert obj.add.call_count == 2
         obj.notify.assert_called_once_with(
             **{"body": data["message"], "title": data["title"], "tag": None}
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This resolves #110242

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
HA after v2024.2.1 no longer passes a string and sends a list instead.  This fix handles this case.

- This PR fixes or closes issue: fixes #110242
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
