### PR TITLE
Add async_schedule_reload helper to the ConfigEntries manager

### DIFF
--- a/homeassistant/components/flux_led/config_flow.py
+++ b/homeassistant/components/flux_led/config_flow.py
@@ -125,9 +125,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     config_entries.ConfigEntryState.NOT_LOADED,
                 )
             ) or entry.state == config_entries.ConfigEntryState.SETUP_RETRY:
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(entry.entry_id)
-                )
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
             else:
                 async_dispatcher_send(
                     self.hass,

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -125,18 +125,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     if self.hass.config_entries.async_update_entry(
                         entry, unique_id=gateway_din
                     ):
-                        self.hass.async_create_task(
-                            self.hass.config_entries.async_reload(entry.entry_id)
-                        )
+                        self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
             if entry.unique_id == gateway_din:
                 if await self._async_powerwall_is_offline(entry):
                     if self.hass.config_entries.async_update_entry(
                         entry, data={**entry.data, CONF_IP_ADDRESS: self.ip_address}
                     ):
-                        self.hass.async_create_task(
-                            self.hass.config_entries.async_reload(entry.entry_id)
-                        )
+                        self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
         # Still need to abort for ignored entries
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import DiscoveryInfoType
 
@@ -88,14 +88,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         entry_config_dict = entry_data.get(CONF_DEVICE_CONFIG)
         if entry_config_dict == config and entry_data[CONF_HOST] == host:
             return
-        self.hass.config_entries.async_update_entry(
-            entry, data={**entry.data, CONF_DEVICE_CONFIG: config, CONF_HOST: host}
+        self.async_update_reload_and_abort(
+            entry,
+            data={**entry.data, CONF_DEVICE_CONFIG: config, CONF_HOST: host},
+            reason="already_configured",
         )
-        self.hass.async_create_task(
-            self.hass.config_entries.async_reload(entry.entry_id),
-            f"config entry reload {entry.title} {entry.domain} {entry.entry_id}",
-        )
-        raise AbortFlow("already_configured")
 
     async def _async_handle_discovery(
         self, host: str, formatted_mac: str, config: dict | None = None

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -216,9 +216,7 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 # SETUP_RETRY, another load is started,
                 # causing the entry to be loaded twice.
                 LOGGER.debug("Reloading entry: %s", entry.entry_id)
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(entry.entry_id)
-                )
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
             return self.async_abort(reason="config_entry_updated")
 
         # Store discovery.

--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -206,18 +206,12 @@ class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="discovery_ignored")
 
             LOGGER.debug("Updating entry: %s", entry.entry_id)
-            self.hass.config_entries.async_update_entry(
+            return self.async_update_reload_and_abort(
                 entry,
                 unique_id=unique_id,
                 data={**entry.data, CONFIG_ENTRY_UDN: discovery_info.ssdp_udn},
+                reason="config_entry_updated",
             )
-            if entry.state == config_entries.ConfigEntryState.LOADED:
-                # Only reload when entry has state LOADED; when entry has state
-                # SETUP_RETRY, another load is started,
-                # causing the entry to be loaded twice.
-                LOGGER.debug("Reloading entry: %s", entry.entry_id)
-                self.hass.config_entries.async_schedule_reload(entry.entry_id)
-            return self.async_abort(reason="config_entry_updated")
 
         # Store discovery.
         self._add_discovery(discovery_info)

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import CONF_ALWAYS_CONNECTED, CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
@@ -113,13 +113,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 local_name_is_unique(lock_cfg.local_name)
                 and entry.data.get(CONF_LOCAL_NAME) == lock_cfg.local_name
             ):
-                if hass.config_entries.async_update_entry(
-                    entry, data={**entry.data, **new_data}
-                ):
-                    hass.async_create_task(
-                        hass.config_entries.async_reload(entry.entry_id)
-                    )
-                raise AbortFlow(reason="already_configured")
+                self.async_update_reload_and_abort(
+                    entry, data={**entry.data, **new_data}, reason="already_configured"
+                )
 
         self._discovery_info = async_find_existing_service_info(
             hass, local_name, address

--- a/homeassistant/components/yalexs_ble/config_flow.py
+++ b/homeassistant/components/yalexs_ble/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.components.bluetooth import (
 )
 from homeassistant.const import CONF_ADDRESS
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import CONF_ALWAYS_CONNECTED, CONF_KEY, CONF_LOCAL_NAME, CONF_SLOT, DOMAIN
@@ -113,9 +113,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 local_name_is_unique(lock_cfg.local_name)
                 and entry.data.get(CONF_LOCAL_NAME) == lock_cfg.local_name
             ):
-                self.async_update_reload_and_abort(
-                    entry, data={**entry.data, **new_data}, reason="already_configured"
-                )
+                if hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, **new_data}
+                ):
+                    hass.async_create_task(
+                        hass.config_entries.async_reload(entry.entry_id)
+                    )
+                raise AbortFlow(reason="already_configured")
 
         self._discovery_info = async_find_existing_service_info(
             hass, local_name, address

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -102,9 +102,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     ConfigEntryState.LOADED,
                 )
             if reload:
-                self.hass.async_create_task(
-                    self.hass.config_entries.async_reload(entry.entry_id)
-                )
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
             return self.async_abort(reason="already_configured")
         return await self._async_handle_discovery()
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -750,9 +750,7 @@ class OptionsFlowHandler(BaseZwaveJSFlow, config_entries.OptionsFlow):
                 }
             )
 
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
             return self.async_create_entry(title=TITLE, data={})
 
         return self.async_show_form(
@@ -917,9 +915,7 @@ class OptionsFlowHandler(BaseZwaveJSFlow, config_entries.OptionsFlow):
             }
         )
         # Always reload entry since we may have disconnected the client.
-        self.hass.async_create_task(
-            self.hass.config_entries.async_reload(self.config_entry.entry_id)
-        )
+        self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
         return self.async_create_entry(title=TITLE, data={})
 
     async def async_revert_addon_config(self, reason: str) -> FlowResult:
@@ -935,9 +931,7 @@ class OptionsFlowHandler(BaseZwaveJSFlow, config_entries.OptionsFlow):
             )
 
         if self.revert_reason or not self.original_addon_config:
-            self.hass.async_create_task(
-                self.hass.config_entries.async_reload(self.config_entry.entry_id)
-            )
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
             return self.async_abort(reason=reason)
 
         self.revert_reason = reason

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3629,6 +3629,12 @@ async def test_scheduling_reload_cancels_setup_retry(hass: HomeAssistant) -> Non
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
+async def test_scheduling_reload_unknown_entry(hass: HomeAssistant) -> None:
+    """Test scheduling a reload raises with an unknown entry."""
+    with pytest.raises(config_entries.UnknownEntry):
+        hass.config_entries.async_schedule_reload("non-existing")
+
+
 @pytest.mark.parametrize(
     ("matchers", "reason"),
     [

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3602,6 +3602,33 @@ async def test_setup_retrying_during_shutdown(hass: HomeAssistant) -> None:
     entry.async_cancel_retry_setup()
 
 
+async def test_scheduling_reload_cancels_setup_retry(hass: HomeAssistant) -> None:
+    """Test scheduling a reload cancels setup retry."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+
+    mock_setup_entry = AsyncMock(side_effect=ConfigEntryNotReady)
+    mock_integration(hass, MockModule("test", async_setup_entry=mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+    cancel_mock = Mock()
+
+    with patch(
+        "homeassistant.config_entries.async_call_later", return_value=cancel_mock
+    ):
+        await entry.async_setup(hass)
+
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert len(cancel_mock.mock_calls) == 0
+
+    mock_setup_entry.side_effect = None
+    mock_setup_entry.return_value = True
+    hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    assert len(cancel_mock.mock_calls) == 1
+    await hass.async_block_till_done()
+    assert entry.state is config_entries.ConfigEntryState.LOADED
+
+
 @pytest.mark.parametrize(
     ("matchers", "reason"),
     [
@@ -3947,7 +3974,7 @@ async def test_unique_id_update_while_setup_in_progress(
     assert entry.state is config_entries.ConfigEntryState.LOADED
 
 
-async def test_disallow_entry_reload_with_setup_in_progresss(
+async def test_disallow_entry_reload_with_setup_in_progress(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
     """Test we do not allow reload while the config entry is still setting up."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We have cases where the the setup retry kicks in right before a reload happens because the reload is going to run the next iteration of the event loop from a task which causes the reload to fail with `OperationNotAllowed` because the config entry code catches the attempt to setup concurrently. The `async_schedule_reload` call will cancel the setup retry before the `async_reload` task is created to avoid this problem.

I updated a few integrations that were more likely to have this problem. Future PRs will do a more extensive audit

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
