### PR TITLE
Create more relevant names for myuplink DeviceInfo

### DIFF
--- a/homeassistant/components/myuplink/__init__.py
+++ b/homeassistant/components/myuplink/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from http import HTTPStatus
 
 from aiohttp import ClientError, ClientResponseError
-from myuplink import MyUplinkAPI
+from myuplink import MyUplinkAPI, get_manufacturer, get_model, get_system_name
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -83,12 +83,16 @@ def create_devices(
     """Update all devices."""
     device_registry = dr.async_get(hass)
 
-    for device_id, device in coordinator.data.devices.items():
-        device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, device_id)},
-            name=device.productName,
-            manufacturer=device.productName.split(" ")[0],
-            model=device.productName,
-            sw_version=device.firmwareCurrent,
-        )
+    for system in coordinator.data.systems:
+        devices_in_system = [x.id for x in system.devices]
+        for device_id, device in coordinator.data.devices.items():
+            if device_id in devices_in_system:
+                device_registry.async_get_or_create(
+                    config_entry_id=config_entry.entry_id,
+                    identifiers={(DOMAIN, device_id)},
+                    name=get_system_name(system),
+                    manufacturer=get_manufacturer(device),
+                    model=get_model(device),
+                    sw_version=device.firmwareCurrent,
+                    serial_number=device.product_serial_number,
+                )

--- a/tests/components/myuplink/fixtures/systems.json
+++ b/tests/components/myuplink/fixtures/systems.json
@@ -5,7 +5,7 @@
   "systems": [
     {
       "systemId": "123456-7890-1234",
-      "name": "Gotham City",
+      "name": "Batcave",
       "securityLevel": "admin",
       "hasAlarm": false,
       "country": "Sweden",

--- a/tests/components/myuplink/snapshots/test_diagnostics.ambr
+++ b/tests/components/myuplink/snapshots/test_diagnostics.ambr
@@ -2051,7 +2051,7 @@
               }),
             ]),
             'hasAlarm': False,
-            'name': 'Batcave',
+            'name': 'Gotham City',
             'securityLevel': 'admin',
             'systemId': '123456-7890-1234',
           }),

--- a/tests/components/myuplink/snapshots/test_diagnostics.ambr
+++ b/tests/components/myuplink/snapshots/test_diagnostics.ambr
@@ -2051,7 +2051,7 @@
               }),
             ]),
             'hasAlarm': False,
-            'name': 'Gotham City',
+            'name': 'Batcave',
             'securityLevel': 'admin',
             'systemId': '123456-7890-1234',
           }),

--- a/tests/components/myuplink/test_binary_sensor.py
+++ b/tests/components/myuplink/test_binary_sensor.py
@@ -17,9 +17,9 @@ async def test_sensor_states(
     """Test sensor state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("binary_sensor.f730_cu_3x400v_pump_heating_medium_gp1")
+    state = hass.states.get("binary_sensor.batcave_pump_heating_medium_gp1")
     assert state is not None
     assert state.state == "on"
     assert state.attributes == {
-        "friendly_name": "F730 CU 3x400V Pump: Heating medium (GP1)",
+        "friendly_name": "Batcave Pump: Heating medium (GP1)",
     }

--- a/tests/components/myuplink/test_binary_sensor.py
+++ b/tests/components/myuplink/test_binary_sensor.py
@@ -17,9 +17,9 @@ async def test_sensor_states(
     """Test sensor state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("binary_sensor.batcave_pump_heating_medium_gp1")
+    state = hass.states.get("binary_sensor.gotham_city_pump_heating_medium_gp1")
     assert state is not None
     assert state.state == "on"
     assert state.attributes == {
-        "friendly_name": "Batcave Pump: Heating medium (GP1)",
+        "friendly_name": "Gotham City Pump: Heating medium (GP1)",
     }

--- a/tests/components/myuplink/test_number.py
+++ b/tests/components/myuplink/test_number.py
@@ -14,8 +14,8 @@ from homeassistant.helpers import entity_registry as er
 TEST_PLATFORM = Platform.NUMBER
 pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
-ENTITY_ID = "number.f730_cu_3x400v_degree_minutes"
-ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Degree minutes"
+ENTITY_ID = "number.gotham_city_degree_minutes"
+ENTITY_FRIENDLY_NAME = "Gotham City Degree minutes"
 ENTITY_UID = "robin-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff-40940"
 
 

--- a/tests/components/myuplink/test_sensor.py
+++ b/tests/components/myuplink/test_sensor.py
@@ -17,11 +17,11 @@ async def test_sensor_states(
     """Test sensor state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.f730_cu_3x400v_average_outdoor_temp_bt1")
+    state = hass.states.get("sensor.batcave_average_outdoor_temp_bt1")
     assert state is not None
     assert state.state == "-12.2"
     assert state.attributes == {
-        "friendly_name": "F730 CU 3x400V Average outdoor temp (BT1)",
+        "friendly_name": "Batcave Average outdoor temp (BT1)",
         "device_class": "temperature",
         "state_class": "measurement",
         "unit_of_measurement": "°C",

--- a/tests/components/myuplink/test_sensor.py
+++ b/tests/components/myuplink/test_sensor.py
@@ -17,11 +17,11 @@ async def test_sensor_states(
     """Test sensor state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("sensor.batcave_average_outdoor_temp_bt1")
+    state = hass.states.get("sensor.gotham_city_average_outdoor_temp_bt1")
     assert state is not None
     assert state.state == "-12.2"
     assert state.attributes == {
-        "friendly_name": "Batcave Average outdoor temp (BT1)",
+        "friendly_name": "Gotham City Average outdoor temp (BT1)",
         "device_class": "temperature",
         "state_class": "measurement",
         "unit_of_measurement": "°C",

--- a/tests/components/myuplink/test_switch.py
+++ b/tests/components/myuplink/test_switch.py
@@ -19,8 +19,8 @@ from homeassistant.helpers import entity_registry as er
 TEST_PLATFORM = Platform.SWITCH
 pytestmark = pytest.mark.parametrize("platforms", [(TEST_PLATFORM,)])
 
-ENTITY_ID = "switch.f730_cu_3x400v_temporary_lux"
-ENTITY_FRIENDLY_NAME = "F730 CU 3x400V Tempo­rary lux"
+ENTITY_ID = "switch.gotham_city_temporary_lux"
+ENTITY_FRIENDLY_NAME = "Gotham City Tempo\xadrary lux"
 ENTITY_UID = "robin-r-1234-20240201-123456-aa-bb-cc-dd-ee-ff-50004"
 
 

--- a/tests/components/myuplink/test_update.py
+++ b/tests/components/myuplink/test_update.py
@@ -17,6 +17,6 @@ async def test_update_states(
     """Test update state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("update.batcave_firmware")
+    state = hass.states.get("update.gotham_city_firmware")
     assert state is not None
     assert state.state == "off"

--- a/tests/components/myuplink/test_update.py
+++ b/tests/components/myuplink/test_update.py
@@ -17,6 +17,6 @@ async def test_update_states(
     """Test update state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("update.f730_cu_3x400v_firmware")
+    state = hass.states.get("update.batcave_firmware")
     assert state is not None
     assert state.state == "off"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are no data fields in the API that specifies manufacturer or a practical version of model label. An example is "F730 CU 3x400V" where F730 is the common model name that is printed on the appliance and used in marketing material. "CU" is probably the material in the lining of the water container. 3x400V is the phase count and voltage rating. 

It is not so simple that the first word designates the model. For some appliances it is the name of the manufacturer and the model string is somewhere in the middle of this string.

Therefore we deduce manufacturer and model label from combinations of actual meta-data. We have placed the logic in myuplink lib since it is very device-specific and easier to maintain there. If the logic will not find a match the lib will deliver same strings as are used in the integration today.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
