### PR TITLE
Remove deprecated `hass.components` usage in config entry flow

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from homeassistant import config_entries
 from homeassistant.components import onboarding
-from homeassistant.components.webhook import async_generate_id, async_generate_url
 from homeassistant.core import HomeAssistant
 
 from .typing import DiscoveryInfoType
@@ -221,8 +220,6 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         if user_input is None:
             return self.async_show_form(step_id="user")
 
-        webhook_id = async_generate_id()
-
         # Local import to be sure cloud is loaded and setup
         # pylint: disable-next=import-outside-toplevel
         from homeassistant.components.cloud import (
@@ -230,6 +227,15 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
             async_create_cloudhook,
             async_is_connected,
         )
+
+        # Local import to be sure webhook is loaded and setup
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.webhook import (
+            async_generate_id,
+            async_generate_url,
+        )
+
+        webhook_id = async_generate_id()
 
         if "cloud" in self.hass.config.components and async_active_subscription(
             self.hass

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -7,12 +7,6 @@ from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
 
 from homeassistant import config_entries
 from homeassistant.components import onboarding
-from homeassistant.components.cloud import (
-    async_active_subscription,
-    async_create_cloudhook,
-    async_delete_cloudhook,
-    async_is_connected,
-)
 from homeassistant.components.webhook import async_generate_id, async_generate_url
 from homeassistant.core import HomeAssistant
 
@@ -229,6 +223,14 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
         webhook_id = async_generate_id()
 
+        # Local import to be sure cloud is loaded and setup
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components.cloud import (
+            async_active_subscription,
+            async_create_cloudhook,
+            async_is_connected,
+        )
+
         if "cloud" in self.hass.config.components and async_active_subscription(
             self.hass
         ):
@@ -270,5 +272,9 @@ async def webhook_async_remove_entry(
     """Remove a webhook config entry."""
     if not entry.data.get("cloudhook") or "cloud" not in hass.config.components:
         return
+
+    # Local import to be sure cloud is loaded and setup
+    # pylint: disable-next=import-outside-toplevel
+    from homeassistant.components.cloud import async_delete_cloudhook
 
     await async_delete_cloudhook(hass, entry.data["webhook_id"])


### PR DESCRIPTION
## Proposed change
Remove deprecated `hass.components` in config entry flow

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
