### PR TITLE
Remove ZHA IasZone sensor migration

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import functools
-from typing import Any
 
 from zigpy.quirks.v2 import BinarySensorMetadata, EntityMetadata
 import zigpy.types as t
@@ -207,36 +206,6 @@ class IASZone(BinarySensor):
     def parse(value: bool | int) -> bool:
         """Parse the raw attribute into a bool state."""
         return BinarySensor.parse(value & 3)  # use only bit 0 and 1 for alarm state
-
-    # temporary code to migrate old IasZone sensors to update attribute cache state once
-    # remove in 2024.4.0
-    @property
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return state attributes."""
-        return {"migrated_to_cache": True}  # writing new state means we're migrated
-
-    # temporary migration code
-    @callback
-    def async_restore_last_state(self, last_state):
-        """Restore previous state."""
-        # trigger migration if extra state attribute is not present
-        if "migrated_to_cache" not in last_state.attributes:
-            self.migrate_to_zigpy_cache(last_state)
-
-    # temporary migration code
-    @callback
-    def migrate_to_zigpy_cache(self, last_state):
-        """Save old IasZone sensor state to attribute cache."""
-        # previous HA versions did not update the attribute cache for IasZone sensors, so do it once here
-        # a HA state write is triggered shortly afterwards and writes the "migrated_to_cache" extra state attribute
-        if last_state.state == STATE_ON:
-            migrated_state = IasZone.ZoneStatus.Alarm_1
-        else:
-            migrated_state = IasZone.ZoneStatus(0)
-
-        self._cluster_handler.cluster.update_attribute(
-            IasZone.attributes_by_name[self._attribute_name].id, migrated_state
-        )
 
 
 @STRICT_MATCH(cluster_handler_names=CLUSTER_HANDLER_ZONE, models={"WL4200", "WL4200S"})

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -15,7 +15,6 @@ from .common import (
     async_test_rejoin,
     find_entity_id,
     send_attributes_report,
-    update_attribute_cache,
 )
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
 
@@ -148,66 +147,6 @@ async def test_binary_sensor(
     # test rejoin
     await async_test_rejoin(hass, zigpy_device, [cluster], reporting)
     assert hass.states.get(entity_id).state == STATE_OFF
-
-
-@pytest.mark.parametrize(
-    "restored_state",
-    [
-        STATE_ON,
-        STATE_OFF,
-    ],
-)
-async def test_binary_sensor_migration_not_migrated(
-    hass: HomeAssistant,
-    zigpy_device_mock,
-    core_rs,
-    zha_device_restored,
-    restored_state,
-) -> None:
-    """Test temporary ZHA IasZone binary_sensor migration to zigpy cache."""
-
-    entity_id = "binary_sensor.fakemanufacturer_fakemodel_ias_zone"
-    core_rs(entity_id, state=restored_state, attributes={})  # migration sensor state
-    await async_mock_load_restore_state_from_storage(hass)
-
-    zigpy_device = zigpy_device_mock(DEVICE_IAS)
-
-    zha_device = await zha_device_restored(zigpy_device)
-    entity_id = find_entity_id(Platform.BINARY_SENSOR, zha_device, hass)
-
-    assert entity_id is not None
-    assert hass.states.get(entity_id).state == restored_state
-
-    # confirm migration extra state attribute was set to True
-    assert hass.states.get(entity_id).attributes["migrated_to_cache"]
-
-
-async def test_binary_sensor_migration_already_migrated(
-    hass: HomeAssistant,
-    zigpy_device_mock,
-    core_rs,
-    zha_device_restored,
-) -> None:
-    """Test temporary ZHA IasZone binary_sensor migration doesn't migrate multiple times."""
-
-    entity_id = "binary_sensor.fakemanufacturer_fakemodel_ias_zone"
-    core_rs(entity_id, state=STATE_OFF, attributes={"migrated_to_cache": True})
-    await async_mock_load_restore_state_from_storage(hass)
-
-    zigpy_device = zigpy_device_mock(DEVICE_IAS)
-
-    cluster = zigpy_device.endpoints.get(1).ias_zone
-    cluster.PLUGGED_ATTR_READS = {
-        "zone_status": security.IasZone.ZoneStatus.Alarm_1,
-    }
-    update_attribute_cache(cluster)
-
-    zha_device = await zha_device_restored(zigpy_device)
-    entity_id = find_entity_id(Platform.BINARY_SENSOR, zha_device, hass)
-
-    assert entity_id is not None
-    assert hass.states.get(entity_id).state == STATE_ON  # matches attribute cache
-    assert hass.states.get(entity_id).attributes["migrated_to_cache"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
This removes a migration for ZHA IasZone binary sensors (after 12 months).
This essentially reverts this PR from a year ago:
- https://github.com/home-assistant/core/pull/90508

Previously, zigpy didn't keep track of the `zone_status` attribute in its attribute cache and HA state was restored. Since 2023.4, ZHA/zigpy only use the `zone_status` attribute for `IasZone` binary sensors.

The migration was in place for a year now. Even if a user upgrades directly from 2023.3 (or earlier) to 2024.4 (or later), so skipping the migration completely, the worst case is that the binary sensor might have the wrong state until the contact/motion sensor is toggled once again.

Note: This should **NOT** be tagged for 2024.3.x, but should land with 2024.4.0.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
