### PR TITLE
Avoid creating multiple tasks for config entry init

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -7,6 +7,7 @@ aiohttp-zlib-ng==0.3.1
 aiohttp==3.9.3
 aiohttp_cors==0.7.0
 astral==2.2
+async-interrupt==1.1.1
 async-upnp-client==0.38.2
 atomicwrites-homeassistant==1.4.1
 attrs==23.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies    = [
     "aiohttp-fast-url-dispatcher==0.3.0",
     "aiohttp-zlib-ng==0.3.1",
     "astral==2.2",
+    "async-interrupt==1.1.1",
     "attrs==23.2.0",
     "atomicwrites-homeassistant==1.4.1",
     "awesomeversion==24.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ aiohttp_cors==0.7.0
 aiohttp-fast-url-dispatcher==0.3.0
 aiohttp-zlib-ng==0.3.1
 astral==2.2
+async-interrupt==1.1.1
 attrs==23.2.0
 atomicwrites-homeassistant==1.4.1
 awesomeversion==24.2.0


### PR DESCRIPTION
Races to fix before this can move forward:

- [x] https://github.com/home-assistant/core/pull/110911
- [x] https://github.com/home-assistant/core/pull/110913
- [x] https://github.com/home-assistant/core/pull/110914
- [x] https://github.com/home-assistant/core/pull/110915
- [x] https://github.com/home-assistant/core/pull/110916
- [x] https://github.com/home-assistant/core/pull/110917

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I added a new task in #49241 to ensure we could cancel the discovery flow at shutdown.  I added the task before I fully understood the impact of #47683 and how many more discoveries it would create. The discovery flows can exceed all the other idle tasks unless the user has a lot of polling integrations (ie `EntityPlatform._update_entity_states` and `DataUpdateCoordinator._handle_refresh_interval`).  While I've since optimized zeroconf quite a bit to reduce churn, there are so many real world devices with 120s ttls (some of the Spotify devices use 15s) that generate updates that we can't get away from without breaking from the spec.  We also can't get rid of the outer task but at least we can avoid creating 2.

Instead of making a new task we can use the interrupt context manager to cancel the awaited coro when a future resolves with [`async-interrupt`](https://github.com/bdraco/async_interrupt).  [`async-interrupt`](https://github.com/bdraco/async_interrupt) is based on the original design of `async-timeout`. It’s currently used in aioesphomeapi and a few other places.  It was originally built to solve a race problem resulting from task with esphome Bluetooth proxies but no longer used directly after #104644



There will be some test failures as a result because discovery flows will initialize sooner because there is one less task for every flow creation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
