### PR TITLE
Bump bring-api to 0.5.4

### DIFF
--- a/homeassistant/components/bring/coordinator.py
+++ b/homeassistant/components/bring/coordinator.py
@@ -6,7 +6,7 @@ import logging
 
 from bring_api.bring import Bring
 from bring_api.exceptions import BringParseException, BringRequestException
-from bring_api.types import BringItemsResponse, BringList
+from bring_api.types import BringList, BringPurchase
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -20,8 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 class BringData(BringList):
     """Coordinator data class."""
 
-    purchase_items: list[BringItemsResponse]
-    recently_items: list[BringItemsResponse]
+    purchase_items: list[BringPurchase]
+    recently_items: list[BringPurchase]
 
 
 class BringDataUpdateCoordinator(DataUpdateCoordinator[dict[str, BringData]]):

--- a/homeassistant/components/bring/manifest.json
+++ b/homeassistant/components/bring/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bring",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["bring-api==0.4.1"]
+  "requirements": ["bring-api==0.5.2"]
 }

--- a/homeassistant/components/bring/manifest.json
+++ b/homeassistant/components/bring/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bring",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["bring-api==0.5.3"]
+  "requirements": ["bring-api==0.5.4"]
 }

--- a/homeassistant/components/bring/manifest.json
+++ b/homeassistant/components/bring/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/bring",
   "integration_type": "service",
   "iot_class": "cloud_polling",
-  "requirements": ["bring-api==0.5.2"]
+  "requirements": ["bring-api==0.5.3"]
 }

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -2,8 +2,10 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+import uuid
 
 from bring_api.exceptions import BringRequestException
+from bring_api.types import BringItem, BringItemOperation
 
 from homeassistant.components.todo import (
     TodoItem,
@@ -76,7 +78,7 @@ class BringTodoListEntity(
         return [
             *(
                 TodoItem(
-                    uid=item["itemId"],
+                    uid=item["uuid"],
                     summary=item["itemId"],
                     description=item["specification"] or "",
                     status=TodoItemStatus.NEEDS_ACTION,
@@ -85,7 +87,7 @@ class BringTodoListEntity(
             ),
             *(
                 TodoItem(
-                    uid=item["itemId"],
+                    uid=item["uuid"],
                     summary=item["itemId"],
                     description=item["specification"] or "",
                     status=TodoItemStatus.COMPLETED,
@@ -103,7 +105,10 @@ class BringTodoListEntity(
         """Add an item to the To-do list."""
         try:
             await self.coordinator.bring.save_item(
-                self.bring_list["listUuid"], item.summary, item.description or ""
+                self.bring_list["listUuid"],
+                item.summary,
+                item.description or "",
+                str(uuid.uuid4()),
             )
         except BringRequestException as e:
             raise HomeAssistantError("Unable to save todo item for bring") from e
@@ -121,60 +126,67 @@ class BringTodoListEntity(
 
         - Completed items will move to the "completed" section in home assistant todo
             list and get moved to the recently list in bring
-        - Bring items do not have unique identifiers and are using the
-            name/summery/title. Therefore the name is not to be changed! Should a name
-            be changed anyway, a new item will be created instead and no update for
-            this item is performed and on the next cloud pull update, it will get
-            cleared and replaced seamlessly
+        - Bring shows some odd behaviour when renaming items. This is because Bring
+            did not have unique identifiers for items in the past and this is still
+            a relic from it. Therefore the name is not to be changed! Should a name
+            be changed anyway, the item will be deleted and a new item will be created
+            instead and no update for this item is performed and on the next cloud pull
+            update, it will get cleared and replaced seamlessly.
         """
 
         bring_list = self.bring_list
 
         bring_purchase_item = next(
-            (i for i in bring_list["purchase_items"] if i["itemId"] == item.uid),
+            (i for i in bring_list["purchase_items"] if i["uuid"] == item.uid),
             None,
         )
 
         bring_recently_item = next(
-            (i for i in bring_list["recently_items"] if i["itemId"] == item.uid),
+            (i for i in bring_list["recently_items"] if i["uuid"] == item.uid),
             None,
         )
 
         if TYPE_CHECKING:
             assert item.uid
 
-        if item.status == TodoItemStatus.COMPLETED and bring_purchase_item:
-            await self.coordinator.bring.complete_item(
-                bring_list["listUuid"],
-                item.uid,
-            )
-
-        elif item.status == TodoItemStatus.NEEDS_ACTION and bring_recently_item:
-            await self.coordinator.bring.save_item(
-                bring_list["listUuid"],
-                item.uid,
-            )
-
-        elif item.summary == item.uid:
+        current_item = bring_purchase_item or bring_recently_item
+        if item.summary == current_item["itemId"]:
             try:
-                await self.coordinator.bring.update_item(
+                await self.coordinator.bring.batch_update_list(
                     bring_list["listUuid"],
-                    item.uid,
-                    item.description or "",
+                    BringItem(
+                        itemId=item.summary,
+                        spec=item.description,
+                        uuid=item.uid,
+                    ),
+                    BringItemOperation.ADD
+                    if item.status == TodoItemStatus.NEEDS_ACTION
+                    else BringItemOperation.COMPLETE,
                 )
             except BringRequestException as e:
                 raise HomeAssistantError("Unable to update todo item for bring") from e
         else:
             try:
-                await self.coordinator.bring.remove_item(
+                await self.coordinator.bring.batch_update_list(
                     bring_list["listUuid"],
-                    item.uid,
+                    [
+                        BringItem(
+                            itemId=current_item["itemId"],
+                            spec=item.description,
+                            uuid=item.uid,
+                            operation=BringItemOperation.REMOVE,
+                        ),
+                        BringItem(
+                            itemId=item.summary,
+                            spec=item.description,
+                            uuid=str(uuid.uuid4()),
+                            operation=BringItemOperation.ADD
+                            if item.status == TodoItemStatus.NEEDS_ACTION
+                            else BringItemOperation.COMPLETE,
+                        ),
+                    ],
                 )
-                await self.coordinator.bring.save_tem(
-                    bring_list["listUuid"],
-                    item.summary,
-                    item.description or "",
-                )
+
             except BringRequestException as e:
                 raise HomeAssistantError("Unable to replace todo item for bring") from e
 
@@ -182,12 +194,21 @@ class BringTodoListEntity(
 
     async def async_delete_todo_items(self, uids: list[str]) -> None:
         """Delete an item from the To-do list."""
-        for uid in uids:
-            try:
-                await self.coordinator.bring.remove_item(
-                    self.bring_list["listUuid"], uid
-                )
-            except BringRequestException as e:
-                raise HomeAssistantError("Unable to delete todo item for bring") from e
+
+        try:
+            await self.coordinator.bring.batch_update_list(
+                self.bring_list["listUuid"],
+                [
+                    BringItem(
+                        itemId=uid,
+                        spec="",
+                        uuid=uid,
+                    )
+                    for uid in uids
+                ],
+                BringItemOperation.REMOVE,
+            )
+        except BringRequestException as e:
+            raise HomeAssistantError("Unable to delete todo item for bring") from e
 
         await self.coordinator.async_refresh()

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -146,10 +146,12 @@ class BringTodoListEntity(
             None,
         )
 
+        current_item = bring_purchase_item or bring_recently_item
+
         if TYPE_CHECKING:
             assert item.uid
+            assert current_item
 
-        current_item = bring_purchase_item or bring_recently_item
         if item.summary == current_item["itemId"]:
             try:
                 await self.coordinator.bring.batch_update_list(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -603,7 +603,7 @@ boschshcpy==0.2.75
 boto3==1.33.13
 
 # homeassistant.components.bring
-bring-api==0.4.1
+bring-api==0.5.2
 
 # homeassistant.components.broadlink
 broadlink==0.18.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -603,7 +603,7 @@ boschshcpy==0.2.75
 boto3==1.33.13
 
 # homeassistant.components.bring
-bring-api==0.5.3
+bring-api==0.5.4
 
 # homeassistant.components.broadlink
 broadlink==0.18.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -603,7 +603,7 @@ boschshcpy==0.2.75
 boto3==1.33.13
 
 # homeassistant.components.bring
-bring-api==0.5.2
+bring-api==0.5.3
 
 # homeassistant.components.broadlink
 broadlink==0.18.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -514,7 +514,7 @@ bond-async==0.2.1
 boschshcpy==0.2.75
 
 # homeassistant.components.bring
-bring-api==0.4.1
+bring-api==0.5.2
 
 # homeassistant.components.broadlink
 broadlink==0.18.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -514,7 +514,7 @@ bond-async==0.2.1
 boschshcpy==0.2.75
 
 # homeassistant.components.bring
-bring-api==0.5.3
+bring-api==0.5.4
 
 # homeassistant.components.broadlink
 broadlink==0.18.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -514,7 +514,7 @@ bond-async==0.2.1
 boschshcpy==0.2.75
 
 # homeassistant.components.bring
-bring-api==0.5.2
+bring-api==0.5.3
 
 # homeassistant.components.broadlink
 broadlink==0.18.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Diff: https://github.com/miaucl/bring-api/compare/0.4.1...0.5.4
- Changelog: https://github.com/miaucl/bring-api/blob/0.5.4/CHANGELOG.md

Version 0.5.3 adds a new method that allows it to interact with the Bring API in the same way as the mobile apps and therefore it is now possible to use the uuid of items as unique identifiers (API Endpoints used by the webApp did not expose the item uuid). This allows it do add multiple items with the same name but different descriptions (specifications), an issue that a user tried to fix in this PR:
- #110226

Additionally the bring-api is now packaged with translation tables. The translation tables that are used by the webApp and were downloaded in the bring-api library before, but are outdated and differ slightly from the translation tables used in the mobile apps. 





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
