### PR TITLE
Avoid creating system monitor disk sensors for non-dirs

### DIFF
--- a/homeassistant/components/systemmonitor/util.py
+++ b/homeassistant/components/systemmonitor/util.py
@@ -30,6 +30,12 @@ def get_all_disk_mounts(hass: HomeAssistant) -> set[str]:
             # Ignore disks which are memory
             continue
         try:
+            if not os.path.isdir(part.mountpoint):
+                _LOGGER.debug(
+                    "Mountpoint %s was excluded because it is not a directory",
+                    part.mountpoint,
+                )
+                continue
             usage = psutil_wrapper.psutil.disk_usage(part.mountpoint)
         except PermissionError:
             _LOGGER.debug(

--- a/tests/components/systemmonitor/conftest.py
+++ b/tests/components/systemmonitor/conftest.py
@@ -162,6 +162,7 @@ def mock_psutil(mock_process: list[MockProcess]) -> Generator:
             sdiskpart("test", "/", "ext4", "", 1, 1),
             sdiskpart("test2", "/media/share", "ext4", "", 1, 1),
             sdiskpart("test3", "/incorrect", "", "", 1, 1),
+            sdiskpart("hosts", "/etc/hosts", "bind", "", 1, 1),
             sdiskpart("proc", "/proc/run", "proc", "", 1, 1),
         ]
         mock_psutil.boot_time.return_value = 1708786800.0
@@ -172,6 +173,11 @@ def mock_psutil(mock_process: list[MockProcess]) -> Generator:
 @pytest.fixture
 def mock_os() -> Generator:
     """Mock os."""
+
+    def isdir(path: str) -> bool:
+        """Mock os.path.isdir."""
+        return path != "/etc/hosts"
+
     with patch(
         "homeassistant.components.systemmonitor.coordinator.os"
     ) as mock_os, patch(
@@ -179,4 +185,5 @@ def mock_os() -> Generator:
     ) as mock_os_util:
         mock_os_util.name = "nt"
         mock_os.getloadavg.return_value = (1, 2, 3)
+        mock_os_util.path.isdir = isdir
         yield mock_os


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we create sensors for /etc/hosts, /etc/asound.conf, etc, since they are bind mounts in the container. These all have to have their own coordinator which increases startup time. This seemed like a bug to include these files since they are unlikely to change in size and are provided by haos in most cases.

```
2024-02-27 21:01:53.363 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Mountpoint /etc/asound.conf was excluded because it is not a directory
2024-02-27 21:01:53.363 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Mountpoint /etc/resolv.conf was excluded because it is not a directory
2024-02-27 21:01:53.363 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Mountpoint /etc/hostname was excluded because it is not a directory
2024-02-27 21:01:53.363 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Mountpoint /etc/hosts was excluded because it is not a directory
2024-02-27 21:01:53.364 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Mountpoint /etc/pulse/client.conf was excluded because it is not a directory
2024-02-27 21:01:53.364 DEBUG (SyncWorker_11) [homeassistant.components.systemmonitor.util] Adding disks: /, /ssl, /config, /run/audio, /media, /share
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
