### PR TITLE
Add entities for lights and pumps to Balboa Spa integration

### DIFF
--- a/homeassistant/components/balboa/__init__.py
+++ b/homeassistant/components/balboa/__init__.py
@@ -17,7 +17,7 @@ from .const import CONF_SYNC_TIME, DEFAULT_SYNC_TIME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.FAN, Platform.LIGHT]
 
 
 KEEP_ALIVE_INTERVAL = timedelta(minutes=1)

--- a/homeassistant/components/balboa/fan.py
+++ b/homeassistant/components/balboa/fan.py
@@ -1,0 +1,71 @@
+"""Support for Balboa Spa pumps."""
+from __future__ import annotations
+
+from typing import Any
+import math
+
+from pybalboa import SpaClient
+from pybalboa.enums import OffOnState
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+from .const import DOMAIN
+from .entity import BalboaToggleEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the spa's pumps."""
+    spa: SpaClient = hass.data[DOMAIN][entry.entry_id]
+    entities = [BalboaPumpFanEntity(control) for control in spa.pumps]
+    async_add_entities(entities)
+
+
+PUMP_ICON_ON = "mdi:pump"
+PUMP_ICON_OFF = "mdi:pump-off"
+
+
+class BalboaPumpFanEntity(BalboaToggleEntity, FanEntity):
+    """Representation of a Balboa Spa pump fan entity."""
+
+    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_translation_key = "pump"
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any
+    ) -> None:
+        if percentage is None:
+            percentage = 100
+        await self.async_set_percentage(percentage)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        if percentage > 0:
+            state = math.ceil(percentage_to_ranged_value((1, self.speed_count), percentage))
+        else:
+            state = OffOnState.OFF
+        await self._control.set_state(state)
+
+    @property
+    def percentage(self) -> int | None:
+        if self._control.state == OffOnState.OFF:
+            return 0
+        return ranged_value_to_percentage((1, self.speed_count), self._control.state)
+
+    @property
+    def icon(self) -> str | None:
+        return PUMP_ICON_ON if self.is_on else PUMP_ICON_OFF
+
+    @property
+    def speed_count(self) -> int:
+        return int(max(self._control.options))

--- a/homeassistant/components/balboa/light.py
+++ b/homeassistant/components/balboa/light.py
@@ -1,0 +1,27 @@
+"""Support for Balboa Spa lights."""
+from __future__ import annotations
+
+from pybalboa import SpaClient
+
+from homeassistant.components.light import LightEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import BalboaToggleEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the spa's lights."""
+    spa: SpaClient = hass.data[DOMAIN][entry.entry_id]
+    entities = [BalboaLightEntity(control) for control in spa.lights]
+    async_add_entities(entities)
+
+
+class BalboaLightEntity(BalboaToggleEntity, LightEntity):
+    """Representation of a Balboa Spa light entity."""
+
+    _attr_translation_key = "light"

--- a/homeassistant/components/balboa/strings.json
+++ b/homeassistant/components/balboa/strings.json
@@ -52,6 +52,16 @@
           }
         }
       }
+    },
+    "fan": {
+      "pump": {
+        "name": "Pump {index}"
+      }
+    },
+    "light": {
+      "light": {
+        "name": "Light {index}"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Balboa Spa integration was missing entities to control the lights and pumps (for the jets) of the Hot Tub. This PR is adding these entities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~~This PR fixes or closes issue: fixes #~~
- ~~This PR is related to issue:~~
- Link to documentation pull request: home-assistant/home-assistant.io#31587

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - (Do I need to bother running tests locally, or will they run when I submit this PR automatically?)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
