### PR TITLE
Update pylint to 3.0.4

### DIFF
--- a/homeassistant/components/bang_olufsen/media_player.py
+++ b/homeassistant/components/bang_olufsen/media_player.py
@@ -523,7 +523,6 @@ class BangOlufsenMediaPlayer(MediaPlayerEntity, BangOlufsenEntity):
             )
             return
 
-        # pylint: disable=consider-using-dict-items
         key = [x for x in self._sources if self._sources[x] == source][0]
 
         # Check for source type

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -15,8 +15,6 @@ from typing import TYPE_CHECKING, Any, Final, Self, cast, final
 from typing_extensions import override
 
 from homeassistant.config_entries import ConfigEntry
-
-# pylint: disable-next=hass-deprecated-import
 from homeassistant.const import (  # noqa: F401
     _DEPRECATED_DEVICE_CLASS_AQI,
     _DEPRECATED_DEVICE_CLASS_BATTERY,

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -421,8 +421,7 @@ class PeekIterator(Iterator):
         # Items consumed are added to a buffer for future calls to __next__
         # or peek. First iterate over the buffer from previous calls to peek.
         self._next = self._pop_buffer
-        for packet in self._buffer:
-            yield packet
+        yield from self._buffer
         for packet in self._iterator:
             self._buffer.append(packet)
             yield packet

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -63,7 +63,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Get all devices from Tuya
     try:
         await hass.async_add_executor_job(manager.update_device_cache)
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as exc:
         # While in general, we should avoid catching broad exceptions,
         # we have no other way of detecting this case.
         if "sign invalid" in str(exc):

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -158,7 +158,7 @@ async def async_setup_component(
         if setup_done_future := setup_done_futures.pop(domain, None):
             setup_done_future.set_result(result)
         return result
-    except BaseException as err:  # pylint: disable=broad-except
+    except BaseException as err:
         futures = [setup_future]
         if setup_done_future := setup_done_futures.pop(domain, None):
             futures.append(setup_done_future)

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,14 +7,14 @@
 
 -c homeassistant/package_constraints.txt
 -r requirements_test_pre_commit.txt
-astroid==3.0.1
+astroid==3.0.3
 coverage==7.4.2
 freezegun==1.3.1
 mock-open==1.4.0
 mypy==1.8.0
 pre-commit==3.6.2
 pydantic==1.10.12
-pylint==3.0.3
+pylint==3.0.4
 pylint-per-file-ignores==1.3.2
 pipdeptree==2.13.2
 pytest-asyncio==0.23.5


### PR DESCRIPTION
## Proposed change
Update pylint to `3.0.4` and astroid to `3.0.3`.

https://github.com/pylint-dev/pylint/releases/tag/v3.0.4
https://github.com/pylint-dev/astroid/releases/tag/v3.0.2
https://github.com/pylint-dev/astroid/releases/tag/v3.0.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
