### PR TITLE
Always allow ignore and unignore flows for single config entry integrations

### DIFF
--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
+from contextlib import AbstractContextManager, nullcontext as does_not_raise
 from datetime import timedelta
 import logging
 from typing import Any
@@ -4434,10 +4435,53 @@ async def test_hashable_non_string_unique_id(
     assert entries.get_entry_by_domain_and_unique_id("test", unique_id) is None
 
 
-async def test_avoid_starting_config_flow_on_single_config_entry(
-    hass: HomeAssistant, manager: config_entries.ConfigEntries
+RAISES_SINGLE_ENTRY_ERROR = pytest.raises(
+    HomeAssistantError,
+    match=r"Cannot start a config flow, the integration supports only a single config entry but already has one",
+)
+
+
+@pytest.mark.parametrize(
+    ("source", "user_input", "expectation", "expected_result"),
+    [
+        (
+            config_entries.SOURCE_IGNORE,
+            {"unique_id": "blah", "title": "blah"},
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.CREATE_ENTRY},
+        ),
+        (
+            config_entries.SOURCE_REAUTH,
+            None,
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.FORM, "step_id": "reauth_confirm"},
+        ),
+        (
+            config_entries.SOURCE_UNIGNORE,
+            None,
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
+        ),
+        (
+            config_entries.SOURCE_USER,
+            None,
+            RAISES_SINGLE_ENTRY_ERROR,
+            {},
+        ),
+    ],
+)
+async def test_starting_config_flow_on_single_config_entry(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    source: str,
+    user_input: dict,
+    expectation: AbstractContextManager,
+    expected_result: dict,
 ) -> None:
-    """Test that we cannot start a config flow for a single config entry integration."""
+    """Test starting a config flow for a single config entry integration.
+
+    In this test, the integration has one ignored flow and one entry added by user.
+    """
     integration = loader.Integration(
         hass,
         "components.comp",
@@ -4458,17 +4502,105 @@ async def test_avoid_starting_config_flow_on_single_config_entry(
         options={"vendor": "options"},
     )
     entry.add_to_hass(hass)
+    ignored_entry = MockConfigEntry(
+        domain="comp",
+        unique_id="2345",
+        title="Test",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+        source=config_entries.SOURCE_IGNORE,
+    )
+    ignored_entry.add_to_hass(hass)
 
     mock_platform(hass, "comp.config_flow", None)
 
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
-    ), pytest.raises(
-        HomeAssistantError,
-        match=r"Cannot start a config flow, the integration supports only a single config entry but already has one",
-    ):
-        await hass.config_entries.flow.async_init("comp", context={"source": "user"})
+    ), expectation:
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": source}, data=user_input
+        )
+
+    for key in expected_result:
+        assert result[key] == expected_result[key]
+
+
+@pytest.mark.parametrize(
+    ("source", "user_input", "expectation", "expected_result"),
+    [
+        (
+            config_entries.SOURCE_IGNORE,
+            {"unique_id": "blah", "title": "blah"},
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.CREATE_ENTRY},
+        ),
+        (
+            config_entries.SOURCE_REAUTH,
+            None,
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.FORM, "step_id": "reauth_confirm"},
+        ),
+        (
+            config_entries.SOURCE_UNIGNORE,
+            None,
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
+        ),
+        (
+            config_entries.SOURCE_USER,
+            None,
+            does_not_raise(),
+            {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
+        ),
+    ],
+)
+async def test_starting_config_flow_on_single_config_entry_2(
+    hass: HomeAssistant,
+    manager: config_entries.ConfigEntries,
+    source: str,
+    user_input: dict,
+    expectation: AbstractContextManager,
+    expected_result: dict,
+) -> None:
+    """Test starting a config flow for a single config entry integration.
+
+    In this test, the integration has one ignored flow but no entry added by user.
+    """
+    integration = loader.Integration(
+        hass,
+        "components.comp",
+        None,
+        {
+            "name": "Comp",
+            "dependencies": [],
+            "requirements": [],
+            "domain": "comp",
+            "single_config_entry": True,
+        },
+    )
+    ignored_entry = MockConfigEntry(
+        domain="comp",
+        unique_id="2345",
+        title="Test",
+        data={"vendor": "data"},
+        options={"vendor": "options"},
+        source=config_entries.SOURCE_IGNORE,
+    )
+    ignored_entry.add_to_hass(hass)
+
+    mock_platform(hass, "comp.config_flow", None)
+
+    with patch(
+        "homeassistant.loader.async_get_integration",
+        return_value=integration,
+    ), expectation:
+        result = await hass.config_entries.flow.async_init(
+            "comp", context={"source": source}, data=user_input
+        )
+
+    for key in expected_result:
+        assert result[key] == expected_result[key]
 
 
 async def test_avoid_adding_second_config_entry_on_single_config_entry(
@@ -4564,45 +4696,6 @@ async def test_in_progress_get_canceled_when_entry_is_created(
 
     assert len(manager.flow.async_progress()) == 0
     assert len(manager.async_entries()) == 1
-
-
-async def test_start_reauth_still_possible_for_single_config_entry(
-    hass: HomeAssistant, manager: config_entries.ConfigEntries
-):
-    """Test that we can still start a reauth flow on a single config entry integration."""
-    integration = loader.Integration(
-        hass,
-        "components.comp",
-        None,
-        {
-            "name": "Comp",
-            "dependencies": [],
-            "requirements": [],
-            "domain": "comp",
-            "single_config_entry": True,
-        },
-    )
-    entry = MockConfigEntry(
-        domain="comp",
-        unique_id="1234",
-        title="Test",
-        data={"vendor": "data"},
-        options={"vendor": "options"},
-    )
-    entry.add_to_hass(hass)
-
-    mock_platform(hass, "comp.config_flow", None)
-
-    with patch(
-        "homeassistant.loader.async_get_integration",
-        return_value=integration,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            "comp", context={"source": config_entries.SOURCE_REAUTH}
-        )
-
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "reauth_confirm"
 
 
 async def test_directly_mutating_blocked(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4437,7 +4437,10 @@ async def test_hashable_non_string_unique_id(
 
 RAISES_SINGLE_ENTRY_ERROR = pytest.raises(
     HomeAssistantError,
-    match=r"Cannot start a config flow, the integration supports only a single config entry but already has one",
+    match=(
+        r"Cannot start a config flow, "
+        r"the integration supports only a single config entry but already has one"
+    ),
 )
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Always allow ignore and unignore flows for single config entry integrations

This addresses a late review comment in https://github.com/home-assistant/core/pull/109505

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
