### PR TITLE
Bump tplink-omada-client to 1.3.11

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -1,13 +1,13 @@
 """The TP-Link Omada integration."""
 from __future__ import annotations
 
+from tplink_omada_client import OmadaSite
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
     OmadaClientException,
     UnsupportedControllerVersion,
 )
-from tplink_omada_client.omadaclient import OmadaSite
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -5,7 +5,11 @@ from collections.abc import Callable, Generator
 
 from attr import dataclass
 from tplink_omada_client.definitions import GatewayPortMode, LinkStatus
-from tplink_omada_client.devices import OmadaDevice, OmadaGateway, OmadaGatewayPort
+from tplink_omada_client.devices import (
+    OmadaDevice,
+    OmadaGateway,
+    OmadaGatewayPortStatus,
+)
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -81,7 +85,7 @@ class GatewayPortBinarySensorConfig:
     id_suffix: str
     name_suffix: str
     device_class: BinarySensorDeviceClass
-    update_func: Callable[[OmadaGatewayPort], bool]
+    update_func: Callable[[OmadaGatewayPortStatus], bool]
 
 
 class OmadaGatewayPortBinarySensor(OmadaDeviceEntity[OmadaGateway], BinarySensorEntity):

--- a/homeassistant/components/tplink_omada/config_flow.py
+++ b/homeassistant/components/tplink_omada/config_flow.py
@@ -9,13 +9,13 @@ from typing import Any, NamedTuple
 from urllib.parse import urlsplit
 
 from aiohttp import CookieJar
+from tplink_omada_client import OmadaClient, OmadaSite
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
     OmadaClientException,
     UnsupportedControllerVersion,
 )
-from tplink_omada_client.omadaclient import OmadaClient, OmadaSite
 import voluptuous as vol
 
 from homeassistant import config_entries

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -1,11 +1,11 @@
 """Controller for sharing Omada API coordinators between platforms."""
 
+from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import (
     OmadaGateway,
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
-from tplink_omada_client.omadasiteclient import OmadaSiteClient
 
 from homeassistant.core import HomeAssistant
 

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -4,8 +4,8 @@ from datetime import timedelta
 import logging
 from typing import Generic, TypeVar
 
+from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.exceptions import OmadaClientException
-from tplink_omada_client.omadaclient import OmadaSiteClient
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed

--- a/homeassistant/components/tplink_omada/manifest.json
+++ b/homeassistant/components/tplink_omada/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/tplink_omada",
   "integration_type": "hub",
   "iot_class": "local_polling",
-  "requirements": ["tplink-omada-client==1.3.2"]
+  "requirements": ["tplink-omada-client==1.3.11"]
 }

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from tplink_omada_client import SwitchPortOverrides
 from tplink_omada_client.definitions import PoEMode
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
-from tplink_omada_client.omadasiteclient import SwitchPortOverrides
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any, NamedTuple
 
+from tplink_omada_client import OmadaSiteClient
 from tplink_omada_client.devices import OmadaFirmwareUpdate, OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
-from tplink_omada_client.omadasiteclient import OmadaSiteClient
 
 from homeassistant.components.update import (
     UpdateDeviceClass,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2734,7 +2734,7 @@ total-connect-client==2023.2
 tp-connected==0.0.4
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.3.2
+tplink-omada-client==1.3.11
 
 # homeassistant.components.transmission
 transmission-rpc==7.0.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2084,7 +2084,7 @@ toonapi==0.3.0
 total-connect-client==2023.2
 
 # homeassistant.components.tplink_omada
-tplink-omada-client==1.3.2
+tplink-omada-client==1.3.11
 
 # homeassistant.components.transmission
 transmission-rpc==7.0.3

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -1,13 +1,13 @@
 """Test the TP-Link Omada config flows."""
 from unittest.mock import patch
 
+from tplink_omada_client import OmadaSite
 from tplink_omada_client.exceptions import (
     ConnectionFailed,
     LoginFailed,
     OmadaClientException,
     UnsupportedControllerVersion,
 )
-from tplink_omada_client.omadaclient import OmadaSite
 
 from homeassistant import config_entries
 from homeassistant.components.tplink_omada.config_flow import (

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -2,9 +2,9 @@
 from unittest.mock import MagicMock
 
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client import SwitchPortOverrides
 from tplink_omada_client.definitions import PoEMode
 from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
-from tplink_omada_client.omadasiteclient import SwitchPortOverrides
 
 from homeassistant.components import switch
 from homeassistant.const import ATTR_ENTITY_ID


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump to latest version of TP-Link Omada API. The only impact this will have is slightly better error messages at this stage. This is  a precursor to adding new features to the integration.

Going from version 1.3.2 to 1.3.11:
* [Commit history](https://github.com/MarkGodwin/tplink-omada-api/compare/release/v1.3.2...release/v1.3.11)
* [Changelog](https://github.com/MarkGodwin/tplink-omada-api/releases)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: None
- This PR is related to issue: None
- Link to documentation pull request: No change

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
