### PR TITLE
Add Wi-Fi to device tracker location SourceType

### DIFF
--- a/homeassistant/components/device_tracker/const.py
+++ b/homeassistant/components/device_tracker/const.py
@@ -31,6 +31,7 @@ class SourceType(StrEnum):
     ROUTER = "router"
     BLUETOOTH = "bluetooth"
     BLUETOOTH_LE = "bluetooth_le"
+    WIFI = "wifi"
 
 
 # SOURCE_TYPE_* below are deprecated as of 2022.9

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -36,7 +36,8 @@
             "bluetooth_le": "Bluetooth LE",
             "bluetooth": "Bluetooth",
             "gps": "GPS",
-            "router": "Router"
+            "router": "Router",
+            "wifi": "Wi-Fi"
           }
         }
       }

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -535,7 +535,10 @@ class Person(collection.CollectionEntity, RestoreEntity):
             if not state or state.state in IGNORE_STATES:
                 continue
 
-            if state.attributes.get(ATTR_SOURCE_TYPE) == SourceType.GPS:
+            if state.attributes.get(ATTR_SOURCE_TYPE) in [
+                SourceType.GPS,
+                SourceType.WIFI,
+            ]:
                 latest_gps = _get_latest(latest_gps, state)
             elif state.state == STATE_HOME:
                 latest_non_gps_home = _get_latest(latest_non_gps_home, state)

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -708,7 +708,9 @@ def test_all(module: ModuleType) -> None:
     help_test_all(module)
 
 
-@pytest.mark.parametrize(("enum"), list(SourceType))
+@pytest.mark.parametrize(
+    ("enum"), filter(lambda type: type != "wifi", list(SourceType))
+)
 @pytest.mark.parametrize(
     "module",
     [device_tracker, device_tracker.const],


### PR DESCRIPTION

## Proposed change

This PR adds Wi-Fi as a possible location source for device tracker/person: some trackers are able to scan surrounding Wi-Fi access points MAC address and resolve a GPS position against databases like [Mozilla Location Services](https://ichnaea.readthedocs.io/en/latest/api/geolocate.html#wifi-access-point-fields) or [Google](https://developers.google.com/maps/documentation/geolocation/requests-geolocation#wifi_access_point_object).


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request (home-assistant.io): https://github.com/home-assistant/home-assistant.io/pull/31546
- Link to documentation pull request (developers.home-assistant): https://github.com/home-assistant/developers.home-assistant/pull/2084

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
