### PR TITLE
Use correct service name with Wyoming satellite + local wake word detection

### DIFF
--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -24,14 +24,19 @@ class WyomingService:
         self.host = host
         self.port = port
         self.info = info
-        platforms = []
+        self.platforms = []
+
+        if (self.info.satellite is not None) and self.info.satellite.installed:
+            # Don't load platforms for satellite services, such as local wake
+            # word detection.
+            return
+
         if any(asr.installed for asr in info.asr):
-            platforms.append(Platform.STT)
+            self.platforms.append(Platform.STT)
         if any(tts.installed for tts in info.tts):
-            platforms.append(Platform.TTS)
+            self.platforms.append(Platform.TTS)
         if any(wake.installed for wake in info.wake):
-            platforms.append(Platform.WAKE_WORD)
-        self.platforms = platforms
+            self.platforms.append(Platform.WAKE_WORD)
 
     def has_services(self) -> bool:
         """Return True if services are installed that Home Assistant can use."""

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -55,10 +55,7 @@ class WyomingService:
         satellite_installed: Satellite | None = None
 
         if (self.info.satellite is not None) and self.info.satellite.installed:
-            satellite_installed = self.info.satellite
-
-        if satellite_installed:
-            return satellite_installed.name
+            return self.info.satellite.name
 
         # ASR = automated speech recognition (speech-to-text)
         asr_installed = [asr for asr in self.info.asr if asr.installed]

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -1,4 +1,5 @@
 """Base class for Wyoming providers."""
+
 from __future__ import annotations
 
 import asyncio
@@ -43,6 +44,17 @@ class WyomingService:
 
     def get_name(self) -> str | None:
         """Return name of first installed usable service."""
+
+        # Wyoming satellite
+        # Must be checked first because satellites may contain wake services, etc.
+        satellite_installed: Satellite | None = None
+
+        if (self.info.satellite is not None) and self.info.satellite.installed:
+            satellite_installed = self.info.satellite
+
+        if satellite_installed:
+            return satellite_installed.name
+
         # ASR = automated speech recognition (speech-to-text)
         asr_installed = [asr for asr in self.info.asr if asr.installed]
         if asr_installed:
@@ -57,15 +69,6 @@ class WyomingService:
         wake_installed = [wake for wake in self.info.wake if wake.installed]
         if wake_installed:
             return wake_installed[0].name
-
-        # satellite
-        satellite_installed: Satellite | None = None
-
-        if (self.info.satellite is not None) and self.info.satellite.installed:
-            satellite_installed = self.info.satellite
-
-        if satellite_installed:
-            return satellite_installed.name
 
         return None
 

--- a/homeassistant/components/wyoming/data.py
+++ b/homeassistant/components/wyoming/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from wyoming.client import AsyncTcpClient
-from wyoming.info import Describe, Info, Satellite
+from wyoming.info import Describe, Info
 
 from homeassistant.const import Platform
 
@@ -52,8 +52,6 @@ class WyomingService:
 
         # Wyoming satellite
         # Must be checked first because satellites may contain wake services, etc.
-        satellite_installed: Satellite | None = None
-
         if (self.info.satellite is not None) and self.info.satellite.installed:
             return self.info.satellite.name
 

--- a/tests/components/wyoming/test_data.py
+++ b/tests/components/wyoming/test_data.py
@@ -1,9 +1,11 @@
 """Test tts."""
+
 from __future__ import annotations
 
 from unittest.mock import patch
 
 from syrupy.assertion import SnapshotAssertion
+from wyoming.info import Info
 
 from homeassistant.components.wyoming.data import WyomingService, load_wyoming_info
 from homeassistant.core import HomeAssistant
@@ -27,10 +29,13 @@ async def test_load_info_oserror(hass: HomeAssistant) -> None:
     """Test loading info and error raising."""
     mock_client = MockAsyncTcpClient([STT_INFO.event()])
 
-    with patch(
-        "homeassistant.components.wyoming.data.AsyncTcpClient",
-        mock_client,
-    ), patch.object(mock_client, "read_event", side_effect=OSError("Boom!")):
+    with (
+        patch(
+            "homeassistant.components.wyoming.data.AsyncTcpClient",
+            mock_client,
+        ),
+        patch.object(mock_client, "read_event", side_effect=OSError("Boom!")),
+    ):
         info = await load_wyoming_info(
             "localhost",
             1234,
@@ -75,3 +80,20 @@ async def test_service_name(hass: HomeAssistant) -> None:
         service = await WyomingService.create("localhost", 1234)
         assert service is not None
         assert service.get_name() == SATELLITE_INFO.satellite.name
+
+
+async def test_satellite_with_wake_word(hass: HomeAssistant) -> None:
+    """Test that wake word info with satellite doesn't overwrite the service name."""
+    # Info for local wake word detection
+    satellite_info = Info(
+        satellite=SATELLITE_INFO.satellite,
+        wake=WAKE_WORD_INFO.wake,
+    )
+
+    with patch(
+        "homeassistant.components.wyoming.data.AsyncTcpClient",
+        MockAsyncTcpClient([satellite_info.event()]),
+    ):
+        service = await WyomingService.create("localhost", 1234)
+        assert service is not None
+        assert service.get_name() == satellite_info.satellite.name

--- a/tests/components/wyoming/test_data.py
+++ b/tests/components/wyoming/test_data.py
@@ -97,3 +97,4 @@ async def test_satellite_with_wake_word(hass: HomeAssistant) -> None:
         service = await WyomingService.create("localhost", 1234)
         assert service is not None
         assert service.get_name() == satellite_info.satellite.name
+        assert not service.platforms


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix for issue: https://github.com/rhasspy/wyoming-satellite/issues/124

When using local wake word detection, the name of the wake word system was being used instead of the satellite.
Additionally, local satellite services (wake, etc.) would be advertised as available to HA but fail to work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # https://github.com/rhasspy/wyoming-satellite/issues/124
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
