### PR TITLE
Avoid scheduling a task to add each entity when not using update_before_add

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -535,7 +535,7 @@ class EntityPlatform:
                     entity = entities[idx]
                     self.logger.exception(
                         "Error adding entity %s for domain %s with platform %s",
-                        entity,
+                        entity.entity_id,
                         self.domain,
                         self.platform_name,
                         exc_info=result,
@@ -563,7 +563,7 @@ class EntityPlatform:
                         entity = entities[idx]
                         self.logger.exception(
                             "Error adding entity %s for domain %s with platform %s",
-                            entity,
+                            entity.entity_id,
                             self.domain,
                             self.platform_name,
                             exc_info=ex,

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -612,7 +612,7 @@ class EntityPlatform:
         if (
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
-            or not any(entity.should_poll for entity in new_entities)
+            or not any(entity.should_poll for entity in entities)
         ):
             return
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -504,7 +504,7 @@ class EntityPlatform:
             self.hass.loop,
         ).result()
 
-    async def _async_add_and_update_entities_with_timeout(
+    async def _async_add_and_update_entities(
         self, coros: list[Coroutine[Any, Any, None]], timeout: float
     ) -> None:
         """Add entities for a single platform and update them.
@@ -536,7 +536,7 @@ class EntityPlatform:
                 )
                 raise result
 
-    async def _async_add_entities_with_timeout(
+    async def _async_add_entities(
         self, coros: list[Coroutine[Any, Any, None]], timeout: float
     ) -> None:
         """Add entities for a single platform without updating.
@@ -596,9 +596,9 @@ class EntityPlatform:
 
         timeout = max(SLOW_ADD_ENTITY_MAX_WAIT * len(coros), SLOW_ADD_MIN_TIMEOUT)
         if update_before_add:
-            await self._async_add_and_update_entities_with_timeout(coros, timeout)
+            await self._async_add_and_update_entities(coros, timeout)
         else:
-            await self._async_add_entities_with_timeout(coros, timeout)
+            await self._async_add_entities(coros, timeout)
 
         if (
             (self.config_entry and self.config_entry.pref_disable_polling)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -514,7 +514,7 @@ class EntityPlatform:
         loop. This is because the update is likely to yield control to the
         event loop and will finish faster if we run them concurrently.
         """
-        results = None
+        results: list[BaseException | None] | None = None
         try:
             async with self.hass.timeout.async_timeout(timeout, self.domain):
                 results = await asyncio.gather(*coros, return_exceptions=True)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -547,7 +547,7 @@ class EntityPlatform:
                     )
                     raise
             else:
-                # If we aren't updating its unlikely that we will have to yield
+                # If we aren't updating its unlikely that we will not have to yield
                 # control to the event loop so we can await the coros directly
                 # without scheduling them as tasks.
                 for coro in coros:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -535,7 +535,6 @@ class EntityPlatform:
                         self.platform_name,
                         exc_info=result,
                     )
-                    raise result
 
     async def _async_add_entities(
         self, coros: list[Coroutine[Any, Any, None]], timeout: float
@@ -547,14 +546,12 @@ class EntityPlatform:
         to the event loop so we can await the coros directly without
         scheduling them as tasks.
         """
-        last_exception: BaseException | None = None
         try:
             async with self.hass.timeout.async_timeout(timeout, self.domain):
                 for coro in coros:
                     try:
                         await coro
-                    except Exception as ex:  # pylint: disable=broad-except
-                        last_exception = ex
+                    except Exception:  # pylint: disable=broad-except
                         self.logger.exception(
                             "Error adding entities for domain %s with platform %s",
                             self.domain,
@@ -567,9 +564,6 @@ class EntityPlatform:
                 self.platform_name,
                 timeout,
             )
-
-        if last_exception:
-            raise last_exception
 
     async def async_add_entities(
         self, new_entities: Iterable[Entity], update_before_add: bool = False

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -603,7 +603,7 @@ class EntityPlatform:
         if (
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
-            or not any(entity.should_poll for entity in self.entities.values())
+            or not any(entity.should_poll for entity in new_entities)
         ):
             return
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -524,7 +524,6 @@ class EntityPlatform:
                 self.platform_name,
                 timeout,
             )
-            raise
 
         for result in results:
             if isinstance(result, Exception):
@@ -566,7 +565,6 @@ class EntityPlatform:
                 self.platform_name,
                 timeout,
             )
-            raise
 
         if last_exception:
             raise last_exception

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -529,17 +529,19 @@ class EntityPlatform:
                 timeout,
             )
 
-        if results:
-            for idx, result in enumerate(results):
-                if isinstance(result, Exception):
-                    entity = entities[idx]
-                    self.logger.exception(
-                        "Error adding entity %s for domain %s with platform %s",
-                        entity.entity_id,
-                        self.domain,
-                        self.platform_name,
-                        exc_info=result,
-                    )
+        if not results:
+            return
+
+        for idx, result in enumerate(results):
+            if isinstance(result, Exception):
+                entity = entities[idx]
+                self.logger.exception(
+                    "Error adding entity %s for domain %s with platform %s",
+                    entity.entity_id,
+                    self.domain,
+                    self.platform_name,
+                    exc_info=result,
+                )
 
     async def _async_add_entities(
         self,

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -543,6 +543,8 @@ class EntityPlatform:
                     self.platform_name,
                     exc_info=result,
                 )
+            elif isinstance(result, BaseException):
+                raise result
 
     async def _async_add_entities(
         self,

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -346,11 +346,11 @@ class EntityPlatform:
 
                 # Block till all entities are done
                 while self._tasks:
-                    pending = [task for task in self._tasks if not task.done()]
+                    # Await all tasks even if they are done
+                    # to ensure exceptions are propagated
+                    pending = self._tasks.copy()
                     self._tasks.clear()
-
-                    if pending:
-                        await asyncio.gather(*pending)
+                    await asyncio.gather(*pending)
 
                 hass.config.components.add(full_name)
                 self._setup_complete = True

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -514,6 +514,7 @@ class EntityPlatform:
         loop. This is because the update is likely to yield control to the
         event loop and will finish faster if we run them concurrently.
         """
+        results = None
         try:
             async with self.hass.timeout.async_timeout(timeout, self.domain):
                 results = await asyncio.gather(*coros, return_exceptions=True)
@@ -525,15 +526,16 @@ class EntityPlatform:
                 timeout,
             )
 
-        for result in results:
-            if isinstance(result, Exception):
-                self.logger.exception(
-                    "Error adding entities for domain %s with platform %s",
-                    self.domain,
-                    self.platform_name,
-                    exc_info=result,
-                )
-                raise result
+        if results:
+            for result in results:
+                if isinstance(result, Exception):
+                    self.logger.exception(
+                        "Error adding entities for domain %s with platform %s",
+                        self.domain,
+                        self.platform_name,
+                        exc_info=result,
+                    )
+                    raise result
 
     async def _async_add_entities(
         self, coros: list[Coroutine[Any, Any, None]], timeout: float

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -1,4 +1,5 @@
 """Test ESPHome binary sensors."""
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock
@@ -21,8 +22,13 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import (
+    EventStateChangedData,
+    async_track_state_change_event,
+)
+from homeassistant.helpers.typing import EventType
 
 from .conftest import MockESPHomeDevice
 
@@ -215,8 +221,19 @@ async def test_entities_removed_after_reload(
     )
 
     assert await hass.config_entries.async_setup(entry.entry_id)
+    on_future = hass.loop.create_future()
+
+    @callback
+    def _async_wait_for_on(event: EventType[EventStateChangedData]) -> None:
+        if event.data["new_state"].state == STATE_ON:
+            on_future.set_result(None)
+
+    async_track_state_change_event(
+        hass, ["binary_sensor.test_mybinary_sensor"], _async_wait_for_on
+    )
     await hass.async_block_till_done()
-    await hass.async_block_till_done()
+    async with asyncio.timeout(2):
+        await on_future
 
     assert mock_device.entry.entry_id == entry_id
     state = hass.states.get("binary_sensor.test_mybinary_sensor")

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -216,6 +216,7 @@ async def test_entities_removed_after_reload(
 
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert mock_device.entry.entry_id == entry_id
     state = hass.states.get("binary_sensor.test_mybinary_sensor")

--- a/tests/components/mqtt_statestream/test_init.py
+++ b/tests/components/mqtt_statestream/test_init.py
@@ -150,6 +150,7 @@ async def test_state_changed_event_sends_message(
     platform = MockEntityPlatform(hass)
     entity = MockEntity(unique_id="1234")
     await platform.async_add_entities([entity])
+    await hass.async_block_till_done()
 
     mqtt_mock.async_publish.assert_called_with(
         "pub/test_domain/test_platform_1234/state", "unknown", 1, True

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1992,7 +1992,7 @@ async def test_non_numeric_validation_raise(
     state = hass.states.get(entity0.entity_id)
     assert state is None
 
-    assert ("Error adding entities for domain sensor with platform test") in caplog.text
+    assert ("for domain sensor with platform test") in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1710,14 +1710,16 @@ async def test_register_entity_service_limited_to_matching_platforms(
     }
 
 
-async def test_invalid_entity_id(hass: HomeAssistant) -> None:
+async def test_invalid_entity_id(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test specifying an invalid entity id."""
     platform = MockEntityPlatform(hass)
     entity = MockEntity(entity_id="invalid_entity_id")
-    with pytest.raises(HomeAssistantError):
-        await platform.async_add_entities([entity])
+    await platform.async_add_entities([entity])
     assert entity.hass is None
     assert entity.platform is None
+    assert "Invalid entity ID: invalid_entity_id" in caplog.text
 
 
 class MockBlockingEntity(MockEntity):

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1710,13 +1710,14 @@ async def test_register_entity_service_limited_to_matching_platforms(
     }
 
 
+@pytest.mark.parametrize("update_before_add", (True, False))
 async def test_invalid_entity_id(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, update_before_add: bool
 ) -> None:
     """Test specifying an invalid entity id."""
     platform = MockEntityPlatform(hass)
     entity = MockEntity(entity_id="invalid_entity_id")
-    await platform.async_add_entities([entity])
+    await platform.async_add_entities([entity], update_before_add=update_before_add)
     assert entity.hass is None
     assert entity.platform is None
     assert "Invalid entity ID: invalid_entity_id" in caplog.text

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1717,10 +1717,16 @@ async def test_invalid_entity_id(
     """Test specifying an invalid entity id."""
     platform = MockEntityPlatform(hass)
     entity = MockEntity(entity_id="invalid_entity_id")
-    await platform.async_add_entities([entity], update_before_add=update_before_add)
+    entity2 = MockEntity(entity_id="valid.entity_id")
+    await platform.async_add_entities(
+        [entity, entity2], update_before_add=update_before_add
+    )
     assert entity.hass is None
     assert entity.platform is None
     assert "Invalid entity ID: invalid_entity_id" in caplog.text
+    # Ensure the valid entity was still added
+    assert entity2.hass is not None
+    assert entity2.platform is not None
 
 
 class MockBlockingEntity(MockEntity):


### PR DESCRIPTION
needs:
- [x] https://github.com/home-assistant/core/pull/111179

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the past `updated_before_add=True` was a much more common case. Its now become the rare case.

Its unlikely that the we will have to yield to the event loop when adding an entity if update_before_add is False since only thing being awaited is `add_to_platform_finish` and the only thing that is actually awaited in there is `async_added_to_hass`. 

There is a risk that if integrations are doing something that takes a long time in `async_added_to_hass` that this will take more wall clock time in that case. For the vast majority of cases it should be much faster (wall clock time and cpu time) since it avoids having to schedule each entity add on the event loop.

Each platform will still create an add entities task with every call to `add_entities` or `async_add_entities`, and this PR does not propose to change that. It only removes the additional tasks being created inside the `(async)_add_entities` tasks.

> [!warning]
> There is a misalignment between tests on what should happen if the entity addition failure raises an exception. The misalignment was hidden because it relied on races to have different behaviors. Most tests expect that if you add multiple entities and one fails, the other entities get added, and the exception gets swallowed. Since gather doesn't cancel tasks when one raises, how everything worked depends on which entity raised the exception, which entity took longer to add, and which order. The core entity tests expect a single exception raised from a single added entity, which will raise an exception. I've reworked both paths to log the exception and continue as most cases expect one broken entity in a collection of entities won't cause all the others to fail or raise. Alternatively, we could still raise the exception, and all the tests could be adjusted. If we go that route, we need to decide if polling should still be scheduled for all the other entities that didn't raise.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
