### PR TITLE
Deprecate old config options for MQTT json light

### DIFF
--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -75,7 +75,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "mqtt_json"
 
-DEFAULT_BRIGHTNESS = False
+DEFAULT_BRIGHTNESS = True
 DEFAULT_COLOR_MODE = False
 DEFAULT_COLOR_TEMP = False
 DEFAULT_EFFECT = False

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -75,7 +75,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "mqtt_json"
 
-DEFAULT_BRIGHTNESS = True
+DEFAULT_BRIGHTNESS = False
 DEFAULT_COLOR_MODE = False
 DEFAULT_COLOR_TEMP = False
 DEFAULT_EFFECT = False

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -244,21 +244,11 @@ _PLATFORM_SCHEMA_BASE = (
 DISCOVERY_SCHEMA_JSON = vol.All(
     valid_color_configuration(False),
     _PLATFORM_SCHEMA_BASE.extend({}, extra=vol.REMOVE_EXTRA),
-    cv.deprecated(CONF_COLOR_MODE),
-    cv.deprecated(CONF_COLOR_TEMP),
-    cv.deprecated(CONF_HS),
-    cv.deprecated(CONF_RGB),
-    cv.deprecated(CONF_XY),
 )
 
 PLATFORM_SCHEMA_MODERN_JSON = vol.All(
     valid_color_configuration(True),
     _PLATFORM_SCHEMA_BASE,
-    cv.deprecated(CONF_COLOR_MODE),
-    cv.deprecated(CONF_COLOR_TEMP),
-    cv.deprecated(CONF_HS),
-    cv.deprecated(CONF_RGB),
-    cv.deprecated(CONF_XY),
 )
 
 
@@ -305,7 +295,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
         self._attr_supported_features |= (
             config[CONF_EFFECT] and LightEntityFeature.EFFECT
         )
-        if supported_color_modes := self._config.get(CONF_SUPPORTED_COLOR_MODES, []):
+        if supported_color_modes := self._config.get(CONF_SUPPORTED_COLOR_MODES):
             self._attr_supported_color_modes = supported_color_modes
             if self.supported_color_modes and len(self.supported_color_modes) == 1:
                 self._attr_color_mode = next(iter(self.supported_color_modes))
@@ -586,7 +576,8 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
 
     def _scale_rgbxx(self, rgbxx: tuple[int, ...], kwargs: Any) -> tuple[int, ...]:
         # If brightness is supported, we don't want to scale the
-        # RGBxx values given using the brightness.
+        # RGBxx values given using the brightness and
+        # we pop the brightness, to omit it from the payload
         brightness: int
         if self._config[CONF_BRIGHTNESS]:
             brightness = 255
@@ -628,7 +619,7 @@ class MqttLightJson(MqttEntity, LightEntity, RestoreEntity):
                 if self._config[CONF_BRIGHTNESS]:
                     brightness = 255
                 else:
-                    # We pop the brightness, to omit it in the payload
+                    # We pop the brightness, to omit it from the payload
                     brightness = kwargs.pop(ATTR_BRIGHTNESS, 255)
                 rgb = color_util.color_hsv_to_RGB(
                     hs_color[0], hs_color[1], brightness / 255 * 100

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -122,8 +122,8 @@ def valid_color_configuration(
         elif deprecated_flags_used:
             deprecated_flags = ", ".join(key for key in deprecated if key in config)
             _LOGGER.warning(
-                "MQTT json light config uses deprecated flags [%s] for "
-                "handling color mode, `supported_color_modes` not found. "
+                "Deprecated flags [%s] used in MQTT JSON light config "
+                "for handling color mode, please use `supported_color_modes` instead. "
                 "Got: %s. This will stop working in Home Assistant Core 2025.3",
                 deprecated_flags,
                 config,
@@ -151,6 +151,38 @@ def valid_color_configuration(
                 },
                 translation_key="deprecated_color_handling",
             )
+
+        if CONF_COLOR_MODE in config:
+            _LOGGER.warning(
+                "Deprecated flag `color_mode` used in MQTT JSON light config "
+                ", the `color_mode` flag is not used anymore and should be removed. "
+                "Got: %s. This will stop working in Home Assistant Core 2025.3",
+                config,
+            )
+            if not setup_from_yaml:
+                return config
+            issue_id = hex(hash(frozenset(config)))
+            yaml_config_str = yaml_dump(config)
+            learn_more_url = (
+                "https://www.home-assistant.io/integrations/"
+                f"{LIGHT_DOMAIN}.mqtt/#json-schema"
+            )
+            hass = async_get_hass()
+            async_create_issue(
+                hass,
+                MQTT_DOMAIN,
+                issue_id,
+                breaks_in_ha_version="2025.3.0",
+                issue_domain=LIGHT_DOMAIN,
+                is_fixable=False,
+                severity=IssueSeverity.WARNING,
+                learn_more_url=learn_more_url,
+                translation_placeholders={
+                    "config": yaml_config_str,
+                },
+                translation_key="deprecated_color_mode_flag",
+            )
+
         return config
 
     return _valid_color_configuration

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -4,6 +4,10 @@
       "title": "MQTT vacuum entities with deprecated `schema` config settings found in your configuration.yaml",
       "description": "The `schema` setting for MQTT vacuum entities is deprecated and should be removed. Please adjust your configuration.yaml and restart Home Assistant to fix this issue."
     },
+    "deprecated_color_handling": {
+      "title": "Deprecated color handling used for MQTT light",
+      "description": "MQTT light (with `json` schema), with deprecated color handling flags, found in `configuration.yaml`.\n\nConfiguration found:\n```yaml\n{config}\n```\nDeprecated flags: **{deprecated_flags}**.\n\nUse the `supported_color_modes` option instead and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
+    },
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",
       "description": "Home Assistant detected an invalid config for a manually configured item.\n\nPlatform domain: **{domain}**\nConfiguration file: **{config_file}**\nNear line: **{line}**\nConfiguration found:\n```yaml\n{config}\n```\nError: **{error}**.\n\nMake sure the configuration is valid and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."

--- a/homeassistant/components/mqtt/strings.json
+++ b/homeassistant/components/mqtt/strings.json
@@ -6,7 +6,11 @@
     },
     "deprecated_color_handling": {
       "title": "Deprecated color handling used for MQTT light",
-      "description": "MQTT light (with `json` schema), with deprecated color handling flags, found in `configuration.yaml`.\n\nConfiguration found:\n```yaml\n{config}\n```\nDeprecated flags: **{deprecated_flags}**.\n\nUse the `supported_color_modes` option instead and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
+      "description": "An MQTT light config (with `json` schema) found in `configuration.yaml` uses deprecated color handling flags.\n\nConfiguration found:\n```yaml\n{config}\n```\nDeprecated flags: **{deprecated_flags}**.\n\nUse the `supported_color_modes` option instead and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
+    },
+    "deprecated_color_mode_flag": {
+      "title": "Deprecated color_mode option flag used for MQTT light",
+      "description": "An MQTT light config (with `json` schema) found in `configuration.yaml` uses a deprecated `color_mode` flag.\n\nConfiguration found:\n```yaml\n{config}\n```\n\nRemove the option from your config and [reload](/developer-tools/yaml) the manually configured MQTT items or restart Home Assistant to fix this issue."
     },
     "invalid_platform_config": {
       "title": "Invalid config found for mqtt {domain} item",

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1346,7 +1346,6 @@ async def test_sending_hs_color(
                     "name": "test",
                     "command_topic": "test_light_rgb/set",
                     "rgb": True,
-                    "brightness": "False",
                 }
             }
         }
@@ -1406,7 +1405,6 @@ async def test_sending_rgb_color_no_brightness(
                     "name": "test",
                     "schema": "json",
                     "supported_color_modes": ["rgb", "rgbw", "rgbww"],
-                    "brightness": "False",
                 }
             }
         }

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1346,6 +1346,7 @@ async def test_sending_hs_color(
                     "name": "test",
                     "command_topic": "test_light_rgb/set",
                     "rgb": True,
+                    "brightness": "False",
                 }
             }
         }
@@ -1405,6 +1406,7 @@ async def test_sending_rgb_color_no_brightness(
                     "name": "test",
                     "schema": "json",
                     "supported_color_modes": ["rgb", "rgbw", "rgbww"],
+                    "brightness": "False",
                 }
             }
         }

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -1351,7 +1351,7 @@ async def test_sending_hs_color(
         }
     ],
 )
-async def test_sending_rgb_color_no_brightness(
+async def test_sending_rgb_color(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
@@ -1373,19 +1373,25 @@ async def test_sending_rgb_color_no_brightness(
         [
             call(
                 "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 0, "g": 24, "b": 50}}'),
+                JsonValidator(
+                    '{"state":"ON","color":{"r":255,"g":56,"b":59},"brightness":50}'
+                ),
                 0,
                 False,
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 50, "g": 11, "b": 11}}'),
+                JsonValidator(
+                    '{"state":"ON","color":{"r":0,"g":123,"b":255},"brightness":50}'
+                ),
                 0,
                 False,
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
+                JsonValidator(
+                    '{"state":"ON","color":{"r":255,"g":128,"b":0},"brightness":255}'
+                ),
                 0,
                 False,
             ),
@@ -1437,26 +1443,8 @@ async def test_sending_rgb_color_no_brightness2(
         [
             call(
                 "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 0, "g": 24, "b": 50}}'),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 50, "g": 11, "b": 12}}'),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
-                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
                 JsonValidator(
-                    '{"state": "ON", "color": {"r": 64, "g": 32, "b": 16, "w": 8}}'
+                    '{"state": "ON", "color": {"r": 0, "g": 24, "b": 50},"brightness":50}'
                 ),
                 0,
                 False,
@@ -1464,7 +1452,31 @@ async def test_sending_rgb_color_no_brightness2(
             call(
                 "test_light_rgb/set",
                 JsonValidator(
-                    '{"state": "ON", "color": {"r": 32, "g": 16, "b": 8, "c": 4, "w": 2}}'
+                    '{"state": "ON", "color": {"r": 50, "g": 11, "b": 12},"brightness":50}'
+                ),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
+                JsonValidator(
+                    '{"state": "ON", "color": {"r": 255, "g": 128, "b": 0},"brightness":255}'
+                ),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
+                JsonValidator(
+                    '{"state": "ON", "color": {"r": 128, "g": 64, "b": 32, "w": 16},"brightness":128}'
+                ),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
+                JsonValidator(
+                    '{"state": "ON", "color": {"r": 128, "g": 64, "b": 32, "c": 16, "w": 8},"brightness":64}'
                 ),
                 0,
                 False,

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -217,7 +217,7 @@ async def test_fail_setup_if_color_mode_deprecated(
 ) -> None:
     """Test if setup fails if color mode is combined with deprecated config keys."""
     assert await mqtt_mock_entry()
-    assert "color_mode must not be combined with any of" in caplog.text
+    assert "supported_color_modes must not be combined with any of" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -1351,7 +1351,7 @@ async def test_sending_hs_color(
         }
     ],
 )
-async def test_sending_rgb_color(
+async def test_sending_rgb_color_no_brightness(
     hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test light.turn_on with hs color sends rgb color parameters."""
@@ -1373,25 +1373,19 @@ async def test_sending_rgb_color(
         [
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state":"ON","color":{"r":255,"g":56,"b":59},"brightness":50}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"r": 0, "g": 24, "b": 50}}'),
                 0,
                 False,
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state":"ON","color":{"r":0,"g":123,"b":255},"brightness":50}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"r": 50, "g": 11, "b": 11}}'),
                 0,
                 False,
             ),
             call(
                 "test_light_rgb/set",
-                JsonValidator(
-                    '{"state":"ON","color":{"r":255,"g":128,"b":0},"brightness":255}'
-                ),
+                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
                 0,
                 False,
             ),
@@ -1443,8 +1437,26 @@ async def test_sending_rgb_color_no_brightness2(
         [
             call(
                 "test_light_rgb/set",
+                JsonValidator('{"state": "ON", "color": {"r": 0, "g": 24, "b": 50}}'),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
+                JsonValidator('{"state": "ON", "color": {"r": 50, "g": 11, "b": 12}}'),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
+                JsonValidator('{"state": "ON", "color": {"r": 255, "g": 128, "b": 0}}'),
+                0,
+                False,
+            ),
+            call(
+                "test_light_rgb/set",
                 JsonValidator(
-                    '{"state": "ON", "color": {"r": 0, "g": 24, "b": 50},"brightness":50}'
+                    '{"state": "ON", "color": {"r": 64, "g": 32, "b": 16, "w": 8}}'
                 ),
                 0,
                 False,
@@ -1452,31 +1464,7 @@ async def test_sending_rgb_color_no_brightness2(
             call(
                 "test_light_rgb/set",
                 JsonValidator(
-                    '{"state": "ON", "color": {"r": 50, "g": 11, "b": 12},"brightness":50}'
-                ),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"r": 255, "g": 128, "b": 0},"brightness":255}'
-                ),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"r": 128, "g": 64, "b": 32, "w": 16},"brightness":128}'
-                ),
-                0,
-                False,
-            ),
-            call(
-                "test_light_rgb/set",
-                JsonValidator(
-                    '{"state": "ON", "color": {"r": 128, "g": 64, "b": 32, "c": 16, "w": 8},"brightness":64}'
+                    '{"state": "ON", "color": {"r": 32, "g": 16, "b": 8, "c": 4, "w": 2}}'
                 ),
                 0,
                 False,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Support for `brightness` is now assumed for `mqtt` lights with the `json` schema unless only color modes `rgb`, `rgbw` or `rgbww` are supported.

For light which only support  color modes `rgb`, `rgbw` or `rgbww`,  the `brightness` option flag can still be set to `false` if brightness is not supported, in this case brightness support is emulated in Home Assistant by scaling the RGBx-values.

For all other color modes except `ColorMode.ONOFF`, it is assumed brightness is supported and the `brightness` attribute will be included in the MQTT payload when the `brightness` attribute is supplied to the `light.turn_on` service.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate the flag settings `color_mode`, `color_temp`, `hs`, `rgb` and `xy` for the mqtt `light` schema. The options `color_temp`, `hs`, `rgb` and `xy` were already removed from the documentation, but the options were not marked deprecated in the schema yet.

The `color_mode` flag is not used anymore, and should be removed. Instead `supported_color_modes` is checked. If it is not set, then the `color_temp`, hs`, `rgb` and `xy` flags will still be evaluated.

Brightness is assumed to be supported by default. For `rgbx` lights that do not support brightness `brightness` should be explicitly set to `false`.

The deprecated options are planned to be removed with HA Core 2025.3, this is in line with the deprecation grace period on the light entity platform support.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #110682
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31707

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
