### PR TITLE
Add option for template trigger to activate on any change

### DIFF
--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -113,6 +113,7 @@ async def async_attach_trigger(
             "entity_id": entity_id,
             "from_state": from_s,
             "to_state": to_s,
+            "value": result,
         }
         trigger_variables = {
             **trigger_data,

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -356,6 +356,7 @@ async def test_if_not_fires_because_fail(
                                 "from_state.state",
                                 "to_state.state",
                                 "for",
+                                "value",
                             )
                         )
                     },
@@ -375,7 +376,56 @@ async def test_if_fires_on_change_with_template_advanced(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "template - test.entity - hello - world - None"
+    assert (
+        calls[0].data["some"] == "template - test.entity - hello - world - None - True"
+    )
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ states("test.entity") }}',
+                    "on_change": True,
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {
+                        "some": "{{ trigger.%s }}"
+                        % "}} - {{ trigger.".join(
+                            (
+                                "platform",
+                                "entity_id",
+                                "from_state.state",
+                                "to_state.state",
+                                "for",
+                                "value",
+                            )
+                        )
+                    },
+                },
+            }
+        },
+    ],
+)
+async def test_if_fires_on_change_with_on_change_true_template_advanced(
+    hass: HomeAssistant, start_ha, calls
+) -> None:
+    """Test for firing on change with template advanced."""
+    context = Context()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("test.entity", "world", context=context)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].context.parent_id == context.id
+    assert (
+        calls[0].data["some"] == "template - test.entity - hello - world - None - world"
+    )
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
@@ -457,6 +507,7 @@ async def test_if_fires_on_change_with_bad_template(
                                     "from_state.state",
                                     "to_state.state",
                                     "for",
+                                    "value",
                                 )
                             )
                         },
@@ -479,7 +530,9 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, start_ha, calls) 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == "template - test.entity - hello - world - None"
+    assert (
+        calls[0].data["some"] == "template - test.entity - hello - world - None - True"
+    )
 
 
 async def test_if_fires_on_change_with_for(hass: HomeAssistant, calls) -> None:
@@ -529,6 +582,7 @@ async def test_if_fires_on_change_with_for(hass: HomeAssistant, calls) -> None:
                                 "from_state.state",
                                 "to_state.state",
                                 "for",
+                                "value",
                             )
                         )
                     },
@@ -551,7 +605,10 @@ async def test_if_fires_on_change_with_for_advanced(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:05"
+    assert (
+        calls[0].data["some"]
+        == "template - test.entity - hello - world - 0:00:05 - True"
+    )
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
@@ -576,6 +633,7 @@ async def test_if_fires_on_change_with_for_advanced(
                                 "from_state.state",
                                 "to_state.state",
                                 "for",
+                                "value",
                             )
                         )
                     },
@@ -595,7 +653,10 @@ async def test_if_fires_on_change_with_for_0_advanced(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:00"
+    assert (
+        calls[0].data["some"]
+        == "template - test.entity - hello - world - 0:00:00 - True"
+    )
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])
@@ -620,6 +681,7 @@ async def test_if_fires_on_change_with_for_0_advanced(
                                 "from_state.state",
                                 "to_state.state",
                                 "for",
+                                "value",
                             )
                         )
                     },
@@ -640,7 +702,10 @@ async def test_if_fires_on_change_with_for_2(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "template - test.entity - hello - world - 0:00:05"
+    assert (
+        calls[0].data["some"]
+        == "template - test.entity - hello - world - 0:00:05 - True"
+    )
 
 
 @pytest.mark.parametrize(("count", "domain"), [(1, automation.DOMAIN)])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `on_change` setting to the template trigger. Setting `on_change: true` wil cause the tirgger to activate any time the template changes value. 

This allows for triggering on templates which return a number for example. It also allows for a single template which triggers on both a false -> true or true -> false change.

Also added the value returned by the template to trigger data.

See https://github.com/home-assistant/core/pull/110664 for more discussion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/31606

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
