### PR TITLE
Rework how shade updates are processed in powerview

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
     pv_entry: PowerviewEntryData = hass.data[DOMAIN][entry.entry_id]
     coordinator: PowerviewShadeUpdateCoordinator = pv_entry.coordinator
 
-    async def _async_refresh_after_import() -> None:
+    async def _async_initial_refresh() -> None:
         """Force position refresh shortly after adding.
 
         Legacy shades can become out of sync with hub when moved
@@ -88,7 +88,7 @@ async def async_setup_entry(
     # background the fetching of state for initial launch
     entry.async_create_background_task(
         hass,
-        _async_refresh_after_import(),
+        _async_initial_refresh(),
         f"powerview {entry.title} initial shade refresh",
     )
 

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -56,14 +56,38 @@ async def async_setup_entry(
 
     pv_entry: PowerviewEntryData = hass.data[DOMAIN][entry.entry_id]
     coordinator: PowerviewShadeUpdateCoordinator = pv_entry.coordinator
+    cancel_resync: CALLBACK_TYPE | None = None
+
+    async def _async_refresh_after_import(self, *_: Any) -> None:
+        """Force position refresh shortly after adding.
+
+        Legacy shades can become out of sync with hub when moved
+        using physical remotes. This also allows reducing speed
+        of calls to older generation hubs in an effort to
+        prevent hub crashes.
+        """
+
+        for shade in pv_entry.shade_data.values():
+            with suppress(asyncio.TimeoutError):
+                # hold off to avoid spamming the hub
+                async with asyncio.timeout(10):
+                    _LOGGER.debug("Initial refresh of shade: %s", shade.name)
+                    await shade.refresh()
+
+    if cancel_resync is None:
+        cancel_resync = async_call_later(
+            hass, RESYNC_DELAY, _async_refresh_after_import
+        )
+
+    @callback
+    def _async_cancel_resync() -> None:
+        nonlocal cancel_resync
+        if cancel_resync is not None:
+            cancel_resync()
+            cancel_resync = None
 
     entities: list[ShadeEntity] = []
     for shade in pv_entry.shade_data.values():
-        # The shade may be out of sync with the hub
-        # so we force a refresh when we add it if possible
-        with suppress(TimeoutError):
-            async with asyncio.timeout(1):
-                await shade.refresh()
         coordinator.data.update_shade_position(shade.id, shade.current_position)
         room_name = getattr(pv_entry.room_data.get(shade.room_id), ATTR_NAME, "")
         entities.extend(
@@ -73,6 +97,7 @@ async def async_setup_entry(
         )
 
     async_add_entities(entities)
+    entry.async_on_unload(_async_cancel_resync)
 
 
 class PowerViewShadeBase(ShadeEntity, CoverEntity):
@@ -306,7 +331,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
             return
         # suppress timeouts caused by hub nightly reboot
         with suppress(asyncio.TimeoutError):
-            async with asyncio.timeout(5):
+            async with asyncio.timeout(10):
                 await self._shade.refresh()
         _LOGGER.debug("Process update %s: %s", self.name, self._shade.current_position)
         self._async_update_shade_data(self._shade.current_position)

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -323,7 +323,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
             # error if are already have one in flight
             return
         # suppress timeouts caused by hub nightly reboot
-        with suppress(asyncio.TimeoutError):
+        with suppress(TimeoutError):
             async with asyncio.timeout(10):
                 await self._shade.refresh()
         _LOGGER.debug("Process update %s: %s", self.name, self._shade.current_position)

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
     # background the fetching of state for initial launch
     entry.async_create_background_task(
         hass,
-        _async_refresh_after_import(pv_entry),
+        _async_refresh_after_import(),
         "powerview.shade-refresh",
     )
 

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -70,7 +70,7 @@ async def async_setup_entry(
             with suppress(asyncio.TimeoutError):
                 # hold off to avoid spamming the hub
                 async with asyncio.timeout(10):
-                    _LOGGER.warning("Initial refresh of shade: %s", shade.name)
+                    _LOGGER.debug("Initial refresh of shade: %s", shade.name)
                     await shade.refresh()
 
     entities: list[ShadeEntity] = []

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
     pv_entry: PowerviewEntryData = hass.data[DOMAIN][entry.entry_id]
     coordinator: PowerviewShadeUpdateCoordinator = pv_entry.coordinator
 
-    async def _async_refresh_after_import(self, *_: Any) -> None:
+    async def _async_refresh_after_import() -> None:
         """Force position refresh shortly after adding.
 
         Legacy shades can become out of sync with hub when moved

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
     entry.async_create_background_task(
         hass,
         _async_refresh_after_import(),
-        "powerview.shade-refresh",
+        f"powerview {entry.title} initial shade refresh",
     )
 
 

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -67,7 +67,7 @@ async def async_setup_entry(
         """
 
         for shade in pv_entry.shade_data.values():
-            with suppress(asyncio.TimeoutError):
+            with suppress(TimeoutError):
                 # hold off to avoid spamming the hub
                 async with asyncio.timeout(10):
                     _LOGGER.debug("Initial refresh of shade: %s", shade.name)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There has been a long standing issue of hub timeouts caused by excessive polling. This has been raised under two seperate issues at the moment

This rework should allow the hub to better process shade positioning rather than spamming the shade with a timeout. Testing indicates that a shade always takes less than 10 seconds to respond so only one shade will be processed at a time

My hub has not suffered from this issue consistently so end user testing will determine if this is truly fixed.

Additionally, this resolves a long standing bug of ``Setup of cover platform hunterdouglas_powerview is taking over 10 seconds.``
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
https://github.com/home-assistant/core/issues/73900
https://github.com/home-assistant/core/issues/92552
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
