### PR TITLE
Switch nmap_tracker to use aiooui

### DIFF
--- a/homeassistant/components/nmap_tracker/__init__.py
+++ b/homeassistant/components/nmap_tracker/__init__.py
@@ -2,16 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import partial
 import logging
 from typing import Final
 
-import aiohttp
+import aiooui
 from getmac import get_mac_address
-from mac_vendor_lookup import AsyncMacLookup
 from nmap import PortScanner, PortScannerError
 
 from homeassistant.components.device_tracker import (
@@ -158,7 +156,6 @@ class NmapDeviceScanner:
         self._known_mac_addresses: dict[str, str] = {}
         self._finished_first_scan = False
         self._last_results: list[NmapDevice] = []
-        self._mac_vendor_lookup = None
 
     async def async_setup(self):
         """Set up the tracker."""
@@ -207,12 +204,6 @@ class NmapDeviceScanner:
         return f"{DOMAIN}-device-missing-{self._entry_id}"
 
     @callback
-    def _async_get_vendor(self, mac_address):
-        """Lookup the vendor."""
-        oui = self._mac_vendor_lookup.sanitise(mac_address)[:6]
-        return self._mac_vendor_lookup.prefixes.get(oui)
-
-    @callback
     def _async_stop(self):
         """Stop the scanner."""
         self._stopping = True
@@ -227,11 +218,8 @@ class NmapDeviceScanner:
                 self._scan_interval,
             )
         )
-        self._mac_vendor_lookup = AsyncMacLookup()
-        with contextlib.suppress((TimeoutError, aiohttp.ClientError)):
-            # We don't care if this fails since it only
-            # improves the data when we don't have it from nmap
-            await self._mac_vendor_lookup.load_vendors()
+        if not aiooui.is_loaded():
+            await aiooui.async_load()
         self._hass.async_create_task(self._async_scan_devices())
 
     def _build_options(self):
@@ -293,7 +281,7 @@ class NmapDeviceScanner:
                 None,
                 original_name,
                 None,
-                self._async_get_vendor(mac_address),
+                aiooui.get_vendor(mac_address),
                 "Device not found in initial scan",
                 now,
                 1,
@@ -402,7 +390,7 @@ class NmapDeviceScanner:
                 continue
 
             hostname = info["hostnames"][0]["name"] if info["hostnames"] else ipv4
-            vendor = info.get("vendor", {}).get(mac) or self._async_get_vendor(mac)
+            vendor = info.get("vendor", {}).get(mac) or aiooui.get_vendor(mac)
             name = human_readable_name(hostname, vendor, mac)
             device = NmapDevice(
                 formatted_mac, hostname, name, ipv4, vendor, reason, now, None

--- a/homeassistant/components/nmap_tracker/manifest.json
+++ b/homeassistant/components/nmap_tracker/manifest.json
@@ -7,9 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nmap_tracker",
   "iot_class": "local_polling",
   "loggers": ["nmap"],
-  "requirements": [
-    "netmap==0.7.0.2",
-    "getmac==0.9.4",
-    "mac-vendor-lookup==0.1.12"
-  ]
+  "requirements": ["netmap==0.7.0.2", "getmac==0.9.4", "aiooui==0.1.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -323,6 +323,9 @@ aiooncue==0.3.5
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.4.0
 
+# homeassistant.components.nmap_tracker
+aiooui==0.1.5
+
 # homeassistant.components.pegel_online
 aiopegelonline==0.0.9
 
@@ -1263,9 +1266,6 @@ lw12==0.9.2
 
 # homeassistant.components.scrape
 lxml==5.1.0
-
-# homeassistant.components.nmap_tracker
-mac-vendor-lookup==0.1.12
 
 # homeassistant.components.matrix
 matrix-nio==0.24.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -296,6 +296,9 @@ aiooncue==0.3.5
 # homeassistant.components.openexchangerates
 aioopenexchangerates==0.4.0
 
+# homeassistant.components.nmap_tracker
+aiooui==0.1.5
+
 # homeassistant.components.pegel_online
 aiopegelonline==0.0.9
 
@@ -1005,9 +1008,6 @@ lupupy==0.3.2
 
 # homeassistant.components.scrape
 lxml==5.1.0
-
-# homeassistant.components.nmap_tracker
-mac-vendor-lookup==0.1.12
 
 # homeassistant.components.matrix
 matrix-nio==0.24.0


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
mac-vendor-lookup can take a long time to startup because it has to fetch the oui db from the web.  Additional we likely won't have to wait for the database to be loaded from disk since its a single source which is shared between some other integrations already using this (including bluetooth)

aiooui: https://github.com/Bluetooth-Devices/aiooui

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
