### PR TITLE
Deprecate `hass.components` and log warning if used inside custom component

### DIFF
--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -86,6 +86,7 @@ def report(
     exclude_integrations: set | None = None,
     error_if_core: bool = True,
     level: int = logging.WARNING,
+    log_custom_component_only: bool = False,
 ) -> None:
     """Report incorrect usage.
 
@@ -99,10 +100,14 @@ def report(
         msg = f"Detected code that {what}. Please report this issue."
         if error_if_core:
             raise RuntimeError(msg) from err
-        _LOGGER.warning(msg, stack_info=True)
+        if not log_custom_component_only:
+            _LOGGER.warning(msg, stack_info=True)
         return
 
-    _report_integration(what, integration_frame, level)
+    if not log_custom_component_only or (
+        integration_frame.custom_integration and log_custom_component_only
+    ):
+        _report_integration(what, integration_frame, level)
 
 
 def _report_integration(

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -104,9 +104,7 @@ def report(
             _LOGGER.warning(msg, stack_info=True)
         return
 
-    if not log_custom_component_only or (
-        integration_frame.custom_integration and log_custom_component_only
-    ):
+    if not log_custom_component_only or integration_frame.custom_integration:
         _report_integration(what, integration_frame, level)
 
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1247,6 +1247,18 @@ class Components:
         if component is None:
             raise ImportError(f"Unable to load {comp_name}")
 
+        from .helpers.frame import report  # pylint: disable=import-outside-toplevel
+
+        report(
+            (
+                f"accesses hass.components.{comp_name}."
+                " This is deprecated and will stop working in Home Assistant 2024.9, it"
+                f" should be updated to import functions used from {comp_name} directly"
+            ),
+            error_if_core=False,
+            log_custom_component_only=True,
+        )
+
         wrapped = ModuleWrapper(self._hass, component)
         setattr(self, comp_name, wrapped)
         return wrapped

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1247,6 +1247,7 @@ class Components:
         if component is None:
             raise ImportError(f"Unable to load {comp_name}")
 
+        # Local import to avoid circular dependencies
         from .helpers.frame import report  # pylint: disable=import-outside-toplevel
 
         report(

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1252,7 +1252,7 @@ class Components:
         report(
             (
                 f"accesses hass.components.{comp_name}."
-                " This is deprecated and will stop working in Home Assistant 2024.9, it"
+                " This is deprecated and will stop working in Home Assistant 2024.6, it"
                 f" should be updated to import functions used from {comp_name} directly"
             ),
             error_if_core=False,

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1273,6 +1273,18 @@ def bind_hass(func: _CallableT) -> _CallableT:
     The use of this decorator is discouraged, and it should not be used
     for new functions.
     """
+    from .helpers.frame import report  # pylint: disable=import-outside-toplevel
+
+    report(
+        (
+            "uses @bind_hass decorator."
+            " This is deprecated and will stop working in Home Assistant 2024.9, it"
+            " should be updated to pass hass object as first argument"
+        ),
+        error_if_core=False,
+        log_custom_component_only=True,
+    )
+
     setattr(func, "__bind_hass", True)
     return func
 

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1285,18 +1285,6 @@ def bind_hass(func: _CallableT) -> _CallableT:
     The use of this decorator is discouraged, and it should not be used
     for new functions.
     """
-    from .helpers.frame import report  # pylint: disable=import-outside-toplevel
-
-    report(
-        (
-            "uses @bind_hass decorator."
-            " This is deprecated and will stop working in Home Assistant 2024.9, it"
-            " should be updated to pass hass object as first argument"
-        ),
-        error_if_core=False,
-        log_custom_component_only=True,
-    )
-
     setattr(func, "__bind_hass", True)
     return func
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1580,6 +1580,33 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
 
 
 @pytest.fixture
+def mock_integration_frame() -> Generator[Mock, None, None]:
+    """Mock as if we're calling code from inside an integration."""
+    correct_frame = Mock(
+        filename="/home/paulus/homeassistant/components/hue/light.py",
+        lineno="23",
+        line="self.light.is_on",
+    )
+    with patch(
+        "homeassistant.helpers.frame.extract_stack",
+        return_value=[
+            Mock(
+                filename="/home/paulus/homeassistant/core.py",
+                lineno="23",
+                line="do_something()",
+            ),
+            correct_frame,
+            Mock(
+                filename="/home/paulus/aiohue/lights.py",
+                lineno="2",
+                line="something()",
+            ),
+        ],
+    ):
+        yield correct_frame
+
+
+@pytest.fixture
 def mock_bluetooth(
     mock_bleak_scanner_start: MagicMock, mock_bluetooth_adapters: None
 ) -> None:

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -1,39 +1,11 @@
 """Test the frame helper."""
 
-from collections.abc import Generator
 from unittest.mock import ANY, Mock, patch
 
 import pytest
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import frame
-
-
-@pytest.fixture
-def mock_integration_frame() -> Generator[Mock, None, None]:
-    """Mock as if we're calling code from inside an integration."""
-    correct_frame = Mock(
-        filename="/home/paulus/homeassistant/components/hue/light.py",
-        lineno="23",
-        line="self.light.is_on",
-    )
-    with patch(
-        "homeassistant.helpers.frame.extract_stack",
-        return_value=[
-            Mock(
-                filename="/home/paulus/homeassistant/core.py",
-                lineno="23",
-                line="do_something()",
-            ),
-            correct_frame,
-            Mock(
-                filename="/home/paulus/aiohue/lights.py",
-                lineno="2",
-                line="something()",
-            ),
-        ],
-    ):
-        yield correct_frame
 
 
 async def test_extract_frame_integration(

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -174,3 +174,8 @@ async def test_report_missing_integration_frame(
         frame.report(what, error_if_core=False)
         assert what in caplog.text
         assert caplog.text.count(what) == 1
+
+        caplog.clear()
+
+        frame.report(what, error_if_core=False, log_custom_component_only=True)
+        assert caplog.text == ""

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,6 @@
 """Test to verify that we can load components."""
 import asyncio
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -8,6 +8,7 @@ from homeassistant import loader
 from homeassistant.components import http, hue
 from homeassistant.components.hue import light as hue_light
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import frame
 
 from .common import MockModule, async_get_persistent_notifications, mock_integration
 
@@ -287,6 +288,7 @@ async def test_get_integration_custom_component(
 ) -> None:
     """Test resolving integration."""
     integration = await loader.async_get_integration(hass, "test_package")
+
     assert integration.get_component().DOMAIN == "test_package"
     assert integration.name == "Test Package"
 
@@ -1001,3 +1003,32 @@ async def test_config_folder_not_in_path(hass):
 
     # Verify that we are able to load the file with absolute path
     import tests.testing_config.check_config_not_in_path  # noqa: F401
+
+
+async def test_bind_hass_use_reported(
+    caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+) -> None:
+    """Test that use of @bind_hass is reported."""
+    from homeassistant.loader import bind_hass
+
+    integration_frame = frame.IntegrationFrame(
+        custom_integration=True,
+        frame=mock_integration_frame,
+        integration="test_integration_frame",
+        module="custom_components.test_integration_frame",
+        relative_filename="custom_components/test_integration_frame/__init__.py",
+    )
+
+    with patch(
+        "homeassistant.helpers.frame.get_integration_frame",
+        return_value=integration_frame,
+    ):
+
+        @bind_hass
+        def _test(hass: HomeAssistant):
+            pass
+
+        assert (
+            "Detected that custom integration 'test_integration_frame'"
+            " uses @bind_hass decorator. This is deprecated"
+        ) in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1032,3 +1032,30 @@ async def test_bind_hass_use_reported(
             "Detected that custom integration 'test_integration_frame'"
             " uses @bind_hass decorator. This is deprecated"
         ) in caplog.text
+
+
+async def test_hass_components_use_reported(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+) -> None:
+    """Test that use of hass.components is reported."""
+    integration_frame = frame.IntegrationFrame(
+        custom_integration=True,
+        frame=mock_integration_frame,
+        integration="test_integration_frame",
+        module="custom_components.test_integration_frame",
+        relative_filename="custom_components/test_integration_frame/__init__.py",
+    )
+
+    with patch(
+        "homeassistant.helpers.frame.get_integration_frame",
+        return_value=integration_frame,
+    ), patch(
+        "homeassistant.components.http.start_http_server_and_save_config",
+        return_value=None,
+    ):
+        await hass.components.http.start_http_server_and_save_config(hass, [], None)
+
+        assert (
+            "Detected that custom integration 'test_integration_frame'"
+            " accesses hass.components.http. This is deprecated"
+        ) in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1005,39 +1005,13 @@ async def test_config_folder_not_in_path(hass):
     import tests.testing_config.check_config_not_in_path  # noqa: F401
 
 
-async def test_bind_hass_use_reported(
-    caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
-) -> None:
-    """Test that use of @bind_hass is reported."""
-    from homeassistant.loader import bind_hass
-
-    integration_frame = frame.IntegrationFrame(
-        custom_integration=True,
-        frame=mock_integration_frame,
-        integration="test_integration_frame",
-        module="custom_components.test_integration_frame",
-        relative_filename="custom_components/test_integration_frame/__init__.py",
-    )
-
-    with patch(
-        "homeassistant.helpers.frame.get_integration_frame",
-        return_value=integration_frame,
-    ):
-
-        @bind_hass
-        def _test(hass: HomeAssistant):
-            pass
-
-        assert (
-            "Detected that custom integration 'test_integration_frame'"
-            " uses @bind_hass decorator. This is deprecated"
-        ) in caplog.text
-
-
 async def test_hass_components_use_reported(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
     """Test that use of hass.components is reported."""
+    mock_integration_frame.filename = (
+        "/home/paulus/homeassistant/custom_components/demo/light.py"
+    )
     integration_frame = frame.IntegrationFrame(
         custom_integration=True,
         frame=mock_integration_frame,
@@ -1053,7 +1027,7 @@ async def test_hass_components_use_reported(
         "homeassistant.components.http.start_http_server_and_save_config",
         return_value=None,
     ):
-        await hass.components.http.start_http_server_and_save_config(hass, [], None)
+        hass.components.http.start_http_server_and_save_config(hass, [], None)
 
         assert (
             "Detected that custom integration 'test_integration_frame'"


### PR DESCRIPTION
## Proposed change
~Deprecate the use of `@bind_hass` decorator~ (isn't used that much in custom integrations), 

Deprecate the use of `hass.components`. The use within a custom component will issue a warning to the log.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
