### PR TITLE
Fix time trigger tests with leap year

### DIFF
--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -210,7 +210,7 @@ async def test_if_not_fires_using_wrong_at(
     now = dt_util.utcnow()
 
     time_that_will_not_match_right_away = now.replace(
-        year=now.year + 1, hour=1, minute=0, second=0
+        year=now.year + 1, day=1, hour=1, minute=0, second=0
     )
 
     freezer.move_to(time_that_will_not_match_right_away)
@@ -233,7 +233,7 @@ async def test_if_not_fires_using_wrong_at(
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 1, hour=1, minute=0, second=5)
+        hass, now.replace(year=now.year + 1, day=1, hour=1, minute=0, second=5)
     )
 
     await hass.async_block_till_done()

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -33,7 +33,7 @@ async def test_if_fires_when_hour_matches(
     """Test for firing if hour is matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, hour=3
+        year=now.year + 1, day=1, hour=3
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -55,7 +55,7 @@ async def test_if_fires_when_hour_matches(
         },
     )
 
-    async_fire_time_changed(hass, now.replace(year=now.year + 2, hour=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, day=1, hour=0))
     await hass.async_block_till_done()
     assert len(calls) == 1
 
@@ -66,7 +66,7 @@ async def test_if_fires_when_hour_matches(
         blocking=True,
     )
 
-    async_fire_time_changed(hass, now.replace(year=now.year + 1, hour=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 1, day=1, hour=0))
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].data["id"] == 0
@@ -78,7 +78,7 @@ async def test_if_fires_when_minute_matches(
     """Test for firing if minutes are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, minute=30
+        year=now.year + 1, day=1, minute=30
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -97,7 +97,7 @@ async def test_if_fires_when_minute_matches(
         },
     )
 
-    async_fire_time_changed(hass, now.replace(year=now.year + 2, minute=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, day=1, minute=0))
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -109,7 +109,7 @@ async def test_if_fires_when_second_matches(
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, second=30
+        year=now.year + 1, day=1, second=30
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -128,7 +128,7 @@ async def test_if_fires_when_second_matches(
         },
     )
 
-    async_fire_time_changed(hass, now.replace(year=now.year + 2, second=0))
+    async_fire_time_changed(hass, now.replace(year=now.year + 2, day=1, second=0))
 
     await hass.async_block_till_done()
     assert len(calls) == 1
@@ -140,7 +140,7 @@ async def test_if_fires_when_second_as_string_matches(
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, second=15
+        year=now.year + 1, day=1, second=15
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -173,7 +173,7 @@ async def test_if_fires_when_all_matches(
     """Test for firing if everything matches."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, hour=4
+        year=now.year + 1, day=1, hour=4
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -193,7 +193,7 @@ async def test_if_fires_when_all_matches(
     )
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=3)
+        hass, now.replace(year=now.year + 2, day=1, hour=1, minute=2, second=3)
     )
 
     await hass.async_block_till_done()
@@ -206,7 +206,7 @@ async def test_if_fires_periodic_seconds(
     """Test for firing periodically every second."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, second=1
+        year=now.year + 1, day=1, second=1
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -226,7 +226,7 @@ async def test_if_fires_periodic_seconds(
     )
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=0, minute=0, second=10)
+        hass, now.replace(year=now.year + 2, day=1, hour=0, minute=0, second=10)
     )
 
     await hass.async_block_till_done()
@@ -240,7 +240,7 @@ async def test_if_fires_periodic_minutes(
 
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, minute=1
+        year=now.year + 1, day=1, minute=1
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -260,7 +260,7 @@ async def test_if_fires_periodic_minutes(
     )
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=0, minute=2, second=0)
+        hass, now.replace(year=now.year + 2, day=1, hour=0, minute=2, second=0)
     )
 
     await hass.async_block_till_done()
@@ -273,7 +273,7 @@ async def test_if_fires_periodic_hours(
     """Test for firing periodically every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, hour=1
+        year=now.year + 1, day=1, hour=1
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -293,7 +293,7 @@ async def test_if_fires_periodic_hours(
     )
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=2, minute=0, second=0)
+        hass, now.replace(year=now.year + 2, day=1, hour=2, minute=0, second=0)
     )
 
     await hass.async_block_till_done()
@@ -306,7 +306,7 @@ async def test_default_values(
     """Test for firing at 2 minutes every hour."""
     now = dt_util.utcnow()
     time_that_will_not_match_right_away = dt_util.utcnow().replace(
-        year=now.year + 1, minute=1
+        year=now.year + 1, day=1, minute=1
     )
     freezer.move_to(time_that_will_not_match_right_away)
     assert await async_setup_component(
@@ -321,21 +321,21 @@ async def test_default_values(
     )
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=0)
+        hass, now.replace(year=now.year + 2, day=1, hour=1, minute=2, second=0)
     )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=1, minute=2, second=1)
+        hass, now.replace(year=now.year + 2, day=1, hour=1, minute=2, second=1)
     )
 
     await hass.async_block_till_done()
     assert len(calls) == 1
 
     async_fire_time_changed(
-        hass, now.replace(year=now.year + 2, hour=2, minute=2, second=0)
+        hass, now.replace(year=now.year + 2, day=1, hour=2, minute=2, second=0)
     )
 
     await hass.async_block_till_done()


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
day 29 doesn't exist 1 or 2 years from now so these tests were failing today

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
