### PR TITLE
Allow Shelly CoAP to honour default network adapter

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -7,7 +7,7 @@ from typing import Any, Final
 
 from aioshelly.block_device import BlockDevice, BlockUpdateType
 from aioshelly.common import ConnectionOptions
-from aioshelly.const import RPC_GENERATIONS
+from aioshelly.const import DEFAULT_COAP_PORT, RPC_GENERATIONS
 from aioshelly.exceptions import (
     DeviceConnectionError,
     FirmwareUnsupported,
@@ -37,7 +37,6 @@ from .const import (
     CONF_COAP_PORT,
     CONF_SLEEP_PERIOD,
     DATA_CONFIG_ENTRY,
-    DEFAULT_COAP_PORT,
     DOMAIN,
     FIRMWARE_UNSUPPORTED_ISSUE_ID,
     LOGGER,

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -33,7 +33,6 @@ LOGGER: Logger = getLogger(__package__)
 
 DATA_CONFIG_ENTRY: Final = "config_entry"
 CONF_COAP_PORT: Final = "coap_port"
-DEFAULT_COAP_PORT: Final = 5683
 FIRMWARE_PATTERN: Final = re.compile(r"^(\d{8})")
 
 # max light transition time in milliseconds

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -3,7 +3,7 @@
   "name": "Shelly",
   "codeowners": ["@balloob", "@bieniu", "@thecode", "@chemelli74", "@bdraco"],
   "config_flow": true,
-  "dependencies": ["bluetooth", "http"],
+  "dependencies": ["bluetooth", "http", "network"],
   "documentation": "https://www.home-assistant.io/integrations/shelly",
   "integration_type": "device",
   "iot_class": "local_push",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -243,7 +243,7 @@ async def get_coap_context(hass: HomeAssistant) -> COAP:
     else:
         port = DEFAULT_COAP_PORT
     LOGGER.info("Starting CoAP context with UDP port %s", port)
-    await context.initialize(ipv4, port)
+    await context.initialize(port, ipv4)
 
     @callback
     def shutdown_listener(ev: Event) -> None:

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -237,6 +237,7 @@ async def get_coap_context(hass: HomeAssistant) -> COAP:
                 or address.is_unspecified
             ):
                 ipv4.append(address)
+    LOGGER.debug("Network IPv4 addresses: %s", ipv4)
     if DOMAIN in hass.data:
         port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
     else:

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -51,10 +51,35 @@ async def test_custom_coap_port(
     assert "Starting CoAP context with UDP port 7632" in caplog.text
 
 
-async def test_ip_address(
+async def test_ip_address_with_only_default_interface(
     hass: HomeAssistant, mock_block_device: Mock, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Test more local ip addresses."""
+    """Test more local ip addresses with only the default interface.."""
+    with patch(
+        "homeassistant.components.network.async_only_default_interface_enabled",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.network.async_get_enabled_source_ips",
+        return_value=[IPv4Address("192.168.1.10"), IPv4Address("10.10.10.10")],
+    ), patch(
+        "homeassistant.components.shelly.utils.COAP",
+        autospec=COAP,
+    ) as mock_coap_init:
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"coap_port": 7632}})
+        await hass.async_block_till_done()
+
+        await init_integration(hass, 1)
+        assert "Starting CoAP context with UDP port 7632" in caplog.text
+        # Make sure COAP.initialize is called with an empty list
+        # when async_only_default_interface_enabled is True even if
+        # async_get_enabled_source_ips returns more than one address
+        assert mock_coap_init.mock_calls[1] == call().initialize(7632, [])
+
+
+async def test_ip_address_without_only_default_interface(
+    hass: HomeAssistant, mock_block_device: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test more local ip addresses without only the default interface.."""
     with patch(
         "homeassistant.components.network.async_only_default_interface_enabled",
         return_value=False,

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -1,5 +1,6 @@
 """Test cases for the Shelly component."""
 
+from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, Mock, patch
 
 from aioshelly.exceptions import (
@@ -47,6 +48,24 @@ async def test_custom_coap_port(
 
     await init_integration(hass, 1)
     assert "Starting CoAP context with UDP port 7632" in caplog.text
+
+
+async def test_ip_address(
+    hass: HomeAssistant, mock_block_device: Mock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test more local ip addresses."""
+    with patch(
+        "homeassistant.components.network.async_only_default_interface_enabled",
+        return_value=False,
+    ), patch(
+        "homeassistant.components.network.async_get_enabled_source_ips",
+        return_value=[IPv4Address("192.168.1.10"), IPv4Address("10.10.10.10")],
+    ):
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"coap_port": 7632}})
+        await hass.async_block_till_done()
+
+        await init_integration(hass, 1)
+        assert "Starting CoAP context with UDP port 7632" in caplog.text
 
 
 @pytest.mark.parametrize("gen", [1, 2, 3])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently Shelly integration start listening on "0.0.0.0".
This not always honours the user selected internal network
On top of that, not all users have a default route.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #97817, https://github.com/home-assistant-libs/aioshelly/issues/149
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
