### PR TITLE
Follow real AtlanticPassAPCZoneControlZone physical mode on Overkiz (HEAT, COOL or HEAT_COOL)

### DIFF
--- a/homeassistant/components/overkiz/climate.py
+++ b/homeassistant/components/overkiz/climate.py
@@ -27,15 +27,16 @@ async def async_setup_entry(
     """Set up the Overkiz climate from a config entry."""
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
 
-    async_add_entities(
+    # Match devices based on the widget.
+    entities_based_on_widget = [
         WIDGET_TO_CLIMATE_ENTITY[device.widget](device.device_url, data.coordinator)
         for device in data.platforms[Platform.CLIMATE]
         if device.widget in WIDGET_TO_CLIMATE_ENTITY
-    )
+    ]
 
-    # Match devices based on the widget and controllableName
-    # This is for example used for Atlantic APC, where devices with different functionality share the same uiClass and widget.
-    async_add_entities(
+    # Match devices based on the widget and controllableName.
+    # ie Atlantic APC
+    entities_based_on_widget_and_controllable = [
         WIDGET_AND_CONTROLLABLE_TO_CLIMATE_ENTITY[device.widget][
             cast(Controllable, device.controllable_name)
         ](device.device_url, data.coordinator)
@@ -43,14 +44,21 @@ async def async_setup_entry(
         if device.widget in WIDGET_AND_CONTROLLABLE_TO_CLIMATE_ENTITY
         and device.controllable_name
         in WIDGET_AND_CONTROLLABLE_TO_CLIMATE_ENTITY[device.widget]
-    )
+    ]
 
-    # Hitachi Air To Air Heat Pumps
-    async_add_entities(
+    # Match devices based on the widget and protocol.
+    # #ie Hitachi Air To Air Heat Pumps
+    entities_based_on_widget_and_protocol = [
         WIDGET_AND_PROTOCOL_TO_CLIMATE_ENTITY[device.widget][device.protocol](
             device.device_url, data.coordinator
         )
         for device in data.platforms[Platform.CLIMATE]
         if device.widget in WIDGET_AND_PROTOCOL_TO_CLIMATE_ENTITY
         and device.protocol in WIDGET_AND_PROTOCOL_TO_CLIMATE_ENTITY[device.widget]
+    ]
+
+    async_add_entities(
+        entities_based_on_widget
+        + entities_based_on_widget_and_controllable
+        + entities_based_on_widget_and_protocol
     )

--- a/homeassistant/components/overkiz/climate.py
+++ b/homeassistant/components/overkiz/climate.py
@@ -7,6 +7,7 @@ from typing import cast
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantOverkizData
@@ -28,7 +29,7 @@ async def async_setup_entry(
     data: HomeAssistantOverkizData = hass.data[DOMAIN][entry.entry_id]
 
     # Match devices based on the widget.
-    entities_based_on_widget = [
+    entities_based_on_widget: list[Entity] = [
         WIDGET_TO_CLIMATE_ENTITY[device.widget](device.device_url, data.coordinator)
         for device in data.platforms[Platform.CLIMATE]
         if device.widget in WIDGET_TO_CLIMATE_ENTITY
@@ -36,7 +37,7 @@ async def async_setup_entry(
 
     # Match devices based on the widget and controllableName.
     # ie Atlantic APC
-    entities_based_on_widget_and_controllable = [
+    entities_based_on_widget_and_controllable: list[Entity] = [
         WIDGET_AND_CONTROLLABLE_TO_CLIMATE_ENTITY[device.widget][
             cast(Controllable, device.controllable_name)
         ](device.device_url, data.coordinator)
@@ -48,7 +49,7 @@ async def async_setup_entry(
 
     # Match devices based on the widget and protocol.
     # #ie Hitachi Air To Air Heat Pumps
-    entities_based_on_widget_and_protocol = [
+    entities_based_on_widget_and_protocol: list[Entity] = [
         WIDGET_AND_PROTOCOL_TO_CLIMATE_ENTITY[device.widget][device.protocol](
             device.device_url, data.coordinator
         )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
@@ -159,7 +159,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         await self.async_set_heating_mode(PRESET_MODES_TO_OVERKIZ[preset_mode])
 
     @property
-    def preset_mode(self) -> str:
+    def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., home, away, temp."""
         heating_mode = cast(
             str, self.executor.select_state(OverkizState.IO_PASS_APC_HEATING_MODE)

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
@@ -179,7 +179,7 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
         return OVERKIZ_TO_PRESET_MODES[heating_mode]
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> float | None:
         """Return hvac target temperature."""
         current_heating_profile = self.current_heating_profile
         if current_heating_profile in OVERKIZ_TEMPERATURE_STATE_BY_PROFILE:

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
@@ -449,7 +449,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
                 ),
             )
 
-        return self._attr_min_temp
+        return super().min_temp
 
     @property
     def max_temp(self) -> float:
@@ -473,4 +473,4 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
                 ),
             )
 
-        return self._attr_max_temp
+        return super().max_temp

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
@@ -16,7 +16,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..executor import OverkizExecutor
@@ -81,7 +81,7 @@ OVERKIZ_THERMAL_CONFIGURATION_TO_HVAC_MODE: dict[
 class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
     """Representation of Atlantic Pass APC Heating And Cooling Zone Control."""
 
-    _attr_target_temperature_step = PRECISION_TENTHS
+    _attr_target_temperature_step = PRECISION_HALVES
 
     def __init__(
         self, device_url: str, coordinator: OverkizDataUpdateCoordinator

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
@@ -7,12 +7,19 @@ from typing import Any, cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
-from homeassistant.components.climate import PRESET_NONE, HVACMode
-from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.components.climate import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    PRESET_NONE,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS
 
 from ..coordinator import OverkizDataUpdateCoordinator
+from ..executor import OverkizExecutor
 from .atlantic_pass_apc_heating_zone import AtlanticPassAPCHeatingZone
-from .atlantic_pass_apc_zone_control import OVERKIZ_TO_HVAC_MODE
 
 PRESET_SCHEDULE = "schedule"
 PRESET_MANUAL = "manual"
@@ -22,14 +29,53 @@ OVERKIZ_MODE_TO_PRESET_MODES: dict[str, str] = {
     OverkizCommandParam.INTERNAL_SCHEDULING: PRESET_SCHEDULE,
 }
 
+# Maps the HVAC current ZoneControl system operating mode.
+OVERKIZ_TO_HVAC_ACTION: dict[str, HVACAction] = {
+    OverkizCommandParam.COOLING: HVACAction.COOLING,
+    OverkizCommandParam.DRYING: HVACAction.DRYING,
+    OverkizCommandParam.HEATING: HVACAction.HEATING,
+    # There is no known way to differenciate OFF from Idle.
+    OverkizCommandParam.STOP: HVACAction.OFF,
+}
+
+# Maps the HVAC ZoneControlZone mode.
+HVAC_ACTION_TO_HVAC_MODES: dict[HVACAction, HVACMode] = {
+    HVACAction.COOLING: HVACMode.COOL,
+    HVACAction.DRYING: HVACMode.DRY,
+    HVACAction.HEATING: HVACMode.HEAT,
+    HVACAction.OFF: HVACMode.OFF,
+}
+
+HVAC_ACTION_TO_OVERKIZ_PROFILE_STATE: dict[HVACAction, OverkizState] = {
+    HVACAction.COOLING: OverkizState.IO_PASS_APC_COOLING_PROFILE,
+    HVACAction.HEATING: OverkizState.IO_PASS_APC_HEATING_PROFILE,
+}
+
+HVAC_ACTION_TO_OVERKIZ_MODE_STATE: dict[HVACAction, OverkizState] = {
+    HVACAction.COOLING: OverkizState.IO_PASS_APC_COOLING_MODE,
+    HVACAction.HEATING: OverkizState.IO_PASS_APC_HEATING_MODE,
+}
+
 PRESET_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_MODE_TO_PRESET_MODES.items()}
 
 TEMPERATURE_ZONECONTROL_DEVICE_INDEX = 20
 
+SUPPORTED_FEATURES = (
+    ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.TURN_OFF
+    | ClimateEntityFeature.TURN_ON
+)
+SUPPORTED_FEATURES_MANUAL = SUPPORTED_FEATURES | ClimateEntityFeature.TARGET_TEMPERATURE
+SUPPORTED_FEATURES_AUTO = (
+    SUPPORTED_FEATURES | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+)
 
-# Those device depends on a main probe that choose the operating mode (heating, cooling, ...)
+
+# Those device depends on a main probe that choose the operating mode (heating, cooling, ...).
 class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
     """Representation of Atlantic Pass APC Heating And Cooling Zone Control."""
+
+    _attr_target_temperature_step = PRECISION_TENTHS
 
     def __init__(
         self, device_url: str, coordinator: OverkizDataUpdateCoordinator
@@ -37,20 +83,36 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         """Init method."""
         super().__init__(device_url, coordinator)
 
-        # There is less supported functions, because they depend on the ZoneControl.
-        if not self.is_using_derogated_temperature_fallback:
-            # Modes are not configurable, they will follow current HVAC Mode of Zone Control.
-            self._attr_hvac_modes = []
+        # When using derogated temperature, we fallback to legacy behavior.
+        if self.is_using_derogated_temperature_fallback:
+            return
 
-            # Those are available and tested presets on Shogun.
-            self._attr_preset_modes = [*PRESET_MODES_TO_OVERKIZ]
+        self._attr_min_temp = 0
+        self._attr_max_temp = 0
+
+        self._attr_supported_features = SUPPORTED_FEATURES
+
+        # Modes are not configurable, they will follow current HVAC Mode of Zone Control.
+        self._attr_hvac_modes = []
+
+        # Those are available and tested presets on Shogun.
+        self._attr_preset_modes = [*PRESET_MODES_TO_OVERKIZ]
 
         # Those APC Heating and Cooling probes depends on the zone control device (main probe).
         # Only the base device (#1) can be used to get/set some states.
         # Like to retrieve and set the current operating mode (heating, cooling, drying, off).
-        self.zone_control_device = self.executor.linked_device(
-            TEMPERATURE_ZONECONTROL_DEVICE_INDEX
-        )
+
+        self.zone_control_executor: OverkizExecutor | None = None
+
+        if (
+            zone_control_device := self.executor.linked_device(
+                TEMPERATURE_ZONECONTROL_DEVICE_INDEX
+            )
+        ) is not None:
+            self.zone_control_executor = OverkizExecutor(
+                zone_control_device.device_url,
+                coordinator,
+            )
 
     @property
     def is_using_derogated_temperature_fallback(self) -> bool:
@@ -61,21 +123,53 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         )
 
     @property
-    def zone_control_hvac_mode(self) -> HVACMode:
+    def zone_control_hvac_action(self) -> HVACAction:
         """Return hvac operation ie. heat, cool, dry, off mode."""
 
-        if (
-            self.zone_control_device is not None
-            and (
-                state := self.zone_control_device.states[
+        if self.zone_control_executor is not None and (
+            (
+                state := self.zone_control_executor.select_state(
                     OverkizState.IO_PASS_APC_OPERATING_MODE
-                ]
+                )
             )
             is not None
-            and (value := state.value_as_str) is not None
         ):
-            return OVERKIZ_TO_HVAC_MODE[value]
-        return HVACMode.OFF
+            return OVERKIZ_TO_HVAC_ACTION[cast(str, state)]
+
+        return HVACAction.OFF
+
+    @property
+    def is_zone_control_auto_switch_active(self) -> bool:
+        """Check if auto mode is available and active on the ZoneControl."""
+
+        if self.zone_control_executor is not None and (
+            (
+                state := self.zone_control_executor.select_state(
+                    OverkizState.CORE_HEATING_COOLING_AUTO_SWITCH
+                )
+            )
+            is not None
+        ):
+            return cast(str, state) == OverkizCommandParam.ON
+
+        return False
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac operation."""
+
+        # When ZoneControl action is heating/cooling but Zone is stopped, means the zone is idle.
+        if (
+            hvac_action := self.zone_control_hvac_action
+        ) in HVAC_ACTION_TO_OVERKIZ_PROFILE_STATE and cast(
+            str,
+            self.executor.select_state(
+                HVAC_ACTION_TO_OVERKIZ_PROFILE_STATE[hvac_action]
+            ),
+        ) == OverkizCommandParam.STOP:
+            return HVACAction.IDLE
+
+        return hvac_action
 
     @property
     def hvac_mode(self) -> HVACMode:
@@ -84,30 +178,34 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         if self.is_using_derogated_temperature_fallback:
             return super().hvac_mode
 
-        zone_control_hvac_mode = self.zone_control_hvac_mode
+        zone_control_hvac_mode = HVAC_ACTION_TO_HVAC_MODES[
+            zone_control_hvac_action := self.zone_control_hvac_action
+        ]
 
-        # Should be same, because either thermostat or this integration change both.
-        on_off_state = cast(
-            str,
-            self.executor.select_state(
-                OverkizState.CORE_COOLING_ON_OFF
-                if zone_control_hvac_mode == HVACMode.COOL
-                else OverkizState.CORE_HEATING_ON_OFF
-            ),
-        )
+        # Selectable mode is kept in synced with the Zone Control current mode.
+        # When auto switching is enabled on Zone Control, we can use the HEAT_COOL mode.
+        if self.is_zone_control_auto_switch_active:
+            selectable_hvac_mode = HVACMode.HEAT_COOL
+        else:
+            selectable_hvac_mode = zone_control_hvac_mode
+
+        self.sync_attrs_from_mode(selectable_hvac_mode)
 
         # Device is Stopped, it means the air flux is flowing but its venting door is closed.
-        if on_off_state == OverkizCommandParam.OFF:
-            hvac_mode = HVACMode.OFF
-        else:
-            hvac_mode = zone_control_hvac_mode
+        if (
+            cast(
+                str,
+                self.executor.select_state(
+                    OverkizState.CORE_COOLING_ON_OFF
+                    if zone_control_hvac_action == HVACAction.COOLING
+                    else OverkizState.CORE_HEATING_ON_OFF
+                ),
+            )
+            == OverkizCommandParam.OFF
+        ):
+            return HVACMode.OFF
 
-        # It helps keep it consistent with the Zone Control, within the interface.
-        if self._attr_hvac_modes != [zone_control_hvac_mode, HVACMode.OFF]:
-            self._attr_hvac_modes = [zone_control_hvac_mode, HVACMode.OFF]
-            self.async_write_ha_state()
-
-        return hvac_mode
+        return selectable_hvac_mode
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
@@ -140,24 +238,23 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         await self.async_refresh_modes()
 
     @property
-    def preset_mode(self) -> str:
+    def preset_mode(self) -> str | None:
         """Return the current preset mode, e.g., schedule, manual."""
 
         if self.is_using_derogated_temperature_fallback:
             return super().preset_mode
 
-        mode = OVERKIZ_MODE_TO_PRESET_MODES[
-            cast(
-                str,
-                self.executor.select_state(
-                    OverkizState.IO_PASS_APC_COOLING_MODE
-                    if self.zone_control_hvac_mode == HVACMode.COOL
-                    else OverkizState.IO_PASS_APC_HEATING_MODE
-                ),
-            )
-        ]
+        mode_state = HVAC_ACTION_TO_OVERKIZ_MODE_STATE[self.zone_control_hvac_action]
 
-        return mode if mode is not None else PRESET_NONE
+        if mode_state is not None and (
+            mode := OVERKIZ_MODE_TO_PRESET_MODES[
+                cast(str, self.executor.select_state(mode_state))
+            ]
+            is not None
+        ):
+            return mode
+
+        return PRESET_NONE
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""
@@ -178,13 +275,18 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         await self.async_refresh_modes()
 
     @property
-    def target_temperature(self) -> float:
+    def target_temperature(self) -> float | None:
         """Return hvac target temperature."""
 
         if self.is_using_derogated_temperature_fallback:
             return super().target_temperature
 
-        if self.zone_control_hvac_mode == HVACMode.COOL:
+        hvac_mode = self.hvac_mode
+
+        if hvac_mode == HVACMode.HEAT_COOL:
+            return None
+
+        if hvac_mode == HVACMode.COOL:
             return cast(
                 float,
                 self.executor.select_state(
@@ -192,7 +294,7 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
                 ),
             )
 
-        if self.zone_control_hvac_mode == HVACMode.HEAT:
+        if hvac_mode == HVACMode.HEAT:
             return cast(
                 float,
                 self.executor.select_state(
@@ -204,32 +306,72 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
             float, self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
         )
 
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the highbound target temperature we try to reach (cooling)."""
+
+        if self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+
+        return cast(
+            float,
+            self.executor.select_state(OverkizState.CORE_COOLING_TARGET_TEMPERATURE),
+        )
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the lowbound target temperature we try to reach (heating)."""
+        if self.hvac_mode != HVACMode.HEAT_COOL:
+            return None
+
+        return cast(
+            float,
+            self.executor.select_state(OverkizState.CORE_HEATING_TARGET_TEMPERATURE),
+        )
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new temperature."""
 
         if self.is_using_derogated_temperature_fallback:
             return await super().async_set_temperature(**kwargs)
 
-        temperature = kwargs[ATTR_TEMPERATURE]
+        target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
+        target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
+        hvac_mode = self.hvac_mode
 
-        # Change both (heating/cooling) temperature is a good way to have consistency
-        await self.executor.async_execute_command(
-            OverkizCommand.SET_HEATING_TARGET_TEMPERATURE,
-            temperature,
-        )
-        await self.executor.async_execute_command(
-            OverkizCommand.SET_COOLING_TARGET_TEMPERATURE,
-            temperature,
-        )
+        if hvac_mode == HVACMode.HEAT_COOL:
+            if target_temp_low is not None:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_HEATING_TARGET_TEMPERATURE,
+                    target_temp_low,
+                )
+
+            if target_temp_high is not None:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_COOLING_TARGET_TEMPERATURE,
+                    target_temp_high,
+                )
+
+        elif target_temperature is not None:
+            if hvac_mode == HVACMode.HEAT:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_HEATING_TARGET_TEMPERATURE,
+                    target_temperature,
+                )
+
+            elif hvac_mode == HVACMode.COOL:
+                await self.executor.async_execute_command(
+                    OverkizCommand.SET_COOLING_TARGET_TEMPERATURE,
+                    target_temperature,
+                )
+
         await self.executor.async_execute_command(
             OverkizCommand.SET_DEROGATION_ON_OFF_STATE,
             OverkizCommandParam.OFF,
         )
 
-        # Target temperature may take up to 1 minute to get refreshed.
-        await self.executor.async_execute_command(
-            OverkizCommand.REFRESH_TARGET_TEMPERATURE
-        )
+        await self.async_refresh_modes()
 
     async def async_refresh_modes(self) -> None:
         """Refresh the device modes to have new states."""
@@ -256,3 +398,78 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         await self.executor.async_execute_command(
             OverkizCommand.REFRESH_TARGET_TEMPERATURE
         )
+
+    def sync_attrs_from_mode(self, hvac_mode: HVACMode) -> None:
+        """Synchronise attrs from zone control mode."""
+
+        should_write_state = False
+
+        # Selectable mode is kept in synced with the Zone Control current mode.
+        # When auto switching is enabled on Zone Control, we can use the HEAT_COOL mode.
+        if hvac_mode == HVACMode.HEAT_COOL:
+            supported_features = SUPPORTED_FEATURES_AUTO
+        else:
+            supported_features = SUPPORTED_FEATURES_MANUAL
+
+        # Only HEAT_COOL mode supports temperature range.
+        if self._attr_supported_features != supported_features:
+            self._attr_supported_features = supported_features
+            should_write_state = True
+
+        # It helps keep it consistent with the Zone Control, within the interface.
+        if self._attr_hvac_modes != (hvac_modes := [hvac_mode, HVACMode.OFF]):
+            self._attr_hvac_modes = hvac_modes
+            should_write_state = True
+
+        min_temp = self.get_min_temp(hvac_mode)
+        max_temp = self.get_max_temp(hvac_mode)
+
+        if self._attr_min_temp != min_temp or self._attr_max_temp != max_temp:
+            self._attr_min_temp = min_temp
+            self._attr_max_temp = max_temp
+            should_write_state = True
+
+        if should_write_state is True:
+            self.async_write_ha_state()
+
+    def get_min_temp(self, hvac_mode: HVACMode) -> float:
+        """Compute the minimum temperature."""
+
+        if hvac_mode in (HVACMode.HEAT, HVACMode.HEAT_COOL):
+            return cast(
+                float,
+                self.executor.select_state(
+                    OverkizState.CORE_MINIMUM_HEATING_TARGET_TEMPERATURE
+                ),
+            )
+
+        if hvac_mode == HVACMode.COOL:
+            return cast(
+                float,
+                self.executor.select_state(
+                    OverkizState.CORE_MINIMUM_COOLING_TARGET_TEMPERATURE
+                ),
+            )
+
+        return self._attr_min_temp
+
+    def get_max_temp(self, hvac_mode: HVACMode) -> float:
+        """Compute the maximum temperature."""
+
+        if hvac_mode == HVACMode.HEAT:
+            return cast(
+                float,
+                self.executor.select_state(
+                    OverkizState.CORE_MAXIMUM_HEATING_TARGET_TEMPERATURE
+                ),
+            )
+
+        if hvac_mode in (HVACMode.COOL, HVACMode.HEAT_COOL):
+            return cast(
+                float,
+                self.executor.select_state(
+                    OverkizState.CORE_MAXIMUM_COOLING_TARGET_TEMPERATURE
+                ),
+            )
+
+        return self._attr_max_temp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The following PR: #110510 introduced simple support for ZoneControlZone for Atlantic devices.

Temperature change when AUTO mode is enable, was changing cooling as well as heating temperature, this could be lead to unexpected switch between heating/cooling, as well as higher power consumptions.

This PR fixes that and simplifies the logic by always using a single mode for the subsidiary Zones (the mode depends of the physical configuration of the zone, one of  HEAT_COOL, HEAT or COOL).

![Screenshot](https://github.com/home-assistant/core/assets/211541/5ac93c92-be26-4e1c-a9ff-074e157333c9)

With this fix, hvac_action is set correctly, reflecting the real heating / cooling operating state.
Now, min/max temperature are also in synced with the device configuration.

Like the introduction of the support for those device is included in the 2024.03 release, it would be great to also introduce this fix/refactor. (It's better for the users waiting for the support of those device, since it would not provoke a change of interface in future release)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112602
- This PR is related to issue: #89746 and #108211 )
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
