### PR TITLE
Bump yalexs to 2.0.0

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -305,6 +305,13 @@ class AugustData(AugustSubscriberMixin):
                     exc_info=err,
                 )
 
+    async def refresh_camera_by_id(self, device_id: str) -> None:
+        """Re-fetch doorbell/camera data from API."""
+        await self._async_update_device_detail(
+            self._doorbells_by_id[device_id],
+            self._api.async_get_doorbell_detail,
+        )
+
     async def _async_refresh_device_detail_by_id(self, device_id: str) -> None:
         if device_id in self._locks_by_id:
             if self.activity_stream and self.activity_stream.pubnub.connected:

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -1,9 +1,12 @@
 """Support for August doorbell camera."""
 from __future__ import annotations
 
+import logging
+
 from aiohttp import ClientSession
 from yalexs.activity import ActivityType
-from yalexs.doorbell import Doorbell
+from yalexs.const import Brand
+from yalexs.doorbell import ContentTokenExpired, Doorbell
 from yalexs.util import update_doorbell_image_from_activity
 
 from homeassistant.components.camera import Camera
@@ -15,6 +18,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from . import AugustData
 from .const import DEFAULT_NAME, DEFAULT_TIMEOUT, DOMAIN
 from .entity import AugustEntityMixin
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -47,6 +52,7 @@ class AugustCamera(AugustEntityMixin, Camera):
         self._timeout = timeout
         self._session = session
         self._image_url = None
+        self._content_token = None
         self._image_content = None
         self._attr_unique_id = f"{self._device_id:s}_camera"
         self._attr_motion_detection_enabled = True
@@ -62,6 +68,12 @@ class AugustCamera(AugustEntityMixin, Camera):
         """Return the camera model."""
         return self._detail.model
 
+    async def _async_update(self):
+        """Update device."""
+        _LOGGER.debug("async_update called %s", self._detail.device_name)
+        await self._data.refresh_camera_by_id(self._device_id)
+        self._update_from_data()
+
     @callback
     def _update_from_data(self) -> None:
         """Get the latest state of the sensor."""
@@ -69,7 +81,6 @@ class AugustCamera(AugustEntityMixin, Camera):
             self._device_id,
             {ActivityType.DOORBELL_MOTION, ActivityType.DOORBELL_IMAGE_CAPTURE},
         )
-
         if doorbell_activity is not None:
             update_doorbell_image_from_activity(self._detail, doorbell_activity)
 
@@ -81,7 +92,23 @@ class AugustCamera(AugustEntityMixin, Camera):
 
         if self._image_url is not self._detail.image_url:
             self._image_url = self._detail.image_url
-            self._image_content = await self._detail.async_get_doorbell_image(
-                self._session, timeout=self._timeout
+            self._content_token = self._detail.content_token or self._content_token
+            _LOGGER.debug(
+                "calling doorbell async_get_doorbell_image, %s",
+                self._detail.device_name,
             )
+            try:
+                self._image_content = await self._detail.async_get_doorbell_image(
+                    self._session, timeout=self._timeout
+                )
+            except ContentTokenExpired:
+                if self._data.brand == Brand.YALE_HOME:
+                    _LOGGER.warning(
+                        "Error fetching camera image, updating content-token from api to retry"
+                    )
+                    await self._async_update()
+                    self._image_content = await self._detail.async_get_doorbell_image(
+                        self._session, timeout=self._timeout
+                    )
+
         return self._image_content

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -103,7 +103,7 @@ class AugustCamera(AugustEntityMixin, Camera):
                 )
             except ContentTokenExpired:
                 if self._data.brand == Brand.YALE_HOME:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "Error fetching camera image, updating content-token from api to retry"
                     )
                     await self._async_update()

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -29,5 +29,5 @@
   "import_executor": true,
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==1.11.4", "yalexs-ble==2.4.2"]
+  "requirements": ["yalexs==2.0.0", "yalexs-ble==2.4.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2893,7 +2893,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.4.2
 
 # homeassistant.components.august
-yalexs==1.11.4
+yalexs==2.0.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.14

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2228,7 +2228,7 @@ yalesmartalarmclient==0.3.9
 yalexs-ble==2.4.2
 
 # homeassistant.components.august
-yalexs==1.11.4
+yalexs==2.0.0
 
 # homeassistant.components.yeelight
 yeelight==0.7.14

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -25,11 +25,12 @@ from yalexs.activity import (
     LockOperationActivity,
 )
 from yalexs.authenticator import AuthenticationState
+from yalexs.const import Brand
 from yalexs.doorbell import Doorbell, DoorbellDetail
 from yalexs.lock import Lock, LockDetail
 from yalexs.pubnub_async import AugustPubNub
 
-from homeassistant.components.august.const import CONF_LOGIN_METHOD, DOMAIN
+from homeassistant.components.august.const import CONF_BRAND, CONF_LOGIN_METHOD, DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
@@ -37,13 +38,14 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry, load_fixture
 
 
-def _mock_get_config():
+def _mock_get_config(brand: Brand = Brand.AUGUST):
     """Return a default august config."""
     return {
         DOMAIN: {
             CONF_LOGIN_METHOD: "email",
             CONF_USERNAME: "mocked_username",
             CONF_PASSWORD: "mocked_password",
+            CONF_BRAND: brand,
         }
     }
 
@@ -58,7 +60,7 @@ def _mock_authenticator(auth_state):
 @patch("homeassistant.components.august.gateway.ApiAsync")
 @patch("homeassistant.components.august.gateway.AuthenticatorAsync.async_authenticate")
 async def _mock_setup_august(
-    hass, api_instance, pubnub_mock, authenticate_mock, api_mock
+    hass, api_instance, pubnub_mock, authenticate_mock, api_mock, brand
 ):
     """Set up august integration."""
     authenticate_mock.side_effect = MagicMock(
@@ -69,7 +71,7 @@ async def _mock_setup_august(
     api_mock.return_value = api_instance
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=_mock_get_config()[DOMAIN],
+        data=_mock_get_config(brand)[DOMAIN],
         options={},
     )
     entry.add_to_hass(hass)
@@ -87,21 +89,26 @@ async def _create_august_with_devices(
     api_call_side_effects: dict[str, Any] | None = None,
     activities: list[Any] | None = None,
     pubnub: AugustPubNub | None = None,
+    brand: Brand = Brand.AUGUST,
 ) -> ConfigEntry:
     entry, _ = await _create_august_api_with_devices(
-        hass, devices, api_call_side_effects, activities, pubnub
+        hass, devices, api_call_side_effects, activities, pubnub, brand
     )
     return entry
 
 
 async def _create_august_api_with_devices(  # noqa: C901
-    hass, devices, api_call_side_effects=None, activities=None, pubnub=None
+    hass,
+    devices,
+    api_call_side_effects=None,
+    activities=None,
+    pubnub=None,
+    brand=Brand.AUGUST,
 ):
     if api_call_side_effects is None:
         api_call_side_effects = {}
     if pubnub is None:
         pubnub = AugustPubNub()
-
     device_data = {"doorbells": [], "locks": []}
     for device in devices:
         if isinstance(device, LockDetail):
@@ -110,7 +117,13 @@ async def _create_august_api_with_devices(  # noqa: C901
             )
         elif isinstance(device, DoorbellDetail):
             device_data["doorbells"].append(
-                {"base": _mock_august_doorbell(device.device_id), "detail": device}
+                {
+                    "base": _mock_august_doorbell(
+                        deviceid=device.device_id,
+                        brand=device._data.get("brand", Brand.AUGUST),
+                    ),
+                    "detail": device,
+                }
             )
         else:
             raise ValueError  # noqa: TRY004
@@ -181,7 +194,7 @@ async def _create_august_api_with_devices(  # noqa: C901
     )
 
     api_instance, entry = await _mock_setup_august_with_api_side_effects(
-        hass, api_call_side_effects, pubnub
+        hass, api_call_side_effects, pubnub, brand
     )
 
     if device_data["locks"]:
@@ -192,7 +205,9 @@ async def _create_august_api_with_devices(  # noqa: C901
     return entry, api_instance
 
 
-async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, pubnub):
+async def _mock_setup_august_with_api_side_effects(
+    hass, api_call_side_effects, pubnub, brand=Brand.AUGUST
+):
     api_instance = MagicMock(name="Api")
 
     if api_call_side_effects["get_lock_detail"]:
@@ -235,7 +250,9 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects, 
     api_instance.async_status_async = AsyncMock()
     api_instance.async_get_user = AsyncMock(return_value={"UserID": "abc"})
 
-    return api_instance, await _mock_setup_august(hass, api_instance, pubnub)
+    return api_instance, await _mock_setup_august(
+        hass, api_instance, pubnub, brand=brand
+    )
 
 
 def _mock_august_authentication(token_text, token_timestamp, state):
@@ -252,13 +269,18 @@ def _mock_august_lock(lockid="mocklockid1", houseid="mockhouseid1"):
     return Lock(lockid, _mock_august_lock_data(lockid=lockid, houseid=houseid))
 
 
-def _mock_august_doorbell(deviceid="mockdeviceid1", houseid="mockhouseid1"):
+def _mock_august_doorbell(
+    deviceid="mockdeviceid1", houseid="mockhouseid1", brand=Brand.AUGUST
+):
     return Doorbell(
-        deviceid, _mock_august_doorbell_data(deviceid=deviceid, houseid=houseid)
+        deviceid,
+        _mock_august_doorbell_data(deviceid=deviceid, houseid=houseid, brand=brand),
     )
 
 
-def _mock_august_doorbell_data(deviceid="mockdeviceid1", houseid="mockhouseid1"):
+def _mock_august_doorbell_data(
+    deviceid="mockdeviceid1", houseid="mockhouseid1", brand=Brand.AUGUST
+):
     return {
         "_id": deviceid,
         "DeviceID": deviceid,

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -77,7 +77,7 @@ async def test_doorbell_refresh_content_token_fail(
         doorbell_two,
         "async_get_doorbell_image",
         create=False,
-        side_effect=[ContentTokenExpired],
+        side_effect=ContentTokenExpired,
     ):
         await _create_august_with_devices(
             hass,

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -1,6 +1,10 @@
 """The camera tests for the august platform."""
+
 from http import HTTPStatus
 from unittest.mock import patch
+
+from yalexs.const import Brand
+from yalexs.doorbell import ContentTokenExpired
 
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
@@ -19,7 +23,7 @@ async def test_create_doorbell(
     with patch.object(
         doorbell_one, "async_get_doorbell_image", create=False, return_value="image"
     ):
-        await _create_august_with_devices(hass, [doorbell_one])
+        await _create_august_with_devices(hass, [doorbell_one], brand=Brand.AUGUST)
 
         camera_k98gidt45gul_name_camera = hass.states.get(
             "camera.k98gidt45gul_name_camera"
@@ -35,3 +39,55 @@ async def test_create_doorbell(
         assert resp.status == HTTPStatus.OK
         body = await resp.text()
         assert body == "image"
+
+
+async def test_doorbell_refresh_content_token_recover(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """Test camera image content token expired."""
+    doorbell_two = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
+    with patch.object(
+        doorbell_two,
+        "async_get_doorbell_image",
+        create=False,
+        side_effect=[ContentTokenExpired, "image"],
+    ):
+        await _create_august_with_devices(
+            hass,
+            [doorbell_two],
+            brand=Brand.YALE_HOME,
+        )
+        url = hass.states.get("camera.k98gidt45gul_name_camera").attributes[
+            "entity_picture"
+        ]
+
+        client = await hass_client_no_auth()
+        resp = await client.get(url)
+        assert resp.status == HTTPStatus.OK
+        body = await resp.text()
+        assert body == "image"
+
+
+async def test_doorbell_refresh_content_token_fail(
+    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
+) -> None:
+    """Test camera image content token expired."""
+    doorbell_two = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
+    with patch.object(
+        doorbell_two,
+        "async_get_doorbell_image",
+        create=False,
+        side_effect=[ContentTokenExpired],
+    ):
+        await _create_august_with_devices(
+            hass,
+            [doorbell_two],
+            brand=Brand.YALE_HOME,
+        )
+        url = hass.states.get("camera.k98gidt45gul_name_camera").attributes[
+            "entity_picture"
+        ]
+
+        client = await hass_client_no_auth()
+        resp = await client.get(url)
+        assert resp.status == HTTPStatus.INTERNAL_SERVER_ERROR


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle exception when camera content token is expired and renew it, then retry to load the image, fixing cases when camera snapshots work for a while but break later when updates come in with no new token.
- yalexs 2.0.0 raises a new exception when it cannot load camera snapshots, and this change handles that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

https://github.com/bdraco/yalexs/releases/tag/v2.0.0

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
