### PR TITLE
2024.2.5

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -828,6 +828,7 @@ class ConfigEntry:
             issue_domain=self.domain,
             severity=ir.IssueSeverity.ERROR,
             translation_key="config_entry_reauth",
+            translation_placeholders={"name": self.title},
         )
 
     @callback

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 2
-PATCH_VERSION: Final = "4"
+PATCH_VERSION: Final = "5"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -68,7 +68,7 @@
     "config_flow": {
       "title": {
         "oauth2_pick_implementation": "Pick authentication method",
-        "reauth": "Reauthenticate integration",
+        "reauth": "Authentication expired for {name}",
         "via_hassio_addon": "{name} via Home Assistant add-on"
       },
       "description": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.2.4"
+version     = "2024.2.5"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/tests/components/kitchen_sink/test_init.py
+++ b/tests/components/kitchen_sink/test_init.py
@@ -205,7 +205,7 @@ async def test_issues_created(
                 "learn_more_url": None,
                 "severity": "error",
                 "translation_key": "config_entry_reauth",
-                "translation_placeholders": None,
+                "translation_placeholders": {"name": "Kitchen Sink"},
                 "ignored": False,
             },
         ]
@@ -322,7 +322,7 @@ async def test_issues_created(
                 "learn_more_url": None,
                 "severity": "error",
                 "translation_key": "config_entry_reauth",
-                "translation_placeholders": None,
+                "translation_placeholders": {"name": "Kitchen Sink"},
                 "ignored": False,
             },
         ]

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -963,7 +963,7 @@ async def test_reauth_issue(hass: HomeAssistant) -> None:
         learn_more_url=None,
         severity=ir.IssueSeverity.ERROR,
         translation_key="config_entry_reauth",
-        translation_placeholders=None,
+        translation_placeholders={"name": "test_title"},
     )
 
     result = await hass.config_entries.flow.async_configure(issue.data["flow_id"], {})


### PR DESCRIPTION
- Add title to reauthenticate integration issue ([@timmo001] - [#111275])

[#111275]: https://github.com/home-assistant/core/pull/111275
[@timmo001]: https://github.com/timmo001

_Translations from the dev branch are included in each release. The above PR introduced a new placeholder into an existing translation. When we released 2024.2.4, it tried to render the new translation without providing the placeholder. Doing a hot fix to provide the placeholder value so this translation works again as the issue is quite visible._