### PR TITLE
Dynamic entity creation for tplink

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -190,6 +190,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     child_coordinators: list[TPLinkDataUpdateCoordinator] = []
 
     if device.is_strip:
+        # TODO: child_coordinators should only be necessary for iotdevices
         child_coordinators = [
             # The child coordinators only update energy data so we can
             # set a longer update interval to avoid flooding the device

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -13,8 +13,8 @@ from kasa import (
     Credentials,
     DeviceConfig,
     Discover,
-    SmartDevice,
-    SmartDeviceException,
+    Device,
+    KasaException,
 )
 from kasa.httpclient import get_cookie_jar
 
@@ -67,7 +67,7 @@ def create_async_tplink_clientsession(hass: HomeAssistant) -> ClientSession:
 @callback
 def async_trigger_discovery(
     hass: HomeAssistant,
-    discovered_devices: dict[str, SmartDevice],
+    discovered_devices: dict[str, Device],
 ) -> None:
     """Trigger config flows for discovered devices."""
     for formatted_mac, device in discovered_devices.items():
@@ -87,7 +87,7 @@ def async_trigger_discovery(
         )
 
 
-async def async_discover_devices(hass: HomeAssistant) -> dict[str, SmartDevice]:
+async def async_discover_devices(hass: HomeAssistant) -> dict[str, Device]:
     """Discover TPLink devices on configured network interfaces."""
 
     credentials = await get_credentials(hass)
@@ -101,7 +101,7 @@ async def async_discover_devices(hass: HomeAssistant) -> dict[str, SmartDevice]:
         )
         for address in broadcast_addresses
     ]
-    discovered_devices: dict[str, SmartDevice] = {}
+    discovered_devices: dict[str, Device] = {}
     for device_list in await asyncio.gather(*tasks):
         for device in device_list.values():
             discovered_devices[dr.format_mac(device.mac)] = device
@@ -135,7 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if config_dict := entry.data.get(CONF_DEVICE_CONFIG):
         try:
             config = DeviceConfig.from_dict(config_dict)
-        except SmartDeviceException:
+        except KasaException:
             _LOGGER.warning(
                 "Invalid connection type dict for %s: %s", host, config_dict
             )
@@ -151,10 +151,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if credentials:
         config.credentials = credentials
     try:
-        device: SmartDevice = await SmartDevice.connect(config=config)
+        device: Device = await Device.connect(config=config)
     except AuthenticationException as ex:
         raise ConfigEntryAuthFailed from ex
-    except SmartDeviceException as ex:
+    except KasaException as ex:
         raise ConfigEntryNotReady from ex
 
     device_config_dict = device.config.to_dict(
@@ -218,7 +218,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-def legacy_device_id(device: SmartDevice) -> str:
+def legacy_device_id(device: Device) -> str:
     """Convert the device id so it matches what was used in the original version."""
     device_id: str = device.device_id
     # Plugs are prefixed with the mac in python-kasa but not

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -11,9 +11,9 @@ from aiohttp import ClientSession
 from kasa import (
     AuthenticationException,
     Credentials,
+    Device,
     DeviceConfig,
     Discover,
-    Device,
     KasaException,
 )
 from kasa.httpclient import get_cookie_jar

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -1,7 +1,8 @@
 """Support for TPLink binary sensors."""
+
 from __future__ import annotations
 
-from kasa import Feature, FeatureType, SmartDevice
+from kasa import Feature, SmartDevice
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -12,7 +13,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import legacy_device_id
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import CoordinatedTPLinkEntity
@@ -25,12 +25,11 @@ def _async_sensors_for_device(
     parent: SmartDevice = None,
 ) -> list[BinarySensor]:
     """Generate the sensors for the device."""
-    sensors = [
-        BinarySensor(device, coordinator, id_, feat, parent=parent)
+    return [
+        BinarySensor(device, coordinator, feat, parent=parent)
         for id_, feat in device.features.items()
-        if feat.type == FeatureType.BinarySensor
+        if feat.type == Feature.BinarySensor
     ]
-    return sensors
 
 
 async def async_setup_entry(
@@ -61,19 +60,18 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
         self,
         device: SmartDevice,
         coordinator: TPLinkDataUpdateCoordinator,
-        id_: str,
         feature: Feature,
         parent: SmartDevice = None,
     ) -> None:
         """Initialize the sensor."""
         # TODO: feature-based entities could be generalized
-        super().__init__(device, coordinator, parent=parent)
-        self._device = device
-        self._feature = feature
-        self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
+        super().__init__(device, coordinator, feature=feature, parent=parent)
         _ = BinarySensorDeviceClass  # TODO: no-op to avoid pre-commit removing the import
         self.entity_description = BinarySensorEntityDescription(
-            key=id_, translation_key=id_, name=feature.name, icon=feature.icon
+            key=feature.id,
+            translation_key=feature.id,
+            name=feature.name,
+            icon=feature.icon,
         )
 
     @callback

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for TPLink binary sensors."""
 from __future__ import annotations
 
-from kasa import Feature, FeatureCategory, FeatureType, SmartDevice
+from kasa import Feature, FeatureType, SmartDevice
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,7 +28,7 @@ def _async_sensors_for_device(
     sensors = [
         BinarySensor(device, coordinator, id_, feat)
         for id_, feat in device.features.items()
-        if feat.show_in_hass and feat.type == FeatureType.BinarySensor
+        if feat.type == FeatureType.BinarySensor
     ]
     return sensors
 
@@ -74,14 +73,9 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
         self._device = device
         self._feature = feature
         self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
-        cat = (
-            EntityCategory.DIAGNOSTIC
-            if feature.category == FeatureCategory.Diagnostic
-            else EntityCategory.CONFIG
-        )
-        _ = BinarySensorDeviceClass  # no-op to avoid pre-commit removing the import
+        _ = BinarySensorDeviceClass  # TODO: no-op to avoid pre-commit removing the import
         self.entity_description = BinarySensorEntityDescription(
-            key=id_, name=feature.name, icon=feature.icon, entity_category=cat
+            key=id_, name=feature.name, icon=feature.icon
         )
         self._async_update_attrs()
 

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -1,0 +1,97 @@
+"""Support for TPLink binary sensors."""
+from __future__ import annotations
+
+from kasa import Feature, FeatureCategory, FeatureType, SmartDevice
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import legacy_device_id
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity
+from .models import TPLinkData
+
+
+def _async_sensors_for_device(
+    device: SmartDevice,
+    coordinator: TPLinkDataUpdateCoordinator,
+    has_parent: bool = False,
+) -> list[BinarySensor]:
+    """Generate the sensors for the device."""
+    sensors = [
+        BinarySensor(device, coordinator, id_, feat)
+        for id_, feat in device.features.items()
+        if feat.show_in_hass and feat.type == FeatureType.BinarySensor
+    ]
+    return sensors
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    children_coordinators = data.children_coordinators
+    entities: list[BinarySensor] = []
+    parent = parent_coordinator.device
+
+    if parent.is_strip:
+        # Historically we only add the children if the device is a strip
+        for idx, child in enumerate(parent.children):
+            entities.extend(
+                _async_sensors_for_device(child, children_coordinators[idx], True)
+            )
+    else:
+        entities.extend(_async_sensors_for_device(parent, parent_coordinator))
+
+    async_add_entities(entities)
+
+
+class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
+    """Representation of a TPLink binary sensor."""
+
+    def __init__(
+        self,
+        device: SmartDevice,
+        coordinator: TPLinkDataUpdateCoordinator,
+        id_: str,
+        feature: Feature,
+    ) -> None:
+        """Initialize the sensor."""
+        # TODO: feature-based entities could be generalized
+        super().__init__(device, coordinator)
+        self._device = device
+        self._feature = feature
+        self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
+        cat = (
+            EntityCategory.DIAGNOSTIC
+            if feature.category == FeatureCategory.Diagnostic
+            else EntityCategory.CONFIG
+        )
+        _ = BinarySensorDeviceClass  # no-op to avoid pre-commit removing the import
+        self.entity_description = BinarySensorEntityDescription(
+            key=id_, name=feature.name, icon=feature.icon, entity_category=cat
+        )
+        self._async_update_attrs()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_is_on = self._feature.value
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -59,6 +59,8 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
             **feature.hass_compat.dict(),
         )
 
+        self._async_update_attrs()
+
     @callback
     def _async_update_attrs(self) -> None:
         """Update the entity's attributes."""

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -56,8 +56,7 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
             translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
-            entity_registry_enabled_default=feature.category
-            is not Feature.Category.Debug,
+            **feature.hass_compat.dict(),
         )
 
     @callback

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -41,15 +41,14 @@ async def async_setup_entry(
     """Set up sensors."""
     data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
     parent_coordinator = data.parent_coordinator
-    children_coordinators = data.children_coordinators
     entities: list[BinarySensor] = []
     device = parent_coordinator.device
 
     entities.extend(_async_sensors_for_device(device, parent_coordinator))
 
-    for idx, child in enumerate(device.children):
+    for child in device.children:
         entities.extend(
-            _async_sensors_for_device(child, children_coordinators[idx], parent=device)
+            _async_sensors_for_device(child, parent_coordinator, parent=device)
         )
 
     async_add_entities(entities)

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -81,9 +81,3 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
     def _async_update_attrs(self) -> None:
         """Update the entity's attributes."""
         self._attr_is_on = self._feature.value
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -73,7 +73,7 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
         self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
         _ = BinarySensorDeviceClass  # TODO: no-op to avoid pre-commit removing the import
         self.entity_description = BinarySensorEntityDescription(
-            key=id_, name=feature.name, icon=feature.icon
+            key=id_, translation_key=id_, name=feature.name, icon=feature.icon
         )
         self._async_update_attrs()
 

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from kasa import Feature, SmartDevice
 
 from homeassistant.components.binary_sensor import (
-    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -64,14 +63,15 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
         parent: SmartDevice = None,
     ) -> None:
         """Initialize the sensor."""
-        # TODO: feature-based entities could be generalized
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        _ = BinarySensorDeviceClass  # TODO: no-op to avoid pre-commit removing the import
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         self.entity_description = BinarySensorEntityDescription(
             key=feature.id,
             translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
+            entity_registry_enabled_default=feature.category
+            is not Feature.Category.Debug,
         )
 
     @callback

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -75,7 +75,6 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
         self.entity_description = BinarySensorEntityDescription(
             key=id_, translation_key=id_, name=feature.name, icon=feature.icon
         )
-        self._async_update_attrs()
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, Device
+from kasa import Device, Feature
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -54,6 +54,7 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        self._feature: Feature
         self.entity_description = _description_for_feature(
             BinarySensorEntityDescription, feature
         )

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, SmartDevice
+from kasa import Feature, Device
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
@@ -47,10 +47,10 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: SmartDevice = None,
+        parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -14,7 +14,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import CoordinatedTPLinkEntity, _entities_for_device_and_its_children
+from .entity import (
+    CoordinatedTPLinkEntity,
+    _description_for_feature,
+    _entities_for_device_and_its_children,
+)
 from .models import TPLinkData
 
 
@@ -50,15 +54,9 @@ class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
-        self.entity_description = BinarySensorEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
-            **feature.hass_compat.dict(),
+        self.entity_description = _description_for_feature(
+            BinarySensorEntityDescription, feature
         )
-
         self._async_update_attrs()
 
     @callback

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -1,0 +1,64 @@
+"""Demo platform that offers a fake button entity."""
+
+from __future__ import annotations
+
+from kasa import Feature, SmartDevice
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity, _entities_for_device_and_its_children
+from .models import TPLinkData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up buttons."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = parent_coordinator.device
+
+    entities = _entities_for_device_and_its_children(
+        device,
+        feature_type=Feature.Action,
+        entity_class=Button,
+        coordinator=parent_coordinator,
+    )
+
+    async_add_entities(entities)
+
+
+class Button(CoordinatedTPLinkEntity, ButtonEntity):
+    """Representation of a TPLink button entity."""
+
+    def __init__(
+        self,
+        device: SmartDevice,
+        coordinator: TPLinkDataUpdateCoordinator,
+        feature: Feature,
+        parent: SmartDevice = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(device, coordinator, feature=feature, parent=parent)
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
+        self.entity_description = ButtonEntityDescription(
+            key=feature.id,
+            translation_key=feature.id,
+            name=feature.name,
+            icon=feature.icon,
+            **feature.hass_compat.dict(),
+        )
+
+    async def async_press(self) -> None:
+        """Execute action."""
+        await self._feature.set_value(True)
+
+    def _async_update_attrs(self):
+        """No need to update anything."""

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -51,6 +51,7 @@ class Button(CoordinatedTPLinkEntity, ButtonEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        self._feature: Feature
         self.entity_description = _description_for_feature(
             ButtonEntityDescription, feature
         )

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, SmartDevice
+from kasa import Feature, Device
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -44,10 +44,10 @@ class Button(CoordinatedTPLinkEntity, ButtonEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: SmartDevice = None,
+        parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, Device
+from kasa import Device, Feature
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/tplink/button.py
+++ b/homeassistant/components/tplink/button.py
@@ -11,7 +11,11 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import CoordinatedTPLinkEntity, _entities_for_device_and_its_children
+from .entity import (
+    CoordinatedTPLinkEntity,
+    _description_for_feature,
+    _entities_for_device_and_its_children,
+)
 from .models import TPLinkData
 
 
@@ -47,13 +51,8 @@ class Button(CoordinatedTPLinkEntity, ButtonEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
-        self.entity_description = ButtonEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
-            **feature.hass_compat.dict(),
+        self.entity_description = _description_for_feature(
+            ButtonEntityDescription, feature
         )
 
     async def async_press(self) -> None:

--- a/homeassistant/components/tplink/climate.py
+++ b/homeassistant/components/tplink/climate.py
@@ -1,0 +1,142 @@
+"""Support for TPLink lights."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from kasa import Device, DeviceType
+from kasa.smart.modules.temperaturecontrol import ThermostatState
+
+from homeassistant.components.climate import (
+    ATTR_TEMPERATURE,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity, async_refresh_after
+from .models import TPLinkData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up switches."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = parent_coordinator.device
+
+    entities: list[TPLinkClimate] = []
+    # As there are no standalone thermostats, we just iterate over the children.
+    entities.extend(
+        [
+            TPLinkClimate(child, parent_coordinator)
+            for child in device.children
+            if child.device_type == DeviceType.Thermostat
+        ]
+    )
+
+    async_add_entities(entities)
+
+
+class TPLinkClimate(CoordinatedTPLinkEntity, ClimateEntity):
+    """Representation of a TPLink thermostat."""
+
+    # TODO: should this use ClimateEntityDescription?
+
+    device: Device
+    _attr_name = None
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
+    # TODO: this disables the warning for async_turn_{on,off}, which should be fine?
+    _enable_turn_on_off_backwards_compatibility = False
+    # TODO: use unit from the device
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_precision = PRECISION_WHOLE
+
+    def __init__(
+        self,
+        device: Device,
+        coordinator: TPLinkDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the switch."""
+        super().__init__(device, coordinator)
+        self._temp_feature = self.device.features["temperature"]
+        self._target_feature = self.device.features["target_temperature"]
+        self._state_feature = self.device.features["state"]
+        self._mode_feature = self.device.features["mode"]
+        self._async_update_attrs()
+
+    @async_refresh_after
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Set target temperature."""
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
+            return
+        await self._target_feature.set_value(int(temperature))
+
+    @async_refresh_after
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set hvac mode (on/off)."""
+        if hvac_mode is HVACMode.HEAT:
+            await self._state_feature.set_value(True)
+        elif hvac_mode is HVACMode.OFF:
+            await self._state_feature.set_value(False)
+        else:
+            _LOGGER.warning("Tried to set unsupported hvacmode %s", hvac_mode)
+
+    @async_refresh_after
+    async def async_turn_on(self) -> None:
+        """Turn heating on."""
+        await self._state_feature.set_value(True)
+
+    @async_refresh_after
+    async def async_turn_off(self) -> None:
+        """Turn heating off."""
+        await self._state_feature.set_value(False)
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_min_temp = self._target_feature.minimum_value
+        self._attr_max_temp = self._target_feature.maximum_value
+        self._attr_target_temperature = self._target_feature.value
+
+        self._attr_current_temperature = self._temp_feature.value
+        # TODO: use unit from the device
+        # self._attr_temperature_unit = self._temp_feature.unit
+
+        self._attr_hvac_mode = (
+            HVACMode.HEAT if self._state_feature.value else HVACMode.OFF
+        )
+        action: HVACAction
+        match self._mode_feature.value:
+            case ThermostatState.Idle:
+                action = HVACAction.IDLE
+            case ThermostatState.Heating:
+                action = HVACAction.HEATING
+            case ThermostatState.Off:
+                action = HVACAction.OFF
+            case _:
+                _LOGGER.warning(
+                    "Unknown thermostat state %s, defaulting to OFF",
+                    self._state_feature.value,
+                )
+                action = HVACAction.OFF
+
+        self._attr_hvac_action = action

--- a/homeassistant/components/tplink/climate.py
+++ b/homeassistant/components/tplink/climate.py
@@ -41,11 +41,9 @@ async def async_setup_entry(
     entities: list[TPLinkClimate] = []
     # As there are no standalone thermostats, we just iterate over the children.
     entities.extend(
-        [
-            TPLinkClimate(child, parent_coordinator)
-            for child in device.children
-            if child.device_type == DeviceType.Thermostat
-        ]
+        TPLinkClimate(child, parent_coordinator)
+        for child in device.children
+        if child.device_type == DeviceType.Thermostat
     )
 
     async_add_entities(entities)

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -8,9 +8,9 @@ from typing import Any
 from kasa import (
     AuthenticationException,
     Credentials,
+    Device,
     DeviceConfig,
     Discover,
-    Device,
     KasaException,
     TimeoutException,
 )
@@ -375,9 +375,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             )
         except TimeoutException:
             # Try connect() to legacy devices if discovery fails
-            self._discovered_device = await Device.connect(
-                config=DeviceConfig(host)
-            )
+            self._discovered_device = await Device.connect(config=DeviceConfig(host))
         else:
             if self._discovered_device.config.uses_http:
                 self._discovered_device.config.http_client = (

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -24,4 +24,5 @@ PLATFORMS: Final = [
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
     Platform.UPDATE,
+    Platform.NUMBER,
 ]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -26,4 +26,5 @@ PLATFORMS: Final = [
     #    Platform.UPDATE,
     Platform.NUMBER,
     Platform.CLIMATE,
+    Platform.BUTTON,
 ]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -18,4 +18,9 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
 CONF_DEVICE_CONFIG: Final = "device_config"
 
-PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: Final = [
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+    Platform.BINARY_SENSOR,
+]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -19,12 +19,13 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 CONF_DEVICE_CONFIG: Final = "device_config"
 
 PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.BUTTON,
+    Platform.CLIMATE,
     Platform.LIGHT,
+    Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
-    Platform.BINARY_SENSOR,
-    #    Platform.UPDATE,
-    Platform.NUMBER,
-    Platform.CLIMATE,
-    Platform.BUTTON,
+    # Platform.UPDATE,
 ]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -23,6 +23,6 @@ PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
-    Platform.UPDATE,
+    #    Platform.UPDATE,
     Platform.NUMBER,
 ]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -23,4 +23,5 @@ PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.BINARY_SENSOR,
+    Platform.UPDATE,
 ]

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -25,4 +25,5 @@ PLATFORMS: Final = [
     Platform.BINARY_SENSOR,
     #    Platform.UPDATE,
     Platform.NUMBER,
+    Platform.CLIMATE,
 ]

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from kasa import AuthenticationException, SmartDevice, SmartDeviceException
+from kasa import AuthenticationException, Device, KasaException
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -26,7 +26,7 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
     def __init__(
         self,
         hass: HomeAssistant,
-        device: SmartDevice,
+        device: Device,
         update_interval: timedelta,
     ) -> None:
         """Initialize DataUpdateCoordinator to gather data for specific SmartPlug."""
@@ -49,5 +49,5 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
             await self.device.update(update_children=False)
         except AuthenticationException as ex:
             raise ConfigEntryAuthFailed from ex
-        except SmartDeviceException as ex:
+        except KasaException as ex:
             raise UpdateFailed(ex) from ex

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -13,7 +13,6 @@ from kasa import (
 )
 
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -71,14 +70,20 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator]):
     _attr_has_entity_name = True
 
     def __init__(
-        self, device: SmartDevice, coordinator: TPLinkDataUpdateCoordinator
+        self,
+        device: SmartDevice,
+        coordinator: TPLinkDataUpdateCoordinator,
+        parent: SmartDevice = None,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the entity."""
         super().__init__(coordinator)
         self.device: SmartDevice = device
         self._attr_unique_id = device.device_id
         self._attr_device_info = DeviceInfo(
-            connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
+            # TODO: find out if connections have any use and/or if it should
+            #  still be set for the main device. if set for child devices, all
+            #  devices will be presented by a single device
+            # connections={(dr.CONNECTION_NETWORK_MAC, device.mac)},
             identifiers={(DOMAIN, str(device.device_id))},
             manufacturer="TP-Link",
             model=device.model,
@@ -86,3 +91,6 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator]):
             sw_version=device.hw_info["sw_ver"],
             hw_version=device.hw_info["hw_ver"],
         )
+
+        if parent is not None:
+            self._attr_device_info["via_device"] = (DOMAIN, parent.device_id)

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -95,6 +95,11 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         if feature is not None:
             self._attr_unique_id = f"{legacy_device_id(device)}_{feature.id}"
             self._attr_entity_category = self._category_for_feature(feature)
+            _LOGGER.warning(
+                "Initializing feature-based %s with category %s",
+                self._attr_unique_id,
+                self._attr_entity_category,
+            )
 
         # Otherwise, if we have entity_description, we use its key
         elif self._attr_unique_id is None and hasattr(self, "entity_description"):
@@ -141,14 +146,15 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         match feature.category:
             case Feature.Category.Primary:  # Main controls have no category
                 return None
+            case Feature.Category.Info:
+                return None
             case Feature.Category.Config:
                 return EntityCategory.CONFIG
-            case Feature.Category.Info:
-                return EntityCategory.DIAGNOSTIC
             case Feature.Category.Debug:
                 return EntityCategory.DIAGNOSTIC
 
     @abstractmethod
+    @callback
     def _async_update_attrs(self):
         """Implement to update the entity internals."""
         raise NotImplementedError
@@ -195,6 +201,7 @@ def _entities_for_device(
             DeviceType.Bulb,
             DeviceType.LightStrip,
             DeviceType.Dimmer,
+            DeviceType.Thermostat,
         ]
         if (
             feat.category == Feature.Category.Primary

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -147,10 +147,15 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
             case Feature.Category.Primary:  # Main controls have no category
                 return None
             case Feature.Category.Info:
-                return None
+                return EntityCategory.DIAGNOSTIC
             case Feature.Category.Config:
                 return EntityCategory.CONFIG
             case Feature.Category.Debug:
+                return EntityCategory.DIAGNOSTIC
+            case _:
+                _LOGGER.error(
+                    "Unhandled category, fallback to DIAGNOSTIC: %s", feature.category
+                )
                 return EntityCategory.DIAGNOSTIC
 
     @abstractmethod
@@ -253,3 +258,26 @@ def _entities_for_device_and_its_children(
     )
 
     return entities
+
+
+def _description_for_feature(desc_cls, feature, **extras):
+    """Return description object for the given feature.
+
+    This is responsible for setting the common parameters & deciding based on feature id
+    which additional parameters are passed.
+
+    The *extras* can be used to pass extra parameters, like "options" for selects.
+    """
+
+    if "entity_registry_enabled_default" not in extras:
+        extras["entity_registry_enabled_default"] = (
+            feature.category is not Feature.Category.Debug
+        )
+
+    return desc_cls(
+        key=feature.id,
+        translation_key=feature.id,
+        name=feature.name,
+        icon=feature.icon,
+        **extras,
+    )

--- a/homeassistant/components/tplink/icons.json
+++ b/homeassistant/components/tplink/icons.json
@@ -1,16 +1,43 @@
 {
   "entity": {
+    "binary_sensor": {
+      "alarm": {
+        "default": "mdi:alarm",
+        "state": {
+          "off": "mdi:alarm-off"
+        }
+      },
+      "cloud_connection": {
+        "default": "mdi:cloud",
+        "state": {
+          "off": "mdi:cloud-off-outline"
+        }
+      }
+    },
+    "sensor": {
+      "signal_level": {
+        "default": "mdi:signal",
+        "state": {
+          "1": "mdi:signal-cellular-1",
+          "2": "mdi:signal-cellular-2",
+          "3": "mdi:signal-cellular-3"
+        }
+      },
+      "alarm_volume": {
+        "default": "mdi:volume-medium",
+        "state": {
+          "low": "mdi:volume-low",
+          "high": "mdi:volume-high"
+        }
+      }
+    },
     "switch": {
       "led": {
-        "default": "mdi:led-off",
+        "default": "mdi:led-on",
         "state": {
-          "on": "mdi:led-on"
+          "off": "mdi:led-off"
         }
       }
     }
-  },
-  "services": {
-    "sequence_effect": "mdi:playlist-play",
-    "random_effect": "mdi:shuffle-variant"
   }
 }

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -302,12 +302,6 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
             hue, saturation, _ = device.hsv
             self._attr_hs_color = hue, saturation
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()
-
 
 class TPLinkSmartLightStrip(TPLinkSmartBulb):
     """Representation of a TPLink Smart Light Strip."""

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -269,5 +269,5 @@
   "iot_class": "local_polling",
   "loggers": ["kasa"],
   "quality_scale": "platinum",
-  "requirements": ["python-kasa[speedups]==0.6.2.1"]
+  "requirements": ["python-kasa[speedups]==0.7.0.dev0"]
 }

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -78,7 +78,6 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
             native_min_value=feature.minimum_value,
             native_max_value=feature.maximum_value,
         )
-        self._async_update_attrs()
 
     @async_refresh_after
     async def async_set_native_value(self, value: float) -> None:

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -72,6 +72,7 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
 
         self.entity_description = NumberEntityDescription(
             key=id_,
+            translation_key=id_,
             name=feature.name,
             icon=feature.icon,
             native_min_value=feature.minimum_value,

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -1,0 +1,90 @@
+"""Support for TPLink number entities."""
+from __future__ import annotations
+
+import logging
+from typing import cast
+
+from kasa import Feature, FeatureType, SmartDevice, SmartPlug
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import legacy_device_id
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity, async_refresh_after
+from .models import TPLinkData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up number entities."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = cast(SmartPlug, parent_coordinator.device)
+    entities: list = []
+
+    def _numbers_for_device(dev, parent: SmartDevice = None) -> list[Number]:
+        switches = [
+            Number(dev, data.parent_coordinator, id_, feat, parent=parent)
+            for id_, feat in dev.features.items()
+            if feat.type == FeatureType.Number
+        ]
+        return switches
+
+    if device.children:
+        _LOGGER.debug("Initializing device with %s children", len(device.children))
+        for child in device.children:
+            entities.extend(_numbers_for_device(child, parent=device))
+
+    entities.extend(_numbers_for_device(device))
+
+    async_add_entities(entities)
+
+
+class Number(CoordinatedTPLinkEntity, NumberEntity):
+    """Representation of a feature-based TPLink sensor."""
+
+    def __init__(
+        self,
+        device: SmartDevice,
+        coordinator: TPLinkDataUpdateCoordinator,
+        id_: str,
+        feature: Feature,
+        parent: SmartDevice = None,
+    ):
+        """Initialize the number entity."""
+        super().__init__(device, coordinator, parent=parent)
+        self._device = device
+        self._feature = feature
+        self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
+        self._attr_entity_category = (
+            EntityCategory.CONFIG
+        )  # TODO: read from the feature
+
+        self.entity_description = NumberEntityDescription(
+            key=id_,
+            name=feature.name,
+            icon=feature.icon,
+            native_min_value=feature.minimum_value,
+            native_max_value=feature.maximum_value,
+        )
+        self._async_update_attrs()
+
+    @async_refresh_after
+    async def async_set_native_value(self, value: float) -> None:
+        """Set feature value."""
+        await self._feature.set_value(int(value))
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_native_value = self._feature.value

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -1,18 +1,17 @@
 """Support for TPLink number entities."""
+
 from __future__ import annotations
 
 import logging
 from typing import cast
 
-from kasa import Feature, FeatureType, SmartDevice, SmartPlug
+from kasa import Feature, SmartDevice, SmartPlug
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import legacy_device_id
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import CoordinatedTPLinkEntity, async_refresh_after
@@ -33,12 +32,11 @@ async def async_setup_entry(
     entities: list = []
 
     def _numbers_for_device(dev, parent: SmartDevice = None) -> list[Number]:
-        switches = [
-            Number(dev, data.parent_coordinator, id_, feat, parent=parent)
-            for id_, feat in dev.features.items()
-            if feat.type == FeatureType.Number
+        return [
+            Number(dev, data.parent_coordinator, feat, parent=parent)
+            for feat in dev.features.values()
+            if feat.type == Feature.Number
         ]
-        return switches
 
     if device.children:
         _LOGGER.debug("Initializing device with %s children", len(device.children))
@@ -57,22 +55,15 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
         self,
         device: SmartDevice,
         coordinator: TPLinkDataUpdateCoordinator,
-        id_: str,
         feature: Feature,
         parent: SmartDevice = None,
     ):
         """Initialize the number entity."""
-        super().__init__(device, coordinator, parent=parent)
-        self._device = device
-        self._feature = feature
-        self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
-        self._attr_entity_category = (
-            EntityCategory.CONFIG
-        )  # TODO: read from the feature
+        super().__init__(device, coordinator, feature=feature, parent=parent)
 
         self.entity_description = NumberEntityDescription(
-            key=id_,
-            translation_key=id_,
+            key=feature.id,
+            translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
             native_min_value=feature.minimum_value,

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -60,7 +60,7 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
     ):
         """Initialize the number entity."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         self.entity_description = NumberEntityDescription(
             key=feature.id,
             translation_key=feature.id,
@@ -68,6 +68,8 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
             icon=feature.icon,
             native_min_value=feature.minimum_value,
             native_max_value=feature.maximum_value,
+            entity_registry_enabled_default=feature.category
+            is not Feature.Category.Debug,
         )
 
     @async_refresh_after

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import cast
 
-from kasa import Feature, SmartDevice, SmartPlug
+from kasa import Feature, Device, SmartPlug
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -33,7 +33,7 @@ async def async_setup_entry(
     """Set up number entities."""
     data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
     parent_coordinator = data.parent_coordinator
-    device = cast(SmartPlug, parent_coordinator.device)
+    device = parent_coordinator.device
 
     entities = _entities_for_device_and_its_children(
         device,
@@ -50,10 +50,10 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: SmartDevice = None,
+        parent: Device | None = None,
     ):
         """Initialize the number entity."""
         super().__init__(device, coordinator, feature=feature, parent=parent)

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import cast
 
-from kasa import Feature, Device, SmartPlug
+from kasa import Device, Feature
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -57,6 +57,7 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
     ):
         """Initialize the number entity."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        self._feature: Feature
         self.entity_description = _description_for_feature(
             NumberEntityDescription,
             feature,

--- a/homeassistant/components/tplink/number.py
+++ b/homeassistant/components/tplink/number.py
@@ -16,6 +16,7 @@ from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkEntity,
+    _description_for_feature,
     _entities_for_device_and_its_children,
     async_refresh_after,
 )
@@ -56,16 +57,11 @@ class Number(CoordinatedTPLinkEntity, NumberEntity):
     ):
         """Initialize the number entity."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
-        self.entity_description = NumberEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
+        self.entity_description = _description_for_feature(
+            NumberEntityDescription,
+            feature,
             native_min_value=feature.minimum_value,
             native_max_value=feature.maximum_value,
-            entity_registry_enabled_default=feature.category
-            is not Feature.Category.Debug,
         )
 
     @async_refresh_after

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -1,0 +1,74 @@
+"""Demo platform that offers a fake select entity."""
+
+from __future__ import annotations
+
+from kasa import Feature, SmartDevice
+
+from homeassistant.components.select import SelectEntity, SelectEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import (
+    CoordinatedTPLinkEntity,
+    _entities_for_device_and_its_children,
+    async_refresh_after,
+)
+from .models import TPLinkData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up selects."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = parent_coordinator.device
+
+    entities = _entities_for_device_and_its_children(
+        device,
+        feature_type=Feature.Choice,
+        entity_class=Select,
+        coordinator=parent_coordinator,
+    )
+
+    async_add_entities(entities)
+
+
+class Select(CoordinatedTPLinkEntity, SelectEntity):
+    """Representation of a tplink select entity."""
+
+    def __init__(
+        self,
+        device: SmartDevice,
+        coordinator: TPLinkDataUpdateCoordinator,
+        feature: Feature,
+        parent: SmartDevice = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(device, coordinator, feature=feature, parent=parent)
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
+        self.entity_description = SelectEntityDescription(
+            key=feature.id,
+            translation_key=feature.id,
+            name=feature.name,
+            icon=feature.icon,
+            options=feature.choices,
+            **feature.hass_compat.dict(),
+        )
+
+        self._async_update_attrs()
+
+    @async_refresh_after
+    async def async_select_option(self, option: str) -> None:
+        """Update the current selected option."""
+        await self._feature.set_value(option)
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_current_option = self._feature.value

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, SmartDevice
+from kasa import Feature, Device
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -45,10 +45,10 @@ class Select(CoordinatedTPLinkEntity, SelectEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: SmartDevice = None,
+        parent: Device = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -1,4 +1,4 @@
-"""Demo platform that offers a fake select entity."""
+"""Support for TPLink select entities."""
 
 from __future__ import annotations
 
@@ -13,6 +13,7 @@ from . import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkEntity,
+    _description_for_feature,
     _entities_for_device_and_its_children,
     async_refresh_after,
 )
@@ -51,16 +52,9 @@ class Select(CoordinatedTPLinkEntity, SelectEntity):
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
-        self.entity_description = SelectEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
-            options=feature.choices,
-            **feature.hass_compat.dict(),
+        self.entity_description = _description_for_feature(
+            SelectEntityDescription, feature, options=feature.choices
         )
-
         self._async_update_attrs()
 
     @async_refresh_after

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from kasa import Feature, Device
+from kasa import Device, Feature
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/tplink/select.py
+++ b/homeassistant/components/tplink/select.py
@@ -48,10 +48,11 @@ class Select(CoordinatedTPLinkEntity, SelectEntity):
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: Device = None,
+        parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        self._feature: Feature
         self.entity_description = _description_for_feature(
             SelectEntityDescription, feature, options=feature.choices
         )

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -145,14 +145,14 @@ async def async_setup_entry(
     #  bailed out here after checking has_emeter
     # TODO: this also currently does not create any sensors for strip devices.
 
-    if parent.is_strip:
+    if parent.children:
         # Historically we only add the children if the device is a strip
         for idx, child in enumerate(parent.children):
             entities.extend(
                 _async_sensors_for_device(child, children_coordinators[idx], True)
             )
-    else:
-        entities.extend(_async_sensors_for_device(parent, parent_coordinator))
+
+    entities.extend(_async_sensors_for_device(parent, parent_coordinator))
 
     async_add_entities(entities)
 

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -186,11 +186,6 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
         """Update the entity's attributes."""
         self._attr_native_value = self._feature.value
 
-    @property
-    def native_value(self):
-        """Return the sensors state."""
-        return self._feature.value
-
 
 class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
     """Representation of a TPLink sensor."""

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -173,11 +173,14 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
     ):
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         self.entity_description = SensorEntityDescription(
             key=feature.id,
             translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
+            entity_registry_enabled_default=feature.category
+            is not Feature.Category.Debug,
         )
 
     @callback

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -114,11 +114,13 @@ def _async_sensors_for_device(
     has_parent: bool = False,
 ) -> list[SmartPlugSensor]:
     """Generate the sensors for the device."""
-    sensors = [
-        SmartPlugSensor(device, coordinator, description, has_parent)
-        for description in ENERGY_SENSORS
-        if async_emeter_from_device(device, description) is not None
-    ]
+    sensors = []
+    if device.has_emeter:
+        sensors = [
+            SmartPlugSensor(device, coordinator, description, has_parent)
+            for description in ENERGY_SENSORS
+            if async_emeter_from_device(device, description) is not None
+        ]
     new_sensors = [
         Sensor(device, coordinator, id_, desc)
         for id_, desc in device.features.items()

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -193,9 +193,10 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
             name=feature.name,
             icon=feature.icon,
             native_unit_of_measurement=feature.unit,
-            entity_registry_enabled_default=feature.category
-            is not Feature.Category.Debug,
+            **feature.hass_compat.dict(),
         )
+        # TODO: define `options` if type==Choice
+        #  Requires the enum device class to be set. Cannot be combined with state_class or native_unit_of_measurement.
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -192,6 +192,7 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
             translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
+            native_unit_of_measurement=feature.unit,
             entity_registry_enabled_default=feature.category
             is not Feature.Category.Debug,
         )

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -181,6 +181,11 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
             key=id_, name=feature.name, icon=feature.icon
         )
 
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_native_value = self._feature.value
+
     @property
     def native_value(self):
         """Return the sensors state."""

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -142,9 +142,19 @@ async def async_setup_entry(
     device = parent_coordinator.device
 
     for idx, child in enumerate(device.children):
-        entities.extend(
-            _async_sensors_for_device(child, children_coordinators[idx], parent=device)
-        )
+        # TODO: nicer way for multi-coordinator updates.
+        from kasa import SmartStrip
+
+        if isinstance(device, SmartStrip):
+            entities.extend(
+                _async_sensors_for_device(
+                    child, children_coordinators[idx], parent=device
+                )
+            )
+        else:
+            entities.extend(
+                _async_sensors_for_device(child, parent_coordinator, parent=device)
+            )
 
     entities.extend(_async_sensors_for_device(device, parent_coordinator))
 

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from kasa import Feature, FeatureCategory, FeatureType, SmartDevice
+from kasa import Feature, FeatureType, SmartDevice
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -16,7 +16,6 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_VOLTAGE,
-    EntityCategory,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -123,7 +122,7 @@ def _async_sensors_for_device(
     new_sensors = [
         Sensor(device, coordinator, id_, desc)
         for id_, desc in device.features.items()
-        if desc.show_in_hass and desc.type == FeatureType.Sensor
+        if desc.type == FeatureType.Sensor
     ]
     return sensors + new_sensors
 
@@ -171,13 +170,8 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
         self._device = device
         self._feature = feature
         self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
-        cat = (
-            EntityCategory.DIAGNOSTIC
-            if feature.category == FeatureCategory.Diagnostic
-            else EntityCategory.CONFIG
-        )
         self.entity_description = SensorEntityDescription(
-            key=id_, name=feature.name, icon=feature.icon, entity_category=cat
+            key=id_, name=feature.name, icon=feature.icon
         )
 
     @property

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -178,7 +178,7 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
         self._feature = feature
         self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
         self.entity_description = SensorEntityDescription(
-            key=id_, name=feature.name, icon=feature.icon
+            key=id_, translation_key=id_, name=feature.name, icon=feature.icon
         )
 
     @callback

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -1,4 +1,4 @@
-"""Support for TPLink HS100/HS110/HS200 smart switch energy sensors."""
+"""Support for TPLink sensor entities."""
 
 from __future__ import annotations
 
@@ -33,7 +33,11 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import CoordinatedTPLinkEntity, _entities_for_device
+from .entity import (
+    CoordinatedTPLinkEntity,
+    _description_for_feature,
+    _entities_for_device,
+)
 from .models import TPLinkData
 
 
@@ -186,15 +190,11 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
     ):
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
-        self.entity_description = SensorEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
-            native_unit_of_measurement=feature.unit,
-            **feature.hass_compat.dict(),
+
+        self.entity_description = _description_for_feature(
+            SensorEntityDescription, feature, native_unit_of_measurement=feature.unit
         )
+
         # TODO: define `options` if type==Choice
         #  Requires the enum device class to be set. Cannot be combined with state_class or native_unit_of_measurement.
 

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from kasa import Feature, Device
+from kasa import Device, Feature
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from kasa import Feature, SmartDevice
+from kasa import Feature, Device
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -96,7 +96,7 @@ ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
 
 
 def async_emeter_from_device(
-    device: SmartDevice, description: TPLinkSensorEntityDescription
+    device: Device, description: TPLinkSensorEntityDescription
 ) -> float | None:
     """Map a sensor key to the device attribute."""
     if attr := description.emeter_attr:
@@ -113,9 +113,9 @@ def async_emeter_from_device(
 
 
 def _async_sensors_for_device(
-    device: SmartDevice,
+    device: Device,
     coordinator: TPLinkDataUpdateCoordinator,
-    parent: SmartDevice = None,
+    parent: Device | None = None,
 ) -> list[SmartPlugSensor]:
     """Generate the sensors for the device."""
     sensors = []
@@ -183,10 +183,10 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: SmartDevice = None,
+        parent: Device | None = None,
     ):
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
@@ -215,10 +215,10 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
 
     def __init__(
         self,
-        device: SmartDevice,
+        device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         description: TPLinkSensorEntityDescription,
-        parent: SmartDevice = None,
+        parent: Device = None,
     ) -> None:
         """Initialize the switch."""
         self.entity_description = description

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -201,7 +201,10 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
     @callback
     def _async_update_attrs(self) -> None:
         """Update the entity's attributes."""
-        self._attr_native_value = self._feature.value
+        value = self._feature.value
+        if value is not None and self._feature.precision_hint is not None:
+            value = round(cast(float, value), self._feature.precision_hint)
+        self._attr_native_value = value
 
 
 class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -116,16 +116,16 @@ def _async_sensors_for_device(
     device: Device,
     coordinator: TPLinkDataUpdateCoordinator,
     parent: Device | None = None,
-) -> list[SmartPlugSensor]:
+) -> list[CoordinatedTPLinkEntity]:
     """Generate the sensors for the device."""
-    sensors = []
+    sensors: list[CoordinatedTPLinkEntity] = []
     if device.has_emeter:
         sensors = [
             SmartPlugSensor(device, coordinator, description, parent=parent)
             for description in ENERGY_SENSORS
             if async_emeter_from_device(device, description) is not None
         ]
-    new_sensors = [
+    new_sensors: list[CoordinatedTPLinkEntity] = [
         Sensor(device, coordinator, feat, parent=parent)
         for feat in device.features.values()
         if feat.type == Feature.Sensor
@@ -190,7 +190,7 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
     ):
         """Initialize the sensor."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-
+        self._feature: Feature
         self.entity_description = _description_for_feature(
             SensorEntityDescription, feature, native_unit_of_measurement=feature.unit
         )
@@ -218,7 +218,7 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         description: TPLinkSensorEntityDescription,
-        parent: Device = None,
+        parent: Device | None = None,
     ) -> None:
         """Initialize the switch."""
         self.entity_description = description

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -45,7 +45,7 @@ async def async_setup_entry(
     new_switches = [
         Switch(device, data.parent_coordinator, id_, feat)
         for id_, feat in device.features.items()
-        if feat.show_in_hass and feat.type == FeatureType.Switch
+        if feat.type == FeatureType.Switch
     ]
 
     async_add_entities(entities + new_switches)

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -76,7 +76,7 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
             self._attr_entity_category = None
 
         self.entity_description = SwitchEntityDescription(
-            key=id_, name=feature.name, icon=feature.icon
+            key=id_, translation_key=id_, name=feature.name, icon=feature.icon
         )
         self._async_update_attrs()
 
@@ -94,9 +94,3 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
     def _async_update_attrs(self) -> None:
         """Update the entity's attributes."""
         is_on = self._feature.value
-
-        icon = self._feature.icon
-        # TODO: hacky way to support on/off icons. maybe this should be removed?
-        if icon and "{state}" in icon:
-            icon = icon.replace("{state}", "on" if is_on else "off")
-        self._attr_icon = icon

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -78,7 +78,6 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         self.entity_description = SwitchEntityDescription(
             key=id_, translation_key=id_, name=feature.name, icon=feature.icon
         )
-        self._async_update_attrs()
 
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -100,9 +100,3 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         if icon and "{state}" in icon:
             icon = icon.replace("{state}", "on" if is_on else "off")
         self._attr_icon = icon
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -62,11 +62,14 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
     ):
         """Initialize the switch."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         self.entity_description = SwitchEntityDescription(
             key=feature.id,
             translation_key=feature.id,
             name=feature.name,
             icon=feature.icon,
+            entity_registry_enabled_default=feature.category
+            is not Feature.Category.Debug,
         )
 
     @async_refresh_after

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -32,23 +32,25 @@ async def async_setup_entry(
     parent_coordinator = data.parent_coordinator
     device = cast(SmartPlug, parent_coordinator.device)
     entities: list = []
-    if device.is_strip:
-        # Historically we only add the children if the device is a strip
-        _LOGGER.debug("Initializing strip with %s sockets", len(device.children))
-        entities.extend(
-            SmartPlugSwitchChild(device, parent_coordinator, child)
-            for child in device.children
-        )
-    elif device.is_plug:
-        entities.append(SmartPlugSwitch(device, parent_coordinator))
 
-    new_switches = [
-        Switch(device, data.parent_coordinator, id_, feat)
-        for id_, feat in device.features.items()
-        if feat.type == FeatureType.Switch
-    ]
+    def _switches_for_device(dev, parent: SmartDevice = None) -> list[Switch]:
+        switches = [
+            Switch(dev, data.parent_coordinator, id_, feat, parent=parent)
+            for id_, feat in dev.features.items()
+            if feat.type == FeatureType.Switch
+        ]
+        # TODO: a way to filter state switch for platforms with their own main controls:
+        #  lights and fans?
+        return switches
 
-    async_add_entities(entities + new_switches)
+    if device.children:
+        _LOGGER.debug("Initializing device with %s children", len(device.children))
+        for child in device.children:
+            entities.extend(_switches_for_device(child, parent=device))
+
+    entities.extend(_switches_for_device(device))
+
+    async_add_entities(entities)
 
 
 class Switch(CoordinatedTPLinkEntity, SwitchEntity):
@@ -60,13 +62,19 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         coordinator: TPLinkDataUpdateCoordinator,
         id_: str,
         feature: Feature,
+        parent: SmartDevice = None,
     ):
         """Initialize the switch."""
-        super().__init__(device, coordinator)
+        super().__init__(device, coordinator, parent=parent)
         self._device = device
         self._feature = feature
         self._attr_unique_id = f"{legacy_device_id(device)}_new_{id_}"
-        self._attr_entity_category = EntityCategory.CONFIG
+        self._attr_entity_category = (
+            EntityCategory.CONFIG
+        )  # TODO: read from the feature
+        if feature.name == "State":  # Main switch of the device has no category.
+            self._attr_entity_category = None
+
         self.entity_description = SwitchEntityDescription(
             key=id_, name=feature.name, icon=feature.icon
         )
@@ -88,8 +96,8 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         is_on = self._feature.value
 
         icon = self._feature.icon
-        # TODO: hacky way to support on/off icons..
-        if "{state}" in icon:
+        # TODO: hacky way to support on/off icons. maybe this should be removed?
+        if icon and "{state}" in icon:
             icon = icon.replace("{state}", "on" if is_on else "off")
         self._attr_icon = icon
 
@@ -98,72 +106,3 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         """Handle updated data from the coordinator."""
         self._async_update_attrs()
         super()._handle_coordinator_update()
-
-
-class SmartPlugSwitch(CoordinatedTPLinkEntity, SwitchEntity):
-    """Representation of a TPLink Smart Plug switch."""
-
-    _attr_name: str | None = None
-
-    def __init__(
-        self,
-        device: SmartDevice,
-        coordinator: TPLinkDataUpdateCoordinator,
-    ) -> None:
-        """Initialize the switch."""
-        super().__init__(device, coordinator)
-        # For backwards compat with pyHS100
-        self._attr_unique_id = legacy_device_id(device)
-        self._async_update_attrs()
-
-    @async_refresh_after
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
-        await self.device.turn_on()
-
-    @async_refresh_after
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
-        await self.device.turn_off()
-
-    @callback
-    def _async_update_attrs(self) -> None:
-        """Update the entity's attributes."""
-        self._attr_is_on = self.device.is_on
-
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()
-
-
-class SmartPlugSwitchChild(SmartPlugSwitch):
-    """Representation of an individual plug of a TPLink Smart Plug strip."""
-
-    def __init__(
-        self,
-        device: SmartDevice,
-        coordinator: TPLinkDataUpdateCoordinator,
-        plug: SmartDevice,
-    ) -> None:
-        """Initialize the child switch."""
-        self._plug = plug
-        super().__init__(device, coordinator)
-        self._attr_unique_id = legacy_device_id(plug)
-        self._attr_name = plug.alias
-
-    @async_refresh_after
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the child switch on."""
-        await self._plug.turn_on()
-
-    @async_refresh_after
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the child switch off."""
-        await self._plug.turn_off()
-
-    @callback
-    def _async_update_attrs(self) -> None:
-        """Update the entity's attributes."""
-        self._attr_is_on = self._plug.is_on

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -57,6 +57,10 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
         # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
+        # Use the device name for the primary switch control
+        if feature.category is Feature.Category.Primary:
+            self._attr_name = None
+
         self.entity_description = SwitchEntityDescription(
             key=feature.id,
             translation_key=feature.id,

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -57,12 +57,13 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
     ):
         """Initialize the switch."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
-        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
+        self._feature: Feature
+
         # Use the device name for the primary switch control
-        self._feature = cast(Feature, self._feature)
         if feature.category is Feature.Category.Primary:
             self._attr_name = None
 
+        # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         self.entity_description = _description_for_feature(
             SwitchEntityDescription, feature
         )

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -16,6 +16,7 @@ from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkEntity,
+    _description_for_feature,
     _entities_for_device_and_its_children,
     async_refresh_after,
 )
@@ -61,13 +62,8 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         if feature.category is Feature.Category.Primary:
             self._attr_name = None
 
-        self.entity_description = SwitchEntityDescription(
-            key=feature.id,
-            translation_key=feature.id,
-            name=feature.name,
-            icon=feature.icon,
-            entity_registry_enabled_default=feature.category
-            is not Feature.Category.Debug,
+        self.entity_description = _description_for_feature(
+            SwitchEntityDescription, feature
         )
 
     @async_refresh_after

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -53,12 +53,13 @@ class Switch(CoordinatedTPLinkEntity, SwitchEntity):
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
         feature: Feature,
-        parent: Device = None,
+        parent: Device | None = None,
     ):
         """Initialize the switch."""
         super().__init__(device, coordinator, feature=feature, parent=parent)
         # TODO: generalize creation of entitydescription into CoordinatedTPLinkEntity?
         # Use the device name for the primary switch control
+        self._feature = cast(Feature, self._feature)
         if feature.category is Feature.Category.Primary:
             self._attr_name = None
 

--- a/homeassistant/components/tplink/update.py
+++ b/homeassistant/components/tplink/update.py
@@ -92,12 +92,6 @@ class Update(CoordinatedTPLinkEntity, UpdateEntity):
         )
         self._attr_is_on = self._update_module.update_available
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._async_update_attrs()
-        super()._handle_coordinator_update()
-
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
     ) -> None:

--- a/homeassistant/components/tplink/update.py
+++ b/homeassistant/components/tplink/update.py
@@ -1,0 +1,111 @@
+"""Firmware update platform for tplink."""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+from kasa import Device
+
+# TODO: Firmware should be pulled up for all supported devices
+from kasa.smart.modules.firmware import Firmware
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import legacy_device_id
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity
+from .models import TPLinkData
+
+FAKE_INSTALL_SLEEP_TIME = 0.5
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up demo update platform."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = cast(Device, parent_coordinator.device)
+    entities: list = []
+
+    def _create_entities(dev):
+        entities = []
+        if "Firmware" in device.modules:
+            entities.append(Update(device, parent_coordinator, parent=dev))
+
+        return entities
+
+    for child in device.children:
+        entities.extend(_create_entities(child))
+
+    entities.extend(_create_entities(device))
+
+    async_add_entities(entities)
+
+
+async def _fake_install() -> None:
+    """Fake install an update."""
+    await asyncio.sleep(FAKE_INSTALL_SLEEP_TIME)
+
+
+class Update(CoordinatedTPLinkEntity, UpdateEntity):
+    """Representation of a demo update entity."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_name = "Update"
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        device: Device,
+        coordinator: TPLinkDataUpdateCoordinator,
+        parent: Device = None,
+    ) -> None:
+        """Initialize the Demo select entity."""
+        super().__init__(device, coordinator, parent)
+
+        self._attr_unique_id = f"{legacy_device_id(device)}_update"
+        self._attr_supported_features |= UpdateEntityFeature.INSTALL
+        # TODO: Maybe in the future
+        # self._attr_supported_features |= UpdateEntityFeature.PROGRESS
+
+        self._update_module: Firmware = device.modules["Firmware"]
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_installed_version = self._update_module.current_firmware
+        # self._attr_device_class = device_class  # TODO: separate handling for subdevices?
+        self._attr_latest_version = self._update_module.latest_firmware
+        self._attr_release_summary = (
+            self._update_module.firmware_update_info.release_notes
+        )
+        self._attr_is_on = self._update_module.update_available
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install an update."""
+        self._attr_in_progress = True
+        # TODO: allow passing an awaitable for updates
+        #  the awaitable should update _attr_in_progress and call async_write_ha_state
+        await self._update_module.update()
+
+        self._attr_in_progress = False
+        self.async_write_ha_state()

--- a/homeassistant/components/tplink/update.py
+++ b/homeassistant/components/tplink/update.py
@@ -69,17 +69,17 @@ class Update(CoordinatedTPLinkEntity, UpdateEntity):
         self,
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
-        parent: Device = None,
+        parent: Device | None = None,
     ) -> None:
         """Initialize the Demo select entity."""
-        super().__init__(device, coordinator, parent)
+        super().__init__(device, coordinator, parent=parent)
 
         self._attr_unique_id = f"{legacy_device_id(device)}_update"
         self._attr_supported_features |= UpdateEntityFeature.INSTALL
         # TODO: Maybe in the future
         # self._attr_supported_features |= UpdateEntityFeature.PROGRESS
 
-        self._update_module: Firmware = device.modules["Firmware"]
+        self._update_module: Firmware = cast(Firmware, device.modules["Firmware"])
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/update.py
+++ b/homeassistant/components/tplink/update.py
@@ -1,4 +1,5 @@
 """Firmware update platform for tplink."""
+
 from __future__ import annotations
 
 import asyncio

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2245,7 +2245,7 @@ python-join-api==0.0.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.6.2.1
+python-kasa[speedups]==0.7.0.dev0
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1742,7 +1742,7 @@ python-izone==1.2.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.6.2.1
+python-kasa[speedups]==0.7.0.dev0
 
 # homeassistant.components.matter
 python-matter-server==5.7.0


### PR DESCRIPTION
### This PR was part of the tplink modernizing effort, and is now obsolete as it's been split up into separate PRs:
- #117758
- #117759
- #117760
- #117761
- #117762
- #117764
- #117765
- #116605

Previous description
------

* Use upstream-provided information for creating available entities, allowing exposing more features and moves the maintenance burden from homeassistant to the upstream library.
* Add new platforms: binary_sensor, button, number, select, climate, update
* Expose sub-devices as their own devices that define `via_device`: https://github.com/home-assistant/architecture/discussions/1036

Testing requires master branch from python-kasa, https://github.com/python-kasa/python-kasa/issues/783 lists known issues and/or changes TBD.

![image](https://github.com/python-kasa/python-kasa/assets/3705853/b5b114db-835a-4d6e-a8df-8189e7d01f3e)


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #111238
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
