### PR TITLE
Add device counter entities to ZHA

### DIFF
--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.event import async_track_time_interval
 
-from . import const
+from . import const, discovery
 from .cluster_handlers import ClusterHandler, ZDOClusterHandler
 from .const import (
     ATTR_ACTIVE_COORDINATOR,
@@ -432,6 +432,7 @@ class ZHADevice(LogMixin):
                 zha_dev.async_update_sw_build_id,
             )
         )
+        discovery.PROBE.discover_device_entities(zha_dev)
         return zha_dev
 
     @callback

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -122,6 +122,11 @@ class ProbeEndpoint:
     @callback
     def discover_coordinator_device_entities(self, device: ZHADevice) -> None:
         """Discover entities for the coordinator device."""
+        _LOGGER.debug(
+            "Discovering coordinator entities for device: %s-%s",
+            str(device.ieee),
+            device.name,
+        )
         state: State = device.gateway.application_controller.state
         platforms: dict[Platform, list] = get_zha_data(device.hass).platforms
 

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -110,20 +110,19 @@ class ProbeEndpoint:
     def discover_device_entities(self, device: ZHADevice) -> None:
         """Discover entities for a ZHA device."""
         _LOGGER.debug(
-            "Discovering coordinator entities for device: %s-%s",
+            "Discovering entities for device: %s-%s",
             str(device.ieee),
             device.name,
         )
 
         if device.is_coordinator:
             self.discover_coordinator_device_entities(device)
-            return
 
     @callback
     def discover_coordinator_device_entities(self, device: ZHADevice) -> None:
         """Discover entities for the coordinator device."""
         _LOGGER.debug(
-            "Discovering coordinator entities for device: %s-%s",
+            "Discovering entities for coordinator device: %s-%s",
             str(device.ieee),
             device.name,
         )

--- a/homeassistant/components/zha/core/endpoint.py
+++ b/homeassistant/components/zha/core/endpoint.py
@@ -109,7 +109,9 @@ class Endpoint:
         endpoint = cls(zigpy_endpoint, device)
         endpoint.add_all_cluster_handlers()
         endpoint.add_client_cluster_handlers()
-        if not device.is_coordinator:
+        if device.is_coordinator:
+            discovery.PROBE.discover_coordinator_entities(endpoint)
+        else:
             discovery.PROBE.discover_entities(endpoint)
         return endpoint
 

--- a/homeassistant/components/zha/core/endpoint.py
+++ b/homeassistant/components/zha/core/endpoint.py
@@ -109,9 +109,7 @@ class Endpoint:
         endpoint = cls(zigpy_endpoint, device)
         endpoint.add_all_cluster_handlers()
         endpoint.add_client_cluster_handlers()
-        if device.is_coordinator:
-            discovery.PROBE.discover_coordinator_entities(endpoint)
-        else:
+        if not device.is_coordinator:
             discovery.PROBE.discover_entities(endpoint)
         return endpoint
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -252,6 +252,7 @@ class DeviceCounterSensor(BaseZhaEntity, SensorEntity):
     _attr_should_poll = True
     _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     @classmethod
     def create_entity(

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -1,6 +1,7 @@
 """Sensors on Zigbee Home Automation networks."""
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import enum
@@ -10,6 +11,7 @@ import random
 from typing import TYPE_CHECKING, Any, Self
 
 from zigpy import types
+from zigpy.state import Counter, State
 from zigpy.zcl.clusters.closures import WindowCovering
 from zigpy.zcl.clusters.general import Basic
 
@@ -71,7 +73,7 @@ from .core.const import (
 )
 from .core.helpers import get_zha_data
 from .core.registries import SMARTTHINGS_HUMIDITY_CLUSTER, ZHA_ENTITIES
-from .entity import ZhaEntity
+from .entity import BaseZhaEntity, ZhaEntity
 
 if TYPE_CHECKING:
     from .core.cluster_handlers import ClusterHandler
@@ -242,6 +244,83 @@ class PollableSensor(Sensor):
                 self._zha_device.available,
                 self.hass.data[DATA_ZHA].allow_polling,
             )
+
+
+class CoordinatorCounterSensor(BaseZhaEntity, SensorEntity):
+    """Coordinator counter sensor."""
+
+    _attr_should_poll = True
+    _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    #
+    @classmethod
+    def create_entity(
+        cls,
+        unique_id: str,
+        zha_device: ZHADevice,
+        counter_groups: str,
+        counter_group: str,
+        counter: str,
+        **kwargs: Any,
+    ) -> Self | None:
+        """Entity Factory.
+
+        Return entity if it is a supported configuration, otherwise return None
+        """
+        return cls(
+            unique_id, zha_device, counter_groups, counter_group, counter, **kwargs
+        )
+
+    def __init__(
+        self,
+        unique_id: str,
+        zha_device: ZHADevice,
+        counter_groups: str,
+        counter_group: str,
+        counter: str,
+        **kwargs: Any,
+    ) -> None:
+        """Init this sensor."""
+        super().__init__(unique_id, zha_device, **kwargs)
+        state: State = self._zha_device.gateway.application_controller.state
+        self._zigpy_counter: Counter = (
+            getattr(state, counter_groups).get(counter_group, {}).get(counter, None)
+        )
+        self._attr_name: str = self._zigpy_counter.name
+        self.remove_future: asyncio.Future
+
+    @property
+    def available(self) -> bool:
+        """Return entity availability."""
+        return self._zha_device.available
+
+    async def async_added_to_hass(self) -> None:
+        """Run when about to be added to hass."""
+        self.remove_future = self.hass.loop.create_future()
+        self._zha_device.gateway.register_entity_reference(
+            self._zha_device.ieee,
+            self.entity_id,
+            self._zha_device,
+            {},
+            self.device_info,
+            self.remove_future,
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Disconnect entity object when removed."""
+        await super().async_will_remove_from_hass()
+        self.zha_device.gateway.remove_entity_reference(self)
+        self.remove_future.set_result(True)
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the entity."""
+        return self._zigpy_counter.value
+
+    async def async_update(self) -> None:
+        """Retrieve latest state."""
+        self.async_write_ha_state()
 
 
 # pylint: disable-next=hass-invalid-inheritance # needs fixing

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -246,14 +246,13 @@ class PollableSensor(Sensor):
             )
 
 
-class CoordinatorCounterSensor(BaseZhaEntity, SensorEntity):
-    """Coordinator counter sensor."""
+class DeviceCounterSensor(BaseZhaEntity, SensorEntity):
+    """Device counter sensor."""
 
     _attr_should_poll = True
     _attr_state_class: SensorStateClass = SensorStateClass.TOTAL
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
-    #
     @classmethod
     def create_entity(
         cls,

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -38,6 +38,7 @@ from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 FIXTURE_GRP_ID = 0x1001
 FIXTURE_GRP_NAME = "fixture group"
+COUNTER_NAMES = ["counter_1", "counter_2", "counter_3"]
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -173,6 +174,10 @@ async def zigpy_app_controller():
     app.state.network_info.extended_pan_id = app.state.node_info.ieee
     app.state.network_info.channel = 15
     app.state.network_info.network_key.key = zigpy.types.KeyData(range(16))
+    app.state.counters = zigpy.state.CounterGroups()
+    app.state.counters["ezsp_counters"] = zigpy.state.CounterGroup("ezsp_counters")
+    for name in COUNTER_NAMES:
+        app.state.counters["ezsp_counters"][name].increment()
 
     # Create a fake coordinator device
     dev = app.add_device(nwk=app.state.node_info.nwk, ieee=app.state.node_info.ieee)

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -48,6 +48,7 @@ IGNORE_SUFFIXES = [
     "off_transition_time",
     "default_move_rate",
     "start_up_current_level",
+    "counter",
 ]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds counter entities to ZHA and it establishes a framework to support device entities which will be used in a subsequent PR to add support for entities expressed by zigpy quirks. 

The "coordinator device counters" added to the coordinator device are disabled by default and can be enabled for debugging Zigbee network issues. The counter values are provided by the used radio library (EZSP, ZNP, ..). 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
