### PR TITLE
Import bluetooth in the executor to avoid blocking the event loop

### DIFF
--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -5,6 +5,7 @@
   "config_flow": true,
   "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/bluetooth",
+  "import_executor": true,
   "iot_class": "local_push",
   "loggers": [
     "btsocket",

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -17,7 +17,7 @@ def disable_bluez_manager_socket():
 
 @pytest.fixture(name="disable_dbus_socket", autouse=True, scope="session")
 def disable_dbus_socket():
-    """Mock the bluez manager socket."""
+    """Mock the dbus message bus to avoid creating a socket."""
     with patch.object(message_bus, "MessageBus"):
         yield
 

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -2,7 +2,23 @@
 
 from unittest.mock import patch
 
+from bleak_retry_connector import bleak_manager
+from dbus_fast.aio import message_bus
 import pytest
+
+
+@pytest.fixture(name="disable_bluez_manager_socket", autouse=True, scope="session")
+def mock_disable_bluez_manager_socket():
+    """Mock the bluez manager socket."""
+    with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
+        yield
+
+
+@pytest.fixture(name="disable_dbus_socket", autouse=True, scope="session")
+def mock_disable_dbus_socket():
+    """Mock the bluez manager socket."""
+    with patch.object(message_bus, "MessageBus"):
+        yield
 
 
 @pytest.fixture(name="operating_system_85")

--- a/tests/components/bluetooth/conftest.py
+++ b/tests/components/bluetooth/conftest.py
@@ -4,20 +4,28 @@ from unittest.mock import patch
 
 from bleak_retry_connector import bleak_manager
 from dbus_fast.aio import message_bus
+import habluetooth.util as habluetooth_utils
 import pytest
 
 
 @pytest.fixture(name="disable_bluez_manager_socket", autouse=True, scope="session")
-def mock_disable_bluez_manager_socket():
+def disable_bluez_manager_socket():
     """Mock the bluez manager socket."""
     with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
         yield
 
 
 @pytest.fixture(name="disable_dbus_socket", autouse=True, scope="session")
-def mock_disable_dbus_socket():
+def disable_dbus_socket():
     """Mock the bluez manager socket."""
     with patch.object(message_bus, "MessageBus"):
+        yield
+
+
+@pytest.fixture(name="disable_bluetooth_auto_recovery", autouse=True, scope="session")
+def disable_bluetooth_auto_recovery():
+    """Mock out auto recovery."""
+    with patch.object(habluetooth_utils, "recover_adapter"):
         yield
 
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -6,6 +6,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 
 from bleak import BleakError
 from bleak.backends.scanner import AdvertisementData, BLEDevice
+from bleak_retry_connector import bleak_manager
 from bluetooth_adapters import DEFAULT_ADDRESS
 from habluetooth import scanner
 from habluetooth.wrappers import HaBleakScannerWrapper
@@ -188,7 +189,9 @@ async def test_setup_and_stop_no_bluetooth(
     with patch(
         "habluetooth.scanner.OriginalBleakScanner",
         side_effect=BleakError,
-    ) as mock_ha_bleak_scanner, patch(
+    ) as mock_ha_bleak_scanner, patch.object(
+        bleak_manager, "get_global_bluez_manager_with_timeout"
+    ), patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
     ):
         await async_setup_with_one_adapter(hass)

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -198,10 +198,10 @@ async def test_setup_and_stop_no_bluetooth(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    assert len(mock_ha_bleak_scanner.mock_calls) == 1
-    assert "Failed to initialize Bluetooth" in caplog.text
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+        await hass.async_block_till_done()
+        assert len(mock_ha_bleak_scanner.mock_calls) == 1
+        assert "Failed to initialize Bluetooth" in caplog.text
 
 
 async def test_setup_and_stop_broken_bluetooth(

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -59,6 +59,13 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
+@pytest.fixture(name="disable_bluez_manager_socket", autouse=True)
+def mock_disable_bluez_manager_socket():
+    """Mock the bluez manager socket."""
+    with patch.object(bleak_manager, "get_global_bluez_manager_with_timeout"):
+        yield
+
+
 async def test_setup_and_stop(
     hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, enable_bluetooth: None
 ) -> None:
@@ -179,7 +186,6 @@ async def test_setup_and_stop_old_bluez(
     }
 
 
-@patch.object(bleak_manager, "get_global_bluez_manager_with_timeout", AsyncMock())
 async def test_setup_and_stop_no_bluetooth(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
 ) -> None:

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -47,6 +47,7 @@ from . import (
     FakeScanner,
     _get_manager,
     async_setup_with_default_adapter,
+    async_setup_with_one_adapter,
     generate_advertisement_data,
     generate_ble_device,
     inject_advertisement,
@@ -178,7 +179,7 @@ async def test_setup_and_stop_old_bluez(
 
 
 async def test_setup_and_stop_no_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
 ) -> None:
     """Test we fail gracefully when bluetooth is not available."""
     mock_bt = [
@@ -190,7 +191,7 @@ async def test_setup_and_stop_no_bluetooth(
     ) as mock_ha_bleak_scanner, patch(
         "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
     ):
-        await async_setup_with_default_adapter(hass)
+        await async_setup_with_one_adapter(hass)
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -128,29 +128,6 @@ async def test_setup_and_stop_passive(
     }
 
 
-async def test_setup_and_stop_no_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
-) -> None:
-    """Test we fail gracefully when bluetooth is not available."""
-    mock_bt = [
-        {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
-    ]
-    with patch(
-        "habluetooth.scanner.OriginalBleakScanner",
-        side_effect=BleakError,
-    ) as mock_ha_bleak_scanner, patch(
-        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
-    ), patch("homeassistant.components.bluetooth.discovery_flow.async_create_flow"):
-        await async_setup_with_one_adapter(hass)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    assert len(mock_ha_bleak_scanner.mock_calls) == 1
-    assert "Failed to initialize Bluetooth" in caplog.text
-
-
 async def test_setup_and_stop_old_bluez(
     hass: HomeAssistant,
     mock_bleak_scanner_start: MagicMock,
@@ -244,6 +221,29 @@ async def test_setup_and_stop_broken_bluetooth_hanging(
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
     assert "Timed out starting Bluetooth" in caplog.text
+
+
+async def test_setup_and_stop_no_bluetooth(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
+) -> None:
+    """Test we fail gracefully when bluetooth is not available."""
+    mock_bt = [
+        {"domain": "switchbot", "service_uuid": "cba20d00-224d-11e6-9fb8-0002a5d5c51b"}
+    ]
+    with patch(
+        "habluetooth.scanner.OriginalBleakScanner",
+        side_effect=BleakError,
+    ) as mock_ha_bleak_scanner, patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ), patch("homeassistant.components.bluetooth.discovery_flow.async_create_flow"):
+        await async_setup_with_one_adapter(hass)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert len(mock_ha_bleak_scanner.mock_calls) == 1
+    assert "Failed to initialize Bluetooth" in caplog.text
 
 
 async def test_setup_and_retry_adapter_not_yet_available(

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -178,7 +178,7 @@ async def test_setup_and_stop_old_bluez(
 
 
 async def test_setup_and_stop_no_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we fail gracefully when bluetooth is not available."""
     mock_bt = [

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -178,27 +178,6 @@ async def test_setup_and_stop_old_bluez(
     }
 
 
-async def test_setup_and_stop_broken_bluetooth(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
-) -> None:
-    """Test we fail gracefully when bluetooth/dbus is broken."""
-    mock_bt = []
-    with patch(
-        "habluetooth.scanner.OriginalBleakScanner.start",
-        side_effect=BleakError,
-    ), patch(
-        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
-    ):
-        await async_setup_with_default_adapter(hass)
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
-    assert "Failed to start Bluetooth" in caplog.text
-    assert len(bluetooth.async_discovered_service_info(hass)) == 0
-
-
 async def test_setup_and_stop_no_bluetooth(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, one_adapter: None
 ) -> None:
@@ -220,6 +199,27 @@ async def test_setup_and_stop_no_bluetooth(
     await hass.async_block_till_done()
     assert len(mock_ha_bleak_scanner.mock_calls) == 1
     assert "Failed to initialize Bluetooth" in caplog.text
+
+
+async def test_setup_and_stop_broken_bluetooth(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, macos_adapter: None
+) -> None:
+    """Test we fail gracefully when bluetooth/dbus is broken."""
+    mock_bt = []
+    with patch(
+        "habluetooth.scanner.OriginalBleakScanner.start",
+        side_effect=BleakError,
+    ), patch(
+        "homeassistant.components.bluetooth.async_get_bluetooth", return_value=mock_bt
+    ):
+        await async_setup_with_default_adapter(hass)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+    assert "Failed to start Bluetooth" in caplog.text
+    assert len(bluetooth.async_discovered_service_info(hass)) == 0
 
 
 async def test_setup_and_stop_broken_bluetooth_hanging(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1565,6 +1565,7 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
     # Late imports to avoid loading bleak unless we need it
 
     # pylint: disable-next=import-outside-toplevel
+    from bleak_retry_connector import bleak_manager
     from habluetooth import scanner as bluetooth_scanner
 
     # We need to drop the stop method from the object since we patched
@@ -1574,7 +1575,9 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
     with patch.object(
         bluetooth_scanner.OriginalBleakScanner,
         "start",
-    ) as mock_bleak_scanner_start, patch.object(bluetooth_scanner, "HaScanner"):
+    ) as mock_bleak_scanner_start, patch.object(
+        bleak_manager, "get_global_bluez_manager_with_timeout"
+    ), patch.object(bluetooth_scanner, "HaScanner"):
         yield mock_bleak_scanner_start
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1565,7 +1565,6 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
     # Late imports to avoid loading bleak unless we need it
 
     # pylint: disable-next=import-outside-toplevel
-    from bleak_retry_connector import bleak_manager
     from habluetooth import scanner as bluetooth_scanner
 
     # We need to drop the stop method from the object since we patched
@@ -1575,9 +1574,7 @@ def mock_bleak_scanner_start() -> Generator[MagicMock, None, None]:
     with patch.object(
         bluetooth_scanner.OriginalBleakScanner,
         "start",
-    ) as mock_bleak_scanner_start, patch.object(
-        bleak_manager, "get_global_bluez_manager_with_timeout"
-    ), patch.object(bluetooth_scanner, "HaScanner"):
+    ) as mock_bleak_scanner_start, patch.object(bluetooth_scanner, "HaScanner"):
         yield mock_bleak_scanner_start
 
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This one takes ~0.78s on the green

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
