### PR TITLE
Remove deprecated `hass.components` usage in service tests

### DIFF
--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -13,6 +13,9 @@ import voluptuous as vol
 from homeassistant import exceptions
 from homeassistant.auth.permissions import PolicyPermissions
 import homeassistant.components  # noqa: F401
+from homeassistant.components.group import DOMAIN as DOMAIN_GROUP, Group
+from homeassistant.components.logger import DOMAIN as DOMAIN_LOGGER
+from homeassistant.components.shell_command import DOMAIN as DOMAIN_SHELL_COMMAND
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
@@ -473,7 +476,7 @@ async def test_extract_entity_ids(hass: HomeAssistant) -> None:
 
     assert await async_setup_component(hass, "group", {})
     await hass.async_block_till_done()
-    await hass.components.group.Group.async_create_group(
+    await Group.async_create_group(
         hass,
         "test",
         created_by_service=False,
@@ -563,9 +566,8 @@ async def test_extract_entity_ids_from_devices(hass: HomeAssistant, area_mock) -
 
 async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
     """Test async_get_all_descriptions."""
-    group = hass.components.group
-    group_config = {group.DOMAIN: {}}
-    assert await async_setup_component(hass, group.DOMAIN, group_config)
+    group_config = {DOMAIN_GROUP: {}}
+    assert await async_setup_component(hass, DOMAIN_GROUP, group_config)
     assert await async_setup_component(hass, "system_health", {})
 
     with patch(
@@ -588,8 +590,7 @@ async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
     # Does not have services
     assert "system_health" not in descriptions
 
-    logger = hass.components.logger
-    logger_config = {logger.DOMAIN: {}}
+    logger_config = {DOMAIN_LOGGER: {}}
 
     async def async_get_translations(
         hass: HomeAssistant,
@@ -599,7 +600,7 @@ async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
         config_flow: bool | None = None,
     ) -> dict[str, Any]:
         """Return all backend translations."""
-        translation_key_prefix = f"component.{logger.DOMAIN}.services.set_default_level"
+        translation_key_prefix = f"component.{DOMAIN_LOGGER}.services.set_default_level"
         return {
             f"{translation_key_prefix}.name": "Translated name",
             f"{translation_key_prefix}.description": "Translated description",
@@ -612,58 +613,58 @@ async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
         "homeassistant.helpers.service.translation.async_get_translations",
         side_effect=async_get_translations,
     ):
-        await async_setup_component(hass, logger.DOMAIN, logger_config)
+        await async_setup_component(hass, DOMAIN_LOGGER, logger_config)
         descriptions = await service.async_get_all_descriptions(hass)
 
     assert len(descriptions) == 2
 
-    assert descriptions[logger.DOMAIN]["set_default_level"]["name"] == "Translated name"
+    assert descriptions[DOMAIN_LOGGER]["set_default_level"]["name"] == "Translated name"
     assert (
-        descriptions[logger.DOMAIN]["set_default_level"]["description"]
+        descriptions[DOMAIN_LOGGER]["set_default_level"]["description"]
         == "Translated description"
     )
     assert (
-        descriptions[logger.DOMAIN]["set_default_level"]["fields"]["level"]["name"]
+        descriptions[DOMAIN_LOGGER]["set_default_level"]["fields"]["level"]["name"]
         == "Field name"
     )
     assert (
-        descriptions[logger.DOMAIN]["set_default_level"]["fields"]["level"][
+        descriptions[DOMAIN_LOGGER]["set_default_level"]["fields"]["level"][
             "description"
         ]
         == "Field description"
     )
     assert (
-        descriptions[logger.DOMAIN]["set_default_level"]["fields"]["level"]["example"]
+        descriptions[DOMAIN_LOGGER]["set_default_level"]["fields"]["level"]["example"]
         == "Field example"
     )
 
-    hass.services.async_register(logger.DOMAIN, "new_service", lambda x: None, None)
+    hass.services.async_register(DOMAIN_LOGGER, "new_service", lambda x: None, None)
     service.async_set_service_schema(
-        hass, logger.DOMAIN, "new_service", {"description": "new service"}
+        hass, DOMAIN_LOGGER, "new_service", {"description": "new service"}
     )
     descriptions = await service.async_get_all_descriptions(hass)
-    assert "description" in descriptions[logger.DOMAIN]["new_service"]
-    assert descriptions[logger.DOMAIN]["new_service"]["description"] == "new service"
+    assert "description" in descriptions[DOMAIN_LOGGER]["new_service"]
+    assert descriptions[DOMAIN_LOGGER]["new_service"]["description"] == "new service"
 
     hass.services.async_register(
-        logger.DOMAIN, "another_new_service", lambda x: None, None
+        DOMAIN_LOGGER, "another_new_service", lambda x: None, None
     )
     hass.services.async_register(
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "service_with_optional_response",
         lambda x: None,
         None,
         SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "service_with_only_response",
         lambda x: None,
         None,
         SupportsResponse.ONLY,
     )
     hass.services.async_register(
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "another_service_with_response",
         lambda x: None,
         None,
@@ -671,22 +672,22 @@ async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
     )
     service.async_set_service_schema(
         hass,
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "another_service_with_response",
         {"description": "response service"},
     )
     descriptions = await service.async_get_all_descriptions(hass)
-    assert "another_new_service" in descriptions[logger.DOMAIN]
-    assert "service_with_optional_response" in descriptions[logger.DOMAIN]
-    assert descriptions[logger.DOMAIN]["service_with_optional_response"][
+    assert "another_new_service" in descriptions[DOMAIN_LOGGER]
+    assert "service_with_optional_response" in descriptions[DOMAIN_LOGGER]
+    assert descriptions[DOMAIN_LOGGER]["service_with_optional_response"][
         "response"
     ] == {"optional": True}
-    assert "service_with_only_response" in descriptions[logger.DOMAIN]
-    assert descriptions[logger.DOMAIN]["service_with_only_response"]["response"] == {
+    assert "service_with_only_response" in descriptions[DOMAIN_LOGGER]
+    assert descriptions[DOMAIN_LOGGER]["service_with_only_response"]["response"] == {
         "optional": False
     }
-    assert "another_service_with_response" in descriptions[logger.DOMAIN]
-    assert descriptions[logger.DOMAIN]["another_service_with_response"]["response"] == {
+    assert "another_service_with_response" in descriptions[DOMAIN_LOGGER]
+    assert descriptions[DOMAIN_LOGGER]["another_service_with_response"]["response"] == {
         "optional": True
     }
 
@@ -698,9 +699,8 @@ async def test_async_get_all_descriptions_failing_integration(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test async_get_all_descriptions when async_get_integrations returns an exception."""
-    group = hass.components.group
-    group_config = {group.DOMAIN: {}}
-    await async_setup_component(hass, group.DOMAIN, group_config)
+    group_config = {DOMAIN_GROUP: {}}
+    await async_setup_component(hass, DOMAIN_GROUP, group_config)
     descriptions = await service.async_get_all_descriptions(hass)
 
     assert len(descriptions) == 1
@@ -708,9 +708,8 @@ async def test_async_get_all_descriptions_failing_integration(
     assert "description" in descriptions["group"]["reload"]
     assert "fields" in descriptions["group"]["reload"]
 
-    logger = hass.components.logger
-    logger_config = {logger.DOMAIN: {}}
-    await async_setup_component(hass, logger.DOMAIN, logger_config)
+    logger_config = {DOMAIN_LOGGER: {}}
+    await async_setup_component(hass, DOMAIN_LOGGER, logger_config)
     with patch(
         "homeassistant.helpers.service.async_get_integrations",
         return_value={"logger": ImportError},
@@ -725,32 +724,32 @@ async def test_async_get_all_descriptions_failing_integration(
 
     # Services are empty defaults if the load fails but should
     # not raise
-    assert descriptions[logger.DOMAIN]["set_level"] == {
+    assert descriptions[DOMAIN_LOGGER]["set_level"] == {
         "description": "",
         "fields": {},
         "name": "",
     }
 
-    hass.services.async_register(logger.DOMAIN, "new_service", lambda x: None, None)
+    hass.services.async_register(DOMAIN_LOGGER, "new_service", lambda x: None, None)
     service.async_set_service_schema(
-        hass, logger.DOMAIN, "new_service", {"description": "new service"}
+        hass, DOMAIN_LOGGER, "new_service", {"description": "new service"}
     )
     descriptions = await service.async_get_all_descriptions(hass)
-    assert "description" in descriptions[logger.DOMAIN]["new_service"]
-    assert descriptions[logger.DOMAIN]["new_service"]["description"] == "new service"
+    assert "description" in descriptions[DOMAIN_LOGGER]["new_service"]
+    assert descriptions[DOMAIN_LOGGER]["new_service"]["description"] == "new service"
 
     hass.services.async_register(
-        logger.DOMAIN, "another_new_service", lambda x: None, None
+        DOMAIN_LOGGER, "another_new_service", lambda x: None, None
     )
     hass.services.async_register(
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "service_with_optional_response",
         lambda x: None,
         None,
         SupportsResponse.OPTIONAL,
     )
     hass.services.async_register(
-        logger.DOMAIN,
+        DOMAIN_LOGGER,
         "service_with_only_response",
         lambda x: None,
         None,
@@ -758,13 +757,13 @@ async def test_async_get_all_descriptions_failing_integration(
     )
 
     descriptions = await service.async_get_all_descriptions(hass)
-    assert "another_new_service" in descriptions[logger.DOMAIN]
-    assert "service_with_optional_response" in descriptions[logger.DOMAIN]
-    assert descriptions[logger.DOMAIN]["service_with_optional_response"][
+    assert "another_new_service" in descriptions[DOMAIN_LOGGER]
+    assert "service_with_optional_response" in descriptions[DOMAIN_LOGGER]
+    assert descriptions[DOMAIN_LOGGER]["service_with_optional_response"][
         "response"
     ] == {"optional": True}
-    assert "service_with_only_response" in descriptions[logger.DOMAIN]
-    assert descriptions[logger.DOMAIN]["service_with_only_response"]["response"] == {
+    assert "service_with_only_response" in descriptions[DOMAIN_LOGGER]
+    assert descriptions[DOMAIN_LOGGER]["service_with_only_response"]["response"] == {
         "optional": False
     }
 
@@ -776,9 +775,8 @@ async def test_async_get_all_descriptions_dynamically_created_services(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test async_get_all_descriptions when async_get_integrations when services are dynamic."""
-    group = hass.components.group
-    group_config = {group.DOMAIN: {}}
-    await async_setup_component(hass, group.DOMAIN, group_config)
+    group_config = {DOMAIN_GROUP: {}}
+    await async_setup_component(hass, DOMAIN_GROUP, group_config)
     descriptions = await service.async_get_all_descriptions(hass)
 
     assert len(descriptions) == 1
@@ -786,13 +784,12 @@ async def test_async_get_all_descriptions_dynamically_created_services(
     assert "description" in descriptions["group"]["reload"]
     assert "fields" in descriptions["group"]["reload"]
 
-    shell_command = hass.components.shell_command
-    shell_command_config = {shell_command.DOMAIN: {"test_service": "ls /bin"}}
-    await async_setup_component(hass, shell_command.DOMAIN, shell_command_config)
+    shell_command_config = {DOMAIN_SHELL_COMMAND: {"test_service": "ls /bin"}}
+    await async_setup_component(hass, DOMAIN_SHELL_COMMAND, shell_command_config)
     descriptions = await service.async_get_all_descriptions(hass)
 
     assert len(descriptions) == 2
-    assert descriptions[shell_command.DOMAIN]["test_service"] == {
+    assert descriptions[DOMAIN_SHELL_COMMAND]["test_service"] == {
         "description": "",
         "fields": {},
         "name": "",
@@ -804,9 +801,8 @@ async def test_async_get_all_descriptions_new_service_added_while_loading(
     hass: HomeAssistant,
 ) -> None:
     """Test async_get_all_descriptions when a new service is added while loading translations."""
-    group = hass.components.group
-    group_config = {group.DOMAIN: {}}
-    await async_setup_component(hass, group.DOMAIN, group_config)
+    group_config = {DOMAIN_GROUP: {}}
+    await async_setup_component(hass, DOMAIN_GROUP, group_config)
     descriptions = await service.async_get_all_descriptions(hass)
 
     assert len(descriptions) == 1
@@ -814,8 +810,7 @@ async def test_async_get_all_descriptions_new_service_added_while_loading(
     assert "description" in descriptions["group"]["reload"]
     assert "fields" in descriptions["group"]["reload"]
 
-    logger = hass.components.logger
-    logger_domain = logger.DOMAIN
+    logger_domain = DOMAIN_LOGGER
     logger_config = {logger_domain: {}}
 
     translations_called = asyncio.Event()
@@ -884,9 +879,8 @@ async def test_register_with_mixed_case(hass: HomeAssistant) -> None:
     For backwards compatibility, we have historically allowed mixed case,
     and automatically converted it to lowercase.
     """
-    logger = hass.components.logger
-    logger_config = {logger.DOMAIN: {}}
-    await async_setup_component(hass, logger.DOMAIN, logger_config)
+    logger_config = {DOMAIN_LOGGER: {}}
+    await async_setup_component(hass, DOMAIN_LOGGER, logger_config)
     logger_domain_mixed = "LoGgEr"
     hass.services.async_register(
         logger_domain_mixed, "NeW_SeRVICE", lambda x: None, None
@@ -895,8 +889,8 @@ async def test_register_with_mixed_case(hass: HomeAssistant) -> None:
         hass, logger_domain_mixed, "NeW_SeRVICE", {"description": "new service"}
     )
     descriptions = await service.async_get_all_descriptions(hass)
-    assert "description" in descriptions[logger.DOMAIN]["new_service"]
-    assert descriptions[logger.DOMAIN]["new_service"]["description"] == "new service"
+    assert "description" in descriptions[DOMAIN_LOGGER]["new_service"]
+    assert descriptions[DOMAIN_LOGGER]["new_service"]["description"] == "new service"
 
 
 async def test_call_with_required_features(hass: HomeAssistant, mock_entities) -> None:


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
