### PR TITLE
Add Home Connect light entity for cooling appliances

### DIFF
--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -237,6 +237,14 @@ class DeviceWithAmbientLight(HomeConnectDevice):
         return {ATTR_DEVICE: self, ATTR_DESC: "AmbientLight", ATTR_AMBIENT: True}
 
 
+class DeviceWithCoolingLight(HomeConnectDevice):
+    """Cooling Device with lighting."""
+
+    def get_coolinglight_entity(self):
+        """Get a dictionary with info about the cooling appliance lighting."""
+        return {ATTR_DEVICE: self, ATTR_DESC: "CoolingLight", ATTR_AMBIENT: False}
+
+
 class DeviceWithRemoteControl(HomeConnectDevice):
     """Device that has Remote Control binary sensor."""
 
@@ -429,31 +437,43 @@ class Hood(
         }
 
 
-class FridgeFreezer(DeviceWithDoor):
+class FridgeFreezer(
+    DeviceWithDoor,
+    DeviceWithCoolingLight,
+):
     """Fridge/Freezer class."""
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
-        return {"binary_sensor": [door_entity]}
+        lights = self.get_coolinglight_entity()
+        return {"binary_sensor": [door_entity], "light": [lights]}
 
 
-class Refrigerator(DeviceWithDoor):
+class Refrigerator(
+    DeviceWithDoor,
+    DeviceWithCoolingLight,
+):
     """Refrigerator class."""
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
-        return {"binary_sensor": [door_entity]}
+        lights = self.get_coolinglight_entity()
+        return {"binary_sensor": [door_entity], "light": [lights]}
 
 
-class Freezer(DeviceWithDoor):
+class Freezer(
+    DeviceWithDoor,
+    DeviceWithCoolingLight,
+):
     """Freezer class."""
 
     def get_entity_info(self):
         """Get a dictionary with infos about the associated entities."""
         door_entity = self.get_door_entity()
-        return {"binary_sensor": [door_entity]}
+        lights = self.get_coolinglight_entity()
+        return {"binary_sensor": [door_entity], "light": [lights]}
 
 
 class Hob(DeviceWithOpState, DeviceWithPrograms, DeviceWithRemoteControl):

--- a/homeassistant/components/home_connect/api.py
+++ b/homeassistant/components/home_connect/api.py
@@ -242,7 +242,7 @@ class DeviceWithCoolingLight(HomeConnectDevice):
 
     def get_coolinglight_entity(self):
         """Get a dictionary with info about the cooling appliance lighting."""
-        return {ATTR_DEVICE: self, ATTR_DESC: "CoolingLight", ATTR_AMBIENT: False}
+        return {ATTR_DEVICE: self, ATTR_DESC: "CoolingLight", ATTR_AMBIENT: None}
 
 
 class DeviceWithRemoteControl(HomeConnectDevice):

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -21,6 +21,15 @@ BSH_OPERATION_STATE_FINISHED = "BSH.Common.EnumType.OperationState.Finished"
 COOKING_LIGHTING = "Cooking.Common.Setting.Lighting"
 COOKING_LIGHTING_BRIGHTNESS = "Cooking.Common.Setting.LightingBrightness"
 
+REFRIGERATION_INTERNAL_LIGHT_POWER = "Refrigeration.Common.Setting.Light.Internal.Power"
+REFRIGERATION_INTERNAL_LIGHT_BRIGHTNESS = (
+    "Refrigeration.Common.Setting.Light.Internal.Brightness"
+)
+REFRIGERATION_EXTERNAL_LIGHT_POWER = "Refrigeration.Common.Setting.Light.External.Power"
+REFRIGERATION_EXTERNAL_LIGHT_BRIGHTNESS = (
+    "Refrigeration.Common.Setting.Light.External.Brightness"
+)
+
 BSH_AMBIENT_LIGHT_ENABLED = "BSH.Common.Setting.AmbientLightEnabled"
 BSH_AMBIENT_LIGHT_BRIGHTNESS = "BSH.Common.Setting.AmbientLightBrightness"
 BSH_AMBIENT_LIGHT_COLOR = "BSH.Common.Setting.AmbientLightColor"

--- a/homeassistant/components/home_connect/light.py
+++ b/homeassistant/components/home_connect/light.py
@@ -54,7 +54,7 @@ class HomeConnectLightEntityDescription(LightEntityDescription):
 
 LIGHTS: tuple[HomeConnectLightEntityDescription, ...] = (
     HomeConnectLightEntityDescription(
-        key="InternalLight",
+        key="Internal Light",
         on_key=REFRIGERATION_INTERNAL_LIGHT_POWER,
         brightness_key=REFRIGERATION_INTERNAL_LIGHT_BRIGHTNESS,
         exists_fn=lambda device: bool(
@@ -62,7 +62,7 @@ LIGHTS: tuple[HomeConnectLightEntityDescription, ...] = (
         ),
     ),
     HomeConnectLightEntityDescription(
-        key="ExternalLight",
+        key="External Light",
         on_key=REFRIGERATION_EXTERNAL_LIGHT_POWER,
         brightness_key=REFRIGERATION_EXTERNAL_LIGHT_BRIGHTNESS,
         exists_fn=lambda device: bool(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds entities for controlling the lights of "Cooling" Appliances. Links to the API documentation: [Power](https://api-docs.home-connect.com/settings/#cooling-light-power), [Brightness](https://api-docs.home-connect.com/settings/#cooling-light-brightness)

A new design implementation is also introduced utilizing the [EntityDescription](https://developers.home-assistant.io/docs/core/entity#entity-description) model.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #91216 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
