### PR TITLE
Add label template functions

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1611,16 +1611,18 @@ def label_name(hass: HomeAssistant, lookup_value: str) -> str | None:
     return None
 
 
-def label_areas(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
-    """Return areas for a given label ID or name."""
-    _label_id: str | None
+def _label_id_or_name(hass: HomeAssistant, label_id_or_name: str) -> str | None:
+    """Get the label ID from a label name or ID."""
     # If label_name returns a value, we know the input was an ID, otherwise we
     # assume it's a name, and if it's neither, we return early.
     if label_name(hass, label_id_or_name) is not None:
-        _label_id = label_id_or_name
-    else:
-        _label_id = label_id(hass, label_id_or_name)
-    if _label_id is None:
+        return label_id_or_name
+    return label_id(hass, label_id_or_name)
+
+
+def label_areas(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
+    """Return areas for a given label ID or name."""
+    if (_label_id := _label_id_or_name(hass, label_id_or_name)) is None:
         return []
     area_reg = area_registry.async_get(hass)
     entries = area_registry.async_entries_for_label(area_reg, _label_id)
@@ -1629,14 +1631,7 @@ def label_areas(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
 
 def label_devices(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
     """Return device IDs for a given label ID or name."""
-    _label_id: str | None
-    # If label_name returns a value, we know the input was an ID, otherwise we
-    # assume it's a name, and if it's neither, we return early.
-    if label_name(hass, label_id_or_name) is not None:
-        _label_id = label_id_or_name
-    else:
-        _label_id = label_id(hass, label_id_or_name)
-    if _label_id is None:
+    if (_label_id := _label_id_or_name(hass, label_id_or_name)) is None:
         return []
     dev_reg = device_registry.async_get(hass)
     entries = device_registry.async_entries_for_label(dev_reg, _label_id)
@@ -1645,14 +1640,7 @@ def label_devices(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
 
 def label_entities(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
     """Return entities for a given label ID or name."""
-    _label_id: str | None
-    # If label_name returns a value, we know the input was an ID, otherwise we
-    # assume it's a name, and if it's neither, we return early.
-    if label_name(hass, label_id_or_name) is not None:
-        _label_id = label_id_or_name
-    else:
-        _label_id = label_id(hass, label_id_or_name)
-    if _label_id is None:
+    if (_label_id := _label_id_or_name(hass, label_id_or_name)) is None:
         return []
     ent_reg = entity_registry.async_get(hass)
     entries = entity_registry.async_entries_for_label(ent_reg, _label_id)

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -85,6 +85,7 @@ from . import (
     entity_registry,
     floor_registry as fr,
     issue_registry,
+    label_registry,
     location as loc_helper,
 )
 from .singleton import singleton
@@ -1560,6 +1561,104 @@ def area_devices(hass: HomeAssistant, area_id_or_name: str) -> Iterable[str]:
     return [entry.id for entry in entries]
 
 
+def labels(hass: HomeAssistant, lookup_value: Any = None) -> Iterable[str | None]:
+    """Return all labels, or those from a area ID, device ID, or entity ID."""
+    label_reg = label_registry.async_get(hass)
+    if lookup_value is None:
+        return [label.label_id for label in label_reg.async_list_labels()]
+
+    ent_reg = entity_registry.async_get(hass)
+
+    # Import here, not at top-level to avoid circular import
+    from . import config_validation as cv  # pylint: disable=import-outside-toplevel
+
+    lookup_value = str(lookup_value)
+
+    try:
+        cv.entity_id(lookup_value)
+    except vol.Invalid:
+        pass
+    else:
+        if entity := ent_reg.async_get(lookup_value):
+            return list(entity.labels)
+
+    # Check if this could be a device ID
+    dev_reg = device_registry.async_get(hass)
+    if device := dev_reg.async_get(lookup_value):
+        return list(device.labels)
+
+    # Check if this could be a area ID
+    area_reg = area_registry.async_get(hass)
+    if area := area_reg.async_get_area(lookup_value):
+        return list(area.labels)
+
+    return []
+
+
+def label_id(hass: HomeAssistant, lookup_value: Any) -> str | None:
+    """Get the label ID from a label name."""
+    label_reg = label_registry.async_get(hass)
+    if label := label_reg.async_get_label_by_name(str(lookup_value)):
+        return label.label_id
+    return None
+
+
+def label_name(hass: HomeAssistant, lookup_value: str) -> str | None:
+    """Get the label name from a label ID."""
+    label_reg = label_registry.async_get(hass)
+    if label := label_reg.async_get_label(lookup_value):
+        return label.name
+    return None
+
+
+def label_areas(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
+    """Return areas for a given label ID or name."""
+    _label_id: str | None
+    # If label_name returns a value, we know the input was an ID, otherwise we
+    # assume it's a name, and if it's neither, we return early.
+    if label_name(hass, label_id_or_name) is not None:
+        _label_id = label_id_or_name
+    else:
+        _label_id = label_id(hass, label_id_or_name)
+    if _label_id is None:
+        return []
+    area_reg = area_registry.async_get(hass)
+    entries = area_registry.async_entries_for_label(area_reg, _label_id)
+    return [entry.id for entry in entries]
+
+
+def label_devices(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
+    """Return device IDs for a given label ID or name."""
+    _label_id: str | None
+    # If label_name returns a value, we know the input was an ID, otherwise we
+    # assume it's a name, and if it's neither, we return early.
+    if label_name(hass, label_id_or_name) is not None:
+        _label_id = label_id_or_name
+    else:
+        _label_id = label_id(hass, label_id_or_name)
+    if _label_id is None:
+        return []
+    dev_reg = device_registry.async_get(hass)
+    entries = device_registry.async_entries_for_label(dev_reg, _label_id)
+    return [entry.id for entry in entries]
+
+
+def label_entities(hass: HomeAssistant, label_id_or_name: str) -> Iterable[str]:
+    """Return entities for a given label ID or name."""
+    _label_id: str | None
+    # If label_name returns a value, we know the input was an ID, otherwise we
+    # assume it's a name, and if it's neither, we return early.
+    if label_name(hass, label_id_or_name) is not None:
+        _label_id = label_id_or_name
+    else:
+        _label_id = label_id(hass, label_id_or_name)
+    if _label_id is None:
+        return []
+    ent_reg = entity_registry.async_get(hass)
+    entries = entity_registry.async_entries_for_label(ent_reg, _label_id)
+    return [entry.entity_id for entry in entries]
+
+
 def closest(hass, *args):
     """Find closest entity.
 
@@ -2731,6 +2830,24 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["integration_entities"] = hassfunction(integration_entities)
         self.filters["integration_entities"] = self.globals["integration_entities"]
 
+        self.globals["labels"] = hassfunction(labels)
+        self.filters["labels"] = self.globals["labels"]
+
+        self.globals["label_id"] = hassfunction(label_id)
+        self.filters["label_id"] = self.globals["label_id"]
+
+        self.globals["label_name"] = hassfunction(label_name)
+        self.filters["label_name"] = self.globals["label_name"]
+
+        self.globals["label_areas"] = hassfunction(label_areas)
+        self.filters["label_areas"] = self.globals["label_areas"]
+
+        self.globals["label_devices"] = hassfunction(label_devices)
+        self.filters["label_devices"] = self.globals["label_devices"]
+
+        self.globals["label_entities"] = hassfunction(label_entities)
+        self.filters["label_entities"] = self.globals["label_entities"]
+
         if limited:
             # Only device_entities is available to limited templates, mark other
             # functions and filters as unsupported.
@@ -2764,6 +2881,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "floor_name",
                 "relative_time",
                 "today_at",
+                "label_id",
+                "label_name",
             ]
             hass_filters = [
                 "closest",
@@ -2774,6 +2893,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
                 "floor_id",
                 "floor_name",
                 "has_value",
+                "label_id",
+                "label_name",
             ]
             hass_tests = [
                 "has_value",

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -40,6 +40,7 @@ from homeassistant.helpers import (
     entity_registry as er,
     floor_registry as fr,
     issue_registry as ir,
+    label_registry as lr,
     template,
     translation,
 )
@@ -5308,4 +5309,364 @@ async def test_floor_areas(
 
     info = render_to_info(hass, f"{{{{ '{floor.name}' | floor_areas }}}}")
     assert_result_info(info, [area.id])
+    assert info.rate_limit is None
+
+
+async def test_labels(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test labels function."""
+
+    # Test no labels
+    info = render_to_info(hass, "{{ labels() }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test one label
+    label1 = label_registry.async_create("label1")
+    info = render_to_info(hass, "{{ labels() }}")
+    assert_result_info(info, [label1.label_id])
+    assert info.rate_limit is None
+
+    # Test multiple label
+    label2 = label_registry.async_create("label2")
+    info = render_to_info(hass, "{{ labels() }}")
+    assert_result_info(info, [label1.label_id, label2.label_id])
+    assert info.rate_limit is None
+
+    # Test non-exsting entity ID
+    info = render_to_info(hass, "{{ labels('sensor.fake') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'sensor.fake' | labels }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test non existing device ID (hex value)
+    info = render_to_info(hass, "{{ labels('123abc') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ '123abc' | labels }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Create a device & entity for testing
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=config_entry,
+        device_id=device_entry.id,
+    )
+
+    # Test entity, which has no labels
+    info = render_to_info(hass, f"{{{{ labels('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{entity_entry.entity_id}' | labels }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test device, which has no labels
+    info = render_to_info(hass, f"{{{{ labels('{device_entry.id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{device_entry.id}' | labels }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Add labels to the entity & device
+    device_entry = device_registry.async_update_device(
+        device_entry.id, labels=[label1.label_id]
+    )
+    entity_entry = entity_registry.async_update_entity(
+        entity_entry.entity_id, labels=[label2.label_id]
+    )
+
+    # Test entity, which now has a label
+    info = render_to_info(hass, f"{{{{ '{entity_entry.entity_id}' | labels }}}}")
+    assert_result_info(info, [label2.label_id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ labels('{entity_entry.entity_id}') }}}}")
+    assert_result_info(info, [label2.label_id])
+    assert info.rate_limit is None
+
+    # Test device, which now has a label
+    info = render_to_info(hass, f"{{{{ '{device_entry.id}' | labels }}}}")
+    assert_result_info(info, [label1.label_id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ labels('{device_entry.id}') }}}}")
+    assert_result_info(info, [label1.label_id])
+    assert info.rate_limit is None
+
+    # Create area for testing
+    area = area_registry.async_create("living room")
+
+    # Test area, which has no labels
+    info = render_to_info(hass, f"{{{{ '{area.id}' | labels }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ labels('{area.id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Add label to the area
+    area_registry.async_update(area.id, labels=[label1.label_id, label2.label_id])
+
+    # Test area, which now has labels
+    info = render_to_info(hass, f"{{{{ '{area.id}' | labels }}}}")
+    assert_result_info(info, [label1.label_id, label2.label_id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ labels('{area.id}') }}}}")
+    assert_result_info(info, [label1.label_id, label2.label_id])
+    assert info.rate_limit is None
+
+
+async def test_label_id(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test label_id function."""
+    # Test non existing label name
+    info = render_to_info(hass, "{{ label_id('non-existing label') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'non-existing label' | label_id }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ label_id(42) }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 42 | label_id }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test with an actual label
+    label = label_registry.async_create("existing label")
+    info = render_to_info(hass, "{{ label_id('existing label') }}")
+    assert_result_info(info, label.label_id)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'existing label' | label_id }}")
+    assert_result_info(info, label.label_id)
+    assert info.rate_limit is None
+
+
+async def test_label_name(
+    hass: HomeAssistant,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test label_name function."""
+    # Test non existing label ID
+    info = render_to_info(hass, "{{ label_name('1234567890') }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ '1234567890' | label_name }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ label_name(42) }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 42 | label_name }}")
+    assert_result_info(info, None)
+    assert info.rate_limit is None
+
+    # Test non existing label ID
+    label = label_registry.async_create("choo choo")
+    info = render_to_info(hass, f"{{{{ label_name('{label.label_id}') }}}}")
+    assert_result_info(info, label.name)
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.label_id}' | label_name }}}}")
+    assert_result_info(info, label.name)
+    assert info.rate_limit is None
+
+
+async def test_label_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test label_entities function."""
+
+    # Test non existing device ID
+    info = render_to_info(hass, "{{ label_entities('deadbeef') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'deadbeef' | label_entities }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ label_entities(42) }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 42 | label_entities }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Create a fake config entry with a entity
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    entity_entry = entity_registry.async_get_or_create(
+        "light",
+        "hue",
+        "5678",
+        config_entry=config_entry,
+    )
+
+    # Add a label to the entity
+    label = label_registry.async_create("Romantic Lights")
+    entity_registry.async_update_entity(entity_entry.entity_id, labels={label.label_id})
+
+    # Get entities by label ID
+    info = render_to_info(hass, f"{{{{ label_entities('{label.label_id}') }}}}")
+    assert_result_info(info, ["light.hue_5678"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.label_id}' | label_entities }}}}")
+    assert_result_info(info, ["light.hue_5678"])
+    assert info.rate_limit is None
+
+    # Get entities by label name
+    info = render_to_info(hass, f"{{{{ label_entities('{label.name}') }}}}")
+    assert_result_info(info, ["light.hue_5678"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.name}' | label_entities }}}}")
+    assert_result_info(info, ["light.hue_5678"])
+    assert info.rate_limit is None
+
+
+async def test_label_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    label_registry: ar.AreaRegistry,
+) -> None:
+    """Test label_devices function."""
+
+    # Test non existing device ID
+    info = render_to_info(hass, "{{ label_devices('deadbeef') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'deadbeef' | label_devices }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ label_devices(42) }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 42 | label_devices }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Create a fake config entry with a device
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
+    # Add a label to it
+    label = label_registry.async_create("Romantic Lights")
+    device_registry.async_update_device(device_entry.id, labels=[label.label_id])
+
+    # Get the devices from a label by its ID
+    info = render_to_info(hass, f"{{{{ label_devices('{label.label_id}') }}}}")
+    assert_result_info(info, [device_entry.id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.label_id}' | label_devices }}}}")
+    assert_result_info(info, [device_entry.id])
+    assert info.rate_limit is None
+
+    # Get the devices from a label by its name
+    info = render_to_info(hass, f"{{{{ label_devices('{label.name}') }}}}")
+    assert_result_info(info, [device_entry.id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.name}' | label_devices }}}}")
+    assert_result_info(info, [device_entry.id])
+    assert info.rate_limit is None
+
+
+async def test_label_areas(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test label_areas function."""
+
+    # Test non existing area ID
+    info = render_to_info(hass, "{{ label_areas('deadbeef') }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 'deadbeef' | label_areas }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Test wrong value type
+    info = render_to_info(hass, "{{ label_areas(42) }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, "{{ 42 | label_areas }}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # Create an area with an label
+    label = label_registry.async_create("Upstairs")
+    master_bedroom = area_registry.async_create(
+        "Master Bedroom", labels=[label.label_id]
+    )
+
+    # Get areas by label ID
+    info = render_to_info(hass, f"{{{{ label_areas('{label.label_id}') }}}}")
+    assert_result_info(info, [master_bedroom.id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.label_id}' | label_areas }}}}")
+    assert_result_info(info, [master_bedroom.id])
+    assert info.rate_limit is None
+
+    # Get areas by label name
+    info = render_to_info(hass, f"{{{{ label_areas('{label.name}') }}}}")
+    assert_result_info(info, [master_bedroom.id])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{label.name}' | label_areas }}}}")
+    assert_result_info(info, [master_bedroom.id])
     assert info.rate_limit is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow up of #110821, originally split out of #69996

This PR adds the `labels`, `label_id`, and `label_name` template methods, that are similar to their area counterparts. Additionally, `label_entities`, `label_devices`, `label_areas` are available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
