### PR TITLE
Include filename in exception when loading a json file fails

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -79,12 +79,12 @@ def load_json(
     except FileNotFoundError:
         # This is not a fatal error
         _LOGGER.debug("JSON file not found: %s", filename)
-    except ValueError as error:
+    except JSON_DECODE_EXCEPTIONS as error:
         _LOGGER.exception("Could not parse JSON content: %s", filename)
-        raise HomeAssistantError(error) from error
+        raise HomeAssistantError(f"Error while loading {filename}: {error}") from error
     except OSError as error:
         _LOGGER.exception("JSON file reading failed: %s", filename)
-        raise HomeAssistantError(error) from error
+        raise HomeAssistantError(f"Error while loading {filename}: {error}") from error
     return {} if default is _SENTINEL else default
 
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -706,8 +706,8 @@ async def test_loading_corrupt_core_file(
         assert issue_entry.translation_placeholders["storage_key"] == storage_key
         assert issue_entry.issue_domain == HOMEASSISTANT_DOMAIN
         assert (
-            issue_entry.translation_placeholders["error"]
-            == "unexpected character: line 1 column 1 (char 0)"
+            "unexpected character: line 1 column 1 (char 0)"
+            in issue_entry.translation_placeholders["error"]
         )
 
         files = await hass.async_add_executor_job(
@@ -767,8 +767,8 @@ async def test_loading_corrupt_file_known_domain(
         assert issue_entry.translation_placeholders["storage_key"] == storage_key
         assert issue_entry.issue_domain == "testdomain"
         assert (
-            issue_entry.translation_placeholders["error"]
-            == "unexpected content after document: line 1 column 17 (char 16)"
+            "unexpected content after document: line 1 column 17 (char 16)"
+            in issue_entry.translation_placeholders["error"]
         )
 
         files = await hass.async_add_executor_job(

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,5 +1,6 @@
 """Test Home Assistant json utility functions."""
 from pathlib import Path
+import re
 
 import orjson
 import pytest
@@ -21,11 +22,11 @@ TEST_BAD_SERIALIED = "THIS IS NOT JSON\n"
 
 
 def test_load_bad_data(tmp_path: Path) -> None:
-    """Test error from trying to load unserialisable data."""
+    """Test error from trying to load unserializable data."""
     fname = tmp_path / "test5.json"
     with open(fname, "w") as fh:
         fh.write(TEST_BAD_SERIALIED)
-    with pytest.raises(HomeAssistantError) as err:
+    with pytest.raises(HomeAssistantError, match=re.escape(str(fname))) as err:
         load_json(fname)
     assert isinstance(err.value.__cause__, ValueError)
 
@@ -33,7 +34,7 @@ def test_load_bad_data(tmp_path: Path) -> None:
 def test_load_json_os_error() -> None:
     """Test trying to load JSON data from a directory."""
     fname = "/"
-    with pytest.raises(HomeAssistantError) as err:
+    with pytest.raises(HomeAssistantError, match=re.escape(str(fname))) as err:
         load_json(fname)
     assert isinstance(err.value.__cause__, OSError)
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include filename in exception when loading a json file fails

```
  File "/usr/src/homeassistant/homeassistant/util/json.py", line 78, in load_json
    return orjson.loads(fdesc.read())  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
orjson.JSONDecodeError: unexpected character: line 595 column 131 (char 19468)
```

Right now its very hard to figure out which translation file has the bad data in it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/wlcrs/huawei_solar/issues/636
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
