### PR TITLE
2024.2.3

### DIFF
--- a/homeassistant/components/airzone/manifest.json
+++ b/homeassistant/components/airzone/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/airzone",
   "iot_class": "local_polling",
   "loggers": ["aioairzone"],
-  "requirements": ["aioairzone==0.7.2"]
+  "requirements": ["aioairzone==0.7.4"]
 }

--- a/homeassistant/components/apprise/notify.py
+++ b/homeassistant/components/apprise/notify.py
@@ -52,9 +52,11 @@ def get_service(
             return None
 
     # Ordered list of URLs
-    if config.get(CONF_URL) and not a_obj.add(config[CONF_URL]):
-        _LOGGER.error("Invalid Apprise URL(s) supplied")
-        return None
+    if urls := config.get(CONF_URL):
+        for entry in urls:
+            if not a_obj.add(entry):
+                _LOGGER.error("One or more specified Apprise URL(s) are invalid")
+                return None
 
     return AppriseNotificationService(a_obj)
 

--- a/homeassistant/components/climate/reproduce_state.py
+++ b/homeassistant/components/climate/reproduce_state.py
@@ -68,13 +68,22 @@ async def _async_reproduce_states(
             [ATTR_TEMPERATURE, ATTR_TARGET_TEMP_HIGH, ATTR_TARGET_TEMP_LOW],
         )
 
-    if ATTR_PRESET_MODE in state.attributes:
+    if (
+        ATTR_PRESET_MODE in state.attributes
+        and state.attributes[ATTR_PRESET_MODE] is not None
+    ):
         await call_service(SERVICE_SET_PRESET_MODE, [ATTR_PRESET_MODE])
 
-    if ATTR_SWING_MODE in state.attributes:
+    if (
+        ATTR_SWING_MODE in state.attributes
+        and state.attributes[ATTR_SWING_MODE] is not None
+    ):
         await call_service(SERVICE_SET_SWING_MODE, [ATTR_SWING_MODE])
 
-    if ATTR_FAN_MODE in state.attributes:
+    if (
+        ATTR_FAN_MODE in state.attributes
+        and state.attributes[ATTR_FAN_MODE] is not None
+    ):
         await call_service(SERVICE_SET_FAN_MODE, [ATTR_FAN_MODE])
 
     if ATTR_HUMIDITY in state.attributes:

--- a/homeassistant/components/deluge/manifest.json
+++ b/homeassistant/components/deluge/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "loggers": ["deluge_client"],
-  "requirements": ["deluge-client==1.10.0"]
+  "requirements": ["deluge-client==1.10.2"]
 }

--- a/homeassistant/components/deluge/manifest.json
+++ b/homeassistant/components/deluge/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "local_polling",
   "loggers": ["deluge_client"],
-  "requirements": ["deluge-client==1.7.1"]
+  "requirements": ["deluge-client==1.10.0"]
 }

--- a/homeassistant/components/ecovacs/manifest.json
+++ b/homeassistant/components/ecovacs/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/ecovacs",
   "iot_class": "cloud_push",
   "loggers": ["sleekxmppfs", "sucks", "deebot_client"],
-  "requirements": ["py-sucks==0.9.9", "deebot-client==5.2.1"]
+  "requirements": ["py-sucks==0.9.9", "deebot-client==5.2.2"]
 }

--- a/homeassistant/components/ecovacs/vacuum.py
+++ b/homeassistant/components/ecovacs/vacuum.py
@@ -95,7 +95,7 @@ class EcovacsLegacyVacuum(StateVacuumEntity):
         This will not change the entity's state. If the error caused the state
         to change, that will come through as a separate on_status event
         """
-        if error == "no_error":
+        if error in ["no_error", sucks.ERROR_CODES["100"]]:
             self.error = None
         else:
             self.error = error

--- a/homeassistant/components/govee_light_local/manifest.json
+++ b/homeassistant/components/govee_light_local/manifest.json
@@ -6,5 +6,5 @@
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/govee_light_local",
   "iot_class": "local_push",
-  "requirements": ["govee-local-api==1.4.1"]
+  "requirements": ["govee-local-api==1.4.4"]
 }

--- a/homeassistant/components/holiday/manifest.json
+++ b/homeassistant/components/holiday/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/holiday",
   "iot_class": "local_polling",
-  "requirements": ["holidays==0.42", "babel==2.13.1"]
+  "requirements": ["holidays==0.43", "babel==2.13.1"]
 }

--- a/homeassistant/components/html5/manifest.json
+++ b/homeassistant/components/html5/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/html5",
   "iot_class": "cloud_push",
   "loggers": ["http_ece", "py_vapid", "pywebpush"],
-  "requirements": ["pywebpush==1.9.2"]
+  "requirements": ["pywebpush==1.14.1"]
 }

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -16,8 +16,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.helpers.config_validation as cv
-import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import slugify
@@ -186,6 +186,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     lutron_client.connect()
     _LOGGER.info("Connected to main repeater at %s", host)
 
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
     entry_data = LutronData(
         client=lutron_client,
         binary_sensors=[],
@@ -201,17 +204,39 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     for area in lutron_client.areas:
         _LOGGER.debug("Working on area %s", area.name)
         for output in area.outputs:
+            platform = None
             _LOGGER.debug("Working on output %s", output.type)
             if output.type == "SYSTEM_SHADE":
                 entry_data.covers.append((area.name, output))
+                platform = Platform.COVER
             elif output.type == "CEILING_FAN_TYPE":
                 entry_data.fans.append((area.name, output))
+                platform = Platform.FAN
                 # Deprecated, should be removed in 2024.8
                 entry_data.lights.append((area.name, output))
             elif output.is_dimmable:
                 entry_data.lights.append((area.name, output))
+                platform = Platform.LIGHT
             else:
                 entry_data.switches.append((area.name, output))
+                platform = Platform.SWITCH
+
+            _async_check_entity_unique_id(
+                hass,
+                entity_registry,
+                platform,
+                output.uuid,
+                output.legacy_uuid,
+                entry_data.client.guid,
+            )
+            _async_check_device_identifiers(
+                hass,
+                device_registry,
+                output.uuid,
+                output.legacy_uuid,
+                entry_data.client.guid,
+            )
+
         for keypad in area.keypads:
             for button in keypad.buttons:
                 # If the button has a function assigned to it, add it as a scene
@@ -228,11 +253,46 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     )
                     entry_data.scenes.append((area.name, keypad, button, led))
 
+                    platform = Platform.SCENE
+                    _async_check_entity_unique_id(
+                        hass,
+                        entity_registry,
+                        platform,
+                        button.uuid,
+                        button.legacy_uuid,
+                        entry_data.client.guid,
+                    )
+                    if led is not None:
+                        platform = Platform.SWITCH
+                        _async_check_entity_unique_id(
+                            hass,
+                            entity_registry,
+                            platform,
+                            led.uuid,
+                            led.legacy_uuid,
+                            entry_data.client.guid,
+                        )
+
                 entry_data.buttons.append(LutronButton(hass, area.name, keypad, button))
         if area.occupancy_group is not None:
             entry_data.binary_sensors.append((area.name, area.occupancy_group))
+            platform = Platform.BINARY_SENSOR
+            _async_check_entity_unique_id(
+                hass,
+                entity_registry,
+                platform,
+                area.occupancy_group.uuid,
+                area.occupancy_group.legacy_uuid,
+                entry_data.client.guid,
+            )
+            _async_check_device_identifiers(
+                hass,
+                device_registry,
+                area.occupancy_group.uuid,
+                area.occupancy_group.legacy_uuid,
+                entry_data.client.guid,
+            )
 
-    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, lutron_client.guid)},
@@ -245,6 +305,52 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True
+
+
+def _async_check_entity_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    platform: str,
+    uuid: str,
+    legacy_uuid: str,
+    controller_guid: str,
+) -> None:
+    """If uuid becomes available update to use it."""
+
+    if not uuid:
+        return
+
+    unique_id = f"{controller_guid}_{legacy_uuid}"
+    entity_id = entity_registry.async_get_entity_id(
+        domain=platform, platform=DOMAIN, unique_id=unique_id
+    )
+
+    if entity_id:
+        new_unique_id = f"{controller_guid}_{uuid}"
+        _LOGGER.debug("Updating entity id from %s to %s", unique_id, new_unique_id)
+        entity_registry.async_update_entity(entity_id, new_unique_id=new_unique_id)
+
+
+def _async_check_device_identifiers(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    uuid: str,
+    legacy_uuid: str,
+    controller_guid: str,
+) -> None:
+    """If uuid becomes available update to use it."""
+
+    if not uuid:
+        return
+
+    unique_id = f"{controller_guid}_{legacy_uuid}"
+    device = device_registry.async_get_device(identifiers={(DOMAIN, unique_id)})
+    if device:
+        new_unique_id = f"{controller_guid}_{uuid}"
+        _LOGGER.debug("Updating device id from %s to %s", unique_id, new_unique_id)
+        device_registry.async_update_device(
+            device.id, new_identifiers={(DOMAIN, new_unique_id)}
+        )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/lutron/entity.py
+++ b/homeassistant/components/lutron/entity.py
@@ -41,11 +41,11 @@ class LutronBaseEntity(Entity):
         self.schedule_update_ha_state()
 
     @property
-    def unique_id(self) -> str | None:
+    def unique_id(self) -> str:
         """Return a unique ID."""
-        # Temporary fix for https://github.com/thecynic/pylutron/issues/70
+
         if self._lutron_device.uuid is None:
-            return None
+            return f"{self._controller.guid}_{self._lutron_device.legacy_uuid}"
         return f"{self._controller.guid}_{self._lutron_device.uuid}"
 
     def update(self) -> None:
@@ -63,7 +63,7 @@ class LutronDevice(LutronBaseEntity):
         """Initialize the device."""
         super().__init__(area_name, lutron_device, controller)
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, lutron_device.uuid)},
+            identifiers={(DOMAIN, self.unique_id)},
             manufacturer="Lutron",
             name=lutron_device.name,
             suggested_area=area_name,

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -150,5 +150,5 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     await store.async_save(savable_state(hass))
 
     if CONF_CLOUDHOOK_URL in entry.data:
-        with suppress(cloud.CloudNotAvailable):
+        with suppress(cloud.CloudNotAvailable, ValueError):
             await cloud.async_delete_cloudhook(hass, entry.data[CONF_WEBHOOK_ID])

--- a/homeassistant/components/motion_blinds/manifest.json
+++ b/homeassistant/components/motion_blinds/manifest.json
@@ -21,5 +21,5 @@
   "documentation": "https://www.home-assistant.io/integrations/motion_blinds",
   "iot_class": "local_push",
   "loggers": ["motionblinds"],
-  "requirements": ["motionblinds==0.6.20"]
+  "requirements": ["motionblinds==0.6.21"]
 }

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -354,9 +354,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._user = self._reauth_entry.data[CONF_USERNAME]
         self._server = self._reauth_entry.data[CONF_HUB]
-        self._api_type = self._reauth_entry.data[CONF_API_TYPE]
+        self._api_type = self._reauth_entry.data.get(CONF_API_TYPE, APIType.CLOUD)
 
-        if self._reauth_entry.data[CONF_API_TYPE] == APIType.LOCAL:
+        if self._api_type == APIType.LOCAL:
             self._host = self._reauth_entry.data[CONF_HOST]
 
         return await self.async_step_user(dict(entry_data))

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -100,10 +100,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         async with asyncio.timeout(host.api.timeout * (RETRY_ATTEMPTS + 2)):
             try:
                 return await host.api.check_new_firmware()
-            except (ReolinkError, asyncio.exceptions.CancelledError) as err:
-                task = asyncio.current_task()
-                if task is not None:
-                    task.uncancel()
+            except ReolinkError as err:
                 if starting:
                     _LOGGER.debug(
                         "Error checking Reolink firmware update at startup "
@@ -133,15 +130,16 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         update_interval=FIRMWARE_UPDATE_INTERVAL,
     )
     # Fetch initial data so we have data when entities subscribe
-    try:
-        # If camera WAN blocked, firmware check fails, do not prevent setup
-        await asyncio.gather(
-            device_coordinator.async_config_entry_first_refresh(),
-            firmware_coordinator.async_config_entry_first_refresh(),
-        )
-    except ConfigEntryNotReady:
+    results = await asyncio.gather(
+        device_coordinator.async_config_entry_first_refresh(),
+        firmware_coordinator.async_config_entry_first_refresh(),
+        return_exceptions=True,
+    )
+    # If camera WAN blocked, firmware check fails, do not prevent setup
+    # so don't check firmware_coordinator exceptions
+    if isinstance(results[0], BaseException):
         await host.stop()
-        raise
+        raise results[0]
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = ReolinkData(
         host=host,

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.8.7"]
+  "requirements": ["reolink-aio==0.8.8"]
 }

--- a/homeassistant/components/roku/manifest.json
+++ b/homeassistant/components/roku/manifest.json
@@ -11,7 +11,7 @@
   "iot_class": "local_polling",
   "loggers": ["rokuecp"],
   "quality_scale": "silver",
-  "requirements": ["rokuecp==0.19.0"],
+  "requirements": ["rokuecp==0.19.1"],
   "ssdp": [
     {
       "st": "roku:ecp",

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -24,7 +24,7 @@
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "iot_class": "local_push",
   "loggers": ["paho_mqtt", "roombapy"],
-  "requirements": ["roombapy==1.6.10"],
+  "requirements": ["roombapy==1.6.12"],
   "zeroconf": [
     {
       "type": "_amzn-alexa._tcp.local.",

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -51,11 +51,7 @@ from .entity import (
     async_setup_entry_rest,
     async_setup_entry_rpc,
 )
-from .utils import (
-    get_device_entry_gen,
-    get_device_uptime,
-    is_rpc_wifi_stations_disabled,
-)
+from .utils import get_device_entry_gen, get_device_uptime
 
 
 @dataclass(frozen=True)
@@ -911,7 +907,9 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        removal_condition=is_rpc_wifi_stations_disabled,
+        removal_condition=lambda config, _status, key: (
+            config[key]["sta"]["enable"] is False
+        ),
         entity_category=EntityCategory.DIAGNOSTIC,
         use_polling_coordinator=True,
     ),

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -51,7 +51,11 @@ from .entity import (
     async_setup_entry_rest,
     async_setup_entry_rpc,
 )
-from .utils import get_device_entry_gen, get_device_uptime
+from .utils import (
+    get_device_entry_gen,
+    get_device_uptime,
+    is_rpc_wifi_stations_disabled,
+)
 
 
 @dataclass(frozen=True)
@@ -907,9 +911,7 @@ RPC_SENSORS: Final = {
         device_class=SensorDeviceClass.SIGNAL_STRENGTH,
         state_class=SensorStateClass.MEASUREMENT,
         entity_registry_enabled_default=False,
-        removal_condition=lambda config, _status, key: (
-            config[key]["sta"]["enable"] is False
-        ),
+        removal_condition=is_rpc_wifi_stations_disabled,
         entity_category=EntityCategory.DIAGNOSTIC,
         use_polling_coordinator=True,
     ),

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -447,13 +447,3 @@ def async_create_issue_unsupported_firmware(
             "ip_address": entry.data["host"],
         },
     )
-
-
-def is_rpc_wifi_stations_disabled(
-    config: dict[str, Any], _status: dict[str, Any], key: str
-) -> bool:
-    """Return true if rpc all WiFi stations are disabled."""
-    if config[key]["sta"]["enable"] is True or config[key]["sta1"]["enable"] is True:
-        return False
-
-    return True

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -447,3 +447,13 @@ def async_create_issue_unsupported_firmware(
             "ip_address": entry.data["host"],
         },
     )
+
+
+def is_rpc_wifi_stations_disabled(
+    config: dict[str, Any], _status: dict[str, Any], key: str
+) -> bool:
+    """Return true if rpc all WiFi stations are disabled."""
+    if config[key]["sta"]["enable"] is True or config[key]["sta1"]["enable"] is True:
+        return False
+
+    return True

--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -12,6 +12,7 @@ from aiotankerkoenig import (
     TankerkoenigConnectionError,
     TankerkoenigError,
     TankerkoenigInvalidKeyError,
+    TankerkoenigRateLimitError,
 )
 
 from homeassistant.config_entries import ConfigEntry
@@ -19,7 +20,7 @@ from homeassistant.const import CONF_API_KEY, CONF_SHOW_ON_MAP
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_FUEL_TYPES, CONF_STATIONS
 
@@ -78,13 +79,22 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator):
         station_ids = list(self.stations)
 
         prices = {}
-
         # The API seems to only return at most 10 results, so split the list in chunks of 10
         # and merge it together.
         for index in range(ceil(len(station_ids) / 10)):
-            data = await self._tankerkoenig.prices(
-                station_ids[index * 10 : (index + 1) * 10]
-            )
+            try:
+                data = await self._tankerkoenig.prices(
+                    station_ids[index * 10 : (index + 1) * 10]
+                )
+            except TankerkoenigInvalidKeyError as err:
+                raise ConfigEntryAuthFailed(err) from err
+            except (TankerkoenigError, TankerkoenigConnectionError) as err:
+                if isinstance(err, TankerkoenigRateLimitError):
+                    _LOGGER.warning(
+                        "API rate limit reached, consider to increase polling interval"
+                    )
+                raise UpdateFailed(err) from err
+
             prices.update(data)
 
         return prices

--- a/homeassistant/components/tankerkoenig/manifest.json
+++ b/homeassistant/components/tankerkoenig/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tankerkoenig",
   "iot_class": "cloud_polling",
   "loggers": ["aiotankerkoenig"],
-  "requirements": ["aiotankerkoenig==0.4.0"]
+  "requirements": ["aiotankerkoenig==0.4.1"]
 }

--- a/homeassistant/components/tankerkoenig/manifest.json
+++ b/homeassistant/components/tankerkoenig/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tankerkoenig",
   "iot_class": "cloud_polling",
   "loggers": ["aiotankerkoenig"],
-  "requirements": ["aiotankerkoenig==0.3.0"]
+  "requirements": ["aiotankerkoenig==0.4.0"]
 }

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -3,6 +3,9 @@
 import asyncio
 from typing import Any
 
+from tesla_fleet_api.exceptions import TeslaFleetError
+
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -45,11 +48,22 @@ class TeslemetryVehicleEntity(CoordinatorEntity[TeslemetryVehicleDataCoordinator
     async def wake_up_if_asleep(self) -> None:
         """Wake up the vehicle if its asleep."""
         async with self._wakelock:
+            times = 0
             while self.coordinator.data["state"] != TeslemetryState.ONLINE:
-                state = (await self.api.wake_up())["response"]["state"]
+                try:
+                    if times == 0:
+                        cmd = await self.api.wake_up()
+                    else:
+                        cmd = await self.api.vehicle()
+                    state = cmd["response"]["state"]
+                except TeslaFleetError as e:
+                    raise HomeAssistantError(str(e)) from e
                 self.coordinator.data["state"] = state
                 if state != TeslemetryState.ONLINE:
-                    await asyncio.sleep(5)
+                    times += 1
+                    if times >= 4:  # Give up after 30 seconds total
+                        raise HomeAssistantError("Could not wake up vehicle")
+                    await asyncio.sleep(times * 5)
 
     def get(self, key: str | None = None, default: Any | None = None) -> Any:
         """Return a specific value from coordinator data."""

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -11,6 +11,7 @@ from tessie_api import (
 )
 
 from homeassistant.components.climate import (
+    ATTR_HVAC_MODE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
@@ -112,9 +113,12 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set the climate temperature."""
-        temp = kwargs[ATTR_TEMPERATURE]
-        await self.run(set_temperature, temperature=temp)
-        self.set(("climate_state_driver_temp_setting", temp))
+        if mode := kwargs.get(ATTR_HVAC_MODE):
+            await self.async_set_hvac_mode(mode)
+
+        if temp := kwargs.get(ATTR_TEMPERATURE):
+            await self.run(set_temperature, temperature=temp)
+            self.set(("climate_state_driver_temp_setting", temp))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
+from homeassistant.util.dt import as_utc
 
 from . import TileData
 from .const import DOMAIN
@@ -145,16 +146,23 @@ class TileDeviceTracker(CoordinatorEntity[DataUpdateCoordinator[None]], TrackerE
     @callback
     def _update_from_latest_data(self) -> None:
         """Update the entity from the latest data."""
-        self._attr_extra_state_attributes.update(
-            {
-                ATTR_ALTITUDE: self._tile.altitude,
-                ATTR_IS_LOST: self._tile.lost,
-                ATTR_LAST_LOST_TIMESTAMP: self._tile.lost_timestamp,
-                ATTR_LAST_TIMESTAMP: self._tile.last_timestamp,
-                ATTR_RING_STATE: self._tile.ring_state,
-                ATTR_VOIP_STATE: self._tile.voip_state,
-            }
-        )
+        self._attr_extra_state_attributes = {
+            ATTR_ALTITUDE: self._tile.altitude,
+            ATTR_IS_LOST: self._tile.lost,
+            ATTR_RING_STATE: self._tile.ring_state,
+            ATTR_VOIP_STATE: self._tile.voip_state,
+        }
+        for timestamp_attr in (
+            (ATTR_LAST_LOST_TIMESTAMP, self._tile.lost_timestamp),
+            (ATTR_LAST_TIMESTAMP, self._tile.last_timestamp),
+        ):
+            if not timestamp_attr[1]:
+                # If the API doesn't return a value for a particular timestamp
+                # attribute, skip it:
+                continue
+            self._attr_extra_state_attributes[timestamp_attr[0]] = as_utc(
+                timestamp_attr[1]
+            )
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/homeassistant/components/unifiprotect/light.py
+++ b/homeassistant/components/unifiprotect/light.py
@@ -78,7 +78,7 @@ class ProtectLight(ProtectDeviceEntity, LightEntity):
         is a change.
         """
 
-        return (self._attr_available, self._attr_brightness)
+        return (self._attr_available, self._attr_is_on, self._attr_brightness)
 
     @callback
     def _async_update_device_from_protect(self, device: ProtectModelWithId) -> None:

--- a/homeassistant/components/workday/manifest.json
+++ b/homeassistant/components/workday/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_polling",
   "loggers": ["holidays"],
   "quality_scale": "internal",
-  "requirements": ["holidays==0.42"]
+  "requirements": ["holidays==0.43"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 2
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -141,10 +141,6 @@ pubnub!=6.4.0
 # https://github.com/dahlia/iso4217/issues/16
 iso4217!=1.10.20220401
 
-# Matplotlib 3.6.2 has issues building wheels on armhf/armv7
-# We need at least >=2.1.0 (tensorflow integration -> pycocotools)
-matplotlib==3.6.1
-
 # pyOpenSSL 24.0.0 or later required to avoid import errors when
 # cryptography 42.0.0 is installed with botocore
 pyOpenSSL>=24.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.2.2"
+version     = "2024.2.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -695,7 +695,7 @@ deebot-client==5.2.1
 defusedxml==0.7.1
 
 # homeassistant.components.deluge
-deluge-client==1.7.1
+deluge-client==1.10.0
 
 # homeassistant.components.lametric
 demetriek==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1313,7 +1313,7 @@ moehlenhoff-alpha2==1.3.0
 mopeka-iot-ble==0.5.0
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.20
+motionblinds==0.6.21
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.14

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2450,7 +2450,7 @@ rokuecp==0.19.1
 romy==0.0.7
 
 # homeassistant.components.roomba
-roombapy==1.6.10
+roombapy==1.6.12
 
 # homeassistant.components.roon
 roonapi==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ aioswitcher==3.4.1
 aiosyncthing==0.5.1
 
 # homeassistant.components.tankerkoenig
-aiotankerkoenig==0.3.0
+aiotankerkoenig==0.4.0
 
 # homeassistant.components.tractive
 aiotractive==0.5.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -191,7 +191,7 @@ aioairq==0.3.2
 aioairzone-cloud==0.3.8
 
 # homeassistant.components.airzone
-aioairzone==0.7.2
+aioairzone==0.7.4
 
 # homeassistant.components.ambient_station
 aioambient==2024.01.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -967,7 +967,7 @@ gotailwind==0.2.2
 govee-ble==0.31.0
 
 # homeassistant.components.govee_light_local
-govee-local-api==1.4.1
+govee-local-api==1.4.4
 
 # homeassistant.components.remote_rpi_gpio
 gpiozero==1.6.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -695,7 +695,7 @@ deebot-client==5.2.1
 defusedxml==0.7.1
 
 # homeassistant.components.deluge
-deluge-client==1.10.0
+deluge-client==1.10.2
 
 # homeassistant.components.lametric
 demetriek==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2360,7 +2360,7 @@ pywaze==0.5.1
 pyweatherflowudp==1.4.5
 
 # homeassistant.components.html5
-pywebpush==1.9.2
+pywebpush==1.14.1
 
 # homeassistant.components.wemo
 pywemo==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1059,7 +1059,7 @@ hole==0.8.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.42
+holidays==0.43
 
 # homeassistant.components.frontend
 home-assistant-frontend==20240207.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,7 +377,7 @@ aioswitcher==3.4.1
 aiosyncthing==0.5.1
 
 # homeassistant.components.tankerkoenig
-aiotankerkoenig==0.4.0
+aiotankerkoenig==0.4.1
 
 # homeassistant.components.tractive
 aiotractive==0.5.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2444,7 +2444,7 @@ rjpl==0.3.6
 rocketchat-API==0.6.1
 
 # homeassistant.components.roku
-rokuecp==0.19.0
+rokuecp==0.19.1
 
 # homeassistant.components.romy
 romy==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2423,7 +2423,7 @@ renault-api==0.2.1
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.7
+reolink-aio==0.8.8
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -687,7 +687,7 @@ debugpy==1.8.0
 # decora==0.6
 
 # homeassistant.components.ecovacs
-deebot-client==5.2.1
+deebot-client==5.2.2
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -350,7 +350,7 @@ aioswitcher==3.4.1
 aiosyncthing==0.5.1
 
 # homeassistant.components.tankerkoenig
-aiotankerkoenig==0.3.0
+aiotankerkoenig==0.4.0
 
 # homeassistant.components.tractive
 aiotractive==0.5.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1857,7 +1857,7 @@ renault-api==0.2.1
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.7
+reolink-aio==0.8.8
 
 # homeassistant.components.rflink
 rflink==0.0.65

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -350,7 +350,7 @@ aioswitcher==3.4.1
 aiosyncthing==0.5.1
 
 # homeassistant.components.tankerkoenig
-aiotankerkoenig==0.4.0
+aiotankerkoenig==0.4.1
 
 # homeassistant.components.tractive
 aiotractive==0.5.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1866,7 +1866,7 @@ rflink==0.0.65
 ring-doorbell[listen]==0.8.7
 
 # homeassistant.components.roku
-rokuecp==0.19.0
+rokuecp==0.19.1
 
 # homeassistant.components.romy
 romy==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1872,7 +1872,7 @@ rokuecp==0.19.1
 romy==0.0.7
 
 # homeassistant.components.roomba
-roombapy==1.6.10
+roombapy==1.6.12
 
 # homeassistant.components.roon
 roonapi==0.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -170,7 +170,7 @@ aioairq==0.3.2
 aioairzone-cloud==0.3.8
 
 # homeassistant.components.airzone
-aioairzone==0.7.2
+aioairzone==0.7.4
 
 # homeassistant.components.ambient_station
 aioambient==2024.01.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -570,7 +570,7 @@ deebot-client==5.2.1
 defusedxml==0.7.1
 
 # homeassistant.components.deluge
-deluge-client==1.10.0
+deluge-client==1.10.2
 
 # homeassistant.components.lametric
 demetriek==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -855,7 +855,7 @@ hole==0.8.0
 
 # homeassistant.components.holiday
 # homeassistant.components.workday
-holidays==0.42
+holidays==0.43
 
 # homeassistant.components.frontend
 home-assistant-frontend==20240207.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -784,7 +784,7 @@ gotailwind==0.2.2
 govee-ble==0.31.0
 
 # homeassistant.components.govee_light_local
-govee-local-api==1.4.1
+govee-local-api==1.4.4
 
 # homeassistant.components.gpsd
 gps3==0.33.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1049,7 +1049,7 @@ moehlenhoff-alpha2==1.3.0
 mopeka-iot-ble==0.5.0
 
 # homeassistant.components.motion_blinds
-motionblinds==0.6.20
+motionblinds==0.6.21
 
 # homeassistant.components.motioneye
 motioneye-client==0.3.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -562,7 +562,7 @@ dbus-fast==2.21.1
 debugpy==1.8.0
 
 # homeassistant.components.ecovacs
-deebot-client==5.2.1
+deebot-client==5.2.2
 
 # homeassistant.components.ihc
 # homeassistant.components.namecheapdns

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1809,7 +1809,7 @@ pywaze==0.5.1
 pyweatherflowudp==1.4.5
 
 # homeassistant.components.html5
-pywebpush==1.9.2
+pywebpush==1.14.1
 
 # homeassistant.components.wemo
 pywemo==1.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -570,7 +570,7 @@ deebot-client==5.2.1
 defusedxml==0.7.1
 
 # homeassistant.components.deluge
-deluge-client==1.7.1
+deluge-client==1.10.0
 
 # homeassistant.components.lametric
 demetriek==0.4.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -134,10 +134,6 @@ pubnub!=6.4.0
 # https://github.com/dahlia/iso4217/issues/16
 iso4217!=1.10.20220401
 
-# Matplotlib 3.6.2 has issues building wheels on armhf/armv7
-# We need at least >=2.1.0 (tensorflow integration -> pycocotools)
-matplotlib==3.6.1
-
 # pyOpenSSL 24.0.0 or later required to avoid import errors when
 # cryptography 42.0.0 is installed with botocore
 pyOpenSSL>=24.0.0

--- a/tests/components/apprise/test_notify.py
+++ b/tests/components/apprise/test_notify.py
@@ -118,7 +118,48 @@ async def test_apprise_notification(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
         # Validate calls were made under the hood correctly
-        obj.add.assert_called_once_with([config[BASE_COMPONENT]["url"]])
+        obj.add.assert_called_once_with(config[BASE_COMPONENT]["url"])
+        obj.notify.assert_called_once_with(
+            **{"body": data["message"], "title": data["title"], "tag": None}
+        )
+
+
+async def test_apprise_multiple_notification(hass: HomeAssistant) -> None:
+    """Test apprise notification."""
+
+    config = {
+        BASE_COMPONENT: {
+            "name": "test",
+            "platform": "apprise",
+            "url": [
+                "mailto://user:pass@example.com, mailto://user:pass@gmail.com",
+                "json://user:pass@gmail.com",
+            ],
+        }
+    }
+
+    # Our Message
+    data = {"title": "Test Title", "message": "Test Message"}
+
+    with patch(
+        "homeassistant.components.apprise.notify.apprise.Apprise"
+    ) as mock_apprise:
+        obj = MagicMock()
+        obj.add.return_value = True
+        obj.notify.return_value = True
+        mock_apprise.return_value = obj
+        assert await async_setup_component(hass, BASE_COMPONENT, config)
+        await hass.async_block_till_done()
+
+        # Test the existence of our service
+        assert hass.services.has_service(BASE_COMPONENT, "test")
+
+        # Test the call to our underlining notify() call
+        await hass.services.async_call(BASE_COMPONENT, "test", data)
+        await hass.async_block_till_done()
+
+        # Validate 2 calls were made under the hood
+        assert obj.add.call_count == 2
         obj.notify.assert_called_once_with(
             **{"body": data["message"], "title": data["title"], "tag": None}
         )

--- a/tests/components/climate/test_reproduce_state.py
+++ b/tests/components/climate/test_reproduce_state.py
@@ -119,6 +119,25 @@ async def test_attribute(hass: HomeAssistant, service, attribute) -> None:
     assert calls_1[0].data == {"entity_id": ENTITY_1, attribute: value}
 
 
+@pytest.mark.parametrize(
+    ("service", "attribute"),
+    [
+        (SERVICE_SET_PRESET_MODE, ATTR_PRESET_MODE),
+        (SERVICE_SET_SWING_MODE, ATTR_SWING_MODE),
+        (SERVICE_SET_FAN_MODE, ATTR_FAN_MODE),
+    ],
+)
+async def test_attribute_with_none(hass: HomeAssistant, service, attribute) -> None:
+    """Test that service call is not made for attributes with None value."""
+    calls_1 = async_mock_service(hass, DOMAIN, service)
+
+    await async_reproduce_states(hass, [State(ENTITY_1, None, {attribute: None})])
+
+    await hass.async_block_till_done()
+
+    assert len(calls_1) == 0
+
+
 async def test_attribute_partial_temperature(hass: HomeAssistant) -> None:
     """Test that service call ignores null attributes."""
     calls_1 = async_mock_service(hass, DOMAIN, SERVICE_SET_TEMPERATURE)

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -98,12 +98,12 @@ def _mocked_discovery(*_):
 
     roomba = RoombaInfo(
         hostname="irobot-BLID",
-        robot_name="robot_name",
+        robotname="robot_name",
         ip=MOCK_IP,
         mac="mac",
-        firmware="firmware",
+        sw="firmware",
         sku="sku",
-        capabilities="capabilities",
+        cap={"cap": 1},
     )
 
     roomba_discovery.get_all = MagicMock(return_value=[roomba])

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -159,7 +159,7 @@ MOCK_CONFIG = {
         "ui_data": {},
         "device": {"name": "Test name"},
     },
-    "wifi": {"sta": {"enable": True}},
+    "wifi": {"sta": {"enable": True}, "sta1": {"enable": False}},
 }
 
 MOCK_SHELLY_COAP = {

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -159,7 +159,7 @@ MOCK_CONFIG = {
         "ui_data": {},
         "device": {"name": "Test name"},
     },
-    "wifi": {"sta": {"enable": True}, "sta1": {"enable": False}},
+    "wifi": {"sta": {"enable": True}},
 }
 
 MOCK_SHELLY_COAP = {

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -27,7 +27,6 @@ from homeassistant.helpers.entity_registry import async_get
 from homeassistant.setup import async_setup_component
 
 from . import (
-    get_entity_state,
     init_integration,
     mock_polling_rpc_update,
     mock_rest_update,
@@ -298,32 +297,6 @@ async def test_rpc_sensor(hass: HomeAssistant, mock_rpc_device, monkeypatch) -> 
     mock_rpc_device.mock_update()
 
     assert hass.states.get(entity_id).state == STATE_UNKNOWN
-
-
-async def test_rpc_rssi_sensor_removal(
-    hass: HomeAssistant,
-    mock_rpc_device: Mock,
-    monkeypatch: pytest.MonkeyPatch,
-    entity_registry_enabled_by_default: None,
-) -> None:
-    """Test RPC RSSI sensor removal if no WiFi stations enabled."""
-    entity_id = f"{SENSOR_DOMAIN}.test_name_rssi"
-    entry = await init_integration(hass, 2)
-
-    # WiFi1 enabled, do not remove sensor
-    assert get_entity_state(hass, entity_id) == "-63"
-
-    # WiFi1 & WiFi2 disabled - remove sensor
-    monkeypatch.setitem(mock_rpc_device.config["wifi"]["sta"], "enable", False)
-    await hass.config_entries.async_reload(entry.entry_id)
-    await hass.async_block_till_done()
-    assert hass.states.get(entity_id) is None
-
-    # WiFi2 enabled, do not remove sensor
-    monkeypatch.setitem(mock_rpc_device.config["wifi"]["sta1"], "enable", True)
-    await hass.config_entries.async_reload(entry.entry_id)
-    await hass.async_block_till_done()
-    assert get_entity_state(hass, entity_id) == "-63"
 
 
 async def test_rpc_illuminance_sensor(

--- a/tests/components/tankerkoenig/test_coordinator.py
+++ b/tests/components/tankerkoenig/test_coordinator.py
@@ -1,0 +1,51 @@
+"""Tests for the Tankerkoening integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from aiotankerkoenig.exceptions import TankerkoenigRateLimitError
+import pytest
+
+from homeassistant.components.tankerkoenig.const import DEFAULT_SCAN_INTERVAL
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_rate_limit(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    tankerkoenig: AsyncMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test detection of API rate limit."""
+    assert config_entry.state == ConfigEntryState.LOADED
+    state = hass.states.get("binary_sensor.station_somewhere_street_1_status")
+    assert state
+    assert state.state == "on"
+
+    tankerkoenig.prices.side_effect = TankerkoenigRateLimitError
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(minutes=DEFAULT_SCAN_INTERVAL)
+    )
+    await hass.async_block_till_done()
+    assert (
+        "API rate limit reached, consider to increase polling interval" in caplog.text
+    )
+    state = hass.states.get("binary_sensor.station_somewhere_street_1_status")
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+    tankerkoenig.prices.side_effect = None
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(minutes=DEFAULT_SCAN_INTERVAL * 2)
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("binary_sensor.station_somewhere_street_1_status")
+    assert state
+    assert state.state == "on"

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -38,6 +38,16 @@ def mock_wake_up():
 
 
 @pytest.fixture(autouse=True)
+def mock_vehicle():
+    """Mock Tesla Fleet API Vehicle Specific vehicle method."""
+    with patch(
+        "homeassistant.components.teslemetry.VehicleSpecific.vehicle",
+        return_value=WAKE_UP_ONLINE,
+    ) as mock_vehicle:
+        yield mock_vehicle
+
+
+@pytest.fixture(autouse=True)
 def mock_request():
     """Mock Tesla Fleet API Vehicle Specific class."""
     with patch(

--- a/tests/components/teslemetry/test_climate.py
+++ b/tests/components/teslemetry/test_climate.py
@@ -26,6 +26,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import assert_entities, setup_platform
+from .const import WAKE_UP_ASLEEP, WAKE_UP_ONLINE
 
 from tests.common import async_fire_time_changed
 
@@ -108,7 +109,11 @@ async def test_errors(
 
 
 async def test_asleep_or_offline(
-    hass: HomeAssistant, mock_vehicle_data, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    mock_vehicle_data,
+    mock_wake_up,
+    mock_vehicle,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Tests asleep is handled."""
 
@@ -123,9 +128,47 @@ async def test_asleep_or_offline(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     mock_vehicle_data.assert_called_once()
+    mock_wake_up.reset_mock()
 
-    # Run a command that will wake up the vehicle, but not immediately
+    # Run a command but fail trying to wake up the vehicle
+    mock_wake_up.side_effect = InvalidCommand
+    with pytest.raises(HomeAssistantError) as error:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        assert error
+    mock_wake_up.assert_called_once()
+
+    mock_wake_up.side_effect = None
+    mock_wake_up.reset_mock()
+
+    # Run a command but timeout trying to wake up the vehicle
+    mock_wake_up.return_value = WAKE_UP_ASLEEP
+    mock_vehicle.return_value = WAKE_UP_ASLEEP
+    with patch(
+        "homeassistant.components.teslemetry.entity.asyncio.sleep"
+    ), pytest.raises(HomeAssistantError) as error:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: [entity_id]},
+            blocking=True,
+        )
+        assert error
+    mock_wake_up.assert_called_once()
+    mock_vehicle.assert_called()
+
+    mock_wake_up.reset_mock()
+    mock_vehicle.reset_mock()
+    mock_wake_up.return_value = WAKE_UP_ONLINE
+    mock_vehicle.return_value = WAKE_UP_ONLINE
+
+    # Run a command and wake up the vehicle immediately
     await hass.services.async_call(
         CLIMATE_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: [entity_id]}, blocking=True
     )
     await hass.async_block_till_done()
+    mock_wake_up.assert_called_once()

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -54,14 +54,22 @@ async def test_climate(
     with patch(
         "homeassistant.components.tessie.climate.set_temperature",
         return_value=TEST_RESPONSE,
-    ) as mock_set:
+    ) as mock_set, patch(
+        "homeassistant.components.tessie.climate.start_climate_preconditioning",
+        return_value=TEST_RESPONSE,
+    ) as mock_set2:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_TEMPERATURE,
-            {ATTR_ENTITY_ID: [entity_id], ATTR_TEMPERATURE: 20},
+            {
+                ATTR_ENTITY_ID: [entity_id],
+                ATTR_HVAC_MODE: HVACMode.HEAT_COOL,
+                ATTR_TEMPERATURE: 20,
+            },
             blocking=True,
         )
         mock_set.assert_called_once()
+        mock_set2.assert_called_once()
     state = hass.states.get(entity_id)
     assert state.attributes[ATTR_TEMPERATURE] == 20
 


### PR DESCRIPTION
- Fix reauth in Overkiz for config entries created prior to 2022.12 ([@iMicknl] - [#106251]) ([overkiz docs])
- Handle deep standby and poweroffs of enigma2 devices gracefully ([@autinerd] - [#107462]) ([enigma2 docs])
- Add wake up timeout to Teslemetry ([@Bre77] - [#109037]) ([teslemetry docs])
- Fix set_temperature in Tessie climate platform ([@Bre77] - [#110445]) ([tessie docs])
- Fix uuid issue in Lutron ([@wilburCforce] - [#110524]) ([lutron docs])
- Update rokuecp to 0.19.1 ([@ctalkington] - [#110670]) ([zroku docs]) (dependency)
- Fix scene activation with climate entities with `None` attribute values ([@mib1185] - [#110684]) ([climate docs])
- Remove matplotlib pinning due to Python 3.12 incompatibility ([@sbyx] - [#110706]) (dependency)
- Bump roombapy to 1.6.12 ([@mib1185] - [#110762]) ([roomba docs]) (dependency)
- Ensure Tile timestamps are reported as UTC ([@bachya] - [#110773]) ([tile docs])
- Detect reached API rate limit in Tankerkoenig ([@mib1185] - [#110432]) ([tankerkoenig docs]) (dependency)
- Bump aiotankerkoenig to 0.4.1 ([@jpbede] - [#110840]) ([tankerkoenig docs]) (dependency)
- Update govee-local-api library to 1.4.4 ([@Galorhallen] - [#110854]) ([govee_light_local docs]) (dependency)
- Allow loading of more then 1 defined Apprise URL ([@caronc] - [#110868]) ([apprise docs])
- Reolink continue setup when internet blocked ([@starkillerOG] - [#110888]) ([reolink docs])
- Bump deluge-client to 1.10.0 ([@tkdrob] - [#110663]) ([deluge docs]) (dependency)
- Bump deluge-client to 1.10.2 ([@dsander] - [#110905]) ([deluge docs]) (dependency)
- Bump reolink-aio to 0.8.8 ([@starkillerOG] - [#110959]) ([reolink docs]) (dependency)
- Reset error state when Ecovacs bot is operational again ([@mib1185] - [#110962]) ([ecovacs docs])
- Bump motionblinds to 0.6.21 ([@starkillerOG] - [#110970]) ([motion_blinds docs]) (dependency)
- Bump holidays to 0.43 ([@gjohansson-ST] - [#111039]) ([workday docs]) ([holiday docs]) (dependency)
- Fixes UniFi Protect light state check ([@AngellusMortis] - [#111058]) ([unifiprotect docs])
- Bump pywebpush to 1.14.1 ([@thecode] - [#111082]) ([html5 docs]) (dependency)
- Bump aioairzone to v0.7.4 ([@Noltari] - [#111105]) ([airzone docs]) (dependency)
- Bump deebot-client to 5.2.2 ([@edenhaus] - [#111112]) ([ecovacs docs]) (dependency)
- Ignore cloudhook already removed in mobile app ([@joostlek] - [#111122]) ([mobile_app docs])

[#106251]: https://github.com/home-assistant/core/pull/106251
[#107462]: https://github.com/home-assistant/core/pull/107462
[#109037]: https://github.com/home-assistant/core/pull/109037
[#109883]: https://github.com/home-assistant/core/pull/109883
[#110078]: https://github.com/home-assistant/core/pull/110078
[#110432]: https://github.com/home-assistant/core/pull/110432
[#110445]: https://github.com/home-assistant/core/pull/110445
[#110524]: https://github.com/home-assistant/core/pull/110524
[#110663]: https://github.com/home-assistant/core/pull/110663
[#110670]: https://github.com/home-assistant/core/pull/110670
[#110684]: https://github.com/home-assistant/core/pull/110684
[#110706]: https://github.com/home-assistant/core/pull/110706
[#110720]: https://github.com/home-assistant/core/pull/110720
[#110762]: https://github.com/home-assistant/core/pull/110762
[#110773]: https://github.com/home-assistant/core/pull/110773
[#110840]: https://github.com/home-assistant/core/pull/110840
[#110854]: https://github.com/home-assistant/core/pull/110854
[#110868]: https://github.com/home-assistant/core/pull/110868
[#110888]: https://github.com/home-assistant/core/pull/110888
[#110905]: https://github.com/home-assistant/core/pull/110905
[#110959]: https://github.com/home-assistant/core/pull/110959
[#110962]: https://github.com/home-assistant/core/pull/110962
[#110970]: https://github.com/home-assistant/core/pull/110970
[#111035]: https://github.com/home-assistant/core/pull/111035
[#111039]: https://github.com/home-assistant/core/pull/111039
[#111058]: https://github.com/home-assistant/core/pull/111058
[#111082]: https://github.com/home-assistant/core/pull/111082
[#111105]: https://github.com/home-assistant/core/pull/111105
[#111112]: https://github.com/home-assistant/core/pull/111112
[#111122]: https://github.com/home-assistant/core/pull/111122
[@AngellusMortis]: https://github.com/AngellusMortis
[@Bre77]: https://github.com/Bre77
[@Galorhallen]: https://github.com/Galorhallen
[@Noltari]: https://github.com/Noltari
[@autinerd]: https://github.com/autinerd
[@bachya]: https://github.com/bachya
[@caronc]: https://github.com/caronc
[@ctalkington]: https://github.com/ctalkington
[@dsander]: https://github.com/dsander
[@edenhaus]: https://github.com/edenhaus
[@frenck]: https://github.com/frenck
[@gjohansson-ST]: https://github.com/gjohansson-ST
[@iMicknl]: https://github.com/iMicknl
[@joostlek]: https://github.com/joostlek
[@jpbede]: https://github.com/jpbede
[@mib1185]: https://github.com/mib1185
[@sbyx]: https://github.com/sbyx
[@starkillerOG]: https://github.com/starkillerOG
[@thecode]: https://github.com/thecode
[@tkdrob]: https://github.com/tkdrob
[@wilburCforce]: https://github.com/wilburCforce
[abode docs]: https://www.home-assistant.io/integrations/abode/
[airzone docs]: https://www.home-assistant.io/integrations/airzone/
[apprise docs]: https://www.home-assistant.io/integrations/apprise/
[climate docs]: https://www.home-assistant.io/integrations/climate/
[deluge docs]: https://www.home-assistant.io/integrations/deluge/
[ecovacs docs]: https://www.home-assistant.io/integrations/ecovacs/
[enigma2 docs]: https://www.home-assistant.io/integrations/enigma2/
[govee_light_local docs]: https://www.home-assistant.io/integrations/govee_light_local/
[holiday docs]: https://www.home-assistant.io/integrations/holiday/
[html5 docs]: https://www.home-assistant.io/integrations/html5/
[lutron docs]: https://www.home-assistant.io/integrations/lutron/
[mobile_app docs]: https://www.home-assistant.io/integrations/mobile_app/
[motion_blinds docs]: https://www.home-assistant.io/integrations/motion_blinds/
[overkiz docs]: https://www.home-assistant.io/integrations/overkiz/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[roku docs]: https://www.home-assistant.io/integrations/roku/
[roomba docs]: https://www.home-assistant.io/integrations/roomba/
[shelly docs]: https://www.home-assistant.io/integrations/shelly/
[tankerkoenig docs]: https://www.home-assistant.io/integrations/tankerkoenig/
[teslemetry docs]: https://www.home-assistant.io/integrations/teslemetry/
[tessie docs]: https://www.home-assistant.io/integrations/tessie/
[tile docs]: https://www.home-assistant.io/integrations/tile/
[unifiprotect docs]: https://www.home-assistant.io/integrations/unifiprotect/
[workday docs]: https://www.home-assistant.io/integrations/workday/

Docs: <https://github.com/home-assistant/home-assistant.io/pull/31555>