### PR TITLE
Add entities for Balboa Spa pumps

### DIFF
--- a/homeassistant/components/balboa/__init__.py
+++ b/homeassistant/components/balboa/__init__.py
@@ -17,7 +17,7 @@ from .const import CONF_SYNC_TIME, DEFAULT_SYNC_TIME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.FAN]
 
 
 KEEP_ALIVE_INTERVAL = timedelta(minutes=1)

--- a/homeassistant/components/balboa/fan.py
+++ b/homeassistant/components/balboa/fan.py
@@ -1,0 +1,89 @@
+"""Support for Balboa Spa pumps."""
+from __future__ import annotations
+
+import math
+from typing import Any, cast
+
+from pybalboa import SpaClient, SpaControl
+from pybalboa.enums import OffOnState, UnknownState
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+
+from .const import DOMAIN
+from .entity import BalboaEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the spa's pumps."""
+    spa: SpaClient = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(BalboaPumpFanEntity(control) for control in spa.pumps)
+
+
+class BalboaPumpFanEntity(BalboaEntity, FanEntity):
+    """Representation of a Balboa Spa pump fan entity."""
+
+    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_translation_key = "pump"
+
+    def __init__(self, control: SpaControl) -> None:
+        """Initialize a Balboa pump fan entity."""
+        super().__init__(control.client, control.name)
+        self._control = control
+        self._attr_translation_placeholders = {
+            "index": f"{cast(int, control.index) + 1}"
+        }
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the pump off."""
+        await self._control.set_state(OffOnState.OFF)
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn the pump on (by default on max speed)."""
+        if percentage is None:
+            percentage = 100
+        await self.async_set_percentage(percentage)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed of the pump."""
+        if percentage > 0:
+            state = math.ceil(
+                percentage_to_ranged_value((1, self.speed_count), percentage)
+            )
+        else:
+            state = OffOnState.OFF
+        await self._control.set_state(state)
+
+    @property
+    def percentage(self) -> int | None:
+        """Return the speed of the pump."""
+        if self._control.state == UnknownState.UNKNOWN:
+            return None
+        if self._control.state == OffOnState.OFF:
+            return 0
+        return ranged_value_to_percentage((1, self.speed_count), self._control.state)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the pump is running."""
+        if self._control.state == UnknownState.UNKNOWN:
+            return None
+        return self._control.state != OffOnState.OFF
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of different speed settings the pump supports."""
+        return int(max(self._control.options))

--- a/homeassistant/components/balboa/icons.json
+++ b/homeassistant/components/balboa/icons.json
@@ -19,6 +19,14 @@
           "on": "mdi:pump"
         }
       }
+    },
+    "fan": {
+      "pump": {
+        "default": "mdi:pump",
+        "state": {
+          "off": "mdi:pump-off"
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/balboa/strings.json
+++ b/homeassistant/components/balboa/strings.json
@@ -52,6 +52,11 @@
           }
         }
       }
+    },
+    "fan": {
+      "pump": {
+        "name": "Pump {index}"
+      }
     }
   }
 }

--- a/tests/components/balboa/__init__.py
+++ b/tests/components/balboa/__init__.py
@@ -1,9 +1,11 @@
 """Test the Balboa Spa Client integration."""
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 from homeassistant.components.balboa import CONF_SYNC_TIME, DOMAIN
 from homeassistant.const import CONF_HOST
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 
 from tests.common import MockConfigEntry
 
@@ -19,3 +21,11 @@ async def init_integration(hass: HomeAssistant) -> MockConfigEntry:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry
+
+
+async def client_update(hass: HomeAssistant, client: MagicMock, entity: str) -> State:
+    """Update the client."""
+    client.emit("")
+    await hass.async_block_till_done()
+    assert (state := hass.states.get(entity)) is not None
+    return state

--- a/tests/components/balboa/conftest.py
+++ b/tests/components/balboa/conftest.py
@@ -57,5 +57,6 @@ def client_fixture() -> Generator[MagicMock, None, None]:
         client.heat_mode.set_state = AsyncMock()
         client.heat_mode.options = list(HeatMode)[:2]
         client.heat_state = 2
+        client.pumps = []
 
         yield client

--- a/tests/components/balboa/test_climate.py
+++ b/tests/components/balboa/test_climate.py
@@ -28,7 +28,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 
-from . import init_integration, client_update
+from . import client_update, init_integration
 
 from tests.common import MockConfigEntry
 from tests.components.climate import common

--- a/tests/components/balboa/test_climate.py
+++ b/tests/components/balboa/test_climate.py
@@ -28,7 +28,7 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 
-from . import init_integration
+from . import init_integration, client_update
 
 from tests.common import MockConfigEntry
 from tests.components.climate import common
@@ -149,7 +149,7 @@ async def test_spa_preset_modes(
         client.heat_mode.state = HeatMode[mode.upper()]
         await common.async_set_preset_mode(hass, mode, ENTITY_CLIMATE)
 
-        state = await _client_update(hass, client)
+        state = await client_update(hass, client, ENTITY_CLIMATE)
         assert state
         assert state.attributes[ATTR_PRESET_MODE] == mode
 
@@ -158,7 +158,7 @@ async def test_spa_preset_modes(
 
     # put it in RNR and test assertion
     client.heat_mode.state = HeatMode.READY_IN_REST
-    state = await _client_update(hass, client)
+    state = await client_update(hass, client, ENTITY_CLIMATE)
     assert state
     assert state.attributes[ATTR_PRESET_MODE] == "ready_in_rest"
 
@@ -199,19 +199,13 @@ async def test_spa_with_blower(hass: HomeAssistant, client: MagicMock) -> None:
 
 
 # Helpers
-async def _client_update(hass: HomeAssistant, client: MagicMock) -> State:
-    """Update the client."""
-    client.emit("")
-    await hass.async_block_till_done()
-    assert (state := hass.states.get(ENTITY_CLIMATE)) is not None
-    return state
 
 
 async def _patch_blower(hass: HomeAssistant, client: MagicMock, fan_mode: str) -> State:
     """Patch the blower state."""
     client.blowers[0].state = OffLowMediumHighState[fan_mode.upper()]
     await common.async_set_fan_mode(hass, fan_mode)
-    return await _client_update(hass, client)
+    return await client_update(hass, client, ENTITY_CLIMATE)
 
 
 async def _patch_spa_settemp(
@@ -223,7 +217,7 @@ async def _patch_spa_settemp(
     await common.async_set_temperature(
         hass, temperature=settemp, entity_id=ENTITY_CLIMATE
     )
-    return await _client_update(hass, client)
+    return await client_update(hass, client, ENTITY_CLIMATE)
 
 
 async def _patch_spa_heatmode(
@@ -232,7 +226,7 @@ async def _patch_spa_heatmode(
     """Patch the heatmode."""
     client.heat_mode.state = heat_mode
     await common.async_set_hvac_mode(hass, HVAC_SETTINGS[heat_mode], ENTITY_CLIMATE)
-    return await _client_update(hass, client)
+    return await client_update(hass, client, ENTITY_CLIMATE)
 
 
 async def _patch_spa_heatstate(
@@ -241,4 +235,4 @@ async def _patch_spa_heatstate(
     """Patch the heatmode."""
     client.heat_state = heat_state
     await common.async_set_hvac_mode(hass, HVAC_SETTINGS[heat_state], ENTITY_CLIMATE)
-    return await _client_update(hass, client)
+    return await client_update(hass, client, ENTITY_CLIMATE)

--- a/tests/components/balboa/test_fan.py
+++ b/tests/components/balboa/test_fan.py
@@ -1,19 +1,19 @@
 """Tests of the pump fan entity of the balboa integration."""
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 from pybalboa import SpaControl
 from pybalboa.enums import OffLowHighState, UnknownState
+import pytest
 
 from homeassistant.components.fan import ATTR_PERCENTAGE
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 
-from tests.components.fan import common
+from . import client_update, init_integration
 
-from . import init_integration, client_update
+from tests.components.fan import common
 
 ENTITY_FAN = "fan.fakespa_pump_1"
 
@@ -33,12 +33,10 @@ def mock_pump(client: MagicMock):
     pump.options = list(OffLowHighState)
     client.pumps.append(pump)
 
-    yield pump
+    return pump
 
 
-async def test_pump(
-    hass: HomeAssistant, client: MagicMock, mock_pump
-) -> None:
+async def test_pump(hass: HomeAssistant, client: MagicMock, mock_pump) -> None:
     """Test spa pump."""
     await init_integration(hass)
 

--- a/tests/components/balboa/test_fan.py
+++ b/tests/components/balboa/test_fan.py
@@ -1,0 +1,46 @@
+"""Tests of the pump fan entity of the balboa integration."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pybalboa.enums import OffLowHighState
+
+from homeassistant.components.fan import ATTR_PERCENTAGE
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.fan import common
+
+ENTITY_FAN = "fan.fakepa_pump_1"
+
+
+async def test_pump(
+    hass: HomeAssistant, client: MagicMock, integration: MockConfigEntry
+) -> None:
+    """Test spa filters."""
+    pump = MagicMock()
+
+    async def set_state(state: OffLowHighState):
+        pump.state = state
+
+    pump.client = client
+    pump.index = 0
+    pump.state = OffLowHighState.OFF
+    pump.set_state = set_state
+    pump.options = list(OffLowHighState)
+    client.pumps.append(pump)
+
+    state = hass.states.get(ENTITY_FAN)
+    assert state.state == STATE_OFF
+
+    await common.async_turn_on(hass, ENTITY_FAN)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PERCENTAGE] == 100
+
+    await common.async_set_percentage(hass, ENTITY_FAN, 50)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PERCENTAGE] == 50
+
+    await common.async_turn_off(hass, ENTITY_FAN)
+    assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Balboa Spa integration was missing entities to control the pumps (for the jets) of the Hot Tub. This PR is adding entities for the pumps. As requested this was split out of #111222 to limit the scope.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~~This PR fixes or closes issue: fixes #~~
- ~~This PR is related to issue:~~
- Link to documentation pull request: home-assistant/home-assistant.io#31587

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - (Do I need to bother running tests locally, or will they run when I submit this PR automatically?)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
