### PR TITLE
Refactor deprecated workday argument

### DIFF
--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -38,7 +38,7 @@ def _validate_country_and_province(
     if not province:
         return
     try:
-        country_holidays(country, prov=province)
+        country_holidays(country, subdiv=province)
     except NotImplementedError as ex:
         async_create_issue(
             hass,
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _validate_country_and_province(hass, entry, country, province)
 
     if country and CONF_LANGUAGE not in entry.options:
-        cls: HolidayBase = country_holidays(country, prov=province)
+        cls: HolidayBase = country_holidays(country, subdiv=province)
         default_language = cls.default_language
         new_options = entry.options.copy()
         new_options[CONF_LANGUAGE] = default_language


### PR DESCRIPTION
## Proposed change
Replace deprecated `prov` argument with `subdiv`. The change was first introduced in `python-holiday==0.13`.
https://github.com/vacanza/python-holidays/releases/tag/v.0.13

```
tests/components/workday/test_binary_sensor.py: 16 warnings
tests/components/workday/test_config_flow.py: 3 warnings
tests/components/workday/test_init.py: 2 warnings
tests/components/workday/test_repairs.py: 1 warning
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/holidays/holiday_base.py:321: DeprecationWarning: Arguments prov and state are deprecated, use subdiv='BW' instead.
    warnings.warn(

tests/components/workday/test_binary_sensor.py::test_setup[config3-on]
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/holidays/holiday_base.py:321: DeprecationWarning: Arguments prov and state are deprecated, use subdiv='CA' instead.
    warnings.warn(

tests/components/workday/test_repairs.py::test_bad_country
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/holidays/holiday_base.py:321: DeprecationWarning: Arguments prov and state are deprecated, use subdiv='HB' instead.
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
