### PR TITLE
Fallback to event loop import on deadlock

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -855,6 +855,7 @@ class Integration:
             try:
                 comp = await self.hass.async_add_executor_job(self.get_component)
             except ImportError as ex:
+                load_executor = False
                 _LOGGER.debug("Failed to import %s in executor", domain, exc_info=ex)
                 # If importing in the executor deadlocks because there is a circular
                 # dependency, we fall back to the event loop.
@@ -930,6 +931,7 @@ class Integration:
                     _LOGGER.debug(
                         "Failed to import %s in executor", domain, exc_info=ex
                     )
+                    load_executor = False
                     # If importing in the executor deadlocks because there is a circular
                     # dependency, we fall back to the event loop.
                     platform = self._load_platform(platform_name)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -892,7 +892,7 @@ class Integration:
         except ImportError:
             raise
         except RuntimeError as err:
-            #  _DeadlockError inherits from RuntimeError
+            # _DeadlockError inherits from RuntimeError
             raise ImportError(f"RuntimeError importing {self.pkg_path}: {err}") from err
         except Exception as err:
             _LOGGER.exception(
@@ -1001,7 +1001,7 @@ class Integration:
                 missing_platforms_cache[full_name] = ex
             raise
         except RuntimeError as err:
-            #  _DeadlockError inherits from RuntimeError
+            # _DeadlockError inherits from RuntimeError
             raise ImportError(
                 f"RuntimeError importing {self.pkg_path}.{platform_name}: {err}"
             ) from err

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1074,6 +1074,46 @@ async def test_async_get_component_deadlock_fallback(
     assert module is module_mock
 
 
+async def test_async_get_component_raises_after_import_failure(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify async_get_component raises if we fail to import in both the executor and loop."""
+    executor_import_integration = _get_test_integration(
+        hass, "executor_import", True, import_executor=True
+    )
+    assert executor_import_integration.import_executor is True
+    module_mock = MagicMock()
+    import_attempts = 0
+
+    def mock_import(module: str, *args: Any, **kwargs: Any) -> Any:
+        nonlocal import_attempts
+        if module == "homeassistant.components.executor_import":
+            import_attempts += 1
+
+        if import_attempts == 1:
+            # _DeadlockError inherits from RuntimeError
+            raise RuntimeError(
+                "Detected deadlock trying to import homeassistant.components.executor_import"
+            )
+
+        if import_attempts == 2:
+            raise ImportError("Failed import homeassistant.components.executor_import")
+        return module_mock
+
+    assert "homeassistant.components.executor_import" not in sys.modules
+    assert "custom_components.executor_import" not in sys.modules
+    with patch(
+        "homeassistant.loader.importlib.import_module", mock_import
+    ), pytest.raises(ImportError):
+        await executor_import_integration.async_get_component()
+
+    assert (
+        "Detected deadlock trying to import homeassistant.components.executor_import"
+        in caplog.text
+    )
+    assert "loaded_executor=False" not in caplog.text
+
+
 async def test_async_get_platform_deadlock_fallback(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -1109,3 +1149,47 @@ async def test_async_get_platform_deadlock_fallback(
     )
     assert "loaded_executor=False" in caplog.text
     assert module is module_mock
+
+
+async def test_async_get_platform_raises_after_import_failure(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify async_get_platform raises if we fail to import in both the executor and loop."""
+    executor_import_integration = _get_test_integration(
+        hass, "executor_import", True, import_executor=True
+    )
+    assert executor_import_integration.import_executor is True
+    module_mock = MagicMock()
+    import_attempts = 0
+
+    def mock_import(module: str, *args: Any, **kwargs: Any) -> Any:
+        nonlocal import_attempts
+        if module == "homeassistant.components.executor_import.config_flow":
+            import_attempts += 1
+
+        if import_attempts == 1:
+            # _DeadlockError inherits from RuntimeError
+            raise RuntimeError(
+                "Detected deadlock trying to import homeassistant.components.executor_import"
+            )
+
+        if import_attempts == 2:
+            # _DeadlockError inherits from RuntimeError
+            raise ImportError(
+                "Error trying to import homeassistant.components.executor_import"
+            )
+
+        return module_mock
+
+    assert "homeassistant.components.executor_import" not in sys.modules
+    assert "custom_components.executor_import" not in sys.modules
+    with patch(
+        "homeassistant.loader.importlib.import_module", mock_import
+    ), pytest.raises(ImportError):
+        await executor_import_integration.async_get_platform("config_flow")
+
+    assert (
+        "Detected deadlock trying to import homeassistant.components.executor_import"
+        in caplog.text
+    )
+    assert "loaded_executor=False" not in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1070,6 +1070,7 @@ async def test_async_get_component_deadlock_fallback(
         "Detected deadlock trying to import homeassistant.components.executor_import"
         in caplog.text
     )
+    assert "loaded_executor=False" in caplog.text
     assert module is module_mock
 
 
@@ -1106,4 +1107,5 @@ async def test_async_get_platform_deadlock_fallback(
         "Detected deadlock trying to import homeassistant.components.executor_import"
         in caplog.text
     )
+    assert "loaded_executor=False" in caplog.text
     assert module is module_mock

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,6 +1,8 @@
 """Test to verify that we can load components."""
 import asyncio
-from unittest.mock import Mock, patch
+import sys
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
@@ -1033,3 +1035,75 @@ async def test_hass_components_use_reported(
             "Detected that custom integration 'test_integration_frame'"
             " accesses hass.components.http. This is deprecated"
         ) in caplog.text
+
+
+async def test_async_get_component_deadlock_fallback(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify async_get_component fallback to importing in the event loop on deadlock."""
+    executor_import_integration = _get_test_integration(
+        hass, "executor_import", True, import_executor=True
+    )
+    assert executor_import_integration.import_executor is True
+    module_mock = MagicMock()
+    import_attempts = 0
+
+    def mock_import(module: str, *args: Any, **kwargs: Any) -> Any:
+        nonlocal import_attempts
+        if module == "homeassistant.components.executor_import":
+            import_attempts += 1
+
+        if import_attempts == 1:
+            # _DeadlockError inherits from RuntimeError
+            raise RuntimeError(
+                "Detected deadlock trying to import homeassistant.components.executor_import"
+            )
+
+        return module_mock
+
+    assert "homeassistant.components.executor_import" not in sys.modules
+    assert "custom_components.executor_import" not in sys.modules
+    with patch("homeassistant.loader.importlib.import_module", mock_import):
+        module = await executor_import_integration.async_get_component()
+
+    assert (
+        "Detected deadlock trying to import homeassistant.components.executor_import"
+        in caplog.text
+    )
+    assert module is module_mock
+
+
+async def test_async_get_platform_deadlock_fallback(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Verify async_get_platform fallback to importing in the event loop on deadlock."""
+    executor_import_integration = _get_test_integration(
+        hass, "executor_import", True, import_executor=True
+    )
+    assert executor_import_integration.import_executor is True
+    module_mock = MagicMock()
+    import_attempts = 0
+
+    def mock_import(module: str, *args: Any, **kwargs: Any) -> Any:
+        nonlocal import_attempts
+        if module == "homeassistant.components.executor_import.config_flow":
+            import_attempts += 1
+
+        if import_attempts == 1:
+            # _DeadlockError inherits from RuntimeError
+            raise RuntimeError(
+                "Detected deadlock trying to import homeassistant.components.executor_import"
+            )
+
+        return module_mock
+
+    assert "homeassistant.components.executor_import" not in sys.modules
+    assert "custom_components.executor_import" not in sys.modules
+    with patch("homeassistant.loader.importlib.import_module", mock_import):
+        module = await executor_import_integration.async_get_platform("config_flow")
+
+    assert (
+        "Detected deadlock trying to import homeassistant.components.executor_import"
+        in caplog.text
+    )
+    assert module is module_mock


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the import deadlocks, fallback to importing in the event loop. Fallback should be rare.

fixes #111822

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
