### PR TITLE
Avoid creating tasks to install dependent requirements

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -226,21 +226,28 @@ class RequirementsManager:
         if not deps_to_check:
             return
 
-        results = await asyncio.gather(
-            *(
-                self.async_get_integration_with_requirements(dep, done)
-                for dep in deps_to_check
-            ),
-            return_exceptions=True,
-        )
-        for result in results:
-            if not isinstance(result, BaseException):
-                continue
-            if not isinstance(result, IntegrationNotFound) or not (
-                not integration.is_built_in
-                and result.domain in integration.after_dependencies
-            ):
-                raise result
+        exceptions: list[Exception] = []
+        # We don't create tasks here since everything waits for the pip lock
+        # anyways and we want to make sure we don't start a bunch of tasks
+        # that will just wait for the lock.
+        for dep in deps_to_check:
+            # We want all the async_get_integration_with_requirements calls to
+            # happen even if one fails. So we catch the exception and store it
+            # to raise the first one after all are done to behave like asyncio
+            # gather.
+            try:
+                await self.async_get_integration_with_requirements(dep, done)
+            except IntegrationNotFound as ex:
+                if (
+                    integration.is_built_in
+                    or ex.domain not in integration.after_dependencies
+                ):
+                    exceptions.append(ex)
+            except Exception as ex:  # pylint: disable=broad-except
+                exceptions.insert(0, ex)
+
+        if exceptions:
+            raise exceptions[0]
 
     async def async_process_requirements(
         self, name: str, requirements: list[str]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we create tasks to install each dependent requirement, but since they all wait on the shared pip lock, we should await them in sequence to avoid the task overhead.

https://github.com/home-assistant/core/blob/a542b369973e5f51fae6da56b2a5ee4ae2995c57/homeassistant/requirements.py#L269

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
