### PR TITLE
Improve error reporting in tplink config flow

### DIFF
--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -49,7 +49,8 @@
       }
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "Connection error: {error}",
+      "invalid_auth": "Invalid authentication: {error}"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -151,8 +151,8 @@ async def test_discovery_auth(
 @pytest.mark.parametrize(
     ("error_type", "errors_msg", "error_placement"),
     [
-        (AuthenticationException, "invalid_auth", CONF_PASSWORD),
-        (SmartDeviceException, "cannot_connect", "base"),
+        (AuthenticationException("auth_error_details"), "invalid_auth", CONF_PASSWORD),
+        (SmartDeviceException("smart_device_error_details"), "cannot_connect", "base"),
     ],
     ids=["invalid-auth", "unknown-error"],
 )
@@ -195,6 +195,7 @@ async def test_discovery_auth_errors(
 
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {error_placement: errors_msg}
+    assert result2["description_placeholders"]["error"] == str(error_type)
 
     await hass.async_block_till_done()
 
@@ -524,8 +525,8 @@ async def test_manual_auth(
 @pytest.mark.parametrize(
     ("error_type", "errors_msg", "error_placement"),
     [
-        (AuthenticationException, "invalid_auth", CONF_PASSWORD),
-        (SmartDeviceException, "cannot_connect", "base"),
+        (AuthenticationException("auth_error_details"), "invalid_auth", CONF_PASSWORD),
+        (SmartDeviceException("smart_device_error_details"), "cannot_connect", "base"),
     ],
     ids=["invalid-auth", "unknown-error"],
 )
@@ -570,6 +571,7 @@ async def test_manual_auth_errors(
     assert result3["type"] is FlowResultType.FORM
     assert result3["step_id"] == "user_auth_confirm"
     assert result3["errors"] == {error_placement: errors_msg}
+    assert result3["description_placeholders"]["error"] == str(error_type)
 
     mock_connect["connect"].side_effect = default_connect_side_effect
     result4 = await hass.config_entries.flow.async_configure(
@@ -962,8 +964,8 @@ async def test_reauth_no_update_if_config_and_ip_the_same(
 @pytest.mark.parametrize(
     ("error_type", "errors_msg", "error_placement"),
     [
-        (AuthenticationException, "invalid_auth", CONF_PASSWORD),
-        (SmartDeviceException, "cannot_connect", "base"),
+        (AuthenticationException("auth_error_details"), "invalid_auth", CONF_PASSWORD),
+        (SmartDeviceException("smart_device_error_details"), "cannot_connect", "base"),
     ],
     ids=["invalid-auth", "unknown-error"],
 )
@@ -1002,6 +1004,7 @@ async def test_reauth_errors(
     mock_discovery["mock_device"].update.assert_called_once_with()
     assert result2["type"] is FlowResultType.FORM
     assert result2["errors"] == {error_placement: errors_msg}
+    assert result2["description_placeholders"]["error"] == str(error_type)
 
     mock_discovery["discover_single"].reset_mock()
     mock_discovery["mock_device"].update.reset_mock(side_effect=True)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve error reporting in tplink config flow

The following error happened with a KS240. It was not so helpful:

<img width="499" alt="Screenshot 2024-02-22 at 1 15 41 PM" src="https://github.com/home-assistant/core/assets/663432/620de437-a071-4899-846e-66d446ed01d9">

After:
<img width="578" alt="Screenshot 2024-02-22 at 1 35 54 PM" src="https://github.com/home-assistant/core/assets/663432/e574fd43-9dbb-4701-8280-35348f473642">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
