### PR TITLE
Migrate Bluetooth coordinators to use Debouncer async_schedule_call

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -179,12 +179,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown_debouncer)
 
-    async def _async_call_debouncer(now: datetime.datetime) -> None:
+    @hass_callback
+    def _async_call_debouncer(now: datetime.datetime) -> None:
         """Call the debouncer at a later time."""
-        await discovery_debouncer.async_call()
+        discovery_debouncer.async_schedule_call()
 
     call_debouncer_job = HassJob(_async_call_debouncer, cancel_on_shutdown=True)
 
+    @hass_callback
     def _async_trigger_discovery() -> None:
         # There are so many bluetooth adapter models that
         # we check the bus whenever a usb device is plugged in
@@ -193,7 +195,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         # actually supported unless we ask DBus if its now
         # present.
         _LOGGER.debug("Triggering bluetooth usb discovery")
-        hass.async_create_task(discovery_debouncer.async_call())
+        discovery_debouncer.async_schedule_call()
         # Because it can take 120s for the firmware loader
         # fallback to timeout we need to wait that plus
         # the debounce time to ensure we do not miss the

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -179,14 +179,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown_debouncer)
 
-    @hass_callback
-    def _async_call_debouncer(now: datetime.datetime) -> None:
+    async def _async_call_debouncer(now: datetime.datetime) -> None:
         """Call the debouncer at a later time."""
-        discovery_debouncer.async_schedule_call()
+        await discovery_debouncer.async_call()
 
     call_debouncer_job = HassJob(_async_call_debouncer, cancel_on_shutdown=True)
 
-    @hass_callback
     def _async_trigger_discovery() -> None:
         # There are so many bluetooth adapter models that
         # we check the bus whenever a usb device is plugged in
@@ -195,7 +193,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         # actually supported unless we ask DBus if its now
         # present.
         _LOGGER.debug("Triggering bluetooth usb discovery")
-        discovery_debouncer.async_schedule_call()
+        hass.async_create_task(discovery_debouncer.async_call())
         # Because it can take 120s for the firmware loader
         # fallback to timeout we need to wait that plus
         # the debounce time to ensure we do not miss the

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -168,7 +168,7 @@ class ActiveBluetoothDataUpdateCoordinator(
         # We use bluetooth events to trigger the poll so that we scan as soon as
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
-            self.hass.async_create_task(self._debounced_poll.async_call())
+            self._debounced_poll.async_schedule_call()
 
     @callback
     def _async_stop(self) -> None:

--- a/homeassistant/components/bluetooth/active_update_coordinator.py
+++ b/homeassistant/components/bluetooth/active_update_coordinator.py
@@ -168,7 +168,7 @@ class ActiveBluetoothDataUpdateCoordinator(
         # We use bluetooth events to trigger the poll so that we scan as soon as
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
-            self._debounced_poll.async_schedule_call()
+            self.hass.async_create_task(self._debounced_poll.async_call())
 
     @callback
     def _async_stop(self) -> None:

--- a/homeassistant/components/bluetooth/active_update_processor.py
+++ b/homeassistant/components/bluetooth/active_update_processor.py
@@ -157,7 +157,7 @@ class ActiveBluetoothProcessorCoordinator(
         # We use bluetooth events to trigger the poll so that we scan as soon as
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
-            self.hass.async_create_task(self._debounced_poll.async_call())
+            self._debounced_poll.async_schedule_call()
 
     @callback
     def _async_stop(self) -> None:

--- a/homeassistant/components/bluetooth/active_update_processor.py
+++ b/homeassistant/components/bluetooth/active_update_processor.py
@@ -157,7 +157,7 @@ class ActiveBluetoothProcessorCoordinator(
         # We use bluetooth events to trigger the poll so that we scan as soon as
         # possible after a device comes online or back in range, if a poll is due
         if self.needs_poll(service_info):
-            self._debounced_poll.async_schedule_call()
+            self.hass.async_create_task(self._debounced_poll.async_call())
 
     @callback
     def _async_stop(self) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the debouncer does not fire the underlying call no task has to be scheduled


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
