### PR TITLE
Switch influxdb to use a SimpleQueue

### DIFF
--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -512,7 +512,9 @@ class InfluxThread(threading.Thread):
     def __init__(self, hass, influx, event_to_json, max_tries):
         """Initialize the listener."""
         threading.Thread.__init__(self, name=DOMAIN)
-        self.queue = queue.SimpleQueue()
+        self.queue: queue.SimpleQueue[
+            threading.Event | tuple[float, Event] | None
+        ] = queue.SimpleQueue()
         self.influx = influx
         self.event_to_json = event_to_json
         self.max_tries = max_tries

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -555,8 +555,7 @@ class InfluxThread(threading.Thread):
                     age = time.monotonic() - timestamp
 
                     if age < queue_seconds:
-                        event_json = self.event_to_json(event)
-                        if event_json:
+                        if event_json := self.event_to_json(event):
                             json.append(event_json)
                     else:
                         dropped += 1
@@ -598,6 +597,7 @@ class InfluxThread(threading.Thread):
 
     def block_till_done(self):
         """Block till all events processed."""
-        event = threading.Event()
-        self.queue.put(event)
-        event.wait()
+        for _ in range(self.max_tries + 1):
+            event = threading.Event()
+            self.queue.put(event)
+            event.wait()

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -600,7 +600,6 @@ class InfluxThread(threading.Thread):
 
         Currently only used for testing.
         """
-        for _ in range(self.max_tries + 1):
-            event = threading.Event()
-            self.queue.put(event)
-            event.wait()
+        event = threading.Event()
+        self.queue.put(event)
+        event.wait()

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -550,9 +550,7 @@ class InfluxThread(threading.Thread):
 
                 if item is None:
                     self.shutdown = True
-                elif isinstance(item, threading.Event):
-                    item.set()
-                else:
+                elif type(item) is tuple:  # noqa: E721
                     timestamp, event = item
                     age = time.monotonic() - timestamp
 
@@ -561,6 +559,8 @@ class InfluxThread(threading.Thread):
                             json.append(event_json)
                     else:
                         dropped += 1
+                elif isinstance(item, threading.Event):
+                    item.set()
 
         if dropped:
             _LOGGER.warning(CATCHING_UP_MESSAGE, dropped)

--- a/homeassistant/components/influxdb/__init__.py
+++ b/homeassistant/components/influxdb/__init__.py
@@ -596,7 +596,10 @@ class InfluxThread(threading.Thread):
                 self.write_to_influxdb(json)
 
     def block_till_done(self):
-        """Block till all events processed."""
+        """Block till all events processed.
+
+        Currently only used for testing.
+        """
         for _ in range(self.max_tries + 1):
             event = threading.Event()
             self.queue.put(event)

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1567,6 +1567,7 @@ async def test_invalid_inputs_error(
         hass.states.async_set("fake.something", 1)
         await hass.async_block_till_done()
         hass.data[influxdb.DOMAIN].block_till_done()
+        await hass.async_block_till_done()
 
         write_api.assert_called_once()
         assert (

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -22,6 +22,15 @@ BASE_V2_CONFIG = {
 }
 
 
+async def async_wait_for_queue_to_process(hass: HomeAssistant) -> None:
+    """Wait for the queue to be processed.
+
+    In the future we should refactor this away to not have
+    to access hass.data directly.
+    """
+    await hass.async_add_executor_job(hass.data[influxdb.DOMAIN].block_till_done)
+
+
 @dataclass
 class FilterTest:
     """Class for capturing a filter test."""
@@ -407,7 +416,7 @@ async def test_event_listener(
 
         hass.states.async_set("fake.entity_id", in_, attrs)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -454,7 +463,7 @@ async def test_event_listener_no_units(
         ]
         hass.states.async_set("fake.entity_id", 1, attrs)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -497,7 +506,7 @@ async def test_event_listener_inf(
     ]
     hass.states.async_set("fake.entity_id", 8, attrs)
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -539,7 +548,7 @@ async def test_event_listener_states(
         ]
         hass.states.async_set("fake.entity_id", state_state)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         if state_state == 1:
@@ -564,7 +573,7 @@ async def execute_filter_test(hass: HomeAssistant, tests, write_api, get_mock_ca
         ]
         hass.states.async_set(test.id, 1)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         if test.should_pass:
             write_api.assert_called_once()
@@ -927,7 +936,7 @@ async def test_event_listener_invalid_type(
 
         hass.states.async_set("fake.entity_id", in_, attrs)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -970,7 +979,7 @@ async def test_event_listener_default_measurement(
     ]
     hass.states.async_set("fake.ok", 1)
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -1014,7 +1023,7 @@ async def test_event_listener_unit_of_measurement_field(
     ]
     hass.states.async_set("fake.entity_id", "foo", attrs)
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -1062,7 +1071,7 @@ async def test_event_listener_tags_attributes(
     ]
     hass.states.async_set("fake.something", 1, attrs)
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -1120,7 +1129,7 @@ async def test_event_listener_component_override_measurement(
         ]
         hass.states.async_set(f"{comp['domain']}.{comp['id']}", 1)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -1186,7 +1195,7 @@ async def test_event_listener_component_measurement_attr(
         ]
         hass.states.async_set(f"{comp['domain']}.{comp['id']}", 1, comp["attrs"])
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -1271,7 +1280,7 @@ async def test_event_listener_ignore_attributes(
             },
         )
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         write_api = get_write_api(mock_client)
         assert write_api.call_count == 1
@@ -1317,7 +1326,7 @@ async def test_event_listener_ignore_attributes_overlapping_entities(
     ]
     hass.states.async_set("sensor.fake", 1, {"ignore": 1})
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -1357,7 +1366,7 @@ async def test_event_listener_scheduled_write(
     with patch.object(influxdb.time, "sleep") as mock_sleep:
         hass.states.async_set("entity.entity_id", 1)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
         assert mock_sleep.called
     assert write_api.call_count == 2
 
@@ -1366,7 +1375,7 @@ async def test_event_listener_scheduled_write(
     with patch.object(influxdb.time, "sleep") as mock_sleep:
         hass.states.async_set("entity.entity_id", "2")
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
         assert not mock_sleep.called
     assert write_api.call_count == 3
 
@@ -1406,7 +1415,7 @@ async def test_event_listener_backlog_full(
     with patch("homeassistant.components.influxdb.time.monotonic", new=fast_monotonic):
         hass.states.async_set("entity.id", 1)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await async_wait_for_queue_to_process(hass)
 
         assert get_write_api(mock_client).call_count == 0
 
@@ -1444,7 +1453,7 @@ async def test_event_listener_attribute_name_conflict(
     ]
     hass.states.async_set("fake.something", 1, {"value": "value_str"})
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1
@@ -1566,7 +1575,7 @@ async def test_invalid_inputs_error(
     with patch(f"{INFLUX_PATH}.time.sleep") as sleep:
         hass.states.async_set("fake.something", 1)
         await hass.async_block_till_done()
-        await hass.async_add_executor_job(hass.data[influxdb.DOMAIN].block_till_done)
+        await async_wait_for_queue_to_process(hass)
         await hass.async_block_till_done()
 
         write_api.assert_called_once()
@@ -1671,7 +1680,7 @@ async def test_precision(
         },
     )
     await hass.async_block_till_done()
-    hass.data[influxdb.DOMAIN].block_till_done()
+    await async_wait_for_queue_to_process(hass)
 
     write_api = get_write_api(mock_client)
     assert write_api.call_count == 1

--- a/tests/components/influxdb/test_init.py
+++ b/tests/components/influxdb/test_init.py
@@ -1566,7 +1566,7 @@ async def test_invalid_inputs_error(
     with patch(f"{INFLUX_PATH}.time.sleep") as sleep:
         hass.states.async_set("fake.something", 1)
         await hass.async_block_till_done()
-        hass.data[influxdb.DOMAIN].block_till_done()
+        await hass.async_add_executor_job(hass.data[influxdb.DOMAIN].block_till_done)
         await hass.async_block_till_done()
 
         write_api.assert_called_once()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The only time we needed thread locking was for tests which can be emulated with an `threading.Event`. A SimpleQueue avoids all the under the hood thread locking which was only used for testing and not in production code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
