### PR TITLE
Handle empty name in powerview config flow

### DIFF
--- a/tests/components/hunterdouglas_powerview/const.py
+++ b/tests/components/hunterdouglas_powerview/const.py
@@ -53,6 +53,12 @@ DHCP_DISCOVERY_GEN2 = dhcp.DhcpServiceInfo(
     macaddress="aabbccddeeff",
 )
 
+DHCP_DISCOVERY_GEN2_NO_NAME = dhcp.DhcpServiceInfo(
+    hostname="",
+    ip="1.2.3.4",
+    macaddress="aabbccddeeff",
+)
+
 DHCP_DISCOVERY_GEN3 = dhcp.DhcpServiceInfo(
     hostname="Powerview Generation 3",
     ip="1.2.3.4",
@@ -81,6 +87,11 @@ DHCP_DATA = [
         config_entries.SOURCE_DHCP,
         DHCP_DISCOVERY_GEN3,
         3,
+    ),
+    (
+        config_entries.SOURCE_DHCP,
+        DHCP_DISCOVERY_GEN2_NO_NAME,
+        2,
     ),
 ]
 ZEROCONF_DATA = [


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes

```
2024-02-19 13:51:58.128 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved:   File "/Users/bdraco/home-assistant/venv/bin/hass", line 8, in <module>
    sys.exit(main())
  File "/Users/bdraco/home-assistant/homeassistant/__main__.py", line 209, in main
    exit_code = runner.run(runtime_conf)
  File "/Users/bdraco/home-assistant/homeassistant/runner.py", line 188, in run
    return loop.run_until_complete(setup_and_run_hass(runtime_config))
  File "/opt/homebrew/Cellar/python@3.12/3.12.1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 673, in run_until_complete
    self.run_forever()
  File "/opt/homebrew/Cellar/python@3.12/3.12.1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 640, in run_forever
    self._run_once()
  File "/opt/homebrew/Cellar/python@3.12/3.12.1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/base_events.py", line 1965, in _run_once
    handle._run()
  File "/opt/homebrew/Cellar/python@3.12/3.12.1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/events.py", line 84, in _run
    self._context.run(self._callback, *self._args)
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 610, in async_add_entities
    await add_func(coros, entities, timeout)
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 561, in _async_add_entities
    await coro
  File "/Users/bdraco/home-assistant/homeassistant/helpers/entity_platform.py", line 652, in _async_add_entity
    entity.add_to_platform_start(
  File "/Users/bdraco/home-assistant/homeassistant/components/device_tracker/config_entry.py", line 356, in add_to_platform_start
    _async_connected_device_registered(
  File "/Users/bdraco/home-assistant/homeassistant/components/device_tracker/config_entry.py", line 94, in _async_connected_device_registered
    async_dispatcher_send(
  File "/Users/bdraco/home-assistant/homeassistant/helpers/dispatcher.py", line 227, in async_dispatcher_send
    hass.async_run_hass_job(job, *args)
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 701, in async_run_hass_job
    hassjob.target(*args)
  File "/Users/bdraco/home-assistant/homeassistant/util/logging.py", line 133, in _callback_wrapper
    func(*args)
  File "/Users/bdraco/home-assistant/homeassistant/components/dhcp/__init__.py", line 392, in _async_process_device_data
    self.async_process_client(ip_address, hostname, mac_address)
  File "/Users/bdraco/home-assistant/homeassistant/components/dhcp/__init__.py", line 268, in async_process_client
    discovery_flow.async_create_flow(
  File "/Users/bdraco/home-assistant/homeassistant/helpers/discovery_flow.py", line 32, in async_create_flow
    hass.async_create_task(init_coro, f"discovery flow {domain} {context}")
  File "/Users/bdraco/home-assistant/homeassistant/core.py", line 634, in async_create_task
    task = self.loop.create_task(target, name=name)
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 1017, in async_init
    flow, result = await self._async_init(flow_id, handler, context, data)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/config_entries.py", line 1047, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/data_entry_flow.py", line 501, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/components/hunterdouglas_powerview/config_flow.py", line 127, in async_step_dhcp
    return await self.async_step_discovery_confirm()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/bdraco/home-assistant/homeassistant/components/hunterdouglas_powerview/config_flow.py", line 152, in async_step_discovery_confirm
    assert self.discovered_ip and self.discovered_name
AssertionError
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
