### PR TITLE
PoC DO NOT MERGE: Fix matter blocking the event loop

### DIFF
--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -1,39 +1,14 @@
 """The Matter integration."""
 from __future__ import annotations
 
-import asyncio
-from contextlib import suppress
 from functools import cache
+import importlib
+import sys
 
-from matter_server.client import MatterClient
-from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
-from matter_server.common.errors import MatterError, NodeNotExists
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.typing import ConfigType
 
-from homeassistant.components.hassio import AddonError, AddonManager, AddonState
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
-
-from .adapter import MatterAdapter
-from .addon import get_addon_manager
-from .api import async_register_api
-from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN, LOGGER
-from .discovery import SUPPORTED_PLATFORMS
-from .helpers import (
-    MatterEntryData,
-    get_matter,
-    get_node_from_device_entry,
-    node_from_ha_device_id,
-)
-from .models import MatterDeviceInfo
+from .helpers import MatterDeviceInfo, node_from_ha_device_id
 
 CONNECT_TIMEOUT = 10
 LISTEN_READY_TIMEOUT = 30
@@ -55,214 +30,24 @@ def get_matter_device_info(
     )
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Matter from a config entry."""
-    if use_addon := entry.data.get(CONF_USE_ADDON):
-        await _async_ensure_addon_running(hass, entry)
+async def _async_load_core(hass: HomeAssistant) -> None:
+    """Load the core component.
 
-    matter_client = MatterClient(entry.data[CONF_URL], async_get_clientsession(hass))
-    try:
-        async with asyncio.timeout(CONNECT_TIMEOUT):
-            await matter_client.connect()
-    except (CannotConnect, TimeoutError) as err:
-        raise ConfigEntryNotReady("Failed to connect to matter server") from err
-    except InvalidServerVersion as err:
-        if use_addon:
-            addon_manager = _get_addon_manager(hass)
-            addon_manager.async_schedule_update_addon(catch_error=True)
-        else:
-            async_create_issue(
-                hass,
-                DOMAIN,
-                "invalid_server_version",
-                is_fixable=False,
-                severity=IssueSeverity.ERROR,
-                translation_key="invalid_server_version",
-            )
-        raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
-
-    except Exception as err:
-        LOGGER.exception("Failed to connect to matter server")
-        raise ConfigEntryNotReady(
-            "Unknown error connecting to the Matter server"
-        ) from err
-
-    async_delete_issue(hass, DOMAIN, "invalid_server_version")
-
-    async def on_hass_stop(event: Event) -> None:
-        """Handle incoming stop event from Home Assistant."""
-        await matter_client.disconnect()
-
-    entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
-    )
-
-    async_register_api(hass)
-
-    # launch the matter client listen task in the background
-    # use the init_ready event to wait until initialization is done
-    init_ready = asyncio.Event()
-    listen_task = asyncio.create_task(
-        _client_listen(hass, entry, matter_client, init_ready)
-    )
-
-    try:
-        async with asyncio.timeout(LISTEN_READY_TIMEOUT):
-            await init_ready.wait()
-    except TimeoutError as err:
-        listen_task.cancel()
-        raise ConfigEntryNotReady("Matter client not ready") from err
-
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-
-    # create an intermediate layer (adapter) which keeps track of the nodes
-    # and discovery of platform entities from the node attributes
-    matter = MatterAdapter(hass, matter_client, entry)
-    hass.data[DOMAIN][entry.entry_id] = MatterEntryData(matter, listen_task)
-
-    await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
-    await matter.setup_nodes()
-
-    # If the listen task is already failed, we need to raise ConfigEntryNotReady
-    if listen_task.done() and (listen_error := listen_task.exception()) is not None:
-        await hass.config_entries.async_unload_platforms(entry, SUPPORTED_PLATFORMS)
-        hass.data[DOMAIN].pop(entry.entry_id)
-        try:
-            await matter_client.disconnect()
-        finally:
-            raise ConfigEntryNotReady(listen_error) from listen_error
-
-    return True
-
-
-async def _client_listen(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    matter_client: MatterClient,
-    init_ready: asyncio.Event,
-) -> None:
-    """Listen with the client."""
-    try:
-        await matter_client.start_listening(init_ready)
-    except MatterError as err:
-        if entry.state != ConfigEntryState.LOADED:
-            raise
-        LOGGER.error("Failed to listen: %s", err)
-    except Exception as err:  # pylint: disable=broad-except
-        # We need to guard against unknown exceptions to not crash this task.
-        LOGGER.exception("Unexpected exception: %s", err)
-        if entry.state != ConfigEntryState.LOADED:
-            raise
-
-    if not hass.is_stopping:
-        LOGGER.debug("Disconnected from server. Reloading integration")
-        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
-
-
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(
-        entry, SUPPORTED_PLATFORMS
-    )
-
-    if unload_ok:
-        matter_entry_data: MatterEntryData = hass.data[DOMAIN].pop(entry.entry_id)
-        matter_entry_data.listen_task.cancel()
-        await matter_entry_data.adapter.matter_client.disconnect()
-
-    if entry.data.get(CONF_USE_ADDON) and entry.disabled_by:
-        addon_manager: AddonManager = get_addon_manager(hass)
-        LOGGER.debug("Stopping Matter Server add-on")
-        try:
-            await addon_manager.async_stop_addon()
-        except AddonError as err:
-            LOGGER.error("Failed to stop the Matter Server add-on: %s", err)
-            return False
-
-    return unload_ok
-
-
-async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Config entry is being removed."""
-
-    if not entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
-        return
-
-    addon_manager: AddonManager = get_addon_manager(hass)
-    try:
-        await addon_manager.async_stop_addon()
-    except AddonError as err:
-        LOGGER.error(err)
-        return
-    try:
-        await addon_manager.async_create_backup()
-    except AddonError as err:
-        LOGGER.error(err)
-        return
-    try:
-        await addon_manager.async_uninstall_addon()
-    except AddonError as err:
-        LOGGER.error(err)
-
-
-async def async_remove_config_entry_device(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
-) -> bool:
-    """Remove a config entry from a device."""
-    node = get_node_from_device_entry(hass, device_entry)
-
-    if node is None:
-        return True
-
-    if node.is_bridge_device:
-        device_registry = dr.async_get(hass)
-        devices = dr.async_entries_for_config_entry(
-            device_registry, config_entry.entry_id
-        )
-        for device in devices:
-            if device.via_device_id == device_entry.id:
-                device_registry.async_update_device(
-                    device.id, remove_config_entry_id=config_entry.entry_id
-                )
-
-    matter = get_matter(hass)
-    with suppress(NodeNotExists):
-        # ignore if the server has already removed the node.
-        await matter.matter_client.remove_node(node.node_id)
-
-    return True
-
-
-async def _async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Ensure that Matter Server add-on is installed and running."""
-    addon_manager = _get_addon_manager(hass)
-    try:
-        addon_info = await addon_manager.async_get_addon_info()
-    except AddonError as err:
-        raise ConfigEntryNotReady(err) from err
-
-    addon_state = addon_info.state
-
-    if addon_state == AddonState.NOT_INSTALLED:
-        addon_manager.async_schedule_install_setup_addon(
-            addon_info.options,
-            catch_error=True,
-        )
-        raise ConfigEntryNotReady
-
-    if addon_state == AddonState.NOT_RUNNING:
-        addon_manager.async_schedule_start_addon(catch_error=True)
-        raise ConfigEntryNotReady
-
-
-@callback
-def _get_addon_manager(hass: HomeAssistant) -> AddonManager:
-    """Ensure that Matter Server add-on is updated and running.
-
-    May only be used as part of async_setup_entry above.
+    This function is used to avoid loading chip and matter_server
+    from the event loop.
     """
-    addon_manager: AddonManager = get_addon_manager(hass)
-    if addon_manager.task_in_progress():
-        raise ConfigEntryNotReady
-    return addon_manager
+    if "matter_server" not in sys.modules:
+        await hass.async_add_executor_job(importlib.import_module, "matter_server")
+    # pylint:disable-next=import-outside-toplevel
+    from .core import async_remove_entry, async_setup_entry, async_unload_entry
+
+    _module = sys.modules[__name__]
+    setattr(_module, "async_setup_entry", async_setup_entry)
+    setattr(_module, "async_unload_entry", async_unload_entry)
+    setattr(_module, "async_remove_entry", async_remove_entry)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Matter integration."""
+    await _async_load_core(hass)
+    return True

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from matter_server.client import MatterClient
-from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -47,6 +45,9 @@ def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     """Validate the user input allows us to connect."""
+    # pylint:disable-next=import-outside-toplevel
+    from matter_server.client import MatterClient
+
     client = MatterClient(data[CONF_URL], aiohttp_client.async_get_clientsession(hass))
     await client.connect()
 
@@ -152,6 +153,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         addon_manager: AddonManager = get_addon_manager(self.hass)
 
         await addon_manager.async_schedule_start_addon()
+        # pylint:disable-next=import-outside-toplevel
+        from matter_server.client.exceptions import CannotConnect
+
         # Sleep some seconds to let the add-on start properly before connecting.
         for _ in range(ADDON_SETUP_TIMEOUT_ROUNDS):
             await asyncio.sleep(ADDON_SETUP_TIMEOUT)
@@ -203,6 +207,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         errors = {}
+        # pylint:disable-next=import-outside-toplevel
+        from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
 
         try:
             await validate_input(self.hass, user_input)
@@ -276,7 +282,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Prepare info needed to complete the config entry."""
+
         if not self.ws_address:
+            # pylint:disable-next=import-outside-toplevel
+            from matter_server.client.exceptions import CannotConnect
+
             discovery_info = await self._async_get_addon_discovery_info()
             ws_address = self.ws_address = build_ws_address(
                 discovery_info["host"], discovery_info["port"]

--- a/homeassistant/components/matter/core.py
+++ b/homeassistant/components/matter/core.py
@@ -1,0 +1,245 @@
+"""The Matter integration."""
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+
+from matter_server.client import MatterClient
+from matter_server.client.exceptions import CannotConnect, InvalidServerVersion
+from matter_server.common.errors import MatterError, NodeNotExists
+
+from homeassistant.components.hassio import AddonError, AddonManager, AddonState
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.const import CONF_URL, EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.issue_registry import (
+    IssueSeverity,
+    async_create_issue,
+    async_delete_issue,
+)
+
+from .adapter import MatterAdapter
+from .addon import get_addon_manager
+from .api import async_register_api
+from .const import CONF_INTEGRATION_CREATED_ADDON, CONF_USE_ADDON, DOMAIN, LOGGER
+from .discovery import SUPPORTED_PLATFORMS
+from .helpers import MatterEntryData, get_matter, get_node_from_device_entry
+
+CONNECT_TIMEOUT = 10
+LISTEN_READY_TIMEOUT = 30
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Matter from a config entry."""
+    if use_addon := entry.data.get(CONF_USE_ADDON):
+        await _async_ensure_addon_running(hass, entry)
+
+    matter_client = MatterClient(entry.data[CONF_URL], async_get_clientsession(hass))
+    try:
+        async with asyncio.timeout(CONNECT_TIMEOUT):
+            await matter_client.connect()
+    except (CannotConnect, TimeoutError) as err:
+        raise ConfigEntryNotReady("Failed to connect to matter server") from err
+    except InvalidServerVersion as err:
+        if use_addon:
+            addon_manager = _get_addon_manager(hass)
+            addon_manager.async_schedule_update_addon(catch_error=True)
+        else:
+            async_create_issue(
+                hass,
+                DOMAIN,
+                "invalid_server_version",
+                is_fixable=False,
+                severity=IssueSeverity.ERROR,
+                translation_key="invalid_server_version",
+            )
+        raise ConfigEntryNotReady(f"Invalid server version: {err}") from err
+
+    except Exception as err:
+        LOGGER.exception("Failed to connect to matter server")
+        raise ConfigEntryNotReady(
+            "Unknown error connecting to the Matter server"
+        ) from err
+
+    async_delete_issue(hass, DOMAIN, "invalid_server_version")
+
+    async def on_hass_stop(event: Event) -> None:
+        """Handle incoming stop event from Home Assistant."""
+        await matter_client.disconnect()
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
+    )
+
+    async_register_api(hass)
+
+    # launch the matter client listen task in the background
+    # use the init_ready event to wait until initialization is done
+    init_ready = asyncio.Event()
+    listen_task = asyncio.create_task(
+        _client_listen(hass, entry, matter_client, init_ready)
+    )
+
+    try:
+        async with asyncio.timeout(LISTEN_READY_TIMEOUT):
+            await init_ready.wait()
+    except TimeoutError as err:
+        listen_task.cancel()
+        raise ConfigEntryNotReady("Matter client not ready") from err
+
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+
+    # create an intermediate layer (adapter) which keeps track of the nodes
+    # and discovery of platform entities from the node attributes
+    matter = MatterAdapter(hass, matter_client, entry)
+    hass.data[DOMAIN][entry.entry_id] = MatterEntryData(matter, listen_task)
+
+    await hass.config_entries.async_forward_entry_setups(entry, SUPPORTED_PLATFORMS)
+    await matter.setup_nodes()
+
+    # If the listen task is already failed, we need to raise ConfigEntryNotReady
+    if listen_task.done() and (listen_error := listen_task.exception()) is not None:
+        await hass.config_entries.async_unload_platforms(entry, SUPPORTED_PLATFORMS)
+        hass.data[DOMAIN].pop(entry.entry_id)
+        try:
+            await matter_client.disconnect()
+        finally:
+            raise ConfigEntryNotReady(listen_error) from listen_error
+
+    return True
+
+
+async def _client_listen(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    matter_client: MatterClient,
+    init_ready: asyncio.Event,
+) -> None:
+    """Listen with the client."""
+    try:
+        await matter_client.start_listening(init_ready)
+    except MatterError as err:
+        if entry.state != ConfigEntryState.LOADED:
+            raise
+        LOGGER.error("Failed to listen: %s", err)
+    except Exception as err:  # pylint: disable=broad-except
+        # We need to guard against unknown exceptions to not crash this task.
+        LOGGER.exception("Unexpected exception: %s", err)
+        if entry.state != ConfigEntryState.LOADED:
+            raise
+
+    if not hass.is_stopping:
+        LOGGER.debug("Disconnected from server. Reloading integration")
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+) -> bool:
+    """Remove a config entry from a device."""
+    node = get_node_from_device_entry(hass, device_entry)
+
+    if node is None:
+        return True
+
+    if node.is_bridge_device:
+        device_registry = dr.async_get(hass)
+        devices = dr.async_entries_for_config_entry(
+            device_registry, config_entry.entry_id
+        )
+        for device in devices:
+            if device.via_device_id == device_entry.id:
+                device_registry.async_update_device(
+                    device.id, remove_config_entry_id=config_entry.entry_id
+                )
+
+    matter = get_matter(hass)
+    with suppress(NodeNotExists):
+        # ignore if the server has already removed the node.
+        await matter.matter_client.remove_node(node.node_id)
+
+    return True
+
+
+async def _async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Ensure that Matter Server add-on is installed and running."""
+    addon_manager = _get_addon_manager(hass)
+    try:
+        addon_info = await addon_manager.async_get_addon_info()
+    except AddonError as err:
+        raise ConfigEntryNotReady(err) from err
+
+    addon_state = addon_info.state
+
+    if addon_state == AddonState.NOT_INSTALLED:
+        addon_manager.async_schedule_install_setup_addon(
+            addon_info.options,
+            catch_error=True,
+        )
+        raise ConfigEntryNotReady
+
+    if addon_state == AddonState.NOT_RUNNING:
+        addon_manager.async_schedule_start_addon(catch_error=True)
+        raise ConfigEntryNotReady
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, SUPPORTED_PLATFORMS
+    )
+
+    if unload_ok:
+        matter_entry_data: MatterEntryData = hass.data[DOMAIN].pop(entry.entry_id)
+        matter_entry_data.listen_task.cancel()
+        await matter_entry_data.adapter.matter_client.disconnect()
+
+    if entry.data.get(CONF_USE_ADDON) and entry.disabled_by:
+        addon_manager: AddonManager = get_addon_manager(hass)
+        LOGGER.debug("Stopping Matter Server add-on")
+        try:
+            await addon_manager.async_stop_addon()
+        except AddonError as err:
+            LOGGER.error("Failed to stop the Matter Server add-on: %s", err)
+            return False
+
+    return unload_ok
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Config entry is being removed."""
+
+    if not entry.data.get(CONF_INTEGRATION_CREATED_ADDON):
+        return
+
+    addon_manager: AddonManager = get_addon_manager(hass)
+    try:
+        await addon_manager.async_stop_addon()
+    except AddonError as err:
+        LOGGER.error(err)
+        return
+    try:
+        await addon_manager.async_create_backup()
+    except AddonError as err:
+        LOGGER.error(err)
+        return
+    try:
+        await addon_manager.async_uninstall_addon()
+    except AddonError as err:
+        LOGGER.error(err)
+
+
+@callback
+def _get_addon_manager(hass: HomeAssistant) -> AddonManager:
+    """Ensure that Matter Server add-on is updated and running.
+
+    May only be used as part of async_setup_entry above.
+    """
+    addon_manager: AddonManager = get_addon_manager(hass)
+    if addon_manager.task_in_progress():
+        raise ConfigEntryNotReady
+    return addon_manager

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -12,10 +12,26 @@ from homeassistant.helpers import device_registry as dr
 from .const import DOMAIN, ID_TYPE_DEVICE_ID
 
 if TYPE_CHECKING:
+    # This module must not import from matter_server or chip
+    # as it will lead to the event loop being blocked
     from matter_server.client.models.node import MatterEndpoint, MatterNode
     from matter_server.common.models import ServerInfoMessage
 
     from .adapter import MatterAdapter
+
+
+class MatterDeviceInfo(TypedDict):
+    """Dictionary with Matter Device info.
+
+    Used to send to other Matter controllers,
+    such as Google Home to prevent duplicated devices.
+
+    Reference: https://developers.home.google.com/matter/device-deduplication
+    """
+
+    unique_id: str
+    vendor_id: str  # vendorId hex string
+    product_id: str  # productId hex string
 
 
 class MissingNode(HomeAssistantError):

--- a/homeassistant/components/matter/models.py
+++ b/homeassistant/components/matter/models.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TypedDict
 
 from chip.clusters import Objects as clusters
 from chip.clusters.Objects import ClusterAttributeDescriptor
@@ -15,20 +14,6 @@ from homeassistant.helpers.entity import EntityDescription
 SensorValueTypes = type[
     clusters.uint | int | clusters.Nullable | clusters.float32 | float
 ]
-
-
-class MatterDeviceInfo(TypedDict):
-    """Dictionary with Matter Device info.
-
-    Used to send to other Matter controllers,
-    such as Google Home to prevent duplicated devices.
-
-    Reference: https://developers.home.google.com/matter/device-deduplication
-    """
-
-    unique_id: str
-    vendor_id: str  # vendorId hex string
-    product_id: str  # productId hex string
 
 
 @dataclass

--- a/tests/components/matter/conftest.py
+++ b/tests/components/matter/conftest.py
@@ -10,6 +10,7 @@ from matter_server.common.const import SCHEMA_VERSION
 from matter_server.common.models import ServerInfoMessage
 import pytest
 
+from homeassistant.components.matter import _async_load_core
 from homeassistant.core import HomeAssistant
 
 from .common import setup_integration_with_node_fixture
@@ -20,11 +21,17 @@ MOCK_FABRIC_ID = 12341234
 MOCK_COMPR_FABRIC_ID = 1234
 
 
+@pytest.fixture(name="preload_matter_core")
+async def preload_matter_core(hass: HomeAssistant) -> None:
+    """Preload the Matter core component."""
+    await _async_load_core(hass)
+
+
 @pytest.fixture(name="matter_client")
 async def matter_client_fixture() -> AsyncGenerator[MagicMock, None]:
     """Fixture for a Matter client."""
     with patch(
-        "homeassistant.components.matter.MatterClient", autospec=True
+        "homeassistant.components.matter.core.MatterClient", autospec=True
     ) as client_class:
         client = client_class.return_value
 

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -36,7 +36,7 @@ def setup_entry_fixture() -> Generator[AsyncMock, None, None]:
 def client_connect_fixture() -> Generator[AsyncMock, None, None]:
     """Mock server version."""
     with patch(
-        "homeassistant.components.matter.config_flow.MatterClient.connect"
+        "homeassistant.components.matter.config_flow.core.MatterClient.connect"
     ) as client_connect:
         yield client_connect
 


### PR DESCRIPTION
While investigating Bluetooth problems on a Home Assistant Green, I found that Bluetooth failed to start because the event loop was blocked for 7-12s from loading matter which cause the system to be unstable and timeout many task
https://github.com/home-assistant-libs/python-matter-server/issues/578


This is a proof of concept for testing.  I don't suggest merging this.  I think a better solution would be to add a list of modules to preload in the executor to the `manifest.json` which setup can do before it loads the integration to prevent the module from being loaded in the event loop.

The problem with that solution is that cloud, which loads very early, imports matter (see #103768) by ways of importing [google assistant ](https://github.com/home-assistant/core/blob/d004011d415707ce85cf657c024ff248d7bc2caf/homeassistant/components/google_assistant/helpers.py#L18)so it still get loaded to early in the event loop.





## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PoC DO NOT MERGE: Fix matter blocking the event loop

https://github.com/home-assistant-libs/python-matter-server/issues/578

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
