### PR TITLE
Add icon translations to Tessie

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -92,7 +92,7 @@ DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
     ),
     TessieBinarySensorEntityDescription(
         key="vehicle_state_is_user_present",
-        device_class=BinarySensorDeviceClass.PRESENCE,
+        device_class=BinarySensorDeviceClass.OCCUPANCY,
     ),
     TessieBinarySensorEntityDescription(
         key="vehicle_state_tpms_soft_warning_fl",

--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -31,22 +31,17 @@ class TessieButtonEntityDescription(ButtonEntityDescription):
 
 
 DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
-    TessieButtonEntityDescription(key="wake", func=lambda: wake, icon="mdi:sleep-off"),
+    TessieButtonEntityDescription(key="wake", func=lambda: wake),
+    TessieButtonEntityDescription(key="flash_lights", func=lambda: flash_lights),
+    TessieButtonEntityDescription(key="honk", func=lambda: honk),
     TessieButtonEntityDescription(
-        key="flash_lights", func=lambda: flash_lights, icon="mdi:flashlight"
-    ),
-    TessieButtonEntityDescription(key="honk", func=lambda: honk, icon="mdi:bullhorn"),
-    TessieButtonEntityDescription(
-        key="trigger_homelink", func=lambda: trigger_homelink, icon="mdi:garage"
+        key="trigger_homelink", func=lambda: trigger_homelink
     ),
     TessieButtonEntityDescription(
         key="enable_keyless_driving",
         func=lambda: enable_keyless_driving,
-        icon="mdi:car-key",
     ),
-    TessieButtonEntityDescription(
-        key="boombox", func=lambda: boombox, icon="mdi:volume-high"
-    ),
+    TessieButtonEntityDescription(key="boombox", func=lambda: boombox),
 )
 
 

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -28,6 +28,12 @@
           "on": "mdi:camera"
         }
       },
+      "vehicle_state_is_user_present": {
+        "default": "mdi:account-outline",
+        "state": {
+          "on": "mdi:account"
+        }
+      },
       "vehicle_state_tpms_soft_warning_fl": {
         "default": "mdi:tire",
         "state": {

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -76,6 +76,23 @@
           "high": "mdi:car-seat-heater"
         }
       }
+    },
+    "switch": {
+      "climate_state_defrost_mode": {
+        "default": "mdi:car-defrost-front"
+      },
+      "vehicle_state_sentry_mode": {
+        "default": "mdi:radiobox-marked"
+      },
+      "climate_state_steering_wheel_heater": {
+        "default": "mdi:steering"
+      },
+      "vehicle_state_valet_mode": {
+        "default": "mdi:bow-tie"
+      },
+      "charge_state_charge_enable_request": {
+        "default": "mdi:ev-plug-ccs2"
+      }
     }
   }
 }

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -9,14 +9,56 @@
       }
     },
     "binary_sensor": {
+      "charge_state_scheduled_charging_pending": {
+        "default": "mdi:battery-clock"
+      },
+      "charge_state_trip_charging": {
+        "default": "mdi:car-clock"
+      },
       "climate_state_auto_seat_climate_left": {
-        "default": "mdi:car-seat-heater"
+        "default": "mdi:car-seat",
+        "state": {
+          "on": "mdi:car-seat-heater"
+        }
       },
       "climate_state_auto_seat_climate_right": {
-        "default": "mdi:car-seat-heater"
+        "default": "mdi:car-seat",
+        "state": {
+          "on": "mdi:car-seat-heater"
+        }
       },
       "climate_state_auto_steering_wheel_heat": {
         "default": "mdi:steering"
+      },
+      "vehicle_state_dashcam_state": {
+        "default": "mdi:camera-off",
+        "state": {
+          "on": "mdi:camera"
+        }
+      },
+      "vehicle_state_tpms_soft_warning_fl": {
+        "default": "mdi:tire",
+        "state": {
+          "on": "mdi:car-tire-alert"
+        }
+      },
+      "vehicle_state_tpms_soft_warning_fr": {
+        "default": "mdi:tire",
+        "state": {
+          "on": "mdi:car-tire-alert"
+        }
+      },
+      "vehicle_state_tpms_soft_warning_rl": {
+        "default": "mdi:tire",
+        "state": {
+          "on": "mdi:car-tire-alert"
+        }
+      },
+      "vehicle_state_tpms_soft_warning_rr": {
+        "default": "mdi:tire",
+        "state": {
+          "on": "mdi:car-tire-alert"
+        }
       }
     },
     "select": {

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -18,6 +18,64 @@
       "climate_state_auto_steering_wheel_heat": {
         "default": "mdi:steering"
       }
+    },
+    "select": {
+      "climate_state_seat_heater_left": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_right": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_rear_left": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_rear_center": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_rear_right": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_third_row_left": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      },
+      "climate_state_seat_heater_third_row_right": {
+        "default": "mdi:car-seat",
+        "state": {
+          "low": "mdi:car-seat-heater",
+          "medium": "mdi:car-seat-heater",
+          "high": "mdi:car-seat-heater"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -1,13 +1,5 @@
 {
   "entity": {
-    "sensor": {
-      "drive_state_shift_state": {
-        "default": "mdi:car-shift-pattern"
-      },
-      "drive_state_active_route_destination": {
-        "default": "mdi:map-marker"
-      }
-    },
     "binary_sensor": {
       "charge_state_scheduled_charging_pending": {
         "default": "mdi:battery-clock"
@@ -151,6 +143,32 @@
           "medium": "mdi:car-seat-heater",
           "high": "mdi:car-seat-heater"
         }
+      }
+    },
+    "sensor": {
+      "charge_state_charging_state": {
+        "default": "mdi:ev-station"
+      },
+      "charge_state_minutes_to_full_charge": {
+        "default": "mdi:clock-end"
+      },
+      "drive_state_shift_state": {
+        "default": "mdi:car-shift-pattern"
+      },
+      "vehicle_state_odometer": {
+        "default": "mdi:counter"
+      },
+      "drive_state_active_route_traffic_minutes_delay": {
+        "default": "mdi:clock-alert-outline"
+      },
+      "drive_state_active_route_miles_to_arrival": {
+        "default": "mdi:map-marker-distance"
+      },
+      "drive_state_active_route_minutes_to_arrival": {
+        "default": "mdi:timer-marker-outline"
+      },
+      "drive_state_active_route_destination": {
+        "default": "mdi:map-marker"
       }
     },
     "switch": {

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -61,6 +61,26 @@
         }
       }
     },
+    "button": {
+      "wake": {
+        "default": "mdi:sleep-off"
+      },
+      "flash_lights": {
+        "default": "mdi:flashlight"
+      },
+      "honk": {
+        "default": "mdi:bullhorn"
+      },
+      "trigger_homelink": {
+        "default": "mdi:garage"
+      },
+      "enable_keyless_driving": {
+        "default": "mdi:car-key"
+      },
+      "boombox": {
+        "default": "mdi:volume-high"
+      }
+    },
     "select": {
       "climate_state_seat_heater_left": {
         "default": "mdi:car-seat",

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -87,6 +87,20 @@
         }
       }
     },
+    "device_tracker": {
+      "location": {
+        "default": "mdi:car",
+        "state": {
+          "not_home": "mdi:car-arrow-right"
+        }
+      },
+      "route": {
+        "default": "mdi:map-marker",
+        "state": {
+          "home": "mdi:home-map-marker"
+        }
+      }
+    },
     "select": {
       "climate_state_seat_heater_left": {
         "default": "mdi:car-seat",

--- a/homeassistant/components/tessie/icons.json
+++ b/homeassistant/components/tessie/icons.json
@@ -81,6 +81,20 @@
         "default": "mdi:volume-high"
       }
     },
+    "climate": {
+      "primary": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "off": "mdi:fan",
+              "on": "mdi:thermometer-auto",
+              "dog": "mdi:paw",
+              "camp": "mdi:tent"
+            }
+          }
+        }
+      }
+    },
     "select": {
       "climate_state_seat_heater_left": {
         "default": "mdi:car-seat",

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -56,7 +56,6 @@ class TessieSensorEntityDescription(SensorEntityDescription):
 DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
     TessieSensorEntityDescription(
         key="charge_state_charging_state",
-        icon="mdi:ev-station",
         options=list(TessieChargeStates.values()),
         device_class=SensorDeviceClass.ENUM,
         value_fn=lambda value: TessieChargeStates[cast(str, value)],

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -45,31 +45,26 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
         key="charge_state_charge_enable_request",
         on_func=lambda: start_charging,
         off_func=lambda: stop_charging,
-        icon="mdi:ev-station",
     ),
     TessieSwitchEntityDescription(
         key="climate_state_defrost_mode",
         on_func=lambda: start_defrost,
         off_func=lambda: stop_defrost,
-        icon="mdi:snowflake",
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_sentry_mode",
         on_func=lambda: enable_sentry_mode,
         off_func=lambda: disable_sentry_mode,
-        icon="mdi:shield-car",
     ),
     TessieSwitchEntityDescription(
         key="vehicle_state_valet_mode",
         on_func=lambda: enable_valet_mode,
         off_func=lambda: disable_valet_mode,
-        icon="mdi:car-key",
     ),
     TessieSwitchEntityDescription(
         key="climate_state_steering_wheel_heater",
         on_func=lambda: start_steering_wheel_heater,
         off_func=lambda: stop_steering_wheel_heater,
-        icon="mdi:steering",
     ),
 )
 

--- a/tests/components/tessie/snapshots/test_binary_sensors.ambr
+++ b/tests/components/tessie/snapshots/test_binary_sensors.ambr
@@ -1165,7 +1165,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': <BinarySensorDeviceClass.PRESENCE: 'presence'>,
+    'original_device_class': <BinarySensorDeviceClass.OCCUPANCY: 'occupancy'>,
     'original_icon': None,
     'original_name': 'User present',
     'platform': 'tessie',
@@ -1179,7 +1179,7 @@
 # name: test_binary_sensors[binary_sensor.test_user_present-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'presence',
+      'device_class': 'occupancy',
       'friendly_name': 'Test User present',
     }),
     'context': <ANY>,

--- a/tests/components/tessie/snapshots/test_button.ambr
+++ b/tests/components/tessie/snapshots/test_button.ambr
@@ -22,7 +22,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:flashlight',
+    'original_icon': None,
     'original_name': 'Flash lights',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -36,7 +36,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Flash lights',
-      'icon': 'mdi:flashlight',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_flash_lights',
@@ -68,7 +67,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:garage',
+    'original_icon': None,
     'original_name': 'Homelink',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -82,7 +81,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Homelink',
-      'icon': 'mdi:garage',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_homelink',
@@ -114,7 +112,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:bullhorn',
+    'original_icon': None,
     'original_name': 'Honk horn',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -128,7 +126,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Honk horn',
-      'icon': 'mdi:bullhorn',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_honk_horn',
@@ -160,7 +157,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:car-key',
+    'original_icon': None,
     'original_name': 'Keyless driving',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -174,7 +171,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Keyless driving',
-      'icon': 'mdi:car-key',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_keyless_driving',
@@ -206,7 +202,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:volume-high',
+    'original_icon': None,
     'original_name': 'Play fart',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -220,7 +216,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Play fart',
-      'icon': 'mdi:volume-high',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_play_fart',
@@ -252,7 +247,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:sleep-off',
+    'original_icon': None,
     'original_name': 'Wake',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -266,7 +261,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Wake',
-      'icon': 'mdi:sleep-off',
     }),
     'context': <ANY>,
     'entity_id': 'button.test_wake',

--- a/tests/components/tessie/snapshots/test_sensor.ambr
+++ b/tests/components/tessie/snapshots/test_sensor.ambr
@@ -505,7 +505,7 @@
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
-    'original_icon': 'mdi:ev-station',
+    'original_icon': None,
     'original_name': 'Charging',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -520,7 +520,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'enum',
       'friendly_name': 'Test Charging',
-      'icon': 'mdi:ev-station',
       'options': list([
         'starting',
         'charging',

--- a/tests/components/tessie/snapshots/test_switch.ambr
+++ b/tests/components/tessie/snapshots/test_switch.ambr
@@ -22,7 +22,7 @@
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
-    'original_icon': 'mdi:ev-station',
+    'original_icon': None,
     'original_name': 'Charge',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -37,7 +37,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Charge',
-      'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_charge',
@@ -69,7 +68,7 @@
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
-    'original_icon': 'mdi:snowflake',
+    'original_icon': None,
     'original_name': 'Defrost mode',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -84,7 +83,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Defrost mode',
-      'icon': 'mdi:snowflake',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_defrost_mode',
@@ -116,7 +114,7 @@
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
-    'original_icon': 'mdi:shield-car',
+    'original_icon': None,
     'original_name': 'Sentry mode',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -131,7 +129,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Sentry mode',
-      'icon': 'mdi:shield-car',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_sentry_mode',
@@ -163,7 +160,7 @@
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
-    'original_icon': 'mdi:steering',
+    'original_icon': None,
     'original_name': 'Steering wheel heater',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -178,7 +175,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Steering wheel heater',
-      'icon': 'mdi:steering',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_steering_wheel_heater',
@@ -210,7 +206,7 @@
     'options': dict({
     }),
     'original_device_class': <SwitchDeviceClass.SWITCH: 'switch'>,
-    'original_icon': 'mdi:car-key',
+    'original_icon': None,
     'original_name': 'Valet mode',
     'platform': 'tessie',
     'previous_unique_id': None,
@@ -225,7 +221,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Valet mode',
-      'icon': 'mdi:car-key',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_valet_mode',
@@ -239,7 +234,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Charge',
-      'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_charge',
@@ -253,7 +247,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'switch',
       'friendly_name': 'Test Charge',
-      'icon': 'mdi:ev-station',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_charge',


### PR DESCRIPTION
## Proposed change

Adds icon translations to Tessie for the following domains : 
- binary_sensor
- sensor
- select
- switch
- button
- climate
- device tracker

I also changed the `vehicle_state_is_user_present` binary sensor device class to `occupancy` before `presence` means `Home/Away` according to the [documentation](https://developers.home-assistant.io/docs/core/entity/binary-sensor) 

Don't hesitate to give feedbacks about icons choice.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
