### PR TITLE
Add support for white mode on Lutron temperature controlled devices

### DIFF
--- a/homeassistant/components/lutron_caseta/light.py
+++ b/homeassistant/components/lutron_caseta/light.py
@@ -37,10 +37,11 @@ SUPPORTED_COLOR_MODE_DICT = {
         ColorMode.COLOR_TEMP,
         ColorMode.WHITE,
     },
-    DEVICE_TYPE_WHITE_TUNE: {ColorMode.COLOR_TEMP},
+    DEVICE_TYPE_WHITE_TUNE: {ColorMode.COLOR_TEMP, ColorMode.WHITE},
 }
 
 WARM_DEVICE_TYPES = {DEVICE_TYPE_WHITE_TUNE, DEVICE_TYPE_SPECTRUM_TUNE}
+WHITE_DEVICE_TYPES = {DEVICE_TYPE_WHITE_TUNE, DEVICE_TYPE_SPECTRUM_TUNE}
 
 
 def to_lutron_level(level):
@@ -93,7 +94,7 @@ class LutronCasetaLight(LutronCasetaDeviceUpdatableEntity, LightEntity):
         )
 
         self.supports_warm_cool = light_type in WARM_DEVICE_TYPES
-        self.supports_warm_dim = light_type == DEVICE_TYPE_SPECTRUM_TUNE
+        self.supports_warm_dim = light_type in WHITE_DEVICE_TYPES
         self.supports_spectrum_tune = light_type == DEVICE_TYPE_SPECTRUM_TUNE
 
     def _get_min_color_temp_kelvin(self, light: dict[str, Any]) -> int:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Add support for White Mode to Temperature controlled Lutron lights such as lumaris tape strip. This has been tested by myself and a few others and seems to work fine in practice, but not listed as explicitly compatible in the documentation.

<img width="992" alt="Screenshot 2024-02-26 at 9 02 31 PM" src="https://github.com/home-assistant/core/assets/3183738/e85f22d2-6e96-4b38-9881-c6ca4b0a826f">
<img width="590" alt="Screenshot 2024-02-26 at 8 51 55 PM" src="https://github.com/home-assistant/core/assets/3183738/c53335c7-61cd-4395-9bab-e7929a53ad86">
<img width="575" alt="Screenshot 2024-02-26 at 8 52 01 PM" src="https://github.com/home-assistant/core/assets/3183738/305de7bc-17bf-4f0f-b2f2-8d9041847fbd">

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is a follow up to this PR, and needs further discussion on if there a reason this isnt explicitly defined as supported in the documentation, as it seems to work fine in practice.
- https://github.com/home-assistant/core/pull/109019#discussion_r1468928549
- https://developers.home-assistant.io/docs/core/entity/light?_highlight=light#color-modes

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
