### PR TITLE
Add Identify device class to homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/button.py
+++ b/homeassistant/components/homekit_controller/button.py
@@ -53,6 +53,7 @@ BUTTON_ENTITIES: dict[str, HomeKitButtonEntityDescription] = {
     CharacteristicsTypes.IDENTIFY: HomeKitButtonEntityDescription(
         key=CharacteristicsTypes.IDENTIFY,
         name="Identify",
+        device_class=ButtonDeviceClass.IDENTIFY,
         entity_category=EntityCategory.DIAGNOSTIC,
         write_value=True,
     ),

--- a/tests/components/homekit_controller/snapshots/test_diagnostics.ambr
+++ b/tests/components/homekit_controller/snapshots/test_diagnostics.ambr
@@ -18,11 +18,12 @@
             'disabled_by': None,
             'entity_category': 'diagnostic',
             'icon': None,
-            'original_device_class': None,
+            'original_device_class': 'identify',
             'original_icon': None,
             'original_name': 'Koogeek-LS1-20833F Identify',
             'state': dict({
               'attributes': dict({
+                'device_class': 'identify',
                 'friendly_name': 'Koogeek-LS1-20833F Identify',
               }),
               'entity_id': 'button.koogeek_ls1_20833f_identify',
@@ -342,11 +343,12 @@
           'disabled_by': None,
           'entity_category': 'diagnostic',
           'icon': None,
-          'original_device_class': None,
+          'original_device_class': 'identify',
           'original_icon': None,
           'original_name': 'Koogeek-LS1-20833F Identify',
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Koogeek-LS1-20833F Identify',
             }),
             'entity_id': 'button.koogeek_ls1_20833f_identify',

--- a/tests/components/homekit_controller/snapshots/test_init.ambr
+++ b/tests/components/homekit_controller/snapshots/test_init.ambr
@@ -47,7 +47,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Airversa AP2 1808 Identify',
             'platform': 'homekit_controller',
@@ -59,6 +59,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Airversa AP2 1808 Identify',
             }),
             'entity_id': 'button.airversa_ap2_1808_identify',
@@ -631,7 +632,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'eufy HomeBase2-0AAA Identify',
             'platform': 'homekit_controller',
@@ -643,6 +644,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'eufy HomeBase2-0AAA Identify',
             }),
             'entity_id': 'button.eufy_homebase2_0aaa_identify',
@@ -734,7 +736,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'eufyCam2-0000 Identify',
             'platform': 'homekit_controller',
@@ -746,6 +748,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'eufyCam2-0000 Identify',
             }),
             'entity_id': 'button.eufycam2_0000_identify',
@@ -953,7 +956,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'eufyCam2-000A Identify',
             'platform': 'homekit_controller',
@@ -965,6 +968,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'eufyCam2-000A Identify',
             }),
             'entity_id': 'button.eufycam2_000a_identify',
@@ -1172,7 +1176,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'eufyCam2-000A Identify',
             'platform': 'homekit_controller',
@@ -1184,6 +1188,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'eufyCam2-000A Identify',
             }),
             'entity_id': 'button.eufycam2_000a_identify_2',
@@ -1399,7 +1404,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Aqara-Hub-E1-00A0 Identify',
             'platform': 'homekit_controller',
@@ -1411,6 +1416,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Aqara-Hub-E1-00A0 Identify',
             }),
             'entity_id': 'button.aqara_hub_e1_00a0_identify',
@@ -1585,7 +1591,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Contact Sensor Identify',
             'platform': 'homekit_controller',
@@ -1597,6 +1603,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Contact Sensor Identify',
             }),
             'entity_id': 'button.contact_sensor_identify',
@@ -1738,7 +1745,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Aqara Hub-1563 Identify',
             'platform': 'homekit_controller',
@@ -1750,6 +1757,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Aqara Hub-1563 Identify',
             }),
             'entity_id': 'button.aqara_hub_1563_identify',
@@ -1952,7 +1960,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Programmable Switch Identify',
             'platform': 'homekit_controller',
@@ -1964,6 +1972,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Programmable Switch Identify',
             }),
             'entity_id': 'button.programmable_switch_identify',
@@ -2101,7 +2110,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'ArloBabyA0 Identify',
             'platform': 'homekit_controller',
@@ -2113,6 +2122,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'ArloBabyA0 Identify',
             }),
             'entity_id': 'button.arlobabya0_identify',
@@ -2507,7 +2517,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'InWall Outlet-0394DE Identify',
             'platform': 'homekit_controller',
@@ -2519,6 +2529,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'InWall Outlet-0394DE Identify',
             }),
             'entity_id': 'button.inwall_outlet_0394de_identify',
@@ -2934,7 +2945,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Basement Identify',
             'platform': 'homekit_controller',
@@ -2946,6 +2957,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Basement Identify',
             }),
             'entity_id': 'button.basement_identify',
@@ -3151,7 +3163,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HomeW Identify',
             'platform': 'homekit_controller',
@@ -3163,6 +3175,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HomeW Identify',
             }),
             'entity_id': 'button.homew_identify',
@@ -3494,7 +3507,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Kitchen Identify',
             'platform': 'homekit_controller',
@@ -3506,6 +3519,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Kitchen Identify',
             }),
             'entity_id': 'button.kitchen_identify',
@@ -3638,7 +3652,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Porch Identify',
             'platform': 'homekit_controller',
@@ -3650,6 +3664,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Porch Identify',
             }),
             'entity_id': 'button.porch_identify',
@@ -3859,7 +3874,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HomeW Identify',
             'platform': 'homekit_controller',
@@ -3871,6 +3886,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HomeW Identify',
             }),
             'entity_id': 'button.homew_identify',
@@ -4206,7 +4222,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Basement Identify',
             'platform': 'homekit_controller',
@@ -4218,6 +4234,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Basement Identify',
             }),
             'entity_id': 'button.basement_identify',
@@ -4272,7 +4289,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HomeW Identify',
             'platform': 'homekit_controller',
@@ -4284,6 +4301,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HomeW Identify',
             }),
             'entity_id': 'button.homew_identify',
@@ -4568,7 +4586,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Kitchen Identify',
             'platform': 'homekit_controller',
@@ -4580,6 +4598,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Kitchen Identify',
             }),
             'entity_id': 'button.kitchen_identify',
@@ -4712,7 +4731,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Porch Identify',
             'platform': 'homekit_controller',
@@ -4724,6 +4743,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Porch Identify',
             }),
             'entity_id': 'button.porch_identify',
@@ -4933,7 +4953,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'My ecobee Identify',
             'platform': 'homekit_controller',
@@ -4945,6 +4965,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'My ecobee Identify',
             }),
             'entity_id': 'button.my_ecobee_identify',
@@ -5326,7 +5347,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Master Fan Identify',
             'platform': 'homekit_controller',
@@ -5338,6 +5359,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Master Fan Identify',
             }),
             'entity_id': 'button.master_fan_identify',
@@ -5514,7 +5536,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Eve Degree AA11 Identify',
             'platform': 'homekit_controller',
@@ -5526,6 +5548,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Eve Degree AA11 Identify',
             }),
             'entity_id': 'button.eve_degree_aa11_identify',
@@ -5841,7 +5864,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Eve Energy 50FF Identify',
             'platform': 'homekit_controller',
@@ -5853,6 +5876,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Eve Energy 50FF Identify',
             }),
             'entity_id': 'button.eve_energy_50ff_identify',
@@ -6149,7 +6173,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HAA-C718B3 Identify',
             'platform': 'homekit_controller',
@@ -6161,6 +6185,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HAA-C718B3 Identify',
             }),
             'entity_id': 'button.haa_c718b3_identify',
@@ -6332,7 +6357,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HAA-C718B3 Identify',
             'platform': 'homekit_controller',
@@ -6344,6 +6369,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HAA-C718B3 Identify',
             }),
             'entity_id': 'button.haa_c718b3_identify_2',
@@ -6438,7 +6464,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Family Room North Identify',
             'platform': 'homekit_controller',
@@ -6450,6 +6476,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Family Room North Identify',
             }),
             'entity_id': 'button.family_room_north_identify',
@@ -6584,7 +6611,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -6596,6 +6623,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -6650,7 +6678,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Kitchen Window Identify',
             'platform': 'homekit_controller',
@@ -6662,6 +6690,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Kitchen Window Identify',
             }),
             'entity_id': 'button.kitchen_window_identify',
@@ -6800,7 +6829,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Ceiling Fan Identify',
             'platform': 'homekit_controller',
@@ -6812,6 +6841,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Ceiling Fan Identify',
             }),
             'entity_id': 'button.ceiling_fan_identify',
@@ -6909,7 +6939,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Home Assistant Bridge Identify',
             'platform': 'homekit_controller',
@@ -6921,6 +6951,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Home Assistant Bridge Identify',
             }),
             'entity_id': 'button.home_assistant_bridge_identify',
@@ -6975,7 +7006,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Living Room Fan Identify',
             'platform': 'homekit_controller',
@@ -6987,6 +7018,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Living Room Fan Identify',
             }),
             'entity_id': 'button.living_room_fan_identify',
@@ -7089,7 +7121,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': '89 Living Room Identify',
             'platform': 'homekit_controller',
@@ -7101,6 +7133,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': '89 Living Room Identify',
             }),
             'entity_id': 'button.89_living_room_identify',
@@ -7385,7 +7418,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -7397,6 +7430,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -7455,7 +7489,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -7467,6 +7501,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -7521,7 +7556,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Laundry Smoke ED78 Identify',
             'platform': 'homekit_controller',
@@ -7533,6 +7568,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Laundry Smoke ED78 Identify',
             }),
             'entity_id': 'button.laundry_smoke_ed78_identify',
@@ -7679,7 +7715,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Family Room North Identify',
             'platform': 'homekit_controller',
@@ -7691,6 +7727,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Family Room North Identify',
             }),
             'entity_id': 'button.family_room_north_identify',
@@ -7825,7 +7862,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -7837,6 +7874,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -7891,7 +7929,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Kitchen Window Identify',
             'platform': 'homekit_controller',
@@ -7903,6 +7941,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Kitchen Window Identify',
             }),
             'entity_id': 'button.kitchen_window_identify',
@@ -8041,7 +8080,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Ceiling Fan Identify',
             'platform': 'homekit_controller',
@@ -8053,6 +8092,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Ceiling Fan Identify',
             }),
             'entity_id': 'button.ceiling_fan_identify',
@@ -8150,7 +8190,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Home Assistant Bridge Identify',
             'platform': 'homekit_controller',
@@ -8162,6 +8202,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Home Assistant Bridge Identify',
             }),
             'entity_id': 'button.home_assistant_bridge_identify',
@@ -8216,7 +8257,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Living Room Fan Identify',
             'platform': 'homekit_controller',
@@ -8228,6 +8269,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Living Room Fan Identify',
             }),
             'entity_id': 'button.living_room_fan_identify',
@@ -8331,7 +8373,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Home Assistant Bridge Identify',
             'platform': 'homekit_controller',
@@ -8343,6 +8385,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Home Assistant Bridge Identify',
             }),
             'entity_id': 'button.home_assistant_bridge_identify',
@@ -8397,7 +8440,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Living Room Fan Identify',
             'platform': 'homekit_controller',
@@ -8409,6 +8452,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Living Room Fan Identify',
             }),
             'entity_id': 'button.living_room_fan_identify',
@@ -8512,7 +8556,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': '89 Living Room Identify',
             'platform': 'homekit_controller',
@@ -8524,6 +8568,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': '89 Living Room Identify',
             }),
             'entity_id': 'button.89_living_room_identify',
@@ -8817,7 +8862,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -8829,6 +8874,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -8887,7 +8933,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -8899,6 +8945,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -8953,7 +9000,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Humidifier 182A Identify',
             'platform': 'homekit_controller',
@@ -8965,6 +9012,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Humidifier 182A Identify',
             }),
             'entity_id': 'button.humidifier_182a_identify',
@@ -9118,7 +9166,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -9130,6 +9178,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -9184,7 +9233,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Humidifier 182A Identify',
             'platform': 'homekit_controller',
@@ -9196,6 +9245,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Humidifier 182A Identify',
             }),
             'entity_id': 'button.humidifier_182a_identify',
@@ -9349,7 +9399,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'HASS Bridge S6 Identify',
             'platform': 'homekit_controller',
@@ -9361,6 +9411,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'HASS Bridge S6 Identify',
             }),
             'entity_id': 'button.hass_bridge_s6_identify',
@@ -9415,7 +9466,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Laundry Smoke ED78 Identify',
             'platform': 'homekit_controller',
@@ -9427,6 +9478,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Laundry Smoke ED78 Identify',
             }),
             'entity_id': 'button.laundry_smoke_ed78_identify',
@@ -9588,7 +9640,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Air Conditioner Identify',
             'platform': 'homekit_controller',
@@ -9600,6 +9652,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Air Conditioner Identify',
             }),
             'entity_id': 'button.air_conditioner_identify',
@@ -9771,7 +9824,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance candle Identify',
             'platform': 'homekit_controller',
@@ -9783,6 +9836,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance candle Identify',
             }),
             'entity_id': 'button.hue_ambiance_candle_identify_4',
@@ -9896,7 +9950,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance candle Identify',
             'platform': 'homekit_controller',
@@ -9908,6 +9962,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance candle Identify',
             }),
             'entity_id': 'button.hue_ambiance_candle_identify_3',
@@ -10021,7 +10076,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance candle Identify',
             'platform': 'homekit_controller',
@@ -10033,6 +10088,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance candle Identify',
             }),
             'entity_id': 'button.hue_ambiance_candle_identify_2',
@@ -10146,7 +10202,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance candle Identify',
             'platform': 'homekit_controller',
@@ -10158,6 +10214,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance candle Identify',
             }),
             'entity_id': 'button.hue_ambiance_candle_identify',
@@ -10271,7 +10328,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance spot Identify',
             'platform': 'homekit_controller',
@@ -10283,6 +10340,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance spot Identify',
             }),
             'entity_id': 'button.hue_ambiance_spot_identify_2',
@@ -10406,7 +10464,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue ambiance spot Identify',
             'platform': 'homekit_controller',
@@ -10418,6 +10476,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue ambiance spot Identify',
             }),
             'entity_id': 'button.hue_ambiance_spot_identify',
@@ -10541,7 +10600,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue dimmer switch Identify',
             'platform': 'homekit_controller',
@@ -10553,6 +10612,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue dimmer switch Identify',
             }),
             'entity_id': 'button.hue_dimmer_switch_identify',
@@ -10829,7 +10889,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -10841,6 +10901,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify',
@@ -10941,7 +11002,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -10953,6 +11014,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_2',
@@ -11053,7 +11115,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -11065,6 +11127,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_4',
@@ -11165,7 +11228,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -11177,6 +11240,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_3',
@@ -11277,7 +11341,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -11289,6 +11353,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_7',
@@ -11389,7 +11454,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -11401,6 +11466,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_6',
@@ -11501,7 +11567,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Hue white lamp Identify',
             'platform': 'homekit_controller',
@@ -11513,6 +11579,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Hue white lamp Identify',
             }),
             'entity_id': 'button.hue_white_lamp_identify_5',
@@ -11613,7 +11680,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Philips hue - 482544 Identify',
             'platform': 'homekit_controller',
@@ -11625,6 +11692,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Philips hue - 482544 Identify',
             }),
             'entity_id': 'button.philips_hue_482544_identify',
@@ -11683,7 +11751,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Koogeek-LS1-20833F Identify',
             'platform': 'homekit_controller',
@@ -11695,6 +11763,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Koogeek-LS1-20833F Identify',
             }),
             'entity_id': 'button.koogeek_ls1_20833f_identify',
@@ -11814,7 +11883,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Koogeek-P1-A00AA0 Identify',
             'platform': 'homekit_controller',
@@ -11826,6 +11895,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Koogeek-P1-A00AA0 Identify',
             }),
             'entity_id': 'button.koogeek_p1_a00aa0_identify',
@@ -11962,7 +12032,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Koogeek-SW2-187A91 Identify',
             'platform': 'homekit_controller',
@@ -11974,6 +12044,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Koogeek-SW2-187A91 Identify',
             }),
             'entity_id': 'button.koogeek_sw2_187a91_identify',
@@ -12145,7 +12216,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Lennox Identify',
             'platform': 'homekit_controller',
@@ -12157,6 +12228,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Lennox Identify',
             }),
             'entity_id': 'button.lennox_identify',
@@ -12403,7 +12475,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'LG webOS TV AF80 Identify',
             'platform': 'homekit_controller',
@@ -12415,6 +12487,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'LG webOS TV AF80 Identify',
             }),
             'entity_id': 'button.lg_webos_tv_af80_identify',
@@ -12568,7 +12641,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Caséta® Wireless Fan Speed Control Identify',
             'platform': 'homekit_controller',
@@ -12580,6 +12653,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Caséta® Wireless Fan Speed Control Identify',
             }),
             'entity_id': 'button.caseta_r_wireless_fan_speed_control_identify',
@@ -12677,7 +12751,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Smart Bridge 2 Identify',
             'platform': 'homekit_controller',
@@ -12689,6 +12763,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Smart Bridge 2 Identify',
             }),
             'entity_id': 'button.smart_bridge_2_identify',
@@ -12747,7 +12822,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'MSS425F-15cc Identify',
             'platform': 'homekit_controller',
@@ -12759,6 +12834,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'MSS425F-15cc Identify',
             }),
             'entity_id': 'button.mss425f_15cc_identify',
@@ -12997,7 +13073,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'MSS565-28da Identify',
             'platform': 'homekit_controller',
@@ -13009,6 +13085,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'MSS565-28da Identify',
             }),
             'entity_id': 'button.mss565_28da_identify',
@@ -13113,7 +13190,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Mysa-85dda9 Identify',
             'platform': 'homekit_controller',
@@ -13125,6 +13202,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Mysa-85dda9 Identify',
             }),
             'entity_id': 'button.mysa_85dda9_identify',
@@ -13415,7 +13493,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Nanoleaf Strip 3B32 Identify',
             'platform': 'homekit_controller',
@@ -13427,6 +13505,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Nanoleaf Strip 3B32 Identify',
             }),
             'entity_id': 'button.nanoleaf_strip_3b32_identify',
@@ -13739,7 +13818,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Netatmo-Doorbell-g738658 Identify',
             'platform': 'homekit_controller',
@@ -13751,6 +13830,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Netatmo-Doorbell-g738658 Identify',
             }),
             'entity_id': 'button.netatmo_doorbell_g738658_identify',
@@ -14043,7 +14123,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Smart CO Alarm Identify',
             'platform': 'homekit_controller',
@@ -14055,6 +14135,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Smart CO Alarm Identify',
             }),
             'entity_id': 'button.smart_co_alarm_identify',
@@ -14113,7 +14194,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Healthy Home Coach Identify',
             'platform': 'homekit_controller',
@@ -14125,6 +14206,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Healthy Home Coach Identify',
             }),
             'entity_id': 'button.healthy_home_coach_identify',
@@ -14387,7 +14469,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'RainMachine-00ce4a Identify',
             'platform': 'homekit_controller',
@@ -14399,6 +14481,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'RainMachine-00ce4a Identify',
             }),
             'entity_id': 'button.rainmachine_00ce4a_identify',
@@ -14777,7 +14860,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'Master Bath South Identify',
             'platform': 'homekit_controller',
@@ -14789,6 +14872,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'Master Bath South Identify',
             }),
             'entity_id': 'button.master_bath_south_identify',
@@ -14923,7 +15007,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'RYSE SmartBridge Identify',
             'platform': 'homekit_controller',
@@ -14935,6 +15019,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'RYSE SmartBridge Identify',
             }),
             'entity_id': 'button.ryse_smartbridge_identify',
@@ -14989,7 +15074,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'RYSE SmartShade Identify',
             'platform': 'homekit_controller',
@@ -15001,6 +15086,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'RYSE SmartShade Identify',
             }),
             'entity_id': 'button.ryse_smartshade_identify',
@@ -15139,7 +15225,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'BR Left Identify',
             'platform': 'homekit_controller',
@@ -15151,6 +15237,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'BR Left Identify',
             }),
             'entity_id': 'button.br_left_identify',
@@ -15285,7 +15372,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'LR Left Identify',
             'platform': 'homekit_controller',
@@ -15297,6 +15384,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'LR Left Identify',
             }),
             'entity_id': 'button.lr_left_identify',
@@ -15431,7 +15519,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'LR Right Identify',
             'platform': 'homekit_controller',
@@ -15443,6 +15531,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'LR Right Identify',
             }),
             'entity_id': 'button.lr_right_identify',
@@ -15577,7 +15666,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'RYSE SmartBridge Identify',
             'platform': 'homekit_controller',
@@ -15589,6 +15678,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'RYSE SmartBridge Identify',
             }),
             'entity_id': 'button.ryse_smartbridge_identify',
@@ -15643,7 +15733,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'RZSS Identify',
             'platform': 'homekit_controller',
@@ -15655,6 +15745,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'RZSS Identify',
             }),
             'entity_id': 'button.rzss_identify',
@@ -15793,7 +15884,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'SENSE   Identify',
             'platform': 'homekit_controller',
@@ -15805,6 +15896,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'SENSE   Identify',
             }),
             'entity_id': 'button.sense_identify',
@@ -15900,7 +15992,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'SIMPLEconnect Fan-06F674 Identify',
             'platform': 'homekit_controller',
@@ -15912,6 +16004,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'SIMPLEconnect Fan-06F674 Identify',
             }),
             'entity_id': 'button.simpleconnect_fan_06f674_identify',
@@ -16060,7 +16153,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'VELUX Gateway Identify',
             'platform': 'homekit_controller',
@@ -16072,6 +16165,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'VELUX Gateway Identify',
             }),
             'entity_id': 'button.velux_gateway_identify',
@@ -16126,7 +16220,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'VELUX Sensor Identify',
             'platform': 'homekit_controller',
@@ -16138,6 +16232,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'VELUX Sensor Identify',
             }),
             'entity_id': 'button.velux_sensor_identify',
@@ -16315,7 +16410,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'VELUX Window Identify',
             'platform': 'homekit_controller',
@@ -16327,6 +16422,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'VELUX Window Identify',
             }),
             'entity_id': 'button.velux_window_identify',
@@ -16424,7 +16520,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'VOCOlinc-Flowerbud-0d324b Identify',
             'platform': 'homekit_controller',
@@ -16436,6 +16532,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'VOCOlinc-Flowerbud-0d324b Identify',
             }),
             'entity_id': 'button.vocolinc_flowerbud_0d324b_identify',
@@ -16706,7 +16803,7 @@
             'name': None,
             'options': dict({
             }),
-            'original_device_class': None,
+            'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
             'original_icon': None,
             'original_name': 'VOCOlinc-VP3-123456 Identify',
             'platform': 'homekit_controller',
@@ -16718,6 +16815,7 @@
           }),
           'state': dict({
             'attributes': dict({
+              'device_class': 'identify',
               'friendly_name': 'VOCOlinc-VP3-123456 Identify',
             }),
             'entity_id': 'button.vocolinc_vp3_123456_identify',


### PR DESCRIPTION
## Proposed change

Add the identify device class to the homekit_controller identify buttons.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #110833
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
