### PR TITLE
Add mobile_app return_response to service_call webhook

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -491,6 +491,7 @@ ATTR_SECONDS: Final = "seconds"
 
 # Contains domain, service for a SERVICE_CALL event
 ATTR_DOMAIN: Final = "domain"
+ATTR_RETURN_RESPONSE: Final = "return_response"
 ATTR_SERVICE: Final = "service"
 ATTR_SERVICE_DATA: Final = "service_data"
 

--- a/tests/components/mobile_app/const.py
+++ b/tests/components/mobile_app/const.py
@@ -4,6 +4,16 @@ CALL_SERVICE = {
     "data": {"domain": "test", "service": "mobile_app", "service_data": {"foo": "bar"}},
 }
 
+CALL_SERVICE_RESPONSE = {
+    "type": "call_service",
+    "data": {
+        "domain": "test",
+        "service": "mobile_app",
+        "service_data": {"foo": "bar"},
+        "return_response": True,
+    },
+}
+
 FIRE_EVENT = {
     "type": "fire_event",
     "data": {"event_type": "test_event", "event_data": {"hello": "yo world"}},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some services are read-only (e.g., `todo.get_items`). This change adds an optional `request_response` param to the `call_service` webhook to allow mobile apps to use such services.

This is entirely backwards-compatible: a missing `request_response` or `request_response=False` both lead to the old behavior (empty response).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
