### PR TITLE
Bump georss-qld-bushfire-alert-client to 0.7

### DIFF
--- a/homeassistant/components/qld_bushfire/manifest.json
+++ b/homeassistant/components/qld_bushfire/manifest.json
@@ -6,5 +6,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["georss_qld_bushfire_alert_client"],
-  "requirements": ["georss-qld-bushfire-alert-client==0.5"]
+  "requirements": ["georss-qld-bushfire-alert-client==0.7"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -923,7 +923,7 @@ georss-generic-client==0.8
 georss-ign-sismologia-client==0.8
 
 # homeassistant.components.qld_bushfire
-georss-qld-bushfire-alert-client==0.5
+georss-qld-bushfire-alert-client==0.7
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -749,7 +749,7 @@ georss-generic-client==0.8
 georss-ign-sismologia-client==0.8
 
 # homeassistant.components.qld_bushfire
-georss-qld-bushfire-alert-client==0.5
+georss-qld-bushfire-alert-client==0.7
 
 # homeassistant.components.dlna_dmr
 # homeassistant.components.kef

--- a/tests/components/qld_bushfire/test_geo_location.py
+++ b/tests/components/qld_bushfire/test_geo_location.py
@@ -3,6 +3,7 @@ import datetime
 from unittest.mock import MagicMock, call, patch
 
 from freezegun.api import FrozenDateTimeFactory
+from georss_qld_bushfire_alert_client import QldBushfireAlertFeed
 
 from homeassistant.components import geo_location
 from homeassistant.components.geo_location import ATTR_SOURCE
@@ -93,8 +94,8 @@ async def test_setup(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> Non
     utcnow = dt_util.utcnow()
     freezer.move_to(utcnow)
 
-    with patch("georss_qld_bushfire_alert_client.QldBushfireAlertFeed") as mock_feed:
-        mock_feed.return_value.update.return_value = (
+    with patch("georss_client.feed.GeoRssFeed.update") as mock_feed_update:
+        mock_feed_update.return_value = (
             "OK",
             [mock_entry_1, mock_entry_2, mock_entry_3],
         )
@@ -162,7 +163,7 @@ async def test_setup(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> Non
 
             # Simulate an update - one existing, one new entry,
             # one outdated entry
-            mock_feed.return_value.update.return_value = (
+            mock_feed_update.return_value = (
                 "OK",
                 [mock_entry_1, mock_entry_4, mock_entry_3],
             )
@@ -174,7 +175,7 @@ async def test_setup(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> Non
 
             # Simulate an update - empty data, but successful update,
             # so no changes to entities.
-            mock_feed.return_value.update.return_value = "OK_NO_DATA", None
+            mock_feed_update.return_value = "OK_NO_DATA", None
             async_fire_time_changed(hass, utcnow + 2 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -182,7 +183,7 @@ async def test_setup(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> Non
             assert len(all_states) == 3
 
             # Simulate an update - empty data, removes all entities
-            mock_feed.return_value.update.return_value = "ERROR", None
+            mock_feed_update.return_value = "ERROR", None
             async_fire_time_changed(hass, utcnow + 3 * SCAN_INTERVAL)
             await hass.async_block_till_done()
 
@@ -197,8 +198,11 @@ async def test_setup_with_custom_location(hass: HomeAssistant) -> None:
         "1234", "Title 1", 20.5, (38.1, -3.1), category="Category 1"
     )
 
-    with patch("georss_qld_bushfire_alert_client.QldBushfireAlertFeed") as mock_feed:
-        mock_feed.return_value.update.return_value = "OK", [mock_entry_1]
+    with patch(
+        "georss_qld_bushfire_alert_client.feed_manager.QldBushfireAlertFeed",
+        wraps=QldBushfireAlertFeed,
+    ) as mock_feed, patch("georss_client.feed.GeoRssFeed.update") as mock_feed_update:
+        mock_feed_update.return_value = "OK", [mock_entry_1]
 
         with assert_setup_component(1, geo_location.DOMAIN):
             assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump georss-qld-bushfire-alert-client to 0.7

This version comes with some code quality improvements and Python 3.12 support.
I had to slightly modify the unit tests because after I refactored the file structure of classes in the library, mocking the `update` method of `QldBushfireAlertFeed` did not work anymore, hence I had to fall back to mocking the method where it is actually defined in the super class `GeoRssFeed`.

Changelog: https://github.com/exxamalte/python-georss-qld-bushfire-alert-client/blob/master/CHANGELOG.md
Diff: https://github.com/exxamalte/python-georss-qld-bushfire-alert-client/compare/v0.5...v0.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
