### PR TITLE
Add validation to water_heater set_operation mode at entity component

### DIFF
--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -149,7 +150,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(
         SERVICE_SET_OPERATION_MODE,
         SET_OPERATION_MODE_SCHEMA,
-        "async_set_operation_mode",
+        "async_handle_set_operation_mode",
     )
     component.async_register_entity_service(
         SERVICE_TURN_OFF, ON_OFF_SERVICE_SCHEMA, "async_turn_off"
@@ -358,6 +359,35 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new target operation mode."""
         await self.hass.async_add_executor_job(self.set_operation_mode, operation_mode)
+
+    async def async_handle_set_operation_mode(self, operation_mode: str) -> None:
+        """Handle a set target operation mode service call."""
+        if self.operation_list is None:
+            raise ServiceValidationError(
+                f"Operation mode {operation_mode} not valid for "
+                f"entity {self.entity_id}. The operation list is not defined",
+                translation_domain=DOMAIN,
+                translation_key="operation_list_not_defined",
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                    "operation_mode": operation_mode,
+                },
+            )
+        if operation_mode not in self.operation_list:
+            operation_list = ", ".join(self.operation_list)
+            raise ServiceValidationError(
+                f"Operation mode {operation_mode} not valid for "
+                f"entity {self.entity_id}. Valid "
+                f"operation modes are: {operation_list}",
+                translation_domain=DOMAIN,
+                translation_key="not_valid_operation_mode",
+                translation_placeholders={
+                    "entity_id": self.entity_id,
+                    "operation_mode": operation_mode,
+                    "operation_list": operation_list,
+                },
+            )
+        await self.async_set_operation_mode(operation_mode)
 
     def turn_away_mode_on(self) -> None:
         """Turn away mode on."""

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -360,6 +360,7 @@ class WaterHeaterEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Set new target operation mode."""
         await self.hass.async_add_executor_job(self.set_operation_mode, operation_mode)
 
+    @final
     async def async_handle_set_operation_mode(self, operation_mode: str) -> None:
         """Handle a set target operation mode service call."""
         if self.operation_list is None:

--- a/homeassistant/components/water_heater/strings.json
+++ b/homeassistant/components/water_heater/strings.json
@@ -71,5 +71,13 @@
       "name": "[%key:common::action::turn_off%]",
       "description": "Turns water heater off."
     }
+  },
+  "exceptions": {
+    "not_valid_operation_mode": {
+      "message": "Operation mode {operation_mode} is not valid for {entity_id}. Valid operation modes are: {operation_list}."
+    },
+    "operation_list_not_defined": {
+      "message": "Operation mode {operation_mode} is not valid for {entity_id}. The operation list is not defined."
+    }
   }
 }

--- a/tests/components/water_heater/conftest.py
+++ b/tests/components/water_heater/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for water heater platform tests."""
+from collections.abc import Generator
+
+import pytest
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import HomeAssistant
+
+from tests.common import mock_config_flow, mock_platform
+
+
+class MockFlow(ConfigFlow):
+    """Test flow."""
+
+
+@pytest.fixture
+def config_flow_fixture(hass: HomeAssistant) -> Generator[None, None, None]:
+    """Mock config flow."""
+    mock_platform(hass, "test.config_flow")
+
+    with mock_config_flow("test", MockFlow):
+        yield

--- a/tests/components/water_heater/test_init.py
+++ b/tests/components/water_heater/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the water heater component."""
 from __future__ import annotations
 
+from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -10,17 +11,27 @@ from homeassistant.components import water_heater
 from homeassistant.components.water_heater import (
     ATTR_OPERATION_LIST,
     ATTR_OPERATION_MODE,
+    DOMAIN,
+    SERVICE_SET_OPERATION_MODE,
     SET_TEMPERATURE_SCHEMA,
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
     async_mock_service,
     help_test_all,
     import_and_test_deprecated_constant_enum,
+    mock_integration,
+    mock_platform,
 )
 
 
@@ -65,9 +76,12 @@ async def test_set_temp_schema(
 class MockWaterHeaterEntity(WaterHeaterEntity):
     """Mock water heater device to use in tests."""
 
-    _attr_operation_list: list[str] = ["off", "heat_pump", "gas"]
+    _attr_operation_list: list[str] | None = ["off", "heat_pump", "gas"]
     _attr_operation = "heat_pump"
     _attr_supported_features = WaterHeaterEntityFeature.ON_OFF
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+    set_operation_mode: MagicMock = MagicMock()
 
 
 async def test_sync_turn_on(hass: HomeAssistant) -> None:
@@ -104,6 +118,95 @@ async def test_sync_turn_off(hass: HomeAssistant) -> None:
     await water_heater.async_turn_off()
 
     assert water_heater.async_turn_off.call_count == 1
+
+
+async def test_operation_mode_validation(
+    hass: HomeAssistant, config_flow_fixture: None
+) -> None:
+    """Test operation mode validation."""
+    water_heater_entity = MockWaterHeaterEntity()
+    water_heater_entity.hass = hass
+    water_heater_entity._attr_name = "test"
+    water_heater_entity._attr_unique_id = "test"
+    water_heater_entity._attr_supported_features = (
+        WaterHeaterEntityFeature.OPERATION_MODE
+    )
+    water_heater_entity._attr_current_operation = None
+    water_heater_entity._attr_operation_list = None
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_water_heater_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test water_heater platform via config entry."""
+        async_add_entities([water_heater_entity])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.water_heater",
+        MockPlatform(async_setup_entry=async_setup_entry_water_heater_platform),
+    )
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+
+    data = {"entity_id": "water_heater.test", "operation_mode": "test"}
+
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_SET_OPERATION_MODE, data, blocking=True
+        )
+    assert (
+        str(exc.value) == "Operation mode test not valid for entity water_heater.test. "
+        "The operation list is not defined"
+    )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "operation_list_not_defined"
+    assert exc.value.translation_placeholders == {
+        "entity_id": "water_heater.test",
+        "operation_mode": "test",
+    }
+
+    water_heater_entity._attr_operation_list = ["gas", "eco"]
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            DOMAIN, SERVICE_SET_OPERATION_MODE, data, blocking=True
+        )
+    assert (
+        str(exc.value) == "Operation mode test not valid for entity water_heater.test. "
+        "Valid operation modes are: gas, eco"
+    )
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "not_valid_operation_mode"
+    assert exc.value.translation_placeholders == {
+        "entity_id": "water_heater.test",
+        "operation_mode": "test",
+        "operation_list": "gas, eco",
+    }
+
+    data = {"entity_id": "water_heater.test", "operation_mode": "eco"}
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_OPERATION_MODE, data, blocking=True
+    )
+    await hass.async_block_till_done()
+    water_heater_entity.set_operation_mode.assert_has_calls([mock.call("eco")])
 
 
 def test_all() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add validation to water_heater set_operation mode at entity component.
This removes the need to add validation at integration level.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
