### PR TITLE
Nuki add binary sensor for battery charging

### DIFF
--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -129,6 +129,7 @@ class NukiBatteryChargingEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/nuki/binary_sensor.py
+++ b/homeassistant/components/nuki/binary_sensor.py
@@ -29,6 +29,7 @@ async def async_setup_entry(
         if lock.is_door_sensor_activated:
             entities.append(NukiDoorsensorEntity(entry_data.coordinator, lock))
         entities.append(NukiBatteryCriticalEntity(entry_data.coordinator, lock))
+        entities.append(NukiBatteryChargingEntity(entry_data.coordinator, lock))
 
     for opener in entry_data.openers:
         entities.append(NukiRingactionEntity(entry_data.coordinator, opener))
@@ -108,7 +109,6 @@ class NukiBatteryCriticalEntity(NukiEntity[NukiDevice], BinarySensorEntity):
     """Representation of Nuki Battery Critical."""
 
     _attr_has_entity_name = True
-    _attr_translation_key = "battery_critical"
     _attr_device_class = BinarySensorDeviceClass.BATTERY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -119,5 +119,23 @@ class NukiBatteryCriticalEntity(NukiEntity[NukiDevice], BinarySensorEntity):
 
     @property
     def is_on(self) -> bool:
-        """Return the value of the ring action state."""
+        """Return the value of the battery critical."""
         return self._nuki_device.battery_critical
+
+
+class NukiBatteryChargingEntity(NukiEntity[NukiDevice], BinarySensorEntity):
+    """Representation of a Nuki Battery charging."""
+
+    _attr_has_entity_name = True
+    _attr_device_class = BinarySensorDeviceClass.BATTERY_CHARGING
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self._nuki_device.nuki_id}_battery_charging"
+
+    @property
+    def is_on(self) -> bool:
+        """Return the value of the battery charging."""
+        return self._nuki_device.battery_charging

--- a/homeassistant/components/nuki/manifest.json
+++ b/homeassistant/components/nuki/manifest.json
@@ -12,5 +12,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nuki",
   "iot_class": "local_polling",
   "loggers": ["pynuki"],
-  "requirements": ["pynuki==1.6.2"]
+  "requirements": ["pynuki==1.6.3"]
 }

--- a/homeassistant/components/nuki/strings.json
+++ b/homeassistant/components/nuki/strings.json
@@ -41,9 +41,6 @@
     "binary_sensor": {
       "ring_action": {
         "name": "Ring Action"
-      },
-      "battery_critical": {
-        "name": "Battery critical"
       }
     },
     "lock": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1992,7 +1992,7 @@ pynetio==0.1.9.1
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.6.2
+pynuki==1.6.3
 
 # homeassistant.components.nut
 pynut2==2.1.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1537,7 +1537,7 @@ pynetgear==0.10.10
 pynobo==1.6.0
 
 # homeassistant.components.nuki
-pynuki==1.6.2
+pynuki==1.6.3
 
 # homeassistant.components.nut
 pynut2==2.1.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a binary sensor for battery charging and removes the translation key introduced in #111285 because it's not really needed.

https://github.com/pschmitt/pynuki/compare/1.6.2...1.6.3


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
