### PR TITLE
Remove filter of -1 in Shelly block based sensors

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -78,7 +78,7 @@ def async_setup_block_attribute_entities(
                 continue
 
             # Filter out non-existing sensors and sensors without a value
-            if getattr(block, sensor_id, None) in (-1, None):
+            if getattr(block, sensor_id, None) is None:
                 continue
 
             # Filter and remove entities that according to settings


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Remove filtering of sensors with `-1` at startup to fix missing sensors if their value is -1 when HA start.**

In earlier CoAP versions Shelly defined `-1` as an invalid value and we added a filter not to add a sensor if the current value is `-1`, Later when sensors that send negative values (temperature, power factor, ..) added Shelly changed the value for invalid sensor to `999` to avoid this problem. The logic of filtering a sensor if the current value is `-1` does not fit to our current code which allow adding a sensor and mark it as unavailable. The sensor can be unavailable during runtime anyhow and with the time we addressed sensors that we encountered problems,

**`-1` filtering:**
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/binary_sensor.py#L87
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L84
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L195
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L205
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L280

**`999` filtering:**
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L261
- https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/homeassistant/components/shelly/sensor.py#L271

The problem of filtering sensors with `-1` is that if a sensor that can have a negative value has the value of `-1` at startup we do not create the sensor, this mostly common with energy power factor for solar panels which are near `-1` most of the time.

Removing this filter will create sensors with `-1`. Specific sensors that signal `-1` will show as unavailable if they have a condition to address this value. I have run this change over my prod without any problem. 

Tests are not modified since we already have a test for a sensor without value and no tests for the `-1` value:
https://github.com/home-assistant/core/blob/424080f79f2dd5f9b080805307ccf2db138b6f7d/tests/components/shelly/test_sensor.py#L313

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/104328
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
