### PR TITLE
Remove deprecated `hass.components.hassio` usage

### DIFF
--- a/homeassistant/helpers/network.py
+++ b/homeassistant/helpers/network.py
@@ -40,7 +40,11 @@ def get_supervisor_network_url(
     hass: HomeAssistant, *, allow_ssl: bool = False
 ) -> str | None:
     """Get URL for home assistant within supervisor network."""
-    if hass.config.api is None or not hass.components.hassio.is_hassio():
+    # Local import to avoid circular dependencies
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.components.hassio import is_hassio
+
+    if hass.config.api is None or not is_hassio(hass):
         return None
 
     scheme = "http"
@@ -170,14 +174,17 @@ def get_url(
         and request_host is not None
         and hass.config.api is not None
     ):
+        # Local import to avoid circular dependencies
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.hassio import get_host_info, is_hassio
+
         scheme = "https" if hass.config.api.use_ssl else "http"
         current_url = yarl.URL.build(
             scheme=scheme, host=request_host, port=hass.config.api.port
         )
 
         known_hostnames = ["localhost"]
-        if hass.components.hassio.is_hassio():
-            host_info = hass.components.hassio.get_host_info()
+        if is_hassio(hass) and (host_info := get_host_info(hass)):
             known_hostnames.extend(
                 [host_info["hostname"], f"{host_info['hostname']}.local"]
             )

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -30,7 +30,11 @@ cached_get_user = cache(getuser)
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
-    is_hassio = hass.components.hassio.is_hassio()
+    # Local import to avoid circular dependencies
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.components import hassio
+
+    is_hassio = hassio.is_hassio(hass)
 
     info_object = {
         "installation_type": "Unknown",
@@ -68,11 +72,11 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
 
     # Enrich with Supervisor information
     if is_hassio:
-        if not (info := hass.components.hassio.get_info()):
+        if not (info := hassio.get_info(hass)):
             _LOGGER.warning("No Home Assistant Supervisor info available")
             info = {}
 
-        host = hass.components.hassio.get_host_info() or {}
+        host = hassio.get_host_info(hass) or {}
         info_object["supervisor"] = info.get("supervisor")
         info_object["host_os"] = host.get("operating_system")
         info_object["docker_version"] = info.get("docker")

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -15,7 +15,9 @@ from homeassistant.components.hassio import (
     DOMAIN,
     STORAGE_KEY,
     async_get_addon_store_info,
+    get_core_info,
     hostname_from_addon_slug,
+    is_hassio,
 )
 from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
 from homeassistant.components.hassio.handler import HassioAPIError
@@ -246,8 +248,8 @@ async def test_setup_api_ping(
 
     assert result
     assert aioclient_mock.call_count == 19
-    assert hass.components.hassio.get_core_info()["version_latest"] == "1.0.0"
-    assert hass.components.hassio.is_hassio()
+    assert get_core_info(hass)["version_latest"] == "1.0.0"
+    assert is_hassio(hass)
 
 
 async def test_setup_api_panel(
@@ -465,7 +467,7 @@ async def test_warn_when_cannot_connect(
         result = await async_setup_component(hass, "hassio", {})
         assert result
 
-    assert hass.components.hassio.is_hassio()
+    assert is_hassio(hass)
     assert "Not connected with the supervisor / system too busy!" in caplog.text
 
 


### PR DESCRIPTION
## Proposed change
Remove the deprecated `hass.components.hassio` usage from the code base, but keeps the `@bind_hass` in `hassio` for now to be backward compatible till we reach 2024.9.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
