### PR TITLE
Add alarm and connectivity binary_sensors to myuplink

### DIFF
--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -1,8 +1,9 @@
 """Binary sensors for myUplink."""
 
-from myuplink import DevicePoint
+from myuplink import DeviceConnectionState, DevicePoint
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -13,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import MyUplinkDataCoordinator
 from .const import DOMAIN
-from .entity import MyUplinkEntity
+from .entity import MyUplinkEntity, MyUplinkSystemEntity
 from .helpers import find_matching_platform
 
 CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, BinarySensorEntityDescription]] = {
@@ -24,6 +25,17 @@ CATEGORY_BASED_DESCRIPTIONS: dict[str, dict[str, BinarySensorEntityDescription]]
         ),
     },
 }
+
+CONNECTED_BINARY_SENSOR_DESCRIPTION = BinarySensorEntityDescription(
+    key="connected_state",
+    device_class=BinarySensorDeviceClass.CONNECTIVITY,
+)
+
+ALARM_BINARY_SENSOR_DESCRIPTION = BinarySensorEntityDescription(
+    key="has_alarm",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    name="Alarm",
+)
 
 
 def get_description(device_point: DevicePoint) -> BinarySensorEntityDescription | None:
@@ -46,7 +58,7 @@ async def async_setup_entry(
     entities: list[BinarySensorEntity] = []
     coordinator: MyUplinkDataCoordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Setup device point sensors
+    # Setup device point bound sensors
     for device_id, point_data in coordinator.data.points.items():
         for point_id, device_point in point_data.items():
             if find_matching_platform(device_point) == Platform.BINARY_SENSOR:
@@ -61,11 +73,37 @@ async def async_setup_entry(
                         unique_id_suffix=point_id,
                     )
                 )
+
+    # Setup device bound sensors
+    for system in coordinator.data.systems:
+        for device in system.devices:
+            entities.append(
+                MyUplinkDeviceBinarySensor(
+                    coordinator=coordinator,
+                    device_id=device.id,
+                    entity_description=CONNECTED_BINARY_SENSOR_DESCRIPTION,
+                    unique_id_suffix="connection_state",
+                )
+            )
+
+    # Setup system bound sensors
+    for system in coordinator.data.systems:
+        device_id = system.devices[0].id
+        entities.append(
+            MyUplinkSystemBinarySensor(
+                coordinator=coordinator,
+                device_id=device_id,
+                system_id=system.id,
+                entity_description=ALARM_BINARY_SENSOR_DESCRIPTION,
+                unique_id_suffix="has_alarm",
+            )
+        )
+
     async_add_entities(entities)
 
 
 class MyUplinkDevicePointBinarySensor(MyUplinkEntity, BinarySensorEntity):
-    """Representation of a myUplink device point binary sensor."""
+    """Representation of a myUplink device point bound binary sensor."""
 
     def __init__(
         self,
@@ -94,3 +132,68 @@ class MyUplinkDevicePointBinarySensor(MyUplinkEntity, BinarySensorEntity):
         """Binary sensor state value."""
         device_point = self.coordinator.data.points[self.device_id][self.point_id]
         return int(device_point.value) != 0
+
+    @property
+    def available(self) -> bool:
+        """Return device data availability."""
+        return super().available and (
+            self.coordinator.data.devices[self.device_id].connectionState
+            == DeviceConnectionState.Connected
+        )
+
+
+class MyUplinkDeviceBinarySensor(MyUplinkEntity, BinarySensorEntity):
+    """Representation of a myUplink device bound binary sensor."""
+
+    def __init__(
+        self,
+        coordinator: MyUplinkDataCoordinator,
+        device_id: str,
+        entity_description: BinarySensorEntityDescription | None,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the binary_sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            device_id=device_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+        if entity_description is not None:
+            self.entity_description = entity_description
+
+    @property
+    def is_on(self) -> bool:
+        """Binary sensor state value."""
+        return (
+            self.coordinator.data.devices[self.device_id].connectionState
+            == DeviceConnectionState.Connected
+        )
+
+
+class MyUplinkSystemBinarySensor(MyUplinkSystemEntity, BinarySensorEntity):
+    """Representation of a myUplink system bound binary sensor."""
+
+    def __init__(
+        self,
+        coordinator: MyUplinkDataCoordinator,
+        system_id: str,
+        device_id: str,
+        entity_description: BinarySensorEntityDescription | None,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the binary_sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            system_id=system_id,
+            device_id=device_id,
+            unique_id_suffix=unique_id_suffix,
+        )
+
+        if entity_description is not None:
+            self.entity_description = entity_description
+
+    @property
+    def is_on(self) -> bool:
+        """Binary sensor state value."""
+        return self.coordinator.data.systems[0].has_alarm

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -196,5 +196,9 @@ class MyUplinkSystemBinarySensor(MyUplinkSystemEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Binary sensor state value."""
-        _systems = {x.system_id: x for x in self.coordinator.data.systems}
-        return _systems[self.system_id].has_alarm
+        retval = None
+        for system in self.coordinator.data.systems:
+            if system.id == self.system_id:
+                retval = system.has_alarm
+                break
+        return retval

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -196,7 +196,9 @@ class MyUplinkSystemBinarySensor(MyUplinkSystemEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool | None:
         """Binary sensor state value."""
+        retval = None
         for system in self.coordinator.data.systems:
             if system.id == self.system_id:
-                return system.has_alarm
-        return None
+                retval = system.has_alarm
+                break
+        return retval

--- a/homeassistant/components/myuplink/binary_sensor.py
+++ b/homeassistant/components/myuplink/binary_sensor.py
@@ -194,6 +194,9 @@ class MyUplinkSystemBinarySensor(MyUplinkSystemEntity, BinarySensorEntity):
             self.entity_description = entity_description
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Binary sensor state value."""
-        return self.coordinator.data.systems[0].has_alarm
+        for system in self.coordinator.data.systems:
+            if system.id == self.system_id:
+                return system.has_alarm
+        return None

--- a/homeassistant/components/myuplink/entity.py
+++ b/homeassistant/components/myuplink/entity.py
@@ -29,10 +29,8 @@ class MyUplinkEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
 
 
-class MyUplinkSystemEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
+class MyUplinkSystemEntity(MyUplinkEntity):
     """Representation of a system bound entity."""
-
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -42,11 +40,14 @@ class MyUplinkSystemEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
         unique_id_suffix: str,
     ) -> None:
         """Initialize the entity."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(
+            coordinator=coordinator,
+            device_id=device_id,
+            unique_id_suffix=unique_id_suffix,
+        )
 
         # Internal properties
         self.system_id = system_id
 
         # Basic values
         self._attr_unique_id = f"{system_id}-{unique_id_suffix}"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})

--- a/homeassistant/components/myuplink/entity.py
+++ b/homeassistant/components/myuplink/entity.py
@@ -8,7 +8,7 @@ from .coordinator import MyUplinkDataCoordinator
 
 
 class MyUplinkEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
-    """Representation of a sensor."""
+    """Representation of myuplink entity."""
 
     _attr_has_entity_name = True
 
@@ -18,7 +18,7 @@ class MyUplinkEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
         device_id: str,
         unique_id_suffix: str,
     ) -> None:
-        """Initialize the sensor."""
+        """Initialize the entity."""
         super().__init__(coordinator=coordinator)
 
         # Internal properties
@@ -26,4 +26,27 @@ class MyUplinkEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
 
         # Basic values
         self._attr_unique_id = f"{device_id}-{unique_id_suffix}"
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})
+
+
+class MyUplinkSystemEntity(CoordinatorEntity[MyUplinkDataCoordinator]):
+    """Representation of a system bound entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: MyUplinkDataCoordinator,
+        system_id: str,
+        device_id: str,
+        unique_id_suffix: str,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator=coordinator)
+
+        # Internal properties
+        self.system_id = system_id
+
+        # Basic values
+        self._attr_unique_id = f"{system_id}-{unique_id_suffix}"
         self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, device_id)})

--- a/homeassistant/components/myuplink/strings.json
+++ b/homeassistant/components/myuplink/strings.json
@@ -25,5 +25,12 @@
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "alarm": {
+        "name": "Alarm"
+      }
+    }
   }
 }

--- a/tests/components/myuplink/test_binary_sensor.py
+++ b/tests/components/myuplink/test_binary_sensor.py
@@ -1,6 +1,8 @@
 """Tests for myuplink sensor module."""
 
-from unittest.mock import MagicMock  # noqa: I001
+from unittest.mock import MagicMock
+
+import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
@@ -9,16 +11,29 @@ from . import setup_integration
 
 from tests.common import MockConfigEntry
 
-import pytest
-
 
 # Test one entity from each of binary_sensor classes.
 @pytest.mark.parametrize(
-    ("entity_id", "test_attributes", "expected_state"),
+    ("entity_id", "friendly_name", "test_attributes", "expected_state"),
     [
-        ("binary_sensor.f730_cu_3x400v_pump_heating_medium_gp1", True, STATE_ON),
-        ("binary_sensor.f730_cu_3x400v_connectivity", False, STATE_ON),
-        ("binary_sensor.f730_cu_3x400v_alarm", False, STATE_OFF),
+        (
+            "binary_sensor.gotham_city_pump_heating_medium_gp1",
+            "Gotham City Pump: Heating medium (GP1)",
+            True,
+            STATE_ON,
+        ),
+        (
+            "binary_sensor.gotham_city_connectivity",
+            "Gotham City Connectivity",
+            False,
+            STATE_ON,
+        ),
+        (
+            "binary_sensor.gotham_city_alarm",
+            "Gotham City Pump: Alarm",
+            False,
+            STATE_OFF,
+        ),
     ],
 )
 async def test_sensor_states(
@@ -26,6 +41,7 @@ async def test_sensor_states(
     mock_myuplink_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_id: str,
+    friendly_name: str,
     test_attributes: bool,
     expected_state: str,
 ) -> None:
@@ -37,5 +53,5 @@ async def test_sensor_states(
     assert state.state == expected_state
     if test_attributes:
         assert state.attributes == {
-            "friendly_name": "F730 CU 3x400V Pump: Heating medium (GP1)",
+            "friendly_name": friendly_name,
         }

--- a/tests/components/myuplink/test_binary_sensor.py
+++ b/tests/components/myuplink/test_binary_sensor.py
@@ -1,25 +1,41 @@
 """Tests for myuplink sensor module."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock  # noqa: I001
 
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
 from . import setup_integration
 
 from tests.common import MockConfigEntry
 
+import pytest
 
+
+# Test one entity from each of binary_sensor classes.
+@pytest.mark.parametrize(
+    ("entity_id", "test_attributes", "expected_state"),
+    [
+        ("binary_sensor.f730_cu_3x400v_pump_heating_medium_gp1", True, STATE_ON),
+        ("binary_sensor.f730_cu_3x400v_connectivity", False, STATE_ON),
+        ("binary_sensor.f730_cu_3x400v_alarm", False, STATE_OFF),
+    ],
+)
 async def test_sensor_states(
     hass: HomeAssistant,
     mock_myuplink_client: MagicMock,
     mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    test_attributes: bool,
+    expected_state: str,
 ) -> None:
     """Test sensor state."""
     await setup_integration(hass, mock_config_entry)
 
-    state = hass.states.get("binary_sensor.gotham_city_pump_heating_medium_gp1")
+    state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == "on"
-    assert state.attributes == {
-        "friendly_name": "Gotham City Pump: Heating medium (GP1)",
-    }
+    assert state.state == expected_state
+    if test_attributes:
+        assert state.attributes == {
+            "friendly_name": "F730 CU 3x400V Pump: Heating medium (GP1)",
+        }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds binary sensors for alarm and connected states. The alarm entity is bound to the system level in API and connected_state is bound to device level in api. All previous binary sensors are bound to device-point objects. Therefore we create different binary_sensor classes for these three principially different sensors. This is to avoid intricate checks in a common myuplink binary sensor base class.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
