### PR TITLE
Remove deprecated `hass.components` usage in device_sun_light_trigger

### DIFF
--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -4,11 +4,18 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.device_tracker import (
+    DOMAIN as DOMAIN_DEVICE_TRACKER,
+    is_on as device_tracker_is_on,
+)
+from homeassistant.components.group import get_entity_ids as group_get_entity_ids
 from homeassistant.components.light import (
     ATTR_PROFILE,
     ATTR_TRANSITION,
     DOMAIN as DOMAIN_LIGHT,
+    is_on as light_is_on,
 )
+from homeassistant.components.person import DOMAIN as DOMAIN_PERSON
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     EVENT_HOMEASSISTANT_START,
@@ -86,16 +93,16 @@ async def activate_automation(  # noqa: C901
 ):
     """Activate the automation."""
     logger = logging.getLogger(__name__)
-    device_tracker = hass.components.device_tracker
-    group = hass.components.group
-    light = hass.components.light
-    person = hass.components.person
 
     if device_group is None:
-        device_entity_ids = hass.states.async_entity_ids(device_tracker.DOMAIN)
+        device_entity_ids = hass.states.async_entity_ids(DOMAIN_DEVICE_TRACKER)
     else:
-        device_entity_ids = group.get_entity_ids(device_group, device_tracker.DOMAIN)
-        device_entity_ids.extend(group.get_entity_ids(device_group, person.DOMAIN))
+        device_entity_ids = group_get_entity_ids(
+            hass, device_group, DOMAIN_DEVICE_TRACKER
+        )
+        device_entity_ids.extend(
+            group_get_entity_ids(hass, device_group, DOMAIN_PERSON)
+        )
 
     if not device_entity_ids:
         logger.error("No devices found to track")
@@ -103,9 +110,9 @@ async def activate_automation(  # noqa: C901
 
     # Get the light IDs from the specified group
     if light_group is None:
-        light_ids = hass.states.async_entity_ids(light.DOMAIN)
+        light_ids = hass.states.async_entity_ids(DOMAIN_LIGHT)
     else:
-        light_ids = group.get_entity_ids(light_group, light.DOMAIN)
+        light_ids = group_get_entity_ids(hass, light_group, DOMAIN_LIGHT)
 
     if not light_ids:
         logger.error("No lights found to turn on")
@@ -114,12 +121,12 @@ async def activate_automation(  # noqa: C901
     @callback
     def anyone_home():
         """Test if anyone is home."""
-        return any(device_tracker.is_on(dt_id) for dt_id in device_entity_ids)
+        return any(device_tracker_is_on(hass, dt_id) for dt_id in device_entity_ids)
 
     @callback
     def any_light_on():
         """Test if any light on."""
-        return any(light.is_on(light_id) for light_id in light_ids)
+        return any(light_is_on(hass, light_id) for light_id in light_ids)
 
     def calc_time_for_light_when_sunset():
         """Calculate the time when to start fading lights in when sun sets.
@@ -135,7 +142,7 @@ async def activate_automation(  # noqa: C901
 
     async def async_turn_on_before_sunset(light_id):
         """Turn on lights."""
-        if not anyone_home() or light.is_on(light_id):
+        if not anyone_home() or light_is_on(hass, light_id):
             return
         await hass.services.async_call(
             DOMAIN_LIGHT,


### PR DESCRIPTION
## Proposed change
Remove the deprecated `hass.components` usage in the `device_sun_light_trigger` component

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
