### PR TITLE
Avoid circular import in Storage.async_delay_save

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -108,7 +108,7 @@ class Store(Generic[_T]):
         self.hass = hass
         self._private = private
         self._data: dict[str, Any] | None = None
-        self._unsub_delay_listener: CALLBACK_TYPE | None = None
+        self._unsub_delay_listener: asyncio.TimerHandle | None = None
         self._unsub_final_write_listener: CALLBACK_TYPE | None = None
         self._write_lock = asyncio.Lock()
         self._load_task: asyncio.Future[_T | None] | None = None
@@ -279,9 +279,6 @@ class Store(Generic[_T]):
         delay: float = 0,
     ) -> None:
         """Save data with an optional delay."""
-        # pylint: disable-next=import-outside-toplevel
-        from .event import async_call_later
-
         self._data = {
             "version": self.version,
             "minor_version": self.minor_version,
@@ -295,9 +292,15 @@ class Store(Generic[_T]):
         if self.hass.state is CoreState.stopping:
             return
 
-        self._unsub_delay_listener = async_call_later(
-            self.hass, delay, self._async_callback_delayed_write
+        # We use call_later directly here to avoid a circular import
+        self._unsub_delay_listener = self.hass.loop.call_later(
+            delay, self._async_schedule_callback_delayed_write
         )
+
+    @callback
+    def _async_schedule_callback_delayed_write(self) -> None:
+        """Schedule the delayed write in a task."""
+        self.hass.async_create_task(self._async_callback_delayed_write())
 
     @callback
     def _async_ensure_final_write_listener(self) -> None:
@@ -318,10 +321,10 @@ class Store(Generic[_T]):
     def _async_cleanup_delay_listener(self) -> None:
         """Clean up a delay listener."""
         if self._unsub_delay_listener is not None:
-            self._unsub_delay_listener()
+            self._unsub_delay_listener.cancel()
             self._unsub_delay_listener = None
 
-    async def _async_callback_delayed_write(self, _now):
+    async def _async_callback_delayed_write(self) -> None:
         """Handle a delayed write callback."""
         # catch the case where a call is scheduled and then we stop Home Assistant
         if self.hass.state is CoreState.stopping:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We call Storage.async_delay_save for every entity being added or removed from the registry. The late import took more time than everything else in the function.

I got 4 files deep and many lines later trying to split this up to unwind it before I realized it was simpler to use `loop.call_later` 🤦 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
