### PR TITLE
Make core tests that should run in the event loop coros

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,7 +85,7 @@ def test_split_entity_id() -> None:
         ha.split_entity_id(".empty_domain")
 
 
-def test_async_add_hass_job_schedule_callback() -> None:
+async def test_async_add_hass_job_schedule_callback() -> None:
     """Test that we schedule callbacks and add jobs to the job pool."""
     hass = MagicMock()
     job = MagicMock()
@@ -96,7 +96,7 @@ def test_async_add_hass_job_schedule_callback() -> None:
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_hass_job_coro_named(hass: HomeAssistant) -> None:
+async def test_async_add_hass_job_coro_named(hass: HomeAssistant) -> None:
     """Test that we schedule coroutines and add jobs to the job pool with a name."""
 
     async def mycoro():
@@ -109,7 +109,7 @@ def test_async_add_hass_job_coro_named(hass: HomeAssistant) -> None:
     assert "named coro" in str(task)
 
 
-def test_async_add_hass_job_schedule_partial_callback() -> None:
+async def test_async_add_hass_job_schedule_partial_callback() -> None:
     """Test that we schedule partial coros and add jobs to the job pool."""
     hass = MagicMock()
     job = MagicMock()
@@ -121,9 +121,9 @@ def test_async_add_hass_job_schedule_partial_callback() -> None:
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_hass_job_schedule_coroutinefunction(event_loop) -> None:
+async def test_async_add_hass_job_schedule_coroutinefunction() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -134,9 +134,9 @@ def test_async_add_hass_job_schedule_coroutinefunction(event_loop) -> None:
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_hass_job_schedule_partial_coroutinefunction(event_loop) -> None:
+async def test_async_add_hass_job_schedule_partial_coroutinefunction() -> None:
     """Test that we schedule partial coros and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -149,7 +149,7 @@ def test_async_add_hass_job_schedule_partial_coroutinefunction(event_loop) -> No
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_add_job_add_hass_threaded_job_to_pool() -> None:
+async def test_async_add_job_add_hass_threaded_job_to_pool() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
     hass = MagicMock()
 
@@ -162,11 +162,9 @@ def test_async_add_job_add_hass_threaded_job_to_pool() -> None:
     assert len(hass.loop.run_in_executor.mock_calls) == 2
 
 
-def test_async_create_task_schedule_coroutine(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_async_create_task_schedule_coroutine() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -180,11 +178,9 @@ def test_async_create_task_schedule_coroutine(
 @pytest.mark.skipif(
     sys.version_info < (3, 12), reason="eager_start is only supported for Python 3.12"
 )
-def test_async_create_task_eager_start_schedule_coroutine(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_async_create_task_eager_start_schedule_coroutine() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -198,11 +194,9 @@ def test_async_create_task_eager_start_schedule_coroutine(
 @pytest.mark.skipif(
     sys.version_info >= (3, 12), reason="eager_start is not supported on < 3.12"
 )
-def test_async_create_task_eager_start_fallback_schedule_coroutine(
-    event_loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_async_create_task_eager_start_fallback_schedule_coroutine() -> None:
     """Test that we schedule coroutines and add jobs to the job pool."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -215,9 +209,9 @@ def test_async_create_task_eager_start_fallback_schedule_coroutine(
     assert len(hass.add_job.mock_calls) == 0
 
 
-def test_async_create_task_schedule_coroutine_with_name(event_loop) -> None:
+async def test_async_create_task_schedule_coroutine_with_name() -> None:
     """Test that we schedule coroutines and add jobs to the job pool with a name."""
-    hass = MagicMock(loop=MagicMock(wraps=event_loop))
+    hass = MagicMock(loop=MagicMock(wraps=asyncio.get_running_loop()))
 
     async def job():
         pass
@@ -229,7 +223,7 @@ def test_async_create_task_schedule_coroutine_with_name(event_loop) -> None:
     assert "named task" in str(task)
 
 
-def test_async_run_hass_job_calls_callback() -> None:
+async def test_async_run_hass_job_calls_callback() -> None:
     """Test that the callback annotation is respected."""
     hass = MagicMock()
     calls = []
@@ -242,7 +236,7 @@ def test_async_run_hass_job_calls_callback() -> None:
     assert len(hass.async_add_job.mock_calls) == 0
 
 
-def test_async_run_hass_job_delegates_non_async() -> None:
+async def test_async_run_hass_job_delegates_non_async() -> None:
     """Test that the callback annotation is respected."""
     hass = MagicMock()
     calls = []


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/111425#discussion_r1503484769


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
