### PR TITLE
Enable CONF_STATION_UPDATES by default on AEMET

### DIFF
--- a/homeassistant/components/aemet/config_flow.py
+++ b/homeassistant/components/aemet/config_flow.py
@@ -21,7 +21,7 @@ from .const import CONF_STATION_UPDATES, DEFAULT_NAME, DOMAIN
 
 OPTIONS_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_STATION_UPDATES): bool,
+        vol.Required(CONF_STATION_UPDATES, default=True): bool,
     }
 )
 OPTIONS_FLOW = {

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -59,9 +59,14 @@ async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
         assert len(mock_setup_entry.mock_calls) == 1
 
 
+@pytest.mark.parametrize(
+    ("user_input", "expected"), [({}, True), ({CONF_STATION_UPDATES: False}, False)]
+)
 async def test_form_options(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
+    user_input: dict[str, bool],
+    expected: bool,
 ) -> None:
     """Test the form options."""
 
@@ -87,30 +92,12 @@ async def test_form_options(
         assert result["step_id"] == "init"
 
         result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_STATION_UPDATES: False}
+            result["flow_id"], user_input=user_input
         )
 
         assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
         assert entry.options == {
-            CONF_STATION_UPDATES: False,
-        }
-
-        await hass.async_block_till_done()
-
-        assert entry.state is ConfigEntryState.LOADED
-
-        result = await hass.config_entries.options.async_init(entry.entry_id)
-
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
-        assert result["step_id"] == "init"
-
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"], user_input={CONF_STATION_UPDATES: True}
-        )
-
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-        assert entry.options == {
-            CONF_STATION_UPDATES: True,
+            CONF_STATION_UPDATES: expected,
         }
 
         await hass.async_block_till_done()

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -25,6 +25,14 @@ CONFIG = {
 }
 
 
+def _get_schema_default(schema, key_name):
+    """Iterate schema to find a key."""
+    for schema_key in schema:
+        if schema_key == key_name:
+            return schema_key.default()
+    raise KeyError(f"{key_name} not found in schema")
+
+
 async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test that the form is served with valid input."""
 
@@ -85,6 +93,10 @@ async def test_form_options(
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
+        assert (
+            _get_schema_default(result["data_schema"].schema, CONF_STATION_UPDATES)
+            is True
+        )
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_STATION_UPDATES: False}

--- a/tests/components/aemet/test_config_flow.py
+++ b/tests/components/aemet/test_config_flow.py
@@ -25,14 +25,6 @@ CONFIG = {
 }
 
 
-def _get_schema_default(schema, key_name):
-    """Iterate schema to find a key."""
-    for schema_key in schema:
-        if schema_key == key_name:
-            return schema_key.default()
-    raise KeyError(f"{key_name} not found in schema")
-
-
 async def test_form(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test that the form is served with valid input."""
 
@@ -93,10 +85,6 @@ async def test_form_options(
 
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "init"
-        assert (
-            _get_schema_default(result["data_schema"].schema, CONF_STATION_UPDATES)
-            is True
-        )
 
         result = await hass.config_entries.options.async_configure(
             result["flow_id"], user_input={CONF_STATION_UPDATES: False}


### PR DESCRIPTION
## Proposed change
The default state of CONF_STATION_UPDATES is enabled when it doesn't exist in the config:
https://github.com/home-assistant/core/blob/59066c1770d428ac51c20bf3fc29c8552a924d58/homeassistant/components/aemet/__init__.py#L32
However, the default config schema creates it as False:
https://github.com/home-assistant/core/blob/59066c1770d428ac51c20bf3fc29c8552a924d58/homeassistant/components/aemet/config_flow.py#L22-L26
This results in the checkbox not being enabled when a new config entry is created, despite being treated as enabled since it doesn't exist in the config:
![image](https://github.com/home-assistant/core/assets/264346/02648f18-1084-4c62-84c3-e7b581f67848)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
