### PR TITLE
Run pylint sorted platform check also when platform has type annotations

### DIFF
--- a/homeassistant/components/duotecno/__init__.py
+++ b/homeassistant/components/duotecno/__init__.py
@@ -12,11 +12,11 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 
 PLATFORMS: list[Platform] = [
-    Platform.SWITCH,
+    Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
     Platform.COVER,
     Platform.LIGHT,
-    Platform.CLIMATE,
-    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
 ]
 
 

--- a/homeassistant/components/ecoforest/__init__.py
+++ b/homeassistant/components/ecoforest/__init__.py
@@ -18,7 +18,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 from .coordinator import EcoforestCoordinator
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.NUMBER, Platform.SWITCH]
+PLATFORMS: list[Platform] = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/electric_kiwi/__init__.py
+++ b/homeassistant/components/electric_kiwi/__init__.py
@@ -18,7 +18,7 @@ from .coordinator import (
     ElectricKiwiHOPDataCoordinator,
 )
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SELECT]
+PLATFORMS: list[Platform] = [Platform.SELECT, Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.typing import ConfigType
 
 DOMAIN = "jewish_calendar"
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 CONF_DIASPORA = "diaspora"
 CONF_LANGUAGE = "language"

--- a/homeassistant/components/peco/__init__.py
+++ b/homeassistant/components/peco/__init__.py
@@ -29,7 +29,7 @@ from .const import (
     SMART_METER_SCAN_INTERVAL,
 )
 
-PLATFORMS: Final = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 
 @dataclass

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -18,7 +18,7 @@ from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
 
-PLATFORMS: list[Platform] = [Platform.SWITCH, Platform.UPDATE, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SWITCH, Platform.UPDATE]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/v2c/__init__.py
+++ b/homeassistant/components/v2c/__init__.py
@@ -13,9 +13,9 @@ from .coordinator import V2CUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
-    Platform.NUMBER,
 ]
 
 

--- a/homeassistant/components/vallox/__init__.py
+++ b/homeassistant/components/vallox/__init__.py
@@ -46,10 +46,10 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 PLATFORMS: list[str] = [
-    Platform.SENSOR,
-    Platform.FAN,
     Platform.BINARY_SENSOR,
+    Platform.FAN,
     Platform.NUMBER,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/weatherkit/__init__.py
+++ b/homeassistant/components/weatherkit/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 )
 from .coordinator import WeatherKitDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.WEATHER, Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.WEATHER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/pylint/plugins/hass_enforce_sorted_platforms.py
+++ b/pylint/plugins/hass_enforce_sorted_platforms.py
@@ -20,18 +20,28 @@ class HassEnforceSortedPlatformsChecker(BaseChecker):
     }
     options = ()
 
+    def visit_annassign(self, node: nodes.AnnAssign) -> None:
+        """Check for sorted PLATFORMS const with type annotations."""
+        self._do_sorted_check(node.target, node)
+
     def visit_assign(self, node: nodes.Assign) -> None:
-        """Check for sorted PLATFORMS const."""
+        """Check for sorted PLATFORMS const without type annotations."""
         for target in node.targets:
-            if (
-                isinstance(target, nodes.AssignName)
-                and target.name == "PLATFORMS"
-                and isinstance(node.value, nodes.List)
-            ):
-                platforms = [v.as_string() for v in node.value.elts]
-                sorted_platforms = sorted(platforms)
-                if platforms != sorted_platforms:
-                    self.add_message("hass-enforce-sorted-platforms", node=node)
+            self._do_sorted_check(target, node)
+
+    def _do_sorted_check(
+        self, target: nodes.NodeNG, node: nodes.Assign | nodes.AnnAssign
+    ) -> None:
+        """Check for sorted PLATFORMS const."""
+        if (
+            isinstance(target, nodes.AssignName)
+            and target.name == "PLATFORMS"
+            and isinstance(node.value, nodes.List)
+        ):
+            platforms = [v.as_string() for v in node.value.elts]
+            sorted_platforms = sorted(platforms)
+            if platforms != sorted_platforms:
+                self.add_message("hass-enforce-sorted-platforms", node=node)
 
 
 def register(linter: PyLinter) -> None:

--- a/tests/pylint/test_enforce_sorted_platforms.py
+++ b/tests/pylint/test_enforce_sorted_platforms.py
@@ -27,6 +27,18 @@ from . import assert_adds_messages, assert_no_messages
         """,
             id="multiple_platforms",
         ),
+        pytest.param(
+            """
+        PLATFORMS: list[str] = [Platform.SENSOR]
+        """,
+            id="typed_on_platform",
+        ),
+        pytest.param(
+            """
+        PLATFORMS: list[str] = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR]
+        """,
+            id="typed_multiple_platform",
+        ),
     ],
 )
 def test_enforce_sorted_platforms(
@@ -69,3 +81,31 @@ def test_enforce_sorted_platforms_bad(
         ),
     ):
         enforce_sorted_platforms_checker.visit_assign(assign_node)
+
+
+def test_enforce_sorted_platforms_bad_typed(
+    linter: UnittestLinter,
+    enforce_sorted_platforms_checker: BaseChecker,
+) -> None:
+    """Bad typed test case."""
+    assign_node = astroid.extract_node(
+        """
+    PLATFORMS: list[str] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.BUTTON]
+    """,
+        "homeassistant.components.pylint_test",
+    )
+
+    with assert_adds_messages(
+        linter,
+        MessageTest(
+            msg_id="hass-enforce-sorted-platforms",
+            line=2,
+            node=assign_node,
+            args=None,
+            confidence=UNDEFINED,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=81,
+        ),
+    ):
+        enforce_sorted_platforms_checker.visit_annassign(assign_node)


### PR DESCRIPTION
## Proposed change
The pylint sorted platform check does not run for platform lists that have type annotations because it is a different hook that is called.

This PR fixes this behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
