### PR TITLE
Add entities for Balboa Spa lights

### DIFF
--- a/homeassistant/components/balboa/__init__.py
+++ b/homeassistant/components/balboa/__init__.py
@@ -17,7 +17,7 @@ from .const import CONF_SYNC_TIME, DEFAULT_SYNC_TIME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.FAN]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.CLIMATE, Platform.FAN, Platform.LIGHT]
 
 
 KEEP_ALIVE_INTERVAL = timedelta(minutes=1)

--- a/homeassistant/components/balboa/light.py
+++ b/homeassistant/components/balboa/light.py
@@ -1,0 +1,56 @@
+"""Support for Balboa Spa lights."""
+from __future__ import annotations
+
+from typing import Any, cast
+
+from pybalboa import SpaClient, SpaControl
+from pybalboa.enums import OffOnState, UnknownState
+
+from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import BalboaEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the spa's lights."""
+    spa: SpaClient = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(BalboaLightEntity(control) for control in spa.lights)
+
+
+class BalboaLightEntity(BalboaEntity, LightEntity):
+    """Representation of a Balboa Spa light entity."""
+
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    def __init__(self, control: SpaControl) -> None:
+        """Initialize a Balboa Spa light entity."""
+        super().__init__(control.client, control.name)
+        self._control = control
+        self._attr_translation_key = (
+            "light_of_n" if len(control.client.lights) > 1 else "only_light"
+        )
+        self._attr_translation_placeholders = {
+            "index": f"{cast(int, control.index) + 1}"
+        }
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._control.set_state(OffOnState.OFF)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        await self._control.set_state(OffOnState.ON)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the light is on."""
+        if self._control.state == UnknownState.UNKNOWN:
+            return None
+        return self._control.state != OffOnState.OFF

--- a/homeassistant/components/balboa/strings.json
+++ b/homeassistant/components/balboa/strings.json
@@ -57,6 +57,14 @@
       "pump": {
         "name": "Pump {index}"
       }
+    },
+    "light": {
+      "light_of_n": {
+        "name": "Light {index}"
+      },
+      "only_light": {
+        "name": "Light"
+      }
     }
   }
 }

--- a/tests/components/balboa/conftest.py
+++ b/tests/components/balboa/conftest.py
@@ -57,6 +57,7 @@ def client_fixture() -> Generator[MagicMock, None, None]:
         client.heat_mode.set_state = AsyncMock()
         client.heat_mode.options = list(HeatMode)[:2]
         client.heat_state = 2
+        client.lights = []
         client.pumps = []
 
         yield client

--- a/tests/components/balboa/test_light.py
+++ b/tests/components/balboa/test_light.py
@@ -1,0 +1,65 @@
+"""Tests of the light entity of the balboa integration."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pybalboa import SpaControl
+from pybalboa.enums import OffOnState, UnknownState
+import pytest
+
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant
+
+from . import client_update, init_integration
+
+from tests.components.light import common
+
+ENTITY_LIGHT = "light.fakespa_light"
+
+
+@pytest.fixture
+def mock_light(client: MagicMock):
+    """Return a mock light."""
+    light = MagicMock(SpaControl)
+
+    async def set_state(state: OffOnState):
+        light.state = state
+
+    light.client = client
+    light.index = 0
+    light.state = OffOnState.OFF
+    light.set_state = set_state
+    light.options = list(OffOnState)
+    client.lights.append(light)
+
+    return light
+
+
+async def test_light(hass: HomeAssistant, client: MagicMock, mock_light) -> None:
+    """Test spa light."""
+    await init_integration(hass)
+
+    # check if the initial state is off
+    state = hass.states.get(ENTITY_LIGHT)
+    assert state.state == STATE_OFF
+
+    # test calling turn on
+    await common.async_turn_on(hass, ENTITY_LIGHT)
+    state = await client_update(hass, client, ENTITY_LIGHT)
+    assert state.state == STATE_ON
+
+    # test calling turn off
+    await common.async_turn_off(hass, ENTITY_LIGHT)
+    state = await client_update(hass, client, ENTITY_LIGHT)
+    assert state.state == STATE_OFF
+
+
+async def test_light_unknown_state(
+    hass: HomeAssistant, client: MagicMock, mock_light
+) -> None:
+    """Tests spa light with unknown state."""
+    await init_integration(hass)
+
+    mock_light.state = UnknownState.UNKNOWN
+    state = await client_update(hass, client, ENTITY_LIGHT)
+    assert state.state == STATE_UNKNOWN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Balboa Spa integration was missing entities to control the lights on the Hot Tub. This PR is adding entities for the lights. As requested this was split out of #111222 to limit the scope.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- ~~This PR fixes or closes issue: fixes #~~
- ~~This PR is related to issue:~~
- Link to documentation pull request: home-assistant/home-assistant.io#31587

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - (Do I need to bother running tests locally, or will they run when I submit this PR automatically?)
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
