### PR TITLE
Update rfxtrx library to handle connection retries

### DIFF
--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -1,7 +1,6 @@
 """Support for RFXtrx devices."""
 from __future__ import annotations
 
-import asyncio
 import binascii
 from collections.abc import Callable, Mapping
 import copy
@@ -23,6 +22,7 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
@@ -89,15 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the RFXtrx component."""
     hass.data.setdefault(DOMAIN, {})
 
-    try:
-        await async_setup_internal(hass, entry)
-    except TimeoutError:
-        # Library currently doesn't support reload
-        _LOGGER.error(
-            "Connection timeout: failed to receive response from RFXtrx device"
-        )
-        return False
-
+    await async_setup_internal(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -118,7 +110,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _create_rfx(config: Mapping[str, Any]) -> rfxtrxmod.Connect:
+def _create_rfx(
+    config: Mapping[str, Any], event_callback: Callable[[rfxtrxmod.RFXtrxEvent], None]
+) -> rfxtrxmod.Connect:
     """Construct a rfx object based on config."""
 
     modes = config.get(CONF_PROTOCOLS)
@@ -132,17 +126,17 @@ def _create_rfx(config: Mapping[str, Any]) -> rfxtrxmod.Connect:
         # If port is set then we create a TCP connection
         rfx = rfxtrxmod.Connect(
             (config[CONF_HOST], config[CONF_PORT]),
-            None,
+            event_callback,
             transport_protocol=rfxtrxmod.PyNetworkTransport,
             modes=modes,
         )
     else:
         rfx = rfxtrxmod.Connect(
             config[CONF_DEVICE],
-            None,
+            event_callback,
             modes=modes,
         )
-
+    rfx.connect(30)
     return rfx
 
 
@@ -165,10 +159,6 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Set up the RFXtrx component."""
     config = entry.data
 
-    # Initialize library
-    async with asyncio.timeout(30):
-        rfx_object = await hass.async_add_executor_job(_create_rfx, config)
-
     # Setup some per device config
     devices = _get_device_lookup(config[CONF_DEVICES])
     pt2262_devices: set[str] = set()
@@ -179,8 +169,16 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     @callback
     def async_handle_receive(event: rfxtrxmod.RFXtrxEvent) -> None:
         """Handle received messages from RFXtrx gateway."""
-        # Log RFXCOM event
-        if not event.device.id_string:
+
+        if isinstance(event, rfxtrxmod.ConnectionLost):
+            _LOGGER.warning("Connection was lost, triggering reload")
+            hass.async_create_task(
+                hass.config_entries.async_reload(entry.entry_id),
+                f"config entry reload {entry.title} {entry.domain} {entry.entry_id}",
+            )
+            return
+
+        if not event.device or not event.device.id_string:
             return
 
         event_data = {
@@ -264,6 +262,16 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
         if device_id:
             _remove_device(device_id)
 
+    # Initialize library
+    try:
+        rfx_object = await hass.async_add_executor_job(
+            _create_rfx, config, lambda event: hass.add_job(async_handle_receive, event)
+        )
+    except TimeoutError as exc:
+        raise ConfigEntryNotReady("Timeout on connect") from exc
+
+    hass.data[DOMAIN][DATA_RFXOBJECT] = rfx_object
+
     entry.async_on_unload(
         hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, _updated_device)
     )
@@ -275,9 +283,6 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown_rfxtrx)
     )
-    hass.data[DOMAIN][DATA_RFXOBJECT] = rfx_object
-
-    rfx_object.event_callback = lambda event: hass.add_job(async_handle_receive, event)
 
     def send(call: ServiceCall) -> None:
         event = call.data[ATTR_EVENT]

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -124,18 +124,15 @@ def _create_rfx(
 
     if config[CONF_PORT] is not None:
         # If port is set then we create a TCP connection
-        rfx = rfxtrxmod.Connect(
-            (config[CONF_HOST], config[CONF_PORT]),
-            event_callback,
-            transport_protocol=rfxtrxmod.PyNetworkTransport,
-            modes=modes,
-        )
+        transport = rfxtrxmod.PyNetworkTransport((config[CONF_HOST], config[CONF_PORT]))
     else:
-        rfx = rfxtrxmod.Connect(
-            config[CONF_DEVICE],
-            event_callback,
-            modes=modes,
-        )
+        transport = rfxtrxmod.PySerialTransport(config[CONF_DEVICE])
+
+    rfx = rfxtrxmod.Connect(
+        transport,
+        event_callback,
+        modes=modes,
+    )
     rfx.connect(30)
     return rfx
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -633,23 +633,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 def _test_transport(host: str | None, port: int | None, device: str | None) -> bool:
     """Construct a rfx object based on config."""
-    if port is not None:
-        try:
+    try:
+        if port is not None:
             conn = rfxtrxmod.PyNetworkTransport((host, port))
-        except OSError:
-            return False
-
-        conn.close()
-    else:
-        try:
+        else:
             conn = rfxtrxmod.PySerialTransport(device)
-        except serial.SerialException:
-            return False
-
-        if conn.serial is None:
-            return False
-
-        conn.close()
+        conn.connect()
+    except rfxtrxmod.RFXtrxTransportError:
+        return False
 
     return True
 

--- a/homeassistant/components/rfxtrx/config_flow.py
+++ b/homeassistant/components/rfxtrx/config_flow.py
@@ -633,13 +633,14 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 def _test_transport(host: str | None, port: int | None, device: str | None) -> bool:
     """Construct a rfx object based on config."""
+    if port is not None:
+        conn = rfxtrxmod.PyNetworkTransport((host, port))
+    else:
+        conn = rfxtrxmod.PySerialTransport(device)
+
     try:
-        if port is not None:
-            conn = rfxtrxmod.PyNetworkTransport((host, port))
-        else:
-            conn = rfxtrxmod.PySerialTransport(device)
         conn.connect()
-    except rfxtrxmod.RFXtrxTransportError:
+    except (rfxtrxmod.RFXtrxTransportError, TimeoutError):
         return False
 
     return True

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
   "iot_class": "local_push",
   "loggers": ["RFXtrx"],
-  "requirements": ["pyRFXtrx==0.30.1"]
+  "requirements": ["pyRFXtrx==0.31.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1642,7 +1642,7 @@ pyEmby==1.9
 pyHik==0.3.2
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.30.1
+pyRFXtrx==0.31.0
 
 # homeassistant.components.sony_projector
 pySDCP==1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1280,7 +1280,7 @@ pyDuotecno==2024.1.2
 pyElectra==1.2.0
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.30.1
+pyRFXtrx==0.31.0
 
 # homeassistant.components.tibber
 pyTibber==0.28.2

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -2,6 +2,7 @@
 import os
 from unittest.mock import MagicMock, patch, sentinel
 
+from RFXtrx import RFXtrxTransportError
 import serial.tools.list_ports
 
 from homeassistant import config_entries, data_entry_flow
@@ -13,16 +14,6 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from tests.common import MockConfigEntry
 
 SOME_PROTOCOLS = ["ac", "arc"]
-
-
-def serial_connect(self):
-    """Mock a serial connection."""
-    self.serial = True
-
-
-def serial_connect_fail(self):
-    """Mock a failed serial connection."""
-    self.serial = None
 
 
 def com_port():
@@ -46,7 +37,6 @@ async def start_options_flow(hass, entry):
     return await hass.config_entries.options.async_init(entry.entry_id)
 
 
-@patch("homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport", autospec=True)
 async def test_setup_network(transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup network."""
     result = await hass.config_entries.flow.async_init(
@@ -83,15 +73,7 @@ async def test_setup_network(transport_mock, hass: HomeAssistant) -> None:
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    serial_connect,
-)
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
-    return_value=None,
-)
-async def test_setup_serial(com_mock, connect_mock, hass: HomeAssistant) -> None:
+async def test_setup_serial(com_mock, transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup serial."""
     port = com_port()
 
@@ -129,15 +111,9 @@ async def test_setup_serial(com_mock, connect_mock, hass: HomeAssistant) -> None
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    serial_connect,
-)
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.close",
-    return_value=None,
-)
-async def test_setup_serial_manual(com_mock, connect_mock, hass: HomeAssistant) -> None:
+async def test_setup_serial_manual(
+    com_mock, transport_mock, hass: HomeAssistant
+) -> None:
     """Test we can setup serial with manual entry."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -180,13 +156,9 @@ async def test_setup_serial_manual(com_mock, connect_mock, hass: HomeAssistant) 
     }
 
 
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PyNetworkTransport",
-    autospec=True,
-    side_effect=OSError,
-)
 async def test_setup_network_fail(transport_mock, hass: HomeAssistant) -> None:
     """Test we can setup network."""
+    transport_mock.return_value.connect.side_effect = RFXtrxTransportError
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -214,12 +186,9 @@ async def test_setup_network_fail(transport_mock, hass: HomeAssistant) -> None:
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    side_effect=serial.SerialException,
-)
-async def test_setup_serial_fail(com_mock, connect_mock, hass: HomeAssistant) -> None:
+async def test_setup_serial_fail(com_mock, transport_mock, hass: HomeAssistant) -> None:
     """Test setup serial failed connection."""
+    transport_mock.return_value.connect.side_effect = RFXtrxTransportError
     port = com_port()
 
     result = await hass.config_entries.flow.async_init(
@@ -249,12 +218,11 @@ async def test_setup_serial_fail(com_mock, connect_mock, hass: HomeAssistant) ->
 
 
 @patch("serial.tools.list_ports.comports", return_value=[com_port()])
-@patch(
-    "homeassistant.components.rfxtrx.rfxtrxmod.PySerialTransport.connect",
-    serial_connect_fail,
-)
-async def test_setup_serial_manual_fail(com_mock, hass: HomeAssistant) -> None:
+async def test_setup_serial_manual_fail(
+    com_mock, transport_mock, hass: HomeAssistant
+) -> None:
     """Test setup serial failed connection."""
+    transport_mock.return_value.connect.side_effect = RFXtrxTransportError
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -130,7 +130,7 @@ async def test_ws_device_remove(
     assert mock_entry.data["devices"] == {}
 
 
-async def test_connect(hass: HomeAssistant) -> None:
+async def test_connect(transport_mock, hass: HomeAssistant) -> None:
     """Test that we attempt to connect to the device."""
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake")
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -141,10 +141,11 @@ async def test_connect(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    connect.assert_called_once_with("/dev/ttyUSBfake", ANY, modes=ANY)
+    transport_mock.assert_called_once_with("/dev/ttyUSBfake")
+    connect.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
 
 
-async def test_connect_with_protocols(hass: HomeAssistant) -> None:
+async def test_connect_with_protocols(transport_mock, hass: HomeAssistant) -> None:
     """Test that we attempt to set protocols."""
     entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS)
     mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
@@ -155,4 +156,7 @@ async def test_connect_with_protocols(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    connect.assert_called_once_with("/dev/ttyUSBfake", ANY, modes=SOME_PROTOCOLS)
+    transport_mock.assert_called_once_with("/dev/ttyUSBfake")
+    connect.assert_called_once_with(
+        transport_mock.return_value, ANY, modes=SOME_PROTOCOLS
+    )

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -208,8 +208,10 @@ async def test_reconnect(rfxtrx, hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.LOADED
     rfxtrx.connect.call_count = 1
 
-    rfxtrx.event_callback(rfxtrxmod.ConnectionLost())
-    await hass.async_block_till_done()
+    await hass.async_add_executor_job(
+        rfxtrx.event_callback,
+        rfxtrxmod.ConnectionLost(),
+    )
 
     assert config_entry.state is ConfigEntryState.LOADED
     rfxtrx.connect.call_count = 2

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,19 +1,18 @@
 """The tests for the Rfxtrx component."""
 from __future__ import annotations
 
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, call
 
 import RFXtrx as rfxtrxmod
 
-from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .conftest import create_rfx_test_cfg, setup_rfx_test_cfg
+from .conftest import setup_rfx_test_cfg
 
-from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 SOME_PROTOCOLS = ["ac", "arc"]
@@ -130,33 +129,87 @@ async def test_ws_device_remove(
     assert mock_entry.data["devices"] == {}
 
 
-async def test_connect(transport_mock, hass: HomeAssistant) -> None:
+async def test_connect(
+    rfxtrx, connect_mock, transport_mock, hass: HomeAssistant
+) -> None:
     """Test that we attempt to connect to the device."""
-    entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake")
-    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
 
-    mock_entry.add_to_hass(hass)
-
-    with patch.object(rfxtrxmod, "Connect") as connect:
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
     transport_mock.assert_called_once_with("/dev/ttyUSBfake")
-    connect.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
+    connect_mock.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
+    rfxtrx.connect.assert_called_once_with(ANY)
+
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
-async def test_connect_with_protocols(transport_mock, hass: HomeAssistant) -> None:
+async def test_connect_network(
+    rfxtrx, connect_mock, transport_mock, hass: HomeAssistant
+) -> None:
+    """Test that we attempt to connect to the device."""
+
+    config_entry = await setup_rfx_test_cfg(hass, host="localhost", port=1234)
+    transport_mock.assert_called_once_with(("localhost", 1234))
+    connect_mock.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
+    rfxtrx.connect.assert_called_once_with(ANY)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_connect_with_protocols(
+    rfxtrx, connect_mock, transport_mock, hass: HomeAssistant
+) -> None:
     """Test that we attempt to set protocols."""
-    entry_data = create_rfx_test_cfg(device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS)
-    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
-
-    mock_entry.add_to_hass(hass)
-
-    with patch.object(rfxtrxmod, "Connect") as connect:
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
+    config_entry = await setup_rfx_test_cfg(
+        hass, device="/dev/ttyUSBfake", protocols=SOME_PROTOCOLS
+    )
     transport_mock.assert_called_once_with("/dev/ttyUSBfake")
-    connect.assert_called_once_with(
+    connect_mock.assert_called_once_with(
         transport_mock.return_value, ANY, modes=SOME_PROTOCOLS
     )
+    rfxtrx.connect.assert_called_once_with(ANY)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_connect_timeout(
+    rfxtrx, connect_mock, transport_mock, hass: HomeAssistant
+) -> None:
+    """Test that we attempt to connect to the device."""
+
+    rfxtrx.connect.side_effect = TimeoutError
+
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
+    transport_mock.assert_called_once_with("/dev/ttyUSBfake")
+    connect_mock.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
+    rfxtrx.connect.assert_called_once_with(ANY)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_connect_failed(
+    rfxtrx, connect_mock, transport_mock, hass: HomeAssistant
+) -> None:
+    """Test that we attempt to connect to the device."""
+
+    rfxtrx.connect.side_effect = rfxtrxmod.RFXtrxTransportError
+
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
+    transport_mock.assert_called_once_with("/dev/ttyUSBfake")
+    connect_mock.assert_called_once_with(transport_mock.return_value, ANY, modes=ANY)
+    rfxtrx.connect.assert_called_once_with(ANY)
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_reconnect(rfxtrx, hass: HomeAssistant) -> None:
+    """Test that we reconnect on connection loss."""
+    config_entry = await setup_rfx_test_cfg(hass, device="/dev/ttyUSBfake")
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    rfxtrx.connect.call_count = 1
+
+    rfxtrx.event_callback(rfxtrxmod.ConnectionLost())
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    rfxtrx.connect.call_count = 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Upgrade rfxtrx library to one that leaves reconnection to home assistant and handle loss of connection by reloading the integration.

https://github.com/Danielhiversen/pyRFXtrx/releases/tag/0.31.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #39237 #110480
- This PR is related to issue:  #87905
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
