### PR TITLE
2024.2.4

### DIFF
--- a/homeassistant/components/caldav/manifest.json
+++ b/homeassistant/components/caldav/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/caldav",
   "iot_class": "cloud_polling",
   "loggers": ["caldav", "vobject"],
-  "requirements": ["caldav==1.3.8"]
+  "requirements": ["caldav==1.3.9"]
 }

--- a/homeassistant/components/enigma2/manifest.json
+++ b/homeassistant/components/enigma2/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/enigma2",
   "iot_class": "local_polling",
   "loggers": ["openwebif"],
-  "requirements": ["openwebifpy==4.2.1"]
+  "requirements": ["openwebifpy==4.2.4"]
 }

--- a/homeassistant/components/enigma2/media_player.py
+++ b/homeassistant/components/enigma2/media_player.py
@@ -107,7 +107,7 @@ async def async_setup_platform(
 
     device = OpenWebIfDevice(
         host=session,
-        turn_off_to_deep=config.get(CONF_DEEP_STANDBY),
+        turn_off_to_deep=config.get(CONF_DEEP_STANDBY, False),
         source_bouquet=config.get(CONF_SOURCE_BOUQUET),
     )
 

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -257,7 +257,7 @@
     },
     "uoms_not_matching_no_device_class": {
       "title": "Unit of measurements is not correct",
-      "description": "Unit of measurements `{uoms}` of input sensors `{source_entities}` are not compatible using no device class of sensor group `{entity_id}`.\n\nPlease correct the unit of measurements on the source entities or set a proper device class on the sensor group and reload the group sensor to fix this issue."
+      "description": "Unit of measurements `{uoms}` of input sensors `{source_entities}` are not compatible when not using a device class on sensor group `{entity_id}`.\n\nPlease correct the unit of measurements on the source entities or set a proper device class on the sensor group and reload the group sensor to fix this issue."
     },
     "device_classes_not_matching": {
       "title": "Device classes is not correct",

--- a/homeassistant/components/lutron/switch.py
+++ b/homeassistant/components/lutron/switch.py
@@ -43,6 +43,7 @@ class LutronSwitch(LutronDevice, SwitchEntity):
     """Representation of a Lutron Switch."""
 
     _lutron_device: Output
+    _attr_name = None
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.3.0"]
+  "requirements": ["opower==0.3.1"]
 }

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.2.0"]
+  "requirements": ["opower==0.3.0"]
 }

--- a/homeassistant/components/profiler/manifest.json
+++ b/homeassistant/components/profiler/manifest.json
@@ -5,5 +5,9 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/profiler",
   "quality_scale": "internal",
-  "requirements": ["pyprof2calltree==1.4.5", "guppy3==3.1.4", "objgraph==3.5.0"]
+  "requirements": [
+    "pyprof2calltree==1.4.5",
+    "guppy3==3.1.4.post1",
+    "objgraph==3.5.0"
+  ]
 }

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -24,7 +24,7 @@
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "iot_class": "local_push",
   "loggers": ["paho_mqtt", "roombapy"],
-  "requirements": ["roombapy==1.6.12"],
+  "requirements": ["roombapy==1.6.13"],
   "zeroconf": [
     {
       "type": "_amzn-alexa._tcp.local.",

--- a/homeassistant/components/wyoming/config_flow.py
+++ b/homeassistant/components/wyoming/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.data_entry_flow import FlowResult
 from .const import DOMAIN
 from .data import WyomingService
 
-_LOGGER = logging.getLogger()
+_LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -64,6 +64,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: hassio.HassioServiceInfo
     ) -> FlowResult:
         """Handle Supervisor add-on discovery."""
+        _LOGGER.debug("Supervisor discovery info: %s", discovery_info)
         await self.async_set_unique_id(discovery_info.uuid)
         self._abort_if_unique_id_configured()
 
@@ -105,7 +106,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, discovery_info: zeroconf.ZeroconfServiceInfo
     ) -> FlowResult:
         """Handle zeroconf discovery."""
-        _LOGGER.debug("Discovery info: %s", discovery_info)
+        _LOGGER.debug("Zeroconf discovery info: %s", discovery_info)
         if discovery_info.port is None:
             return self.async_abort(reason="no_port")
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 2
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -36,7 +36,7 @@ janus==1.0.0
 Jinja2==3.1.3
 lru-dict==1.3.0
 mutagen==1.47.0
-orjson==3.9.14
+orjson==3.9.15
 packaging>=23.1
 paho-mqtt==1.6.1
 Pillow==10.2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.2.3"
+version     = "2024.2.4"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies    = [
     "cryptography==42.0.2",
     # pyOpenSSL 23.2.0 is required to work with cryptography 41+
     "pyOpenSSL==24.0.0",
-    "orjson==3.9.14",
+    "orjson==3.9.15",
     "packaging>=23.1",
     "pip>=21.3.1",
     "python-slugify==8.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ lru-dict==1.3.0
 PyJWT==2.8.0
 cryptography==42.0.2
 pyOpenSSL==24.0.0
-orjson==3.9.14
+orjson==3.9.15
 packaging>=23.1
 pip>=21.3.1
 python-slugify==8.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1468,7 +1468,7 @@ openwrt-luci-rpc==1.1.16
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.2.0
+opower==0.3.0
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1468,7 +1468,7 @@ openwrt-luci-rpc==1.1.16
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.3.0
+opower==0.3.1
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -997,7 +997,7 @@ gspread==5.5.0
 gstreamer-player==1.1.2
 
 # homeassistant.components.profiler
-guppy3==3.1.4
+guppy3==3.1.4.post1
 
 # homeassistant.components.iaqualink
 h2==4.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1459,7 +1459,7 @@ openhomedevice==2.2.0
 opensensemap-api==0.2.0
 
 # homeassistant.components.enigma2
-openwebifpy==4.2.1
+openwebifpy==4.2.4
 
 # homeassistant.components.luci
 openwrt-luci-rpc==1.1.16

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2450,7 +2450,7 @@ rokuecp==0.19.1
 romy==0.0.7
 
 # homeassistant.components.roomba
-roombapy==1.6.12
+roombapy==1.6.13
 
 # homeassistant.components.roon
 roonapi==0.1.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -624,7 +624,7 @@ buienradar==1.0.5
 cached_ipaddress==0.3.0
 
 # homeassistant.components.caldav
-caldav==1.3.8
+caldav==1.3.9
 
 # homeassistant.components.circuit
 circuit-webhook==1.0.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1156,7 +1156,7 @@ openerz-api==0.3.0
 openhomedevice==2.2.0
 
 # homeassistant.components.opower
-opower==0.2.0
+opower==0.3.0
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -805,7 +805,7 @@ growattServer==1.3.0
 gspread==5.5.0
 
 # homeassistant.components.profiler
-guppy3==3.1.4
+guppy3==3.1.4.post1
 
 # homeassistant.components.iaqualink
 h2==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1872,7 +1872,7 @@ rokuecp==0.19.1
 romy==0.0.7
 
 # homeassistant.components.roomba
-roombapy==1.6.12
+roombapy==1.6.13
 
 # homeassistant.components.roon
 roonapi==0.1.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1156,7 +1156,7 @@ openerz-api==0.3.0
 openhomedevice==2.2.0
 
 # homeassistant.components.opower
-opower==0.3.0
+opower==0.3.1
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -523,7 +523,7 @@ buienradar==1.0.5
 cached_ipaddress==0.3.0
 
 # homeassistant.components.caldav
-caldav==1.3.8
+caldav==1.3.9
 
 # homeassistant.components.coinbase
 coinbase==2.1.0

--- a/tests/components/group/test_sensor.py
+++ b/tests/components/group/test_sensor.py
@@ -424,6 +424,101 @@ async def test_sensor_calculated_properties(hass: HomeAssistant) -> None:
     assert state.state == str(float(sum(VALUES)))
 
 
+async def test_sensor_with_uoms_but_no_device_class(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test the sensor works with same uom when there is no device class."""
+    config = {
+        SENSOR_DOMAIN: {
+            "platform": GROUP_DOMAIN,
+            "name": "test_sum",
+            "type": "sum",
+            "entities": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+            "unique_id": "very_unique_id_last_sensor",
+        }
+    }
+
+    entity_ids = config["sensor"]["entities"]
+
+    hass.states.async_set(
+        entity_ids[0],
+        VALUES[0],
+        {
+            "device_class": SensorDeviceClass.POWER,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "W",
+        },
+    )
+    hass.states.async_set(
+        entity_ids[1],
+        VALUES[1],
+        {
+            "device_class": SensorDeviceClass.POWER,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "W",
+        },
+    )
+    hass.states.async_set(
+        entity_ids[2],
+        VALUES[2],
+        {
+            "unit_of_measurement": "W",
+        },
+    )
+
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_sum")
+    assert state.attributes.get("device_class") is None
+    assert state.attributes.get("state_class") is None
+    assert state.attributes.get("unit_of_measurement") == "W"
+    assert state.state == str(float(sum(VALUES)))
+
+    assert not issue_registry.issues
+
+    hass.states.async_set(
+        entity_ids[0],
+        VALUES[0],
+        {
+            "device_class": SensorDeviceClass.POWER,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "kW",
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_sum")
+    assert state.attributes.get("device_class") is None
+    assert state.attributes.get("state_class") is None
+    assert state.attributes.get("unit_of_measurement") == "W"
+    assert state.state == STATE_UNKNOWN
+
+    assert (
+        "Unable to use state. Only entities with correct unit of measurement is supported"
+        in caplog.text
+    )
+
+    hass.states.async_set(
+        entity_ids[0],
+        VALUES[0],
+        {
+            "device_class": SensorDeviceClass.POWER,
+            "state_class": SensorStateClass.MEASUREMENT,
+            "unit_of_measurement": "W",
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.test_sum")
+    assert state.attributes.get("device_class") is None
+    assert state.attributes.get("state_class") is None
+    assert state.attributes.get("unit_of_measurement") == "W"
+    assert state.state == str(float(sum(VALUES)))
+
+
 async def test_sensor_calculated_properties_not_same(
     hass: HomeAssistant, issue_registry: ir.IssueRegistry
 ) -> None:
@@ -616,7 +711,7 @@ async def test_sensor_calculated_properties_not_convertible_device_class(
 
     assert (
         "Unable to use state. Only entities with correct unit of measurement is"
-        " supported when having a device class"
+        " supported"
     ) not in caplog.text
 
     hass.states.async_set(
@@ -637,7 +732,7 @@ async def test_sensor_calculated_properties_not_convertible_device_class(
 
     assert (
         "Unable to use state. Only entities with correct unit of measurement is"
-        " supported when having a device class, entity sensor.test_3, value 15.3 with"
+        " supported, entity sensor.test_3, value 15.3 with"
         " device class humidity and unit of measurement None excluded from calculation"
         " in sensor.test_sum"
     ) in caplog.text


### PR DESCRIPTION
- Return group unit of measurement when device_class is None ([@PoppyPop] - [#110973]) ([group docs])
- Bump roombapy to 1.6.13 ([@Orhideous] - [#111187]) ([roomba docs])
- Bump orjson to 3.9.15 ([@bdraco] - [#111233])
- Set Lutron switch to device name ([@joostlek] - [#111293]) ([lutron docs])
- Bump opower to 0.3.0 ([@swartzd] - [#109248]) ([opower docs])
- Bump opower to 0.3.1 ([@benhoff] - [#111307])
- Fix another name missing in wyoming getLogger ([@llluis] - [#111390]) ([wyoming docs])
- Update caldav to 1.3.9 ([@cdce8p] - [#111429]) ([caldav docs])
- Update guppy3 to 3.1.4.post1 ([@cdce8p] - [#111430]) ([profiler docs])
- Bump openwebifpy to 4.2.4 ([@autinerd] - [#110676]) ([enigma2 docs])

[#109248]: https://github.com/home-assistant/core/pull/109248
[#109883]: https://github.com/home-assistant/core/pull/109883
[#110078]: https://github.com/home-assistant/core/pull/110078
[#110676]: https://github.com/home-assistant/core/pull/110676
[#110720]: https://github.com/home-assistant/core/pull/110720
[#110973]: https://github.com/home-assistant/core/pull/110973
[#111133]: https://github.com/home-assistant/core/pull/111133
[#111187]: https://github.com/home-assistant/core/pull/111187
[#111233]: https://github.com/home-assistant/core/pull/111233
[#111293]: https://github.com/home-assistant/core/pull/111293
[#111307]: https://github.com/home-assistant/core/pull/111307
[#111390]: https://github.com/home-assistant/core/pull/111390
[#111429]: https://github.com/home-assistant/core/pull/111429
[#111430]: https://github.com/home-assistant/core/pull/111430
[@Orhideous]: https://github.com/Orhideous
[@PoppyPop]: https://github.com/PoppyPop
[@autinerd]: https://github.com/autinerd
[@bdraco]: https://github.com/bdraco
[@benhoff]: https://github.com/benhoff
[@cdce8p]: https://github.com/cdce8p
[@frenck]: https://github.com/frenck
[@joostlek]: https://github.com/joostlek
[@llluis]: https://github.com/llluis
[@swartzd]: https://github.com/swartzd
[abode docs]: https://www.home-assistant.io/integrations/abode/
[caldav docs]: https://www.home-assistant.io/integrations/caldav/
[enigma2 docs]: https://www.home-assistant.io/integrations/enigma2/
[group docs]: https://www.home-assistant.io/integrations/group/
[lutron docs]: https://www.home-assistant.io/integrations/lutron/
[opower docs]: https://www.home-assistant.io/integrations/opower/
[profiler docs]: https://www.home-assistant.io/integrations/profiler/
[roomba docs]: https://www.home-assistant.io/integrations/roomba/
[wyoming docs]: https://www.home-assistant.io/integrations/wyoming/