### PR TITLE
Bump `pysnmp-lextudio` library to version 6.0.2

### DIFF
--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/snmp",
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
-  "requirements": ["pysnmp-lextudio==5.0.31"]
+  "requirements": ["pysnmp-lextudio==6.0.2"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -159,13 +159,9 @@ faust-cchardet>=2.1.18
 # https://github.com/aaugustin/websockets/issues/1329
 websockets>=11.0.1
 
-# pyasn1 0.5.0 has breaking changes which cause pysnmplib to fail
-# until they are resolved, we need to pin pyasn1 to 0.4.8 and
-# pysnmplib to 5.0.21 to avoid the issue.
-# https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
-# https://github.com/pysnmp/pysnmp/issues/51
-pyasn1==0.4.8
-pysnmplib==5.0.21
+# pysnmplib is no longer maintained and does not work with newer
+# python
+pysnmplib==1000000000.0.0
 # pysnmp is no longer maintained and does not work with newer
 # python
 pysnmp==1000000000.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2154,7 +2154,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp-lextudio==5.0.31
+pysnmp-lextudio==6.0.2
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1669,7 +1669,7 @@ pysmartthings==0.7.8
 pysml==0.0.12
 
 # homeassistant.components.snmp
-pysnmp-lextudio==5.0.31
+pysnmp-lextudio==6.0.2
 
 # homeassistant.components.snooz
 pysnooz==0.8.6

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -151,13 +151,9 @@ faust-cchardet>=2.1.18
 # https://github.com/aaugustin/websockets/issues/1329
 websockets>=11.0.1
 
-# pyasn1 0.5.0 has breaking changes which cause pysnmplib to fail
-# until they are resolved, we need to pin pyasn1 to 0.4.8 and
-# pysnmplib to 5.0.21 to avoid the issue.
-# https://github.com/pyasn1/pyasn1/pull/30#issuecomment-1517564335
-# https://github.com/pysnmp/pysnmp/issues/51
-pyasn1==0.4.8
-pysnmplib==5.0.21
+# pysnmplib is no longer maintained and does not work with newer
+# python
+pysnmplib==1000000000.0.0
 # pysnmp is no longer maintained and does not work with newer
 # python
 pysnmp==1000000000.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- bumps `pysnmp-lextudio` library to version `6.0.2`
- unpin `pyasn1` because `pysnmp-lextudio` uses `pyasn1==0.5.1` https://github.com/lextudio/pysnmp/blob/ced4a36e996126cda9293cac42e75e4669c2914f/pyproject.toml#L30
- pin `pysnmplib` to prevent installation, it uses the same namespace as `pysnmp-lextudio`

Changelog: https://github.com/lextudio/pysnmp/compare/v5.0.31...v6.0.2

This applies to two integrations: `snmp` and `brother`. They both work.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #110100
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
