### PR TITLE
Reduce registry overhead in tests

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -200,9 +200,6 @@ class StoreWithoutWriteLoad(storage.Store):
     async def async_save(self, *args: Any, **kwargs: Any) -> None:
         """Save the data."""
 
-    async def _async_callback_final_write(self, _event: Event) -> None:
-        """Write callback."""
-
 
 @asynccontextmanager
 async def async_test_home_assistant(

--- a/tests/common.py
+++ b/tests/common.py
@@ -194,6 +194,19 @@ def get_test_home_assistant() -> Generator[HomeAssistant, None, None]:
     loop.close()
 
 
+class StoreWithoutWriteLoad(storage.Store):
+    """Fake store that does not write or load. Used for testing."""
+
+    async def async_load(self) -> None:
+        """Load the data."""
+
+    def async_delay_save(self, *args: Any, **kwargs: Any) -> None:
+        """Save the data."""
+
+    async def async_save(self, *args: Any, **kwargs: Any) -> None:
+        """Save the data."""
+
+
 @asynccontextmanager
 async def async_test_home_assistant(
     event_loop: asyncio.AbstractEventLoop | None = None,
@@ -284,9 +297,7 @@ async def async_test_home_assistant(
         hass
     )
     if load_registries:
-        with patch(
-            "homeassistant.helpers.storage.Store.async_load", return_value=None
-        ), patch(
+        with patch("homeassistant.helpers.storage.Store", StoreWithoutWriteLoad), patch(
             "homeassistant.helpers.restore_state.RestoreStateData.async_setup_dump",
             return_value=None,
         ), patch(

--- a/tests/common.py
+++ b/tests/common.py
@@ -292,15 +292,13 @@ async def async_test_home_assistant(
         ), patch(
             "homeassistant.helpers.restore_state.start.async_at_start",
         ):
-            await asyncio.gather(
-                ar.async_load(hass),
-                dr.async_load(hass),
-                er.async_load(hass),
-                fr.async_load(hass),
-                ir.async_load(hass),
-                lr.async_load(hass),
-                rs.async_load(hass),
-            )
+            await ar.async_load(hass)
+            await dr.async_load(hass)
+            await er.async_load(hass)
+            await fr.async_load(hass)
+            await ir.async_load(hass)
+            await lr.async_load(hass)
+            await rs.async_load(hass)
         hass.data[bootstrap.DATA_REGISTRIES_LOADED] = None
 
     hass.set_state(CoreState.running)

--- a/tests/common.py
+++ b/tests/common.py
@@ -197,12 +197,6 @@ def get_test_home_assistant() -> Generator[HomeAssistant, None, None]:
 class StoreWithoutWriteLoad(storage.Store):
     """Fake store that does not write or load. Used for testing."""
 
-    async def async_load(self) -> None:
-        """Load the data."""
-
-    def async_delay_save(self, *args: Any, **kwargs: Any) -> None:
-        """Save the data."""
-
     async def async_save(self, *args: Any, **kwargs: Any) -> None:
         """Save the data."""
 
@@ -297,7 +291,9 @@ async def async_test_home_assistant(
         hass
     )
     if load_registries:
-        with patch("homeassistant.helpers.storage.Store", StoreWithoutWriteLoad), patch(
+        with patch.object(
+            StoreWithoutWriteLoad, "async_load", return_value=None
+        ), patch("homeassistant.helpers.storage.Store", StoreWithoutWriteLoad), patch(
             "homeassistant.helpers.restore_state.RestoreStateData.async_setup_dump",
             return_value=None,
         ), patch(

--- a/tests/common.py
+++ b/tests/common.py
@@ -200,14 +200,20 @@ class StoreWithoutWriteLoad(storage.Store):
     async def async_save(self, *args: Any, **kwargs: Any) -> None:
         """Save the data."""
 
+    async def _async_callback_final_write(self, _event: Event) -> None:
+        """Write callback."""
+
 
 @asynccontextmanager
 async def async_test_home_assistant(
     event_loop: asyncio.AbstractEventLoop | None = None,
     load_registries: bool = True,
+    storage_dir: str | None = None,
 ) -> AsyncGenerator[HomeAssistant, None]:
     """Return a Home Assistant object pointing at test config dir."""
     hass = HomeAssistant(get_test_config_dir())
+    if storage_dir:
+        hass.config.config_dir = storage_dir
     store = auth_store.AuthStore(hass)
     hass.auth = auth.AuthManager(hass, store, {}, {})
     ensure_auth_manager_loaded(hass.auth)

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -560,10 +560,10 @@ async def test_loading_corrupt_core_file(
     tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle unrecoverable corruption in a core file."""
-    async with async_test_home_assistant() as hass:
-        tmp_storage = await hass.async_add_executor_job(tmpdir.mkdir, "temp_storage")
-        hass.config.config_dir = tmp_storage
+    loop = asyncio.get_running_loop()
+    tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
+    async with async_test_home_assistant(storage_dir=tmp_storage) as hass:
         storage_key = "core.anything"
         store = storage.Store(
             hass, MOCK_VERSION_2, storage_key, minor_version=MOCK_MINOR_VERSION_1

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -618,12 +618,13 @@ async def test_loading_corrupt_file_known_domain(
     tmpdir: py.path.local, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we handle unrecoverable corruption for a known domain."""
-    async with async_test_home_assistant() as hass:
+
+    loop = asyncio.get_running_loop()
+    tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
+
+    async with async_test_home_assistant(storage_dir=tmp_storage) as hass:
         hass.config.components.add("testdomain")
         storage_key = "testdomain.testkey"
-
-        tmp_storage = await hass.async_add_executor_job(tmpdir.mkdir, "temp_storage")
-        hass.config.config_dir = tmp_storage
 
         store = storage.Store(
             hass, MOCK_VERSION_2, storage_key, minor_version=MOCK_MINOR_VERSION_1


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid scheduling registry loads as tasks in tests

On production is makes sense to create tasks for these, but in tests we patch out `Store.async_load` which means these will not yield to the event loop so it makes sense to await them instead of creating tasks. 

This reduced my local test run times ~2.5% on average

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
