### PR TITLE
Guide users to migrate from Ubiquiti Cloud Accounts to local for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -68,18 +68,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     auth_user = bootstrap.users.get(bootstrap.auth_user_id)
-    if auth_user and auth_user.cloud_account:
-        ir.async_create_issue(
-            hass,
-            DOMAIN,
-            "cloud_user",
-            is_fixable=True,
-            is_persistent=False,
-            learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
-            severity=IssueSeverity.ERROR,
-            translation_key="cloud_user",
-            data={"entry_id": entry.entry_id},
-        )
+    # if auth_user and auth_user.cloud_account:
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "cloud_user",
+        is_fixable=True,
+        is_persistent=False,
+        learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
+        severity=IssueSeverity.ERROR,
+        translation_key="cloud_user",
+        data={"entry_id": entry.entry_id},
+    )
 
     if nvr_info.version < MIN_REQUIRED_PROTECT_V:
         _LOGGER.error(

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -68,18 +68,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from err
 
     auth_user = bootstrap.users.get(bootstrap.auth_user_id)
-    # if auth_user and auth_user.cloud_account:
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        "cloud_user",
-        is_fixable=True,
-        is_persistent=False,
-        learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
-        severity=IssueSeverity.ERROR,
-        translation_key="cloud_user",
-        data={"entry_id": entry.entry_id},
-    )
+    if auth_user and auth_user.cloud_account:
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "cloud_user",
+            is_fixable=True,
+            is_persistent=False,
+            learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
+            severity=IssueSeverity.ERROR,
+            translation_key="cloud_user",
+            data={"entry_id": entry.entry_id},
+        )
 
     if nvr_info.version < MIN_REQUIRED_PROTECT_V:
         _LOGGER.error(

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             DOMAIN,
             "cloud_user",
             is_fixable=True,
-            is_persistent=True,
+            is_persistent=False,
             learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
             severity=IssueSeverity.ERROR,
             translation_key="cloud_user",

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -69,8 +69,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     auth_user = bootstrap.users.get(bootstrap.auth_user_id)
     if auth_user and auth_user.cloud_account:
-        raise ConfigEntryAuthFailed(
-            "Ubiquiti Cloud SSO Accounts are not supported. Use a local user."
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "cloud_user",
+            is_fixable=True,
+            is_persistent=True,
+            learn_more_url="https://www.home-assistant.io/integrations/unifiprotect/#local-user",
+            severity=IssueSeverity.ERROR,
+            translation_key="cloud_user",
+            data={"entry_id": entry.entry_id},
         )
 
     if nvr_info.version < MIN_REQUIRED_PROTECT_V:

--- a/homeassistant/components/unifiprotect/config_flow.py
+++ b/homeassistant/components/unifiprotect/config_flow.py
@@ -256,7 +256,8 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         nvr_data = None
         try:
-            nvr_data = await protect.get_nvr()
+            bootstrap = await protect.get_bootstrap()
+            nvr_data = bootstrap.nvr
         except NotAuthorized as ex:
             _LOGGER.debug(ex)
             errors[CONF_PASSWORD] = "invalid_auth"
@@ -271,6 +272,10 @@ class ProtectFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     MIN_REQUIRED_PROTECT_V,
                 )
                 errors["base"] = "protect_version"
+
+            auth_user = bootstrap.users.get(bootstrap.auth_user_id)
+            if auth_user and auth_user.cloud_account:
+                errors["base"] = "cloud_user"
 
         return nvr_data, errors
 

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -36,10 +36,11 @@ class ProtectRepair(RepairsFlow):
     @callback
     def _async_get_placeholders(self) -> dict[str, str]:
         issue_registry = async_get_issue_registry(self.hass)
-        description_placeholders = None
+        description_placeholders = {}
         if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
             description_placeholders = issue.translation_placeholders or {}
-            description_placeholders["learn_more"] = issue.learn_more_url
+            if issue.learn_more_url:
+                description_placeholders["learn_more"] = issue.learn_more_url
 
         return description_placeholders
 

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -20,7 +20,7 @@ from .utils import async_create_api_client
 _LOGGER = logging.getLogger(__name__)
 
 
-class EAConfirm(RepairsFlow):
+class ProtectRepair(RepairsFlow):
     """Handler for an issue fixing flow."""
 
     _api: ProtectApiClient
@@ -34,13 +34,17 @@ class EAConfirm(RepairsFlow):
         super().__init__()
 
     @callback
-    def _async_get_placeholders(self) -> dict[str, str] | None:
+    def _async_get_placeholders(self) -> dict[str, str]:
         issue_registry = async_get_issue_registry(self.hass)
         description_placeholders = None
         if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
-            description_placeholders = issue.translation_placeholders
+            description_placeholders = issue.translation_placeholders or {}
+            description_placeholders["learn_more"] = issue.learn_more_url
 
         return description_placeholders
+
+class EAConfirm(ProtectRepair):
+    """Handler for an issue fixing flow."""
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
@@ -85,27 +89,8 @@ class EAConfirm(RepairsFlow):
         )
 
 
-class CloudAccount(RepairsFlow):
+class CloudAccount(ProtectRepair):
     """Handler for an issue fixing flow."""
-
-    _api: ProtectApiClient
-    _entry: ConfigEntry
-
-    def __init__(self, api: ProtectApiClient, entry: ConfigEntry) -> None:
-        """Create flow."""
-
-        self._api = api
-        self._entry = entry
-        super().__init__()
-
-    @callback
-    def _async_get_placeholders(self) -> dict[str, str] | None:
-        issue_registry = async_get_issue_registry(self.hass)
-        description_placeholders = None
-        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
-            description_placeholders = issue.translation_placeholders
-
-        return description_placeholders
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -43,6 +43,7 @@ class ProtectRepair(RepairsFlow):
 
         return description_placeholders
 
+
 class EAConfirm(ProtectRepair):
     """Handler for an issue fixing flow."""
 

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -85,6 +85,52 @@ class EAConfirm(RepairsFlow):
         )
 
 
+class CloudAccount(RepairsFlow):
+    """Handler for an issue fixing flow."""
+
+    _api: ProtectApiClient
+    _entry: ConfigEntry
+
+    def __init__(self, api: ProtectApiClient, entry: ConfigEntry) -> None:
+        """Create flow."""
+
+        self._api = api
+        self._entry = entry
+        super().__init__()
+
+    @callback
+    def _async_get_placeholders(self) -> dict[str, str] | None:
+        issue_registry = async_get_issue_registry(self.hass)
+        description_placeholders = None
+        if issue := issue_registry.async_get_issue(self.handler, self.issue_id):
+            description_placeholders = issue.translation_placeholders
+
+        return description_placeholders
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ) -> data_entry_flow.FlowResult:
+        """Handle the first step of a fix flow."""
+
+        if user_input is None:
+            placeholders = self._async_get_placeholders()
+            return self.async_show_form(
+                step_id="confirm",
+                data_schema=vol.Schema({}),
+                description_placeholders=placeholders,
+            )
+
+        self._entry.async_start_reauth(self.hass)
+        return self.async_create_entry(data={})
+
+
 async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
@@ -96,4 +142,9 @@ async def async_create_fix_flow(
         if (entry := hass.config_entries.async_get_entry(entry_id)) is not None:
             api = async_create_api_client(hass, entry)
             return EAConfirm(api, entry)
+    elif data is not None and issue_id == "cloud_user":
+        entry_id = cast(str, data["entry_id"])
+        if (entry := hass.config_entries.async_get_entry(entry_id)) is not None:
+            api = async_create_api_client(hass, entry)
+            return CloudAccount(api, entry)
     return ConfirmRepairFlow()

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -86,7 +86,7 @@
         "step": {
           "confirm": {
             "title": "Ubiquiti Cloud Users are not Supported",
-            "description": "You are using a Ubiquiti Cloud user. These users have never been supported. You need to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible.\n\nStarting on July 22nd 2024, all Ubiquiti Cloud users will be required to use MFA and there is no way to make Ubiquiti's MFA implementation to work with Home Assistant.\n\nConfirming this repair will trigger a re-authentication flow to enter need authentication credentials."
+            "description": "Starting on July 22nd, 2024, Ubiquiti will require all cloud users to enroll in multi-factor authentication (MFA), which is incompatible with Home Assistant.\n\nIt would be best to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible to keep the integration working.\n\nConfirming this repair will trigger a re-authentication flow to enter the needed authentication credentials."
           }
         }
       }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -68,10 +68,6 @@
           "start": {
             "title": "v{version} is an Early Access version",
             "description": "You are using v{version} of UniFi Protect which is an Early Access version. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and it is recommended to go back to a stable release as soon as possible.\n\nBy submitting this form you have either [downgraded UniFi Protect](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) or you agree to run an unsupported version of UniFi Protect."
-          },
-          "confirm": {
-            "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
-            "description": "Are you sure you want to run unsupported versions of UniFi Protect? This may cause your Home Assistant integration to break."
           }
         }
       }
@@ -82,7 +78,14 @@
     },
     "cloud_user": {
       "title": "Ubiquiti Cloud Users are not Supported",
-      "description": "You are using a Ubiquiti Cloud user. These users have never been supported. You need to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible. Starting on July 22nd 2024, all Ubiquiti Cloud users will be required to use MFA and there is no way to make Ubiquiti's MFA implementation to work with Home Assistant."
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Ubiquiti Cloud Users are not Supported",
+            "description": "You are using a Ubiquiti Cloud user. These users have never been supported. You need to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible.\n\nStarting on July 22nd 2024, all Ubiquiti Cloud users will be required to use MFA and there is no way to make Ubiquiti's MFA implementation to work with Home Assistant.\n\nConfirming this repair will trigger a re-authentication flow to enter need authentication credentials."
+          }
+        }
+      }
     }
   },
   "entity": {

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -38,7 +38,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry.",
-      "cloud_user": "Ubiquiti Cloud SSO Accounts are not supported. Please use a Local only user."
+      "cloud_user": "Ubiquiti Cloud users are not Supported. Please use a Local only user."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -86,7 +86,7 @@
         "step": {
           "confirm": {
             "title": "Ubiquiti Cloud Users are not Supported",
-            "description": "Starting on July 22nd, 2024, Ubiquiti will require all cloud users to enroll in multi-factor authentication (MFA), which is incompatible with Home Assistant.\n\nIt would be best to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible to keep the integration working.\n\nConfirming this repair will trigger a re-authentication flow to enter the needed authentication credentials."
+            "description": "Starting on July 22nd, 2024, Ubiquiti will require all cloud users to enroll in multi-factor authentication (MFA), which is incompatible with Home Assistant.\n\nIt would be best to migrate to using a [local user]({learn_more}) as soon as possible to keep the integration working.\n\nConfirming this repair will trigger a re-authentication flow to enter the needed authentication credentials."
           }
         }
       }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -37,7 +37,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry."
+      "protect_version": "Minimum required version is v1.20.0. Please upgrade UniFi Protect and then retry.",
+      "cloud_user": "Ubiquiti Cloud SSO Accounts are not supported. Please use a Local only user."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -79,6 +79,10 @@
     "ea_setup_failed": {
       "title": "Setup error using Early Access version",
       "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}"
+    },
+    "cloud_user": {
+      "title": "Ubiquiti Cloud Users are not Supported",
+      "description": "You are using a Ubiquiti Cloud user. These users have never been supported. You need to migrate to using a [local user](https://www.home-assistant.io/integrations/unifiprotect/#local-user) as soon as possible. Starting on July 22nd 2024, all Ubiquiti Cloud users will be required to use MFA and there is no way to make Ubiquiti's MFA implementation to work with Home Assistant."
     }
   },
   "entity": {

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -69,6 +69,10 @@
             "title": "v{version} is an Early Access version",
             "description": "You are using v{version} of UniFi Protect which is an Early Access version. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and it is recommended to go back to a stable release as soon as possible.\n\nBy submitting this form you have either [downgraded UniFi Protect](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) or you agree to run an unsupported version of UniFi Protect."
           }
+        },
+        "confirm": {
+          "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
+          "description": "Are you sure you want to run unsupported versions of UniFi Protect? This may cause your Home Assistant integration to break."
         }
       }
     },

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -68,11 +68,11 @@
           "start": {
             "title": "v{version} is an Early Access version",
             "description": "You are using v{version} of UniFi Protect which is an Early Access version. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and it is recommended to go back to a stable release as soon as possible.\n\nBy submitting this form you have either [downgraded UniFi Protect](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) or you agree to run an unsupported version of UniFi Protect."
+          },
+          "confirm": {
+            "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
+            "description": "Are you sure you want to run unsupported versions of UniFi Protect? This may cause your Home Assistant integration to break."
           }
-        },
-        "confirm": {
-          "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
-          "description": "Are you sure you want to run unsupported versions of UniFi Protect? This may cause your Home Assistant integration to break."
         }
       }
     },

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -19,6 +19,7 @@ from pyunifiprotect.data import (
     Bootstrap,
     Camera,
     Chime,
+    CloudAccount,
     Doorlock,
     Light,
     Liveview,
@@ -346,3 +347,19 @@ def chime():
 def fixed_now_fixture():
     """Return datetime object that will be consistent throughout test."""
     return dt_util.utcnow()
+
+
+@pytest.fixture(name="cloud_account")
+def cloud_account() -> CloudAccount:
+    """Return UI Cloud Account."""
+
+    return CloudAccount(
+        id="42",
+        first_name="Test",
+        last_name="User",
+        email="test@example.com",
+        user_id="42",
+        name="Test User",
+        location=None,
+        profile_img=None,
+    )

--- a/tests/components/unifiprotect/conftest.py
+++ b/tests/components/unifiprotect/conftest.py
@@ -119,6 +119,7 @@ def mock_ufp_client(bootstrap: Bootstrap):
     client.base_url = "https://127.0.0.1"
     client.connection_host = IPv4Address("127.0.0.1")
     client.get_nvr = AsyncMock(return_value=nvr)
+    client.get_bootstrap = AsyncMock(return_value=bootstrap)
     client.update = AsyncMock(return_value=bootstrap)
     client.async_disconnect_ws = AsyncMock()
     return client

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import aiohttp
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
-from pyunifiprotect.data import NVR, Bootstrap, Light
+from pyunifiprotect.data import NVR, Bootstrap, CloudAccount, Light
 
 from homeassistant.components.unifiprotect.const import (
     CONF_DISABLE_RTSP,
@@ -139,6 +139,37 @@ async def test_setup_too_old(
     await hass.async_block_till_done()
     assert ufp.entry.state == ConfigEntryState.SETUP_ERROR
     assert not ufp.api.update.called
+
+
+async def test_setup_cloud_account(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    cloud_account: CloudAccount,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test setup of unifiprotect entry with cloud account."""
+
+    bootstrap = ufp.api.bootstrap
+    user = bootstrap.users[bootstrap.auth_user_id]
+    user.cloud_account = cloud_account
+    bootstrap.users[bootstrap.auth_user_id] = user
+    ufp.api.get_bootstrap.return_value = bootstrap
+    ws_client = await hass_ws_client(hass)
+
+    await hass.config_entries.async_setup(ufp.entry.entry_id)
+    await hass.async_block_till_done()
+    assert ufp.entry.state == ConfigEntryState.LOADED
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "cloud_user":
+            issue = i
+    assert issue is not None
 
 
 async def test_setup_failed_update(hass: HomeAssistant, ufp: MockUFPFixture) -> None:

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -131,7 +131,9 @@ async def test_setup_too_old(
 ) -> None:
     """Test setup of unifiprotect entry with too old of version of UniFi Protect."""
 
-    ufp.api.get_nvr.return_value = old_nvr
+    old_bootstrap = ufp.api.bootstrap.copy()
+    old_bootstrap.nvr = old_nvr
+    ufp.api.get_bootstrap.return_value = old_bootstrap
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     await hass.async_block_till_done()
@@ -177,7 +179,7 @@ async def test_setup_failed_update_reauth(
 async def test_setup_failed_error(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test setup of unifiprotect entry with generic error."""
 
-    ufp.api.get_nvr = AsyncMock(side_effect=NvrError)
+    ufp.api.get_bootstrap = AsyncMock(side_effect=NvrError)
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     await hass.async_block_till_done()
@@ -188,7 +190,7 @@ async def test_setup_failed_error(hass: HomeAssistant, ufp: MockUFPFixture) -> N
 async def test_setup_failed_auth(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
     """Test setup of unifiprotect entry with unauthorized error."""
 
-    ufp.api.get_nvr = AsyncMock(side_effect=NotAuthorized)
+    ufp.api.get_bootstrap = AsyncMock(side_effect=NotAuthorized)
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     assert ufp.entry.state == ConfigEntryState.SETUP_ERROR

--- a/tests/components/unifiprotect/test_media_source.py
+++ b/tests/components/unifiprotect/test_media_source.py
@@ -216,6 +216,7 @@ async def test_browse_media_root_multiple_consoles(
     api2.api_path = "/api"
     api2.base_url = "https://127.0.0.2"
     api2.connection_host = IPv4Address("127.0.0.2")
+    api2.get_bootstrap = AsyncMock(return_value=bootstrap2)
     api2.get_nvr = AsyncMock(return_value=bootstrap2.nvr)
     api2.update = AsyncMock(return_value=bootstrap2)
     api2.async_disconnect_ws = AsyncMock()

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -55,7 +55,10 @@ async def test_ea_warning_ignore(
     data = await resp.json()
 
     flow_id = data["flow_id"]
-    assert data["description_placeholders"] == {"version": str(version)}
+    assert data["description_placeholders"] == {
+        "learn_more": "https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access",
+        "version": str(version),
+    }
     assert data["step_id"] == "start"
 
     url = RepairsFlowResourceView.url.format(flow_id=flow_id)
@@ -64,7 +67,10 @@ async def test_ea_warning_ignore(
     data = await resp.json()
 
     flow_id = data["flow_id"]
-    assert data["description_placeholders"] == {"version": str(version)}
+    assert data["description_placeholders"] == {
+        "learn_more": "https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access",
+        "version": str(version),
+    }
     assert data["step_id"] == "confirm"
 
     url = RepairsFlowResourceView.url.format(flow_id=flow_id)
@@ -107,7 +113,10 @@ async def test_ea_warning_fix(
     data = await resp.json()
 
     flow_id = data["flow_id"]
-    assert data["description_placeholders"] == {"version": str(version)}
+    assert data["description_placeholders"] == {
+        "learn_more": "https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access",
+        "version": str(version),
+    }
     assert data["step_id"] == "start"
 
     new_nvr = copy(ufp.api.bootstrap.nvr)

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -5,7 +5,7 @@ from copy import copy
 from http import HTTPStatus
 from unittest.mock import Mock
 
-from pyunifiprotect.data import Version
+from pyunifiprotect.data import CloudAccount, Version
 
 from homeassistant.components.repairs.issue_handler import (
     async_process_repairs_platforms,
@@ -15,6 +15,7 @@ from homeassistant.components.repairs.websocket_api import (
     RepairsFlowResourceView,
 )
 from homeassistant.components.unifiprotect.const import DOMAIN
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import HomeAssistant
 
 from .utils import MockUFPFixture, init_entry
@@ -125,3 +126,50 @@ async def test_ea_warning_fix(
     data = await resp.json()
 
     assert data["type"] == "create_entry"
+
+
+async def test_cloud_user_fix(
+    hass: HomeAssistant,
+    ufp: MockUFPFixture,
+    cloud_account: CloudAccount,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test EA warning is created if using prerelease version of Protect."""
+
+    ufp.api.bootstrap.nvr.version = Version("2.2.6")
+    user = ufp.api.bootstrap.users[ufp.api.bootstrap.auth_user_id]
+    user.cloud_account = cloud_account
+    ufp.api.bootstrap.users[ufp.api.bootstrap.auth_user_id] = user
+    await init_entry(hass, ufp, [])
+    await async_process_repairs_platforms(hass)
+    ws_client = await hass_ws_client(hass)
+    client = await hass_client()
+
+    await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    assert len(msg["result"]["issues"]) > 0
+    issue = None
+    for i in msg["result"]["issues"]:
+        if i["issue_id"] == "cloud_user":
+            issue = i
+    assert issue is not None
+
+    url = RepairsFlowIndexView.url
+    resp = await client.post(url, json={"handler": DOMAIN, "issue_id": "cloud_user"})
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data["step_id"] == "confirm"
+
+    url = RepairsFlowResourceView.url.format(flow_id=flow_id)
+    resp = await client.post(url)
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    assert data["type"] == "create_entry"
+    await hass.async_block_till_done()
+    assert any(ufp.entry.async_get_active_flows(hass, {SOURCE_REAUTH}))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Starting on July 22nd, 2024, Ubiquiti will require all cloud users to enroll in multi-factor authentication (MFA). Ubiquiti Cloud SSO accounts can no longer be used for the Protect integration. Affected users will be issued a repair to migrate to a local only account to use to login with the Protect integration as the documentation expects. This PR blocks new config entries and re-auth attempts from using Cloud accounts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
