### PR TITLE
Isolate systemmonitor from psutil shared state

### DIFF
--- a/homeassistant/components/systemmonitor/__init__.py
+++ b/homeassistant/components/systemmonitor/__init__.py
@@ -2,11 +2,15 @@
 
 import logging
 
+import psutil_home_assistant as ha_psutil
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -15,7 +19,8 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up System Monitor from a config entry."""
-
+    psutil_wrapper = await hass.async_add_executor_job(ha_psutil.PsutilWrapper)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = psutil_wrapper
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
@@ -23,6 +28,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload System Monitor config entry."""
+    hass.data[DOMAIN].pop(entry.entry_id)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/systemmonitor/__init__.py
+++ b/homeassistant/components/systemmonitor/__init__.py
@@ -20,7 +20,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up System Monitor from a config entry."""
     psutil_wrapper = await hass.async_add_executor_job(ha_psutil.PsutilWrapper)
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = psutil_wrapper
+    hass.data[DOMAIN] = psutil_wrapper
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
@@ -28,7 +28,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload System Monitor config entry."""
-    hass.data[DOMAIN].pop(entry.entry_id)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 

--- a/homeassistant/components/systemmonitor/binary_sensor.py
+++ b/homeassistant/components/systemmonitor/binary_sensor.py
@@ -10,6 +10,7 @@ import sys
 from typing import Generic, Literal
 
 import psutil
+import psutil_home_assistant as ha_psutil
 
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -94,8 +95,12 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up System Montor binary sensors based on a config entry."""
+    psutil_wrapper: ha_psutil.PsutilWrapper = hass.data[DOMAIN][entry.entry_id]
+
     entities: list[SystemMonitorSensor] = []
-    process_coordinator = SystemMonitorProcessCoordinator(hass, "Process coordinator")
+    process_coordinator = SystemMonitorProcessCoordinator(
+        hass, psutil_wrapper, "Process coordinator"
+    )
     await process_coordinator.async_request_refresh()
 
     for sensor_description in SENSOR_TYPES:

--- a/homeassistant/components/systemmonitor/binary_sensor.py
+++ b/homeassistant/components/systemmonitor/binary_sensor.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from typing import Generic, Literal
 
-import psutil
+from psutil import NoSuchProcess, Process
 import psutil_home_assistant as ha_psutil
 
 from homeassistant.components.binary_sensor import (
@@ -51,7 +51,7 @@ def get_cpu_icon() -> Literal["mdi:cpu-64-bit", "mdi:cpu-32-bit"]:
     return "mdi:cpu-32-bit"
 
 
-def get_process(entity: SystemMonitorSensor[list[psutil.Process]]) -> bool:
+def get_process(entity: SystemMonitorSensor[list[Process]]) -> bool:
     """Return process."""
     state = False
     for proc in entity.coordinator.data:
@@ -60,7 +60,7 @@ def get_process(entity: SystemMonitorSensor[list[psutil.Process]]) -> bool:
             if entity.argument == proc.name():
                 state = True
                 break
-        except psutil.NoSuchProcess as err:
+        except NoSuchProcess as err:
             _LOGGER.warning(
                 "Failed to load process with ID: %s, old name: %s",
                 err.pid,
@@ -78,10 +78,8 @@ class SysMonitorBinarySensorEntityDescription(
     value_fn: Callable[[SystemMonitorSensor[dataT]], bool]
 
 
-SENSOR_TYPES: tuple[
-    SysMonitorBinarySensorEntityDescription[list[psutil.Process]], ...
-] = (
-    SysMonitorBinarySensorEntityDescription[list[psutil.Process]](
+SENSOR_TYPES: tuple[SysMonitorBinarySensorEntityDescription[list[Process]], ...] = (
+    SysMonitorBinarySensorEntityDescription[list[Process]](
         key="binary_process",
         translation_key="process",
         icon=get_cpu_icon(),

--- a/homeassistant/components/systemmonitor/binary_sensor.py
+++ b/homeassistant/components/systemmonitor/binary_sensor.py
@@ -95,7 +95,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up System Montor binary sensors based on a config entry."""
-    psutil_wrapper: ha_psutil.PsutilWrapper = hass.data[DOMAIN][entry.entry_id]
+    psutil_wrapper: ha_psutil.PsutilWrapper = hass.data[DOMAIN]
 
     entities: list[SystemMonitorSensor] = []
     process_coordinator = SystemMonitorProcessCoordinator(

--- a/homeassistant/components/systemmonitor/config_flow.py
+++ b/homeassistant/components/systemmonitor/config_flow.py
@@ -86,7 +86,7 @@ async def validate_import_sensor_setup(
 async def get_sensor_setup_schema(handler: SchemaCommonFlowHandler) -> vol.Schema:
     """Return process sensor setup schema."""
     hass = handler.parent_handler.hass
-    processes = list(await hass.async_add_executor_job(get_all_running_processes))
+    processes = list(await hass.async_add_executor_job(get_all_running_processes, hass))
     return vol.Schema(
         {
             vol.Required(CONF_PROCESS): SelectSelector(

--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -92,7 +92,8 @@ class SystemMonitorDiskCoordinator(MonitorCoordinator[sdiskusage]):
     def update_data(self) -> sdiskusage:
         """Fetch data."""
         try:
-            return self._psutil.disk_usage(self._argument)
+            usage: sdiskusage = self._psutil.disk_usage(self._argument)
+            return usage
         except PermissionError as err:
             raise UpdateFailed(f"No permission to access {self._argument}") from err
         except OSError as err:
@@ -104,7 +105,8 @@ class SystemMonitorSwapCoordinator(MonitorCoordinator[sswap]):
 
     def update_data(self) -> sswap:
         """Fetch data."""
-        return self._psutil.swap_memory()
+        swap: sswap = self._psutil.swap_memory()
+        return swap
 
 
 class SystemMonitorMemoryCoordinator(MonitorCoordinator[VirtualMemory]):
@@ -123,7 +125,8 @@ class SystemMonitorNetIOCoordinator(MonitorCoordinator[dict[str, snetio]]):
 
     def update_data(self) -> dict[str, snetio]:
         """Fetch data."""
-        return self._psutil.net_io_counters(pernic=True)
+        io_counters: dict[str, snetio] = self._psutil.net_io_counters(pernic=True)
+        return io_counters
 
 
 class SystemMonitorNetAddrCoordinator(MonitorCoordinator[dict[str, list[snicaddr]]]):
@@ -131,14 +134,17 @@ class SystemMonitorNetAddrCoordinator(MonitorCoordinator[dict[str, list[snicaddr
 
     def update_data(self) -> dict[str, list[snicaddr]]:
         """Fetch data."""
-        return self._psutil.net_if_addrs()
+        addresses: dict[str, list[snicaddr]] = self._psutil.net_if_addrs()
+        return addresses
 
 
-class SystemMonitorLoadCoordinator(MonitorCoordinator[tuple[float, float, float]]):
+class SystemMonitorLoadCoordinator(
+    MonitorCoordinator[tuple[float, float, float] | None]
+):
     """A System monitor Load Data Update Coordinator."""
 
     def update_data(self) -> tuple[float, float, float] | None:
-        """This coordinator is not async."""
+        """Coordinator is not async."""
 
     async def _async_update_data(self) -> tuple[float, float, float] | None:
         """Fetch data."""
@@ -149,7 +155,7 @@ class SystemMonitorProcessorCoordinator(MonitorCoordinator[float | None]):
     """A System monitor Processor Data Update Coordinator."""
 
     def update_data(self) -> float | None:
-        """This coordinator is not async."""
+        """Coordinator is not async."""
 
     async def _async_update_data(self) -> float | None:
         """Get cpu usage.
@@ -159,7 +165,10 @@ class SystemMonitorProcessorCoordinator(MonitorCoordinator[float | None]):
         in the same thread every time as psutil checks the thread
         tid and compares it against the previous one.
         """
-        cpu_percent = self._psutil.cpu_percent(interval=None)
+        cpu_percent: float = self._psutil.cpu_percent(interval=None)
+        print(type(self._psutil))
+        print(self._psutil.cpu_percent.__dict__)
+        print(self._psutil.cpu_percent().__dict__)
         if cpu_percent > 0.0:
             return cpu_percent
         return None
@@ -188,6 +197,7 @@ class SystemMonitorCPUtempCoordinator(MonitorCoordinator[dict[str, list[shwtemp]
     def update_data(self) -> dict[str, list[shwtemp]]:
         """Fetch data."""
         try:
-            return self._psutil.sensors_temperatures()
+            temps: dict[str, list[shwtemp]] = self._psutil.sensors_temperatures()
+            return temps
         except AttributeError as err:
             raise UpdateFailed("OS does not provide temperature sensors") from err

--- a/homeassistant/components/systemmonitor/coordinator.py
+++ b/homeassistant/components/systemmonitor/coordinator.py
@@ -8,7 +8,7 @@ import logging
 import os
 from typing import NamedTuple, TypeVar
 
-import psutil
+from psutil import Process
 from psutil._common import sdiskusage, shwtemp, snetio, snicaddr, sswap
 import psutil_home_assistant as ha_psutil
 
@@ -41,7 +41,7 @@ dataT = TypeVar(
     | dict[str, list[snicaddr]]
     | dict[str, snetio]
     | float
-    | list[psutil.Process]
+    | list[Process]
     | sswap
     | VirtualMemory
     | tuple[float, float, float]
@@ -166,9 +166,6 @@ class SystemMonitorProcessorCoordinator(MonitorCoordinator[float | None]):
         tid and compares it against the previous one.
         """
         cpu_percent: float = self._psutil.cpu_percent(interval=None)
-        print(type(self._psutil))
-        print(self._psutil.cpu_percent.__dict__)
-        print(self._psutil.cpu_percent().__dict__)
         if cpu_percent > 0.0:
             return cpu_percent
         return None
@@ -182,10 +179,10 @@ class SystemMonitorBootTimeCoordinator(MonitorCoordinator[datetime]):
         return dt_util.utc_from_timestamp(self._psutil.boot_time())
 
 
-class SystemMonitorProcessCoordinator(MonitorCoordinator[list[psutil.Process]]):
+class SystemMonitorProcessCoordinator(MonitorCoordinator[list[Process]]):
     """A System monitor Process Data Update Coordinator."""
 
-    def update_data(self) -> list[psutil.Process]:
+    def update_data(self) -> list[Process]:
         """Fetch data."""
         processes = self._psutil.process_iter()
         return list(processes)

--- a/homeassistant/components/systemmonitor/manifest.json
+++ b/homeassistant/components/systemmonitor/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/systemmonitor",
   "iot_class": "local_push",
   "loggers": ["psutil"],
-  "requirements": ["psutil==5.9.8"]
+  "requirements": ["psutil-home-assistant==0.0.1", "psutil==5.9.8"]
 }

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -494,7 +494,10 @@ async def async_setup_entry(  # noqa: C901
         """Return startup information."""
         disk_arguments = get_all_disk_mounts(hass)
         network_arguments = get_all_network_interfaces(hass)
-        cpu_temperature = read_cpu_temperature(hass)
+        try:
+            cpu_temperature = read_cpu_temperature(hass)
+        except AttributeError:
+            cpu_temperature = 0.0
         return {
             "disk_arguments": disk_arguments,
             "network_arguments": network_arguments,

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -12,7 +12,6 @@ import sys
 import time
 from typing import Any, Generic, Literal
 
-import psutil
 from psutil import NoSuchProcess, Process
 from psutil._common import sdiskusage, shwtemp, snetio, snicaddr, sswap
 import psutil_home_assistant as ha_psutil

--- a/homeassistant/components/systemmonitor/util.py
+++ b/homeassistant/components/systemmonitor/util.py
@@ -3,7 +3,6 @@
 import logging
 import os
 
-import psutil
 from psutil._common import shwtemp
 import psutil_home_assistant as ha_psutil
 

--- a/homeassistant/components/systemmonitor/util.py
+++ b/homeassistant/components/systemmonitor/util.py
@@ -5,18 +5,22 @@ import os
 
 import psutil
 from psutil._common import shwtemp
+import psutil_home_assistant as ha_psutil
 
-from .const import CPU_SENSOR_PREFIXES
+from homeassistant.core import HomeAssistant
+
+from .const import CPU_SENSOR_PREFIXES, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 SKIP_DISK_TYPES = {"proc", "tmpfs", "devtmpfs"}
 
 
-def get_all_disk_mounts() -> set[str]:
+def get_all_disk_mounts(hass: HomeAssistant) -> set[str]:
     """Return all disk mount points on system."""
+    psutil_wrapper: ha_psutil = hass.data[DOMAIN]
     disks: set[str] = set()
-    for part in psutil.disk_partitions(all=True):
+    for part in psutil_wrapper.psutil.disk_partitions(all=True):
         if os.name == "nt":
             if "cdrom" in part.opts or part.fstype == "":
                 # skip cd-rom drives with no disk in it; they may raise
@@ -27,7 +31,7 @@ def get_all_disk_mounts() -> set[str]:
             # Ignore disks which are memory
             continue
         try:
-            usage = psutil.disk_usage(part.mountpoint)
+            usage = psutil_wrapper.psutil.disk_usage(part.mountpoint)
         except PermissionError:
             _LOGGER.debug(
                 "No permission for running user to access %s", part.mountpoint
@@ -44,10 +48,11 @@ def get_all_disk_mounts() -> set[str]:
     return disks
 
 
-def get_all_network_interfaces() -> set[str]:
+def get_all_network_interfaces(hass: HomeAssistant) -> set[str]:
     """Return all network interfaces on system."""
+    psutil_wrapper: ha_psutil = hass.data[DOMAIN]
     interfaces: set[str] = set()
-    for interface, _ in psutil.net_if_addrs().items():
+    for interface, _ in psutil_wrapper.psutil.net_if_addrs().items():
         if interface.startswith("veth"):
             # Don't load docker virtual network interfaces
             continue
@@ -56,20 +61,24 @@ def get_all_network_interfaces() -> set[str]:
     return interfaces
 
 
-def get_all_running_processes() -> set[str]:
+def get_all_running_processes(hass: HomeAssistant) -> set[str]:
     """Return all running processes on system."""
+    psutil_wrapper: ha_psutil = hass.data.get(DOMAIN, ha_psutil.PsutilWrapper())
     processes: set[str] = set()
-    for proc in psutil.process_iter(["name"]):
+    for proc in psutil_wrapper.psutil.process_iter(["name"]):
         if proc.name() not in processes:
             processes.add(proc.name())
     _LOGGER.debug("Running processes: %s", ", ".join(processes))
     return processes
 
 
-def read_cpu_temperature(temps: dict[str, list[shwtemp]] | None = None) -> float | None:
+def read_cpu_temperature(
+    hass: HomeAssistant, temps: dict[str, list[shwtemp]] | None = None
+) -> float | None:
     """Attempt to read CPU / processor temperature."""
-    if not temps:
-        temps = psutil.sensors_temperatures()
+    if temps is None:
+        psutil_wrapper: ha_psutil = hass.data[DOMAIN]
+        temps = psutil_wrapper.psutil.sensors_temperatures()
     entry: shwtemp
 
     _LOGGER.debug("CPU Temperatures: %s", temps)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1573,6 +1573,7 @@ proxmoxer==2.0.1
 
 # homeassistant.components.hardware
 # homeassistant.components.recorder
+# homeassistant.components.systemmonitor
 psutil-home-assistant==0.0.1
 
 # homeassistant.components.systemmonitor

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1229,6 +1229,7 @@ prometheus-client==0.17.1
 
 # homeassistant.components.hardware
 # homeassistant.components.recorder
+# homeassistant.components.systemmonitor
 psutil-home-assistant==0.0.1
 
 # homeassistant.components.systemmonitor

--- a/tests/components/systemmonitor/test_binary_sensor.py
+++ b/tests/components/systemmonitor/test_binary_sensor.py
@@ -24,7 +24,6 @@ async def test_binary_sensor(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -65,7 +64,6 @@ async def test_binary_sensor(
 async def test_binary_sensor_icon(
     hass: HomeAssistant,
     entity_registry_enabled_by_default: None,
-    mock_util: Mock,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/systemmonitor/test_init.py
+++ b/tests/components/systemmonitor/test_init.py
@@ -71,7 +71,6 @@ async def test_migrate_process_sensor_to_binary_sensors(
     hass: HomeAssistant,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -28,7 +28,6 @@ async def test_migrate_process_sensor(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     hass_client: ClientSessionGenerator,
     hass_ws_client: WebSocketGenerator,
     snapshot: SnapshotAssertion,

--- a/tests/components/systemmonitor/test_sensor.py
+++ b/tests/components/systemmonitor/test_sensor.py
@@ -11,6 +11,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.systemmonitor.const import DOMAIN
+from homeassistant.components.systemmonitor.coordinator import VirtualMemory
 from homeassistant.components.systemmonitor.sensor import get_cpu_icon
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -18,7 +19,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from .conftest import MockProcess, svmem
+from .conftest import MockProcess
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -28,7 +29,6 @@ async def test_sensor(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -82,7 +82,6 @@ async def test_process_sensor_not_loaded(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -128,7 +127,6 @@ async def test_sensor_not_loading_veth_networks(
 async def test_sensor_icon(
     hass: HomeAssistant,
     entity_registry_enabled_by_default: None,
-    mock_util: Mock,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -150,7 +148,6 @@ async def test_sensor_yaml(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
 ) -> None:
     """Test the sensor imported from YAML."""
     config = {
@@ -182,7 +179,6 @@ async def test_sensor_yaml_fails_missing_argument(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
 ) -> None:
     """Test the sensor imported from YAML fails on missing mandatory argument."""
     config = {
@@ -203,7 +199,6 @@ async def test_sensor_updating(
     hass: HomeAssistant,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test the sensor."""
@@ -245,18 +240,12 @@ async def test_sensor_updating(
     assert memory_sensor.state == STATE_UNAVAILABLE
 
     mock_psutil.virtual_memory.side_effect = None
-    mock_psutil.virtual_memory.return_value = svmem(
+    mock_psutil.virtual_memory.return_value = VirtualMemory(
         100 * 1024**2,
         25 * 1024**2,
         25.0,
         60 * 1024**2,
         30 * 1024**2,
-        1,
-        1,
-        1,
-        1,
-        1,
-        1,
     )
     freezer.tick(timedelta(minutes=1))
     async_fire_time_changed(hass)
@@ -271,7 +260,6 @@ async def test_sensor_process_fails(
     hass: HomeAssistant,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     freezer: FrozenDateTimeFactory,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -394,7 +382,6 @@ async def test_sensor_network_sensors(
 async def test_missing_cpu_temperature(
     hass: HomeAssistant,
     entity_registry_enabled_by_default: None,
-    mock_util: Mock,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,
@@ -404,7 +391,7 @@ async def test_missing_cpu_temperature(
     mock_psutil.sensors_temperatures.return_value = {
         "not_exist": [shwtemp("not_exist", 50.0, 60.0, 70.0)]
     }
-    mock_util.sensors_temperatures.return_value = {
+    mock_psutil.sensors_temperatures.return_value = {
         "not_exist": [shwtemp("not_exist", 50.0, 60.0, 70.0)]
     }
     mock_config_entry.add_to_hass(hass)
@@ -419,7 +406,6 @@ async def test_missing_cpu_temperature(
 async def test_processor_temperature(
     hass: HomeAssistant,
     entity_registry_enabled_by_default: None,
-    mock_util: Mock,
     mock_psutil: Mock,
     mock_os: Mock,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/systemmonitor/test_util.py
+++ b/tests/components/systemmonitor/test_util.py
@@ -1,6 +1,6 @@
 """Test System Monitor utils."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from psutil._common import sdiskpart
 import pytest
@@ -22,7 +22,6 @@ async def test_disk_setup_failure(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     mock_config_entry: MockConfigEntry,
     side_effect: Exception,
     error_text: str,
@@ -30,18 +29,15 @@ async def test_disk_setup_failure(
 ) -> None:
     """Test the disk failures."""
 
-    with patch(
-        "homeassistant.components.systemmonitor.util.psutil.disk_usage",
-        side_effect=side_effect,
-    ):
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    mock_psutil.disk_usage.side_effect = side_effect
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-        disk_sensor = hass.states.get("sensor.system_monitor_disk_free_media_share")
-        assert disk_sensor is None
+    disk_sensor = hass.states.get("sensor.system_monitor_disk_free_media_share")
+    assert disk_sensor is None
 
-        assert error_text in caplog.text
+    assert error_text in caplog.text
 
 
 async def test_disk_util(
@@ -49,12 +45,11 @@ async def test_disk_util(
     entity_registry_enabled_by_default: None,
     mock_psutil: Mock,
     mock_os: Mock,
-    mock_util: Mock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the disk failures."""
 
-    mock_util.disk_partitions.return_value = [
+    mock_psutil.psutil.disk_partitions.return_value = [
         sdiskpart("test", "/", "ext4", "", 1, 1),  # Should be ok
         sdiskpart("test2", "/media/share", "ext4", "", 1, 1),  # Should be ok
         sdiskpart("test3", "/incorrect", "", "", 1, 1),  # Should be skipped as no type


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `psutil` with `homeassistant_psutil`'s wrapper to isolate from other `psutil` instances.
Also solves the issue with cpu_percent in different threads (run in main thread).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103298
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
