### PR TITLE
Update mypy to a custom version

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -508,6 +508,11 @@ class HomeAssistant:
         """
         if target is None:
             raise ValueError("Don't call add_job with None")
+        if asyncio.iscoroutine(target):
+            self.loop.call_soon_threadsafe(self.async_add_job, target)
+            return
+        if TYPE_CHECKING:
+            target = cast(Callable[..., Any], target)
         self.loop.call_soon_threadsafe(self.async_add_job, target, *args)
 
     @overload

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ astroid==3.0.3
 coverage==7.4.2
 freezegun==1.3.1
 mock-open==1.4.0
-mypy==1.8.0
+mypy-dev==1.9.0b1
 pre-commit==3.6.2
 pydantic==1.10.12
 pylint==3.0.4


### PR DESCRIPTION
## Proposed change
Unfortunately, the mypy releases don't happen quite as regular as I would like. Usually that isn't a big issue, however this time the next version will include some features and bug fixes which are required for some major typing improvements.

The release itself was originally planned for the end of January, the release branch has even been cut already, unfortunately though there haven't been any updates over the last two weeks. It might happen early next week, or next month.

That's why I decided to create a project to build custom mypy version and upload them to PyPI. These can be used interchangeably which mypy itself, basically as a stop gap, until the next official release. The wheels are build using almost the same workflow, i.e. also compiled with mypyc. Only difference being that I chose not to compile / upload `musllinux` wheels. _(If necessary, I can add that and push a new release.)_

https://pypi.org/project/mypy-dev/1.9.0b1/
https://github.com/cdce8p/mypy-dev/tree/1.9.0b1
https://github.com/cdce8p/mypy-dev/releases/tag/1.9.0b1


Release `1.9.0b1` tracks the current HEAD of the [`release-1.9.0`](https://github.com/python/mypy/tree/release-1.9.0) branch https://github.com/python/mypy/commit/155909ad1bde747d89fcd091621d7cd9b1e15818.

### Changes for Mypy 1.9.0 (incomplete)
- Support for basic TypeVar defaults. Basically current use cases. E.g. for `DataUpdateCoordinator`.
_As long as the default isn't a TypeVarTuple or references another TypeVar._
=> This will also enable us to add generic typing to the `Event` class to get rid of some `type: ignores` around `async_listen`.
- Bugfix for TypeVarTuple inference with default arguments. Mypy will now emit warnings for wrong typing - used for
#106872
https://github.com/python/mypy/pull/16759
- Bugfix for `dict.__setitem__` with custom key types. Required for `aiohttp.web.AppKey` and 
#103844
https://github.com/python/mypy/pull/16803
https://docs.aiohttp.org/en/stable/web_advanced.html#application-s-config
- Better typing stubs. Notably for `asyncio` callback types - anything with a `callback` and only `*args`, e.g. `call_soon`. We could use something similar for `async_add_job`, `async_add_hass_job`, ... .


### Plan for the future
As soon as there is an official release, I'll create a PR to use that one instead. Beyond that, if there is a similar situation in the future, it might make sense to temporarily switch again. So far, I don't expect that. This release is somewhat special as a lot of typing improvements are currently blocked.

### Good to know
`mypy --version` will print the development version as if mypy would have been installed from git. I.e. not `1.9.0b1` but this instead
```
mypy 1.9.0+dev.155909ad1bde747d89fcd091621d7cd9b1e15818 (compiled: yes)
```
_Just in case someone finds an issue and wants to open a bug report on the official mypy repo._

### Refs
- https://github.com/python/mypy/issues/16843

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
