### PR TITLE
Add WAN port connection control to TP-Link Omada gateways

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -47,6 +47,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
     controller = OmadaSiteController(hass, site_client)
+    gateway_coordinator = await controller.get_gateway_coordinator()
+    if gateway_coordinator:
+        await gateway_coordinator.async_config_entry_first_refresh()
+
     hass.data[DOMAIN][entry.entry_id] = controller
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -2,19 +2,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable
+from dataclasses import dataclass
 
-from attr import dataclass
 from tplink_omada_client.definitions import GatewayPortMode, LinkStatus, PoEMode
 from tplink_omada_client.devices import (
     OmadaDevice,
     OmadaGateway,
+    OmadaGatewayPortConfig,
     OmadaGatewayPortStatus,
 )
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
+    BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -23,6 +25,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .controller import OmadaGatewayCoordinator, OmadaSiteController
 from .entity import OmadaDeviceEntity
+
+ONLINE_DETECTION_ICON = "mdi:cloud-check"
 
 
 async def async_setup_entry(
@@ -37,115 +41,100 @@ async def async_setup_entry(
     if not gateway_coordinator:
         return
 
+    entities: list[OmadaDeviceEntity] = []
     for gateway in gateway_coordinator.data.values():
-        async_add_entities(
-            get_gateway_port_status_sensors(gateway, hass, gateway_coordinator)
+        entities.extend(
+            OmadaGatewayPortBinarySensor(
+                gateway_coordinator, gateway, p.port_number, desc
+            )
+            for p in gateway.port_configs
+            for desc in GATEWAY_PORT_SENSORS
+            if desc.exists_func(p)
         )
 
-
-def get_gateway_port_status_sensors(
-    gateway: OmadaGateway, hass: HomeAssistant, coordinator: OmadaGatewayCoordinator
-) -> Generator[BinarySensorEntity, None, None]:
-    """Generate binary sensors for gateway ports."""
-    for port_config in gateway.port_configs:
-        port = port_config.port_status
-        if port.mode == GatewayPortMode.WAN:
-            yield OmadaGatewayPortBinarySensor(
-                coordinator,
-                gateway,
-                GatewayPortBinarySensorConfig(
-                    port_number=port.port_number,
-                    id_suffix="wan_link",
-                    name_suffix="Internet Link",
-                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
-                    update_func=lambda p: p.wan_connected,
-                ),
-            )
-            yield OmadaGatewayPortBinarySensor(
-                coordinator,
-                gateway,
-                GatewayPortBinarySensorConfig(
-                    port_number=port.port_number,
-                    id_suffix="online_detection",
-                    name_suffix="Online Detection",
-                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
-                    update_func=lambda p: p.online_detection,
-                ),
-            )
-
-        if port.mode == GatewayPortMode.LAN:
-            yield OmadaGatewayPortBinarySensor(
-                coordinator,
-                gateway,
-                GatewayPortBinarySensorConfig(
-                    port_number=port.port_number,
-                    id_suffix="lan_status",
-                    name_suffix="LAN Status",
-                    device_class=BinarySensorDeviceClass.CONNECTIVITY,
-                    update_func=lambda p: p.link_status == LinkStatus.LINK_UP,
-                ),
-            )
-            if port_config.poe_mode == PoEMode.ENABLED:
-                yield OmadaGatewayPortBinarySensor(
-                    coordinator,
-                    gateway,
-                    GatewayPortBinarySensorConfig(
-                        port_number=port.port_number,
-                        id_suffix="poe_delivery",
-                        name_suffix="PoE Delivery",
-                        device_class=BinarySensorDeviceClass.POWER,
-                        update_func=lambda p: p.poe_active,
-                    ),
-                )
+    async_add_entities(entities)
 
 
-@dataclass
-class GatewayPortBinarySensorConfig:
-    """Config for a binary status derived from a gateway port."""
+@dataclass(frozen=True, kw_only=True)
+class GatewayPortBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Entity description for a binary status derived from a gateway port."""
 
-    port_number: int
-    id_suffix: str
     name_suffix: str
-    device_class: BinarySensorDeviceClass
+    exists_func: Callable[[OmadaGatewayPortConfig], bool] = lambda _: True
     update_func: Callable[[OmadaGatewayPortStatus], bool]
+
+
+GATEWAY_PORT_SENSORS: list[GatewayPortBinarySensorEntityDescription] = [
+    GatewayPortBinarySensorEntityDescription(
+        key="wan_link",
+        name_suffix="Internet Link",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
+        update_func=lambda p: p.wan_connected,
+    ),
+    GatewayPortBinarySensorEntityDescription(
+        key="online_detection",
+        name_suffix="Online Detection",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        icon=ONLINE_DETECTION_ICON,
+        exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
+        update_func=lambda p: p.online_detection,
+    ),
+    GatewayPortBinarySensorEntityDescription(
+        key="lan_status",
+        name_suffix="LAN Status",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+        exists_func=lambda p: p.port_status.mode == GatewayPortMode.LAN,
+        update_func=lambda p: p.link_status == LinkStatus.LINK_UP,
+    ),
+    GatewayPortBinarySensorEntityDescription(
+        key="poe_delivery",
+        name_suffix="PoE Delivery",
+        device_class=BinarySensorDeviceClass.POWER,
+        exists_func=lambda p: (
+            p.port_status.mode == GatewayPortMode.LAN and p.poe_mode == PoEMode.ENABLED
+        ),
+        update_func=lambda p: p.poe_active,
+    ),
+]
 
 
 class OmadaGatewayPortBinarySensor(OmadaDeviceEntity[OmadaGateway], BinarySensorEntity):
     """Binary status of a property on an internet gateway."""
 
+    entity_description: GatewayPortBinarySensorEntityDescription
     _attr_has_entity_name = True
 
     def __init__(
         self,
         coordinator: OmadaGatewayCoordinator,
         device: OmadaDevice,
-        config: GatewayPortBinarySensorConfig,
+        port_number: int,
+        entity_description: GatewayPortBinarySensorEntityDescription,
     ) -> None:
         """Initialize the gateway port binary sensor."""
         super().__init__(coordinator, device)
-        self._config = config
-        self._attr_unique_id = f"{device.mac}_{config.port_number}_{config.id_suffix}"
-        self._attr_device_class = config.device_class
-
-        self._attr_name = f"Port {config.port_number} {config.name_suffix}"
+        self.entity_description = entity_description
+        self._port_number = port_number
+        self._attr_unique_id = f"{device.mac}_{port_number}_{entity_description.key}"
+        self._attr_name = f"Port {port_number} {entity_description.name_suffix}"
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        self._handle_coordinator_update()
+        self._do_update()
+
+    def _do_update(self) -> None:
+        gateway = self.coordinator.data[self.device.mac]
+
+        port = next(
+            p for p in gateway.port_status if p.port_number == self._port_number
+        )
+        if port:
+            self._attr_is_on = self.entity_description.update_func(port)
 
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        gateway = self.coordinator.data[self.device.mac]
-
-        port = next(
-            p for p in gateway.port_status if p.port_number == self._config.port_number
-        )
-        if port:
-            self._attr_is_on = self._config.update_func(port)
-            self._attr_available = True
-        else:
-            self._attr_available = False
-
+        self._do_update()
         self.async_write_ha_state()

--- a/homeassistant/components/tplink_omada/binary_sensor.py
+++ b/homeassistant/components/tplink_omada/binary_sensor.py
@@ -26,8 +26,6 @@ from .const import DOMAIN
 from .controller import OmadaGatewayCoordinator, OmadaSiteController
 from .entity import OmadaDeviceEntity
 
-ONLINE_DETECTION_ICON = "mdi:cloud-check"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -59,7 +57,6 @@ async def async_setup_entry(
 class GatewayPortBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Entity description for a binary status derived from a gateway port."""
 
-    name_suffix: str
     exists_func: Callable[[OmadaGatewayPortConfig], bool] = lambda _: True
     update_func: Callable[[OmadaGatewayPortStatus], bool]
 
@@ -67,29 +64,28 @@ class GatewayPortBinarySensorEntityDescription(BinarySensorEntityDescription):
 GATEWAY_PORT_SENSORS: list[GatewayPortBinarySensorEntityDescription] = [
     GatewayPortBinarySensorEntityDescription(
         key="wan_link",
-        name_suffix="Internet Link",
+        translation_key="wan_link",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
         update_func=lambda p: p.wan_connected,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="online_detection",
-        name_suffix="Online Detection",
+        translation_key="online_detection",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        icon=ONLINE_DETECTION_ICON,
         exists_func=lambda p: p.port_status.mode == GatewayPortMode.WAN,
         update_func=lambda p: p.online_detection,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="lan_status",
-        name_suffix="LAN Status",
+        translation_key="lan_status",
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         exists_func=lambda p: p.port_status.mode == GatewayPortMode.LAN,
         update_func=lambda p: p.link_status == LinkStatus.LINK_UP,
     ),
     GatewayPortBinarySensorEntityDescription(
         key="poe_delivery",
-        name_suffix="PoE Delivery",
+        translation_key="poe_delivery",
         device_class=BinarySensorDeviceClass.POWER,
         exists_func=lambda p: (
             p.port_status.mode == GatewayPortMode.LAN and p.poe_mode == PoEMode.ENABLED
@@ -117,7 +113,7 @@ class OmadaGatewayPortBinarySensor(OmadaDeviceEntity[OmadaGateway], BinarySensor
         self.entity_description = entity_description
         self._port_number = port_number
         self._attr_unique_id = f"{device.mac}_{port_number}_{entity_description.key}"
-        self._attr_name = f"Port {port_number} {entity_description.name_suffix}"
+        self._attr_translation_placeholders = {"port_name": f"{port_number}"}
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/homeassistant/components/tplink_omada/icons.json
+++ b/homeassistant/components/tplink_omada/icons.json
@@ -3,6 +3,20 @@
     "switch": {
       "poe_control": {
         "default": "mdi:ethernet"
+      },
+      "wan_connect_ipv4": {
+        "default": "mdi:wan"
+      },
+      "wan_connect_ipv6": {
+        "default": "mdi:wan"
+      }
+    },
+    "binary_sensor": {
+      "online_detection": {
+        "default": "mdi:cloud-check",
+        "state": {
+          "off": "mdi:cloud-cancel"
+        }
       }
     }
   }

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -39,5 +39,32 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
+  },
+  "entity": {
+    "switch": {
+      "poe_control": {
+        "name": "Port {port_name} PoE"
+      },
+      "wan_connect_ipv4": {
+        "name": "Port {port_name} Internet Connected"
+      },
+      "wan_connect_ipv6": {
+        "name": "Port {port_name} Internet Connected (IPv6)"
+      }
+    },
+    "binary_sensor": {
+      "wan_link": {
+        "name": "Port {port_name} Internet Link"
+      },
+      "online_detection": {
+        "name": "Port {port_name} Online Detection"
+      },
+      "lan_status": {
+        "name": "Port {port_name} LAN Status"
+      },
+      "poe_delivery": {
+        "name": "Port {port_name} PoE Delivery"
+      }
+    }
   }
 }

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -2,20 +2,31 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
-from tplink_omada_client import SwitchPortOverrides
-from tplink_omada_client.definitions import PoEMode
-from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+from attr import dataclass
+from tplink_omada_client import OmadaSiteClient, SwitchPortOverrides
+from tplink_omada_client.definitions import GatewayPortMode, PoEMode
+from tplink_omada_client.devices import (
+    OmadaGateway,
+    OmadaGatewayPortStatus,
+    OmadaSwitch,
+    OmadaSwitchPortDetails,
+)
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .controller import OmadaSiteController, OmadaSwitchPortCoordinator
+from .controller import (
+    OmadaGatewayCoordinator,
+    OmadaSiteController,
+    OmadaSwitchPortCoordinator,
+)
 from .entity import OmadaDeviceEntity
 
 
@@ -44,7 +55,60 @@ async def async_setup_entry(
                     OmadaNetworkSwitchPortPoEControl(coordinator, switch, port_id)
                 )
 
+    gateway_coordinator = await controller.get_gateway_coordinator()
+    if gateway_coordinator:
+        for gateway in gateway_coordinator.data.values():
+            entities.extend(
+                get_gateway_port_switch_entities(
+                    gateway, gateway_coordinator, omada_client
+                )
+            )
+
     async_add_entities(entities)
+
+
+def get_gateway_port_switch_entities(
+    gateway: OmadaGateway,
+    coordinator: OmadaGatewayCoordinator,
+    omada_client: OmadaSiteClient,
+):
+    """Get switch entities for the ports on a gateway."""
+
+    for port in gateway.port_status:
+        # For WAN ports, create a switch to connect/disconect the port from the internet
+        if port.mode == GatewayPortMode.WAN:
+            yield OmadaGatewayPortSwitchEntity(
+                coordinator,
+                gateway,
+                GatewayPortSwitchConfig(
+                    port_number=port.port_number,
+                    id_suffix="wan_connect_ipv4",
+                    name_suffix="Internet Connected",
+                    device_class=SwitchDeviceClass.SWITCH,
+                    set_func=lambda p,
+                    enable: omada_client.set_gateway_wan_port_connect_state(
+                        p.port_number, enable, gateway, ipv6=False
+                    ),
+                    update_func=lambda p: p.wan_connected,
+                ),
+            )
+
+            if port.wan_ipv6_enabled:
+                yield OmadaGatewayPortSwitchEntity(
+                    coordinator,
+                    gateway,
+                    GatewayPortSwitchConfig(
+                        port_number=port.port_number,
+                        id_suffix="wan_connect_ipv6",
+                        name_suffix="Internet Connected (IPv6)",
+                        device_class=SwitchDeviceClass.SWITCH,
+                        set_func=lambda p,
+                        enable: omada_client.set_gateway_wan_port_connect_state(
+                            p.port_number, enable, gateway, ipv6=True
+                        ),
+                        update_func=lambda p: p.wan_connected,
+                    ),
+                )
 
 
 def get_port_base_name(port: OmadaSwitchPortDetails) -> str:
@@ -109,3 +173,76 @@ class OmadaNetworkSwitchPortPoEControl(
         """Handle updated data from the coordinator."""
         self.port_details = self.coordinator.data[self.port_id]
         self._refresh_state()
+
+
+@dataclass
+class GatewayPortSwitchConfig:
+    """Config for a toggle switch derived from a gateway."""
+
+    port_number: int
+    id_suffix: str
+    name_suffix: str
+    device_class: SwitchDeviceClass
+    set_func: Callable[
+        [OmadaGatewayPortStatus, bool], Awaitable[OmadaGatewayPortStatus]
+    ]
+    update_func: Callable[[OmadaGatewayPortStatus], bool]
+
+
+class OmadaGatewayPortSwitchEntity(OmadaDeviceEntity[OmadaGateway], SwitchEntity):
+    """Generic toggle switch on a Gateway entity."""
+
+    _attr_available = False
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_icon = POE_SWITCH_ICON
+    _port_details: OmadaGatewayPortStatus | None = None
+
+    def __init__(
+        self,
+        coordinator: OmadaGatewayCoordinator,
+        device: OmadaGateway,
+        config: GatewayPortSwitchConfig,
+    ) -> None:
+        """Initialize the toggle switch."""
+        super().__init__(coordinator, device)
+        self._config = config
+        self._attr_unique_id = f"{device.mac}_{config.port_number}_{config.id_suffix}"
+        self._attr_name = f"Port {config.port_number} {config.name_suffix}"
+
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()
+
+    async def _async_turn_on_off(self, enable: bool) -> None:
+        if self._port_details is None:
+            return
+        self._port_details = await self._config.set_func(self._port_details, enable)
+        # Refresh to make sure the requested changes stuck
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        await self._async_turn_on_off(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        await self._async_turn_on_off(False)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        gateway = self.coordinator.data[self.device.mac]
+
+        port = next(
+            p for p in gateway.port_status if p.port_number == self._config.port_number
+        )
+        if port:
+            self._port_details = port
+            self._attr_is_on = self._config.update_func(port)
+            self._attr_available = True
+        else:
+            self._attr_available = False
+
+        self.async_write_ha_state()

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from tplink_omada_client.devices import (
     OmadaGateway,
+    OmadaListDevice,
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
@@ -57,6 +58,10 @@ def mock_omada_site_client() -> Generator[AsyncMock, None, None]:
     switch1_data = json.loads(load_fixture("switch-TL-SG3210XHP-M2.json", DOMAIN))
     switch1 = OmadaSwitch(switch1_data)
     site_client.get_switches.return_value = [switch1]
+
+    devices_data = json.loads(load_fixture("devices.json", DOMAIN))
+    devices = [OmadaListDevice(d) for d in devices_data]
+    site_client.get_devices.return_value = devices
 
     switch1_ports_data = json.loads(
         load_fixture("switch-ports-TL-SG3210XHP-M2.json", DOMAIN)

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -5,7 +5,11 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from tplink_omada_client.devices import OmadaSwitch, OmadaSwitchPortDetails
+from tplink_omada_client.devices import (
+    OmadaGateway,
+    OmadaSwitch,
+    OmadaSwitchPortDetails,
+)
 
 from homeassistant.components.tplink_omada.config_flow import CONF_SITE
 from homeassistant.components.tplink_omada.const import DOMAIN
@@ -45,6 +49,11 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 def mock_omada_site_client() -> Generator[AsyncMock, None, None]:
     """Mock Omada site client."""
     site_client = AsyncMock()
+
+    gateway_data = json.loads(load_fixture("gateway-TL-ER7212PC.json", DOMAIN))
+    gateway = OmadaGateway(gateway_data)
+    site_client.get_gateway.return_value = gateway
+
     switch1_data = json.loads(load_fixture("switch-TL-SG3210XHP-M2.json", DOMAIN))
     switch1 = OmadaSwitch(switch1_data)
     site_client.get_switches.return_value = [switch1]

--- a/tests/components/tplink_omada/fixtures/devices.json
+++ b/tests/components/tplink_omada/fixtures/devices.json
@@ -1,0 +1,41 @@
+[
+  {
+    "type": "gateway",
+    "mac": "AA-BB-CC-DD-EE-FF",
+    "name": "Test Router",
+    "model": "ER7212PC",
+    "compoundModel": "ER7212PC v1.0",
+    "showModel": "ER7212PC v1.0",
+    "firmwareVersion": "1.1.1 Build 20230901 Rel.55651",
+    "version": "1.1.1",
+    "hwVersion": "ER7212PC v1.0",
+    "uptime": "32day(s) 5h 39m 27s",
+    "uptimeLong": 2785167,
+    "cpuUtil": 16,
+    "memUtil": 47,
+    "status": 14,
+    "statusCategory": 1,
+    "site": "Test",
+    "needUpgrade": false
+  },
+  {
+    "type": "switch",
+    "mac": "54-AF-97-00-00-01",
+    "name": "Test PoE Switch",
+    "model": "TL-SG3210XHP-M2",
+    "modelVersion": "1.0",
+    "compoundModel": "TL-SG3210XHP-M2 v1.0",
+    "showModel": "TL-SG3210XHP-M2 v1.0",
+    "firmwareVersion": "1.0.12 Build 20230203 Rel.36545",
+    "version": "1.0.12",
+    "hwVersion": "1.0",
+    "uptime": "1day(s) 8h 27m 26s",
+    "uptimeLong": 116846,
+    "cpuUtil": 10,
+    "memUtil": 20,
+    "status": 14,
+    "statusCategory": 1,
+    "needUpgrade": false,
+    "fwDownload": false
+  }
+]

--- a/tests/components/tplink_omada/fixtures/gateway-TL-ER7212PC.json
+++ b/tests/components/tplink_omada/fixtures/gateway-TL-ER7212PC.json
@@ -1,0 +1,1040 @@
+{
+  "type": "gateway",
+  "mac": "AA-BB-CC-DD-EE-FF",
+  "name": "Test Router",
+  "model": "ER7212PC",
+  "modelVersion": "1.0",
+  "compoundModel": "ER7212PC v1.0",
+  "showModel": "ER7212PC v1.0",
+  "firmwareVersion": "1.1.1 Build 20230901 Rel.55651",
+  "version": "1.1.1",
+  "hwVersion": "ER7212PC v1.0",
+  "status": 14,
+  "statusCategory": 1,
+  "site": "Test",
+  "omadacId": "XXXXX",
+  "compatible": 0,
+  "sn": "XXXX",
+  "addedInAdvanced": false,
+  "portNum": 12,
+  "ledSetting": 2,
+  "snmpSeting": {
+    "location": "",
+    "contact": ""
+  },
+  "iptvSetting": {
+    "igmpEnable": true,
+    "igmpVersion": "2"
+  },
+  "supportHwOffload": false,
+  "supportPoe": true,
+  "hwOffloadEnable": true,
+  "poeSettings": [
+    {
+      "portId": 5,
+      "portName": "LAN5",
+      "enable": true
+    },
+    {
+      "portId": 6,
+      "portName": "LAN6",
+      "enable": true
+    },
+    {
+      "portId": 7,
+      "portName": "LAN7",
+      "enable": true
+    },
+    {
+      "portId": 8,
+      "portName": "LAN8",
+      "enable": true
+    },
+    {
+      "portId": 9,
+      "portName": "LAN9",
+      "enable": true
+    },
+    {
+      "portId": 10,
+      "portName": "LAN10",
+      "enable": true
+    },
+    {
+      "portId": 11,
+      "portName": "LAN11",
+      "enable": true
+    },
+    {
+      "portId": 12,
+      "portName": "LAN12",
+      "enable": true
+    }
+  ],
+  "lldpEnable": false,
+  "echoServer": "0.0.0.0",
+  "ip": "192.168.0.1",
+  "uptime": "5day(s) 3h 29m 49s",
+  "uptimeLong": 444589,
+  "cpuUtil": 9,
+  "memUtil": 86,
+  "lastSeen": 1704219948802,
+  "portStats": [
+    {
+      "port": 1,
+      "name": "SFP WAN/LAN1",
+      "type": 1,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 2,
+      "name": "SFP WAN/LAN2",
+      "type": 1,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 3,
+      "name": "WAN3",
+      "type": 0,
+      "mode": -1,
+      "status": 0,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "mirroredPorts": []
+    },
+    {
+      "port": 4,
+      "name": "WAN/LAN4",
+      "type": 1,
+      "mode": 0,
+      "poe": false,
+      "status": 1,
+      "internetState": 1,
+      "ip": "XX.XX.XX.XX",
+      "speed": 3,
+      "duplex": 2,
+      "rx": 39901007520,
+      "rxPkt": 33051930,
+      "rxPktRate": 25,
+      "rxRate": 18,
+      "tx": 8891933646,
+      "txPkt": 12195464,
+      "txPktRate": 22,
+      "txRate": 3,
+      "proto": "dhcp",
+      "wanIpv6Comptent": 1,
+      "wanPortIpv6Config": {
+        "enable": 0,
+        "addr": "",
+        "gateway": "",
+        "priDns": "",
+        "sndDns": "",
+        "internetState": 0
+      },
+      "wanPortIpv4Config": {
+        "ip": "140.100.128.10",
+        "gateway": "140.100.128.1",
+        "gateway2": "0.0.0.0",
+        "priDns": "8.8.8.8",
+        "sndDns": "8.8.4.4",
+        "priDns2": "0.0.0.0",
+        "sndDns2": "0.0.0.0"
+      },
+      "mirroredPorts": []
+    },
+    {
+      "port": 5,
+      "name": "LAN5",
+      "type": 2,
+      "mode": 1,
+      "poe": true,
+      "status": 1,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 3,
+      "duplex": 2,
+      "rx": 4622709923,
+      "rxPkt": 8985877,
+      "rxPktRate": 21,
+      "rxRate": 4,
+      "tx": 38465362622,
+      "txPkt": 30836050,
+      "txPktRate": 25,
+      "txRate": 17,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 6,
+      "name": "LAN6",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 7,
+      "name": "LAN7",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 1,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 2,
+      "duplex": 2,
+      "rx": 5477288,
+      "rxPkt": 52166,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 66036305,
+      "txPkt": 319810,
+      "txPktRate": 1,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 8,
+      "name": "LAN8",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 1,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 3,
+      "duplex": 2,
+      "rx": 6105639661,
+      "rxPkt": 6200831,
+      "rxPktRate": 4,
+      "rxRate": 0,
+      "tx": 3258101551,
+      "txPkt": 4719927,
+      "txPktRate": 4,
+      "txRate": 1,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 9,
+      "name": "LAN9",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 10,
+      "name": "LAN10",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 11,
+      "name": "LAN11",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    },
+    {
+      "port": 12,
+      "name": "LAN12",
+      "type": 2,
+      "mode": 1,
+      "poe": false,
+      "status": 0,
+      "internetState": 0,
+      "ip": "192.168.0.1",
+      "speed": 1,
+      "duplex": 1,
+      "rx": 0,
+      "rxPkt": 0,
+      "rxPktRate": 0,
+      "rxRate": 0,
+      "tx": 0,
+      "txPkt": 0,
+      "txPktRate": 0,
+      "txRate": 0,
+      "wanIpv6Comptent": 1,
+      "mirroredPorts": []
+    }
+  ],
+  "lanClientStats": [
+    {
+      "lanName": "LAN",
+      "vlan": 1,
+      "ip": "192.168.0.1",
+      "rx": 3365832108,
+      "tx": 19893930205,
+      "clientNum": 3,
+      "lanPortIpv6Config": {
+        "addr": "XXXXX"
+      }
+    }
+  ],
+  "needUpgrade": false,
+  "download": 39901007520,
+  "upload": 8891933646,
+  "networkComptent": 1,
+  "portConfigs": [
+    {
+      "port": 1,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 1,
+        "name": "SFP WAN/LAN1",
+        "type": 1,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 2,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 2,
+        "name": "SFP WAN/LAN2",
+        "type": 1,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 3,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "portStat": {
+        "port": 3,
+        "name": "WAN3",
+        "type": 0,
+        "mode": -1,
+        "status": 0,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 4,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "portStat": {
+        "port": 4,
+        "name": "WAN/LAN4",
+        "type": 1,
+        "mode": 0,
+        "poe": false,
+        "status": 1,
+        "internetState": 1,
+        "ip": "XX.XX.XX.XX",
+        "speed": 3,
+        "duplex": 2,
+        "rx": 39901007520,
+        "rxPkt": 33051930,
+        "rxPktRate": 25,
+        "rxRate": 18,
+        "tx": 8891933646,
+        "txPkt": 12195464,
+        "txPktRate": 22,
+        "txRate": 3,
+        "proto": "dhcp",
+        "wanIpv6Comptent": 1,
+        "wanPortIpv6Config": {
+          "enable": 0,
+          "addr": "",
+          "gateway": "",
+          "priDns": "",
+          "sndDns": "",
+          "internetState": 0
+        },
+        "wanPortIpv4Config": {
+          "ip": "XX.XX.XX.XX",
+          "gateway": "XX.XX.XX.XXX",
+          "gateway2": "0.0.0.0",
+          "priDns": "212.27.40.240",
+          "sndDns": "212.27.40.241",
+          "priDns2": "0.0.0.0",
+          "sndDns2": "0.0.0.0"
+        },
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 5,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 5,
+        "name": "LAN5",
+        "type": 2,
+        "mode": 1,
+        "poe": true,
+        "status": 1,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 3,
+        "duplex": 2,
+        "rx": 4622709923,
+        "rxPkt": 8985877,
+        "rxPktRate": 21,
+        "rxRate": 4,
+        "tx": 38465362622,
+        "txPkt": 30836050,
+        "txPktRate": 25,
+        "txRate": 17,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 6,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 6,
+        "name": "LAN6",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 7,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 7,
+        "name": "LAN7",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 1,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 2,
+        "duplex": 2,
+        "rx": 5477288,
+        "rxPkt": 52166,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 66036305,
+        "txPkt": 319810,
+        "txPktRate": 1,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 8,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 8,
+        "name": "LAN8",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 1,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 3,
+        "duplex": 2,
+        "rx": 6105639661,
+        "rxPkt": 6200831,
+        "rxPktRate": 4,
+        "rxRate": 0,
+        "tx": 3258101551,
+        "txPkt": 4719927,
+        "txPktRate": 4,
+        "txRate": 1,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 9,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 9,
+        "name": "LAN9",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 10,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 10,
+        "name": "LAN10",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 11,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 11,
+        "name": "LAN11",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    },
+    {
+      "port": 12,
+      "linkSpeed": 0,
+      "duplex": 0,
+      "portCap": [
+        {
+          "linkSpeed": 2,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 2,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 1
+        },
+        {
+          "linkSpeed": 1,
+          "duplex": 2
+        },
+        {
+          "linkSpeed": 0,
+          "duplex": 0
+        },
+        {
+          "linkSpeed": 3,
+          "duplex": 2
+        }
+      ],
+      "mirrorEnable": false,
+      "pvid": 1,
+      "availablePvids": [1],
+      "portStat": {
+        "port": 12,
+        "name": "LAN12",
+        "type": 2,
+        "mode": 1,
+        "poe": false,
+        "status": 0,
+        "internetState": 0,
+        "ip": "192.168.0.1",
+        "speed": 1,
+        "duplex": 1,
+        "rx": 0,
+        "rxPkt": 0,
+        "rxPktRate": 0,
+        "rxRate": 0,
+        "tx": 0,
+        "txPkt": 0,
+        "txPktRate": 0,
+        "txRate": 0,
+        "wanIpv6Comptent": 1,
+        "mirroredPorts": []
+      }
+    }
+  ],
+  "supportSpeedDuplex": true,
+  "supportMirror": true,
+  "supportPvid": true,
+  "unsupportedPorts": [],
+  "combinedGateway": true,
+  "speeds": [1, 2, 3],
+  "poeRemain": 105.699997,
+  "poeRemainPercent": 96.090904,
+  "multiChipGateway": true,
+  "multiChipInfos": [
+    [1, 3, 5, 6, 7, 8],
+    [2, 4, 9, 10, 11, 12]
+  ]
+}

--- a/tests/components/tplink_omada/fixtures/switch-TL-SG3210XHP-M2.json
+++ b/tests/components/tplink_omada/fixtures/switch-TL-SG3210XHP-M2.json
@@ -124,7 +124,7 @@
     {
       "id": "000000000000000000000002",
       "port": 2,
-      "name": "Port2",
+      "name": "Renamed Port",
       "disable": false,
       "type": 1,
       "maxSpeed": 4,

--- a/tests/components/tplink_omada/fixtures/switch-TL-SG3210XHP-M2.json
+++ b/tests/components/tplink_omada/fixtures/switch-TL-SG3210XHP-M2.json
@@ -11,7 +11,7 @@
   "hwVersion": "1.0",
   "status": 14,
   "statusCategory": 1,
-  "site": "000000000000000000000000",
+  "site": "Test",
   "omadacId": "00000000000000000000000000000000",
   "compatible": 0,
   "sn": "Y220000000001",

--- a/tests/components/tplink_omada/fixtures/switch-ports-TL-SG3210XHP-M2.json
+++ b/tests/components/tplink_omada/fixtures/switch-ports-TL-SG3210XHP-M2.json
@@ -108,7 +108,7 @@
     "switchId": "640934810000000000000000",
     "switchMac": "54-AF-97-00-00-01",
     "site": "000000000000000000000000",
-    "name": "Port2",
+    "name": "Renamed Port",
     "disable": false,
     "type": 1,
     "maxSpeed": 4,

--- a/tests/components/tplink_omada/snapshots/test_switch.ambr
+++ b/tests/components/tplink_omada/snapshots/test_switch.ambr
@@ -3,7 +3,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
-      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -16,7 +15,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
-      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -42,7 +40,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
-      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -234,7 +231,7 @@
 # name: test_poe_switches.2
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'friendly_name': 'Test PoE Switch Port 2 PoE',
+      'friendly_name': 'Test PoE Switch Port 2 (Renamed Port) PoE',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_2_renamed_port_poe',
@@ -266,7 +263,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 2 (Renamed Port) PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,

--- a/tests/components/tplink_omada/snapshots/test_switch.ambr
+++ b/tests/components/tplink_omada/snapshots/test_switch.ambr
@@ -1,6 +1,42 @@
 # serializer version: 1
+# name: test_gateway_api_fail_disables_switch_entities
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Router Port 4 Internet Connected',
+      'icon': 'mdi:ethernet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.test_router_port_4_internet_connected',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_gateway_connect_ipv4_switch
-  None
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Router Port 4 Internet Connected',
+      'icon': 'mdi:ethernet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.test_router_port_4_internet_connected',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_gateway_disappear_disables_switches
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Router Port 4 Internet Connected',
+      'icon': 'mdi:ethernet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.test_router_port_4_internet_connected',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
 # ---
 # name: test_poe_switches
   StateSnapshot({

--- a/tests/components/tplink_omada/snapshots/test_switch.ambr
+++ b/tests/components/tplink_omada/snapshots/test_switch.ambr
@@ -1,4 +1,7 @@
 # serializer version: 1
+# name: test_gateway_connect_ipv4_switch
+  None
+# ---
 # name: test_poe_switches
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/components/tplink_omada/snapshots/test_switch.ambr
+++ b/tests/components/tplink_omada/snapshots/test_switch.ambr
@@ -3,7 +3,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
-      'icon': 'mdi:ethernet',
+      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -16,7 +16,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
-      'icon': 'mdi:ethernet',
+      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -30,6 +30,19 @@
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test Router Port 4 Internet Connected',
       'icon': 'mdi:ethernet',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.test_router_port_4_internet_connected',
+    'last_changed': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_gateway_port_change_disables_switch_entities
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Test Router Port 4 Internet Connected',
+      'icon': 'mdi:wan',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_router_port_4_internet_connected',
@@ -224,7 +237,7 @@
       'friendly_name': 'Test PoE Switch Port 2 PoE',
     }),
     'context': <ANY>,
-    'entity_id': 'switch.test_poe_switch_port_2_poe',
+    'entity_id': 'switch.test_poe_switch_port_2_renamed_port_poe',
     'last_changed': <ANY>,
     'last_updated': <ANY>,
     'state': 'on',
@@ -242,7 +255,7 @@
     'disabled_by': None,
     'domain': 'switch',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.test_poe_switch_port_2_poe',
+    'entity_id': 'switch.test_poe_switch_port_2_renamed_port_poe',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -253,8 +266,8 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Port 2 PoE',
+    'original_icon': 'mdi:ethernet',
+    'original_name': 'Port 2 (Renamed Port) PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds switches for the configured WAN ports on the TP-Link Omada Routers/Gateways
to allow HA to connect/disconnect the router from the internet. There is a separate IPv6
connection control, which appears for ports that are configured for IPv6. These switches
possibly replace the need for the Internet Link binary sensors, but it's probably better to
keep them for now at least to avoid breaking changes.

In addition, I've added an new binary sensor for exposing the router's Online detection,
which determines if the internet link is good by sending out pings. This is a bit different to
the existing Internet Link entity, which determines everything is good if the ethernet is
connected and the router could get an IP address. The idea here is that you can disable
a network port if the internet connection appears to be offline in a more sensible way
than the Omada controller will do out-of-the-box.

I'm moving towards consolidating the initialization of the coordinator objects so they
can be shared better between the domains, and to reduce API calls out during the
initialization of the platforms. This became necessary because the gateway coordinator
is used from both the `binary_sensor` and `switch` platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [31619](https://github.com/home-assistant/home-assistant.io/pull/31619)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
