### PR TITLE
Add icon translations to Devolo home network

### DIFF
--- a/homeassistant/components/devolo_home_network/binary_sensor.py
+++ b/homeassistant/components/devolo_home_network/binary_sensor.py
@@ -52,7 +52,6 @@ SENSOR_TYPES: dict[str, DevoloBinarySensorEntityDescription] = {
         device_class=BinarySensorDeviceClass.PLUG,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        translation_key="connected_to_router",
         value_func=_is_connected_to_router,
     ),
 }

--- a/homeassistant/components/devolo_home_network/binary_sensor.py
+++ b/homeassistant/components/devolo_home_network/binary_sensor.py
@@ -52,7 +52,7 @@ SENSOR_TYPES: dict[str, DevoloBinarySensorEntityDescription] = {
         device_class=BinarySensorDeviceClass.PLUG,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        icon="mdi:router-network",
+        translation_key="connected_to_router",
         value_func=_is_connected_to_router,
     ),
 }

--- a/homeassistant/components/devolo_home_network/button.py
+++ b/homeassistant/components/devolo_home_network/button.py
@@ -45,7 +45,6 @@ BUTTON_TYPES: dict[str, DevoloButtonEntityDescription] = {
     ),
     PAIRING: DevoloButtonEntityDescription(
         key=PAIRING,
-        translation_key="pairing",
         press_func=lambda device: device.plcnet.async_pair_device(),  # type: ignore[union-attr]
     ),
     RESTART: DevoloButtonEntityDescription(
@@ -56,8 +55,6 @@ BUTTON_TYPES: dict[str, DevoloButtonEntityDescription] = {
     ),
     START_WPS: DevoloButtonEntityDescription(
         key=START_WPS,
-        translation_key="start_wps",
-        icon="mdi:wifi-plus",
         press_func=lambda device: device.device.async_start_wps(),  # type: ignore[union-attr]
     ),
 }

--- a/homeassistant/components/devolo_home_network/button.py
+++ b/homeassistant/components/devolo_home_network/button.py
@@ -40,12 +40,12 @@ BUTTON_TYPES: dict[str, DevoloButtonEntityDescription] = {
     IDENTIFY: DevoloButtonEntityDescription(
         key=IDENTIFY,
         entity_category=EntityCategory.DIAGNOSTIC,
-        icon="mdi:led-on",
+        device_class=ButtonDeviceClass.IDENTIFY,
         press_func=lambda device: device.plcnet.async_identify_device_start(),  # type: ignore[union-attr]
     ),
     PAIRING: DevoloButtonEntityDescription(
         key=PAIRING,
-        icon="mdi:plus-network-outline",
+        translation_key="pairing",
         press_func=lambda device: device.plcnet.async_pair_device(),  # type: ignore[union-attr]
     ),
     RESTART: DevoloButtonEntityDescription(
@@ -56,6 +56,7 @@ BUTTON_TYPES: dict[str, DevoloButtonEntityDescription] = {
     ),
     START_WPS: DevoloButtonEntityDescription(
         key=START_WPS,
+        translation_key="start_wps",
         icon="mdi:wifi-plus",
         press_func=lambda device: device.device.async_start_wps(),  # type: ignore[union-attr]
     ),

--- a/homeassistant/components/devolo_home_network/icons.json
+++ b/homeassistant/components/devolo_home_network/icons.json
@@ -1,0 +1,36 @@
+{
+  "entity": {
+    "binary_sensor": {
+      "connected_to_router": {
+        "default": "mdi:router-network"
+      }
+    },
+    "button": {
+      "pairing": {
+        "default": "mdi:plus-network-outline"
+      },
+      "start_wps": {
+        "default": "mdi:wifi-plus"
+      }
+    },
+    "sensor": {
+      "connected_plc_devices": {
+        "default": "mdi:lan"
+      },
+      "connected_wifi_clients": {
+        "default": "mdi:wifi"
+      },
+      "neighboring_wifi_networks": {
+        "default": "mdi:wifi-marker"
+      }
+    },
+    "switch": {
+      "guest_wifi": {
+        "default": "mdi:wifi"
+      },
+      "leds": {
+        "default": "mdi:led-off"
+      }
+    }
+  }
+}

--- a/homeassistant/components/devolo_home_network/icons.json
+++ b/homeassistant/components/devolo_home_network/icons.json
@@ -25,10 +25,10 @@
       }
     },
     "switch": {
-      "guest_wifi": {
+      "switch_guest_wifi": {
         "default": "mdi:wifi"
       },
-      "leds": {
+      "switch_leds": {
         "default": "mdi:led-off"
       }
     }

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -68,20 +68,17 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any]] = {
         key=CONNECTED_PLC_DEVICES,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        translation_key="connected_plc_devices",
         value_func=lambda data: len(
             {device.mac_address_from for device in data.data_rates}
         ),
     ),
     CONNECTED_WIFI_CLIENTS: DevoloSensorEntityDescription[list[ConnectedStationInfo]](
         key=CONNECTED_WIFI_CLIENTS,
-        translation_key="connected_wifi_clients",
         state_class=SensorStateClass.MEASUREMENT,
         value_func=len,
     ),
     NEIGHBORING_WIFI_NETWORKS: DevoloSensorEntityDescription[list[NeighborAPInfo]](
         key=NEIGHBORING_WIFI_NETWORKS,
-        translation_key="neighboring_wifi_networks",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_func=len,

--- a/homeassistant/components/devolo_home_network/sensor.py
+++ b/homeassistant/components/devolo_home_network/sensor.py
@@ -68,22 +68,22 @@ SENSOR_TYPES: dict[str, DevoloSensorEntityDescription[Any]] = {
         key=CONNECTED_PLC_DEVICES,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        icon="mdi:lan",
+        translation_key="connected_plc_devices",
         value_func=lambda data: len(
             {device.mac_address_from for device in data.data_rates}
         ),
     ),
     CONNECTED_WIFI_CLIENTS: DevoloSensorEntityDescription[list[ConnectedStationInfo]](
         key=CONNECTED_WIFI_CLIENTS,
-        icon="mdi:wifi",
+        translation_key="connected_wifi_clients",
         state_class=SensorStateClass.MEASUREMENT,
         value_func=len,
     ),
     NEIGHBORING_WIFI_NETWORKS: DevoloSensorEntityDescription[list[NeighborAPInfo]](
         key=NEIGHBORING_WIFI_NETWORKS,
+        translation_key="neighboring_wifi_networks",
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
-        icon="mdi:wifi-marker",
         value_func=len,
     ),
     PLC_RX_RATE: DevoloSensorEntityDescription[DataRate](

--- a/homeassistant/components/devolo_home_network/switch.py
+++ b/homeassistant/components/devolo_home_network/switch.py
@@ -42,15 +42,15 @@ class DevoloSwitchEntityDescription(
 SWITCH_TYPES: dict[str, DevoloSwitchEntityDescription[Any]] = {
     SWITCH_GUEST_WIFI: DevoloSwitchEntityDescription[WifiGuestAccessGet](
         key=SWITCH_GUEST_WIFI,
-        icon="mdi:wifi",
+        translation_key="guest_wifi",
         is_on_func=lambda data: data.enabled is True,
         turn_on_func=lambda device: device.device.async_set_wifi_guest_access(True),  # type: ignore[union-attr]
         turn_off_func=lambda device: device.device.async_set_wifi_guest_access(False),  # type: ignore[union-attr]
     ),
     SWITCH_LEDS: DevoloSwitchEntityDescription[bool](
         key=SWITCH_LEDS,
+        translation_key="leds",
         entity_category=EntityCategory.CONFIG,
-        icon="mdi:led-off",
         is_on_func=bool,
         turn_on_func=lambda device: device.device.async_set_led_setting(True),  # type: ignore[union-attr]
         turn_off_func=lambda device: device.device.async_set_led_setting(False),  # type: ignore[union-attr]

--- a/homeassistant/components/devolo_home_network/switch.py
+++ b/homeassistant/components/devolo_home_network/switch.py
@@ -42,14 +42,12 @@ class DevoloSwitchEntityDescription(
 SWITCH_TYPES: dict[str, DevoloSwitchEntityDescription[Any]] = {
     SWITCH_GUEST_WIFI: DevoloSwitchEntityDescription[WifiGuestAccessGet](
         key=SWITCH_GUEST_WIFI,
-        translation_key="guest_wifi",
         is_on_func=lambda data: data.enabled is True,
         turn_on_func=lambda device: device.device.async_set_wifi_guest_access(True),  # type: ignore[union-attr]
         turn_off_func=lambda device: device.device.async_set_wifi_guest_access(False),  # type: ignore[union-attr]
     ),
     SWITCH_LEDS: DevoloSwitchEntityDescription[bool](
         key=SWITCH_LEDS,
-        translation_key="leds",
         entity_category=EntityCategory.CONFIG,
         is_on_func=bool,
         turn_on_func=lambda device: device.device.async_set_led_setting(True),  # type: ignore[union-attr]

--- a/tests/components/devolo_home_network/snapshots/test_binary_sensor.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_binary_sensor.ambr
@@ -4,7 +4,6 @@
     'attributes': ReadOnlyDict({
       'device_class': 'plug',
       'friendly_name': 'Mock Title Connected to router',
-      'icon': 'mdi:router-network',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.mock_title_connected_to_router',
@@ -36,7 +35,7 @@
     'options': dict({
     }),
     'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
-    'original_icon': 'mdi:router-network',
+    'original_icon': None,
     'original_name': 'Connected to router',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,

--- a/tests/components/devolo_home_network/snapshots/test_button.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_button.ambr
@@ -45,8 +45,8 @@
 # name: test_button[identify_device_with_a_blinking_led-plcnet-async_identify_device_start]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_class': 'identify',
       'friendly_name': 'Mock Title Identify device with a blinking LED',
-      'icon': 'mdi:led-on',
     }),
     'context': <ANY>,
     'entity_id': 'button.mock_title_identify_device_with_a_blinking_led',
@@ -77,8 +77,8 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
-    'original_icon': 'mdi:led-on',
+    'original_device_class': <ButtonDeviceClass.IDENTIFY: 'identify'>,
+    'original_icon': None,
     'original_name': 'Identify device with a blinking LED',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,
@@ -224,7 +224,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Start PLC pairing',
-      'icon': 'mdi:plus-network-outline',
     }),
     'context': <ANY>,
     'entity_id': 'button.mock_title_start_plc_pairing',
@@ -256,7 +255,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:plus-network-outline',
+    'original_icon': None,
     'original_name': 'Start PLC pairing',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,

--- a/tests/components/devolo_home_network/snapshots/test_button.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_button.ambr
@@ -312,7 +312,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Start WPS',
-      'icon': 'mdi:wifi-plus',
     }),
     'context': <ANY>,
     'entity_id': 'button.mock_title_start_wps',
@@ -344,7 +343,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi-plus',
+    'original_icon': None,
     'original_name': 'Start WPS',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,

--- a/tests/components/devolo_home_network/snapshots/test_sensor.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_sensor.ambr
@@ -3,7 +3,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Connected PLC devices',
-      'icon': 'mdi:lan',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_title_connected_plc_devices',
@@ -35,7 +34,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:lan',
+    'original_icon': None,
     'original_name': 'Connected PLC devices',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,
@@ -49,7 +48,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Connected Wifi clients',
-      'icon': 'mdi:wifi',
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
@@ -84,7 +82,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Connected Wifi clients',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,
@@ -98,7 +96,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Neighboring Wifi networks',
-      'icon': 'mdi:wifi-marker',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.mock_title_neighboring_wifi_networks',
@@ -130,7 +127,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi-marker',
+    'original_icon': None,
     'original_name': 'Neighboring Wifi networks',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,

--- a/tests/components/devolo_home_network/snapshots/test_switch.ambr
+++ b/tests/components/devolo_home_network/snapshots/test_switch.ambr
@@ -89,7 +89,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Enable guest Wifi',
-      'icon': 'mdi:wifi',
     }),
     'context': <ANY>,
     'entity_id': 'switch.mock_title_enable_guest_wifi',
@@ -121,7 +120,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:wifi',
+    'original_icon': None,
     'original_name': 'Enable guest Wifi',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,
@@ -135,7 +134,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Mock Title Enable LEDs',
-      'icon': 'mdi:led-off',
     }),
     'context': <ANY>,
     'entity_id': 'switch.mock_title_enable_leds',
@@ -167,7 +165,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:led-off',
+    'original_icon': None,
     'original_name': 'Enable LEDs',
     'platform': 'devolo_home_network',
     'previous_unique_id': None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add icon translations to Devolo home network

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr