### PR TITLE
Use friendly name for camera media source

### DIFF
--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -29,13 +29,17 @@ async def async_get_media_source(hass: HomeAssistant) -> CameraMediaSource:
 def _media_source_for_camera(
     hass: HomeAssistant, camera: Camera, content_type: str
 ) -> BrowseMediaSource:
-    assert (camera_state := hass.states.get(camera.entity_id)) is not None
+    camera_state = hass.states.get(camera.entity_id)
+    title = camera.name
+    if camera_state:
+        title = camera_state.attributes.get(ATTR_FRIENDLY_NAME, camera.name)
+
     return BrowseMediaSource(
         domain=DOMAIN,
         identifier=camera.entity_id,
         media_class=MediaClass.VIDEO,
         media_content_type=content_type,
-        title=camera_state.attributes.get(ATTR_FRIENDLY_NAME, camera.name),
+        title=title,
         thumbnail=f"/api/camera_proxy/{camera.entity_id}",
         can_play=True,
         can_expand=False,

--- a/homeassistant/components/camera/media_source.py
+++ b/homeassistant/components/camera/media_source.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import cast
 
 from homeassistant.components.media_player import BrowseError, MediaClass
 from homeassistant.components.media_source.error import Unresolvable
@@ -14,7 +13,7 @@ from homeassistant.components.media_source.models import (
 )
 from homeassistant.components.stream import FORMAT_CONTENT_TYPE, HLS_PROVIDER
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import EntityComponent
 
@@ -30,14 +29,13 @@ async def async_get_media_source(hass: HomeAssistant) -> CameraMediaSource:
 def _media_source_for_camera(
     hass: HomeAssistant, camera: Camera, content_type: str
 ) -> BrowseMediaSource:
+    assert (camera_state := hass.states.get(camera.entity_id)) is not None
     return BrowseMediaSource(
         domain=DOMAIN,
         identifier=camera.entity_id,
         media_class=MediaClass.VIDEO,
         media_content_type=content_type,
-        title=cast(State, hass.states.get(camera.entity_id)).attributes.get(
-            ATTR_FRIENDLY_NAME, camera.name
-        ),
+        title=camera_state.attributes.get(ATTR_FRIENDLY_NAME, camera.name),
         thumbnail=f"/api/camera_proxy/{camera.entity_id}",
         can_play=True,
         can_expand=False,

--- a/tests/components/camera/conftest.py
+++ b/tests/components/camera/conftest.py
@@ -7,6 +7,7 @@ from homeassistant.components import camera
 from homeassistant.components.camera.const import StreamType
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.setup import async_setup_component
 
 from .common import WEBRTC_ANSWER
@@ -67,5 +68,39 @@ async def mock_camera_web_rtc_fixture(hass):
     ), patch(
         "homeassistant.components.camera.Camera.async_handle_web_rtc_offer",
         return_value=WEBRTC_ANSWER,
+    ):
+        yield
+
+
+@pytest.fixture(name="mock_camera_with_device")
+async def mock_camera_with_device_fixture():
+    """Initialize a demo camera platform with a device."""
+    dev_info = DeviceInfo(
+        identifiers={("camera", "test_unique_id")},
+        name="Test Camera Device",
+    )
+
+    class UniqueIdMock(PropertyMock):
+        def __get__(self, obj, obj_type=None):
+            return obj.name
+
+    with patch(
+        "homeassistant.components.camera.Camera.has_entity_name",
+        new_callable=PropertyMock(return_value=True),
+    ), patch(
+        "homeassistant.components.camera.Camera.unique_id", new=UniqueIdMock()
+    ), patch(
+        "homeassistant.components.camera.Camera.device_info",
+        new_callable=PropertyMock(return_value=dev_info),
+    ):
+        yield
+
+
+@pytest.fixture(name="mock_camera_with_no_name")
+async def mock_camera_with_no_name_fixture(mock_camera_with_device):
+    """Initialize a demo camera platform with a device and no name."""
+    with patch(
+        "homeassistant.components.camera.Camera._attr_name",
+        new_callable=PropertyMock(return_value=None),
     ):
         yield

--- a/tests/components/camera/test_media_source.py
+++ b/tests/components/camera/test_media_source.py
@@ -16,6 +16,26 @@ async def setup_media_source(hass):
     assert await async_setup_component(hass, "media_source", {})
 
 
+async def test_device_with_device(
+    hass: HomeAssistant, mock_camera_with_device, mock_camera
+) -> None:
+    """Test browsing when camera has a device and a name."""
+    item = await media_source.async_browse_media(hass, "media-source://camera")
+    assert item.not_shown == 2
+    assert len(item.children) == 1
+    assert item.children[0].title == "Test Camera Device Demo camera without stream"
+
+
+async def test_device_with_no_name(
+    hass: HomeAssistant, mock_camera_with_no_name, mock_camera
+) -> None:
+    """Test browsing when camera has device and name == None."""
+    item = await media_source.async_browse_media(hass, "media-source://camera")
+    assert item.not_shown == 2
+    assert len(item.children) == 1
+    assert item.children[0].title == "Test Camera Device Demo camera without stream"
+
+
 async def test_browsing_hls(hass: HomeAssistant, mock_camera_hls) -> None:
     """Test browsing HLS camera media source."""
     item = await media_source.async_browse_media(hass, "media-source://camera")
@@ -41,6 +61,7 @@ async def test_browsing_mjpeg(hass: HomeAssistant, mock_camera) -> None:
     assert len(item.children) == 1
     assert item.not_shown == 2
     assert item.children[0].media_content_type == "image/jpg"
+    assert item.children[0].title == "Demo camera without stream"
 
 
 async def test_browsing_web_rtc(hass: HomeAssistant, mock_camera_web_rtc) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Camera media sources are currently using the `name` property of the attribute, which only has the name relative to the device, and could be empty when the entity is the main one for the device.
This PR tries to get the friendly name, and falls back to name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
