### PR TITLE
Fix race in otbr config flow

### DIFF
--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -144,10 +144,6 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
             for current_entry in current_entries:
                 if current_entry.source != SOURCE_HASSIO:
                     continue
-                if current_entry.unique_id != discovery_info.uuid:
-                    self.hass.config_entries.async_update_entry(
-                        current_entry, unique_id=discovery_info.uuid
-                    )
                 current_url = yarl.URL(current_entry.data["url"])
                 if (
                     current_url.host != config["host"]
@@ -156,7 +152,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     continue
                 # Update URL with the new port
                 self.hass.config_entries.async_update_entry(
-                    current_entry, data=config_entry_data
+                    current_entry, data=config_entry_data, unique_id=discovery_info.uuid
                 )
             return self.async_abort(reason="single_instance_allowed")
 

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -146,7 +146,8 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     continue
                 current_url = yarl.URL(current_entry.data["url"])
                 if (
-                    current_url.host != config["host"]
+                    current_entry.unique_id != discovery_info.uuid
+                    or current_url.host != config["host"]
                     or current_url.port == config["port"]
                 ):
                     continue

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -146,7 +146,8 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     continue
                 current_url = yarl.URL(current_entry.data["url"])
                 if (
-                    current_entry.unique_id != discovery_info.uuid
+                    current_entry.unique_id
+                    and (current_entry.unique_id != discovery_info.uuid)
                     or current_url.host != config["host"]
                     or current_url.port == config["port"]
                 ):

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -153,7 +153,7 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     continue
                 # Update URL with the new port
                 self.hass.config_entries.async_update_entry(
-                    current_entry, data=config_entry_data, unique_id=discovery_info.uuid
+                    current_entry, data=config_entry_data
                 )
             return self.async_abort(reason="single_instance_allowed")
 

--- a/homeassistant/components/otbr/config_flow.py
+++ b/homeassistant/components/otbr/config_flow.py
@@ -146,6 +146,9 @@ class OTBRConfigFlow(ConfigFlow, domain=DOMAIN):
                     continue
                 current_url = yarl.URL(current_entry.data["url"])
                 if (
+                    # The first version did not set a unique_id
+                    # so if the entry does not have a unique_id
+                    # we have to assume it's the first version
                     current_entry.unique_id
                     and (current_entry.unique_id != discovery_info.uuid)
                     or current_url.host != config["host"]

--- a/tests/components/otbr/test_config_flow.py
+++ b/tests/components/otbr/test_config_flow.py
@@ -368,14 +368,14 @@ async def test_hassio_discovery_flow_2x_addons(
         "homeassistant.components.otbr.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        results = await asyncio.gather(
-            hass.config_entries.flow.async_init(
-                otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
-            ),
-            hass.config_entries.flow.async_init(
-                otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA_2
-            ),
+        result1 = await hass.config_entries.flow.async_init(
+            otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA
         )
+        result2 = await hass.config_entries.flow.async_init(
+            otbr.DOMAIN, context={"source": "hassio"}, data=HASSIO_DATA_2
+        )
+
+        results = [result1, result2]
 
     expected_data = {
         "url": f"http://{HASSIO_DATA.config['host']}:{HASSIO_DATA.config['port']}",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #111034 it was revealed that there is a race here because dependent components now setup faster.

We currently change the unique id without changing the host and port which lead to the test failing if it lost the race.  

If the second discovery ran second it would update the `unique_id` to `HASSIO_DATA_2.uuid` but not change the host so the test would fail at `assert config_entry.unique_id == HASSIO_DATA.uuid` because the unique id had already changed but the host/port stayed the same.

I've updated the code to check the unique ids, and only set the unique id and update if the unique id was missing (ie the original version).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
