### PR TITLE
Return FlowResultType.ABORT when violating single_config_entry

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -1,4 +1,10 @@
 {
+  "config": {
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
+    },
+    "step": {}
+  },
   "issues": {
     "country_not_configured": {
       "title": "The country has not been configured",

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1008,6 +1008,8 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
         if not context or "source" not in context:
             raise KeyError("Context not set or doesn't have a source set")
 
+        flow_id = uuid_util.random_uuid_hex()
+
         # Avoid starting a config flow on an integration that only supports
         # a single config entry, but which already has an entry
         if (
@@ -1015,13 +1017,14 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
             and await _support_single_config_entry_only(self.hass, handler)
             and self.config_entries.async_entries(handler, include_ignore=False)
         ):
-            raise HomeAssistantError(
-                "Cannot start a config flow, the integration"
-                " supports only a single config entry"
-                " but already has one"
+            return FlowResult(
+                type=data_entry_flow.FlowResultType.ABORT,
+                flow_id=flow_id,
+                handler=handler,
+                reason="single_instance_allowed",
+                translation_domain=HA_DOMAIN,
             )
 
-        flow_id = uuid_util.random_uuid_hex()
         loop = self.hass.loop
 
         if context["source"] == SOURCE_IMPORT:
@@ -1110,6 +1113,21 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
 
         if result["type"] != data_entry_flow.FlowResultType.CREATE_ENTRY:
             return result
+
+        # Avoid adding a config entry for a integration
+        # that only supports a single config entry, but already has an entry
+        if (
+            await _support_single_config_entry_only(self.hass, flow.handler)
+            and flow.context["source"] != SOURCE_IGNORE
+            and self.config_entries.async_entries(flow.handler, include_ignore=False)
+        ):
+            return FlowResult(
+                type=data_entry_flow.FlowResultType.ABORT,
+                flow_id=flow.flow_id,
+                handler=flow.handler,
+                reason="single_instance_allowed",
+                translation_domain=HA_DOMAIN,
+            )
 
         # Check if config entry exists with unique ID. Unload it.
         existing_entry = None
@@ -1396,18 +1414,6 @@ class ConfigEntries:
         if entry.entry_id in self._entries.data:
             raise HomeAssistantError(
                 f"An entry with the id {entry.entry_id} already exists."
-            )
-
-        # Avoid adding a config entry for a integration
-        # that only supports a single config entry, but already has an entry
-        if (
-            await _support_single_config_entry_only(self.hass, entry.domain)
-            and entry.source != SOURCE_IGNORE
-            and self.async_entries(entry.domain, include_ignore=False)
-        ):
-            raise HomeAssistantError(
-                f"An entry for {entry.domain} already exists,"
-                f" but integration supports only one config entry"
             )
 
         self._entries[entry.entry_id] = entry

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -157,6 +157,7 @@ class FlowResult(TypedDict, total=False):
     result: Any
     step_id: str
     title: str
+    translation_domain: str
     type: FlowResultType
     url: str
     version: int

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
-from contextlib import AbstractContextManager, nullcontext as does_not_raise
+from contextlib import AbstractContextManager
 from datetime import timedelta
 import logging
 from typing import Any
@@ -4435,41 +4435,32 @@ async def test_hashable_non_string_unique_id(
     assert entries.get_entry_by_domain_and_unique_id("test", unique_id) is None
 
 
-RAISES_SINGLE_ENTRY_ERROR = pytest.raises(
-    HomeAssistantError,
-    match=(
-        r"Cannot start a config flow, "
-        r"the integration supports only a single config entry but already has one"
-    ),
-)
-
-
 @pytest.mark.parametrize(
-    ("source", "user_input", "expectation", "expected_result"),
+    ("source", "user_input", "expected_result"),
     [
         (
             config_entries.SOURCE_IGNORE,
             {"unique_id": "blah", "title": "blah"},
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.CREATE_ENTRY},
         ),
         (
             config_entries.SOURCE_REAUTH,
             None,
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.FORM, "step_id": "reauth_confirm"},
         ),
         (
             config_entries.SOURCE_UNIGNORE,
             None,
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
         ),
         (
             config_entries.SOURCE_USER,
             None,
-            RAISES_SINGLE_ENTRY_ERROR,
-            {},
+            {
+                "type": data_entry_flow.FlowResultType.ABORT,
+                "reason": "single_instance_allowed",
+                "translation_domain": HA_DOMAIN,
+            },
         ),
     ],
 )
@@ -4530,30 +4521,26 @@ async def test_starting_config_flow_on_single_config_entry(
 
 
 @pytest.mark.parametrize(
-    ("source", "user_input", "expectation", "expected_result"),
+    ("source", "user_input", "expected_result"),
     [
         (
             config_entries.SOURCE_IGNORE,
             {"unique_id": "blah", "title": "blah"},
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.CREATE_ENTRY},
         ),
         (
             config_entries.SOURCE_REAUTH,
             None,
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.FORM, "step_id": "reauth_confirm"},
         ),
         (
             config_entries.SOURCE_UNIGNORE,
             None,
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
         ),
         (
             config_entries.SOURCE_USER,
             None,
-            does_not_raise(),
             {"type": data_entry_flow.FlowResultType.ABORT, "reason": "not_implemented"},
         ),
     ],
@@ -4610,6 +4597,19 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:
     """Test that we cannot add a second entry for a single config entry integration."""
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_user(self, user_input=None):
+            """Test user step."""
+            if user_input is None:
+                return self.async_show_form(step_id="user")
+
+            return self.async_create_entry(title="yo", data={})
+
     integration = loader.Integration(
         hass,
         "components.comp",
@@ -4622,27 +4622,36 @@ async def test_avoid_adding_second_config_entry_on_single_config_entry(
             "single_config_entry": True,
         },
     )
-    entry = MockConfigEntry(
-        domain="comp",
-        unique_id="1234",
-        title="Test",
-        data={"vendor": "data"},
-        options={"vendor": "options"},
-    )
-    entry.add_to_hass(hass)
+    mock_integration(hass, MockModule("comp"))
+    mock_platform(hass, "comp.config_flow", None)
 
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
-    ), pytest.raises(
-        HomeAssistantError,
-        match=r"An entry for comp already exists, but integration supports only one config entry",
-    ):
-        await hass.config_entries.async_add(
-            MockConfigEntry(
-                title="Second comp entry", domain="comp", data={"vendor": "data2"}
-            )
+    ), patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        # Start a flow
+        result = await manager.flow.async_init(
+            "comp", context={"source": config_entries.SOURCE_USER}
         )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+
+        # Add a config entry
+        entry = MockConfigEntry(
+            domain="comp",
+            unique_id="1234",
+            title="Test",
+            data={"vendor": "data"},
+            options={"vendor": "options"},
+        )
+        entry.add_to_hass(hass)
+
+        # Finish the in progress flow
+        result = await manager.flow.async_configure(
+            result["flow_id"], user_input={"host": "127.0.0.1"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.ABORT
+        assert result["reason"] == "single_instance_allowed"
+        assert result["translation_domain"] == HA_DOMAIN
 
 
 async def test_in_progress_get_canceled_when_entry_is_created(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Generator
-from contextlib import AbstractContextManager
 from datetime import timedelta
 import logging
 from typing import Any
@@ -4469,7 +4468,6 @@ async def test_starting_config_flow_on_single_config_entry(
     manager: config_entries.ConfigEntries,
     source: str,
     user_input: dict,
-    expectation: AbstractContextManager,
     expected_result: dict,
 ) -> None:
     """Test starting a config flow for a single config entry integration.
@@ -4511,7 +4509,7 @@ async def test_starting_config_flow_on_single_config_entry(
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
-    ), expectation:
+    ):
         result = await hass.config_entries.flow.async_init(
             "comp", context={"source": source}, data=user_input
         )
@@ -4550,7 +4548,6 @@ async def test_starting_config_flow_on_single_config_entry_2(
     manager: config_entries.ConfigEntries,
     source: str,
     user_input: dict,
-    expectation: AbstractContextManager,
     expected_result: dict,
 ) -> None:
     """Test starting a config flow for a single config entry integration.
@@ -4584,7 +4581,7 @@ async def test_starting_config_flow_on_single_config_entry_2(
     with patch(
         "homeassistant.loader.async_get_integration",
         return_value=integration,
-    ), expectation:
+    ):
         result = await hass.config_entries.flow.async_init(
             "comp", context={"source": source}, data=user_input
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Return FlowResultType.ABORT instead of raising when violating `single_config_entry` rules

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
