### PR TITLE
Limit executor imports to a single thread

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -95,6 +95,7 @@ from .util.async_ import (
     run_callback_threadsafe,
     shutdown_run_callback_threadsafe,
 )
+from .util.executor import InterruptibleThreadPoolExecutor
 from .util.json import JsonObjectType
 from .util.read_only_dict import ReadOnlyDict
 from .util.timeout import TimeoutManager
@@ -394,6 +395,9 @@ class HomeAssistant:
         self.timeout: TimeoutManager = TimeoutManager()
         self._stop_future: concurrent.futures.Future[None] | None = None
         self._shutdown_jobs: list[HassJobWithArgs] = []
+        self.import_executor = InterruptibleThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="ImportExecutor"
+        )
 
     @cached_property
     def is_running(self) -> bool:
@@ -676,6 +680,16 @@ class HomeAssistant:
         self._tasks.add(task)
         task.add_done_callback(self._tasks.remove)
 
+        return task
+
+    @callback
+    def async_add_import_executor_job(
+        self, target: Callable[..., _T], *args: Any
+    ) -> asyncio.Future[_T]:
+        """Add an import executor job from within the event loop."""
+        task = self.loop.run_in_executor(self.import_executor, target, *args)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.remove)
         return task
 
     @overload
@@ -992,6 +1006,7 @@ class HomeAssistant:
             self._async_log_running_tasks("close")
 
         self.set_state(CoreState.stopped)
+        self.import_executor.shutdown()
 
         if self._stopped is not None:
             self._stopped.set()

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -853,7 +853,7 @@ class Integration:
         # So we do it before validating config to catch these errors.
         if load_executor:
             try:
-                comp = await self.hass.async_add_executor_job(self.get_component)
+                comp = await self.hass.async_add_import_executor_job(self.get_component)
             except ImportError as ex:
                 load_executor = False
                 _LOGGER.debug("Failed to import %s in executor", domain, exc_info=ex)
@@ -924,7 +924,7 @@ class Integration:
         try:
             if load_executor:
                 try:
-                    platform = await self.hass.async_add_executor_job(
+                    platform = await self.hass.async_add_import_executor_job(
                         self._load_platform, platform_name
                     )
                 except ImportError as ex:

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -1,7 +1,6 @@
 """Test the Z-Wave JS update entities."""
 import asyncio
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 from zwave_js_server.event import Event
@@ -311,8 +310,7 @@ async def test_update_entity_ha_not_running(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test update occurs only after HA is running."""
-    with patch.object(hass.import_executor, "shutdown"):
-        await hass.async_stop()
+    hass.set_state(CoreState.not_running)
 
     client.async_send_command.return_value = {"updates": []}
 
@@ -345,8 +343,6 @@ async def test_update_entity_ha_not_running(
     args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
-
-    hass.import_executor.shutdown()
 
 
 async def test_update_entity_update_failure(
@@ -636,8 +632,7 @@ async def test_update_entity_delay(
     """Test update occurs on a delay after HA starts."""
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"updates": []}
-    with patch.object(hass.import_executor, "shutdown"):
-        await hass.async_stop()
+    hass.set_state(CoreState.not_running)
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
@@ -666,7 +661,6 @@ async def test_update_entity_delay(
     args = client.async_send_command.call_args_list[3][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
-    hass.import_executor.shutdown()
 
 
 async def test_update_entity_partial_restore_data(

--- a/tests/components/zwave_js/test_update.py
+++ b/tests/components/zwave_js/test_update.py
@@ -1,6 +1,7 @@
 """Test the Z-Wave JS update entities."""
 import asyncio
 from datetime import timedelta
+from unittest.mock import patch
 
 import pytest
 from zwave_js_server.event import Event
@@ -310,7 +311,8 @@ async def test_update_entity_ha_not_running(
     hass_ws_client: WebSocketGenerator,
 ) -> None:
     """Test update occurs only after HA is running."""
-    await hass.async_stop()
+    with patch.object(hass.import_executor, "shutdown"):
+        await hass.async_stop()
 
     client.async_send_command.return_value = {"updates": []}
 
@@ -343,6 +345,8 @@ async def test_update_entity_ha_not_running(
     args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
+
+    hass.import_executor.shutdown()
 
 
 async def test_update_entity_update_failure(
@@ -632,7 +636,8 @@ async def test_update_entity_delay(
     """Test update occurs on a delay after HA starts."""
     client.async_send_command.reset_mock()
     client.async_send_command.return_value = {"updates": []}
-    await hass.async_stop()
+    with patch.object(hass.import_executor, "shutdown"):
+        await hass.async_stop()
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
@@ -661,6 +666,7 @@ async def test_update_entity_delay(
     args = client.async_send_command.call_args_list[3][0][0]
     assert args["command"] == "controller.get_available_firmware_updates"
     assert args["nodeId"] == zen_31.node_id
+    hass.import_executor.shutdown()
 
 
 async def test_update_entity_partial_restore_data(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2869,3 +2869,17 @@ def test_one_time_listener_repr(hass: HomeAssistant) -> None:
     assert "OneTimeListener" in repr_str
     assert "test_core" in repr_str
     assert "_listener" in repr_str
+
+
+async def test_async_add_import_executor_job(hass: HomeAssistant) -> None:
+    """Test async_add_import_executor_job."""
+    evt = threading.Event()
+    loop = asyncio.get_running_loop()
+
+    def executor_func() -> None:
+        evt.set()
+        return evt
+
+    future = hass.async_add_import_executor_job(executor_func)
+    await loop.run_in_executor(None, evt.wait)
+    assert await future is evt

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2872,7 +2872,7 @@ def test_one_time_listener_repr(hass: HomeAssistant) -> None:
 
 
 async def test_async_add_import_executor_job(hass: HomeAssistant) -> None:
-    """Test async_add_import_executor_job."""
+    """Test async_add_import_executor_job works and is limited to one thread."""
     evt = threading.Event()
     loop = asyncio.get_running_loop()
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2883,3 +2883,5 @@ async def test_async_add_import_executor_job(hass: HomeAssistant) -> None:
     future = hass.async_add_import_executor_job(executor_func)
     await loop.run_in_executor(None, evt.wait)
     assert await future is evt
+
+    assert hass.import_executor._max_workers == 1


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Limit executor imports to a single thread

This did not have a significant performance decline, and since we were already previously importing them in the main thread even limiting to a single import thread is better than blocking the loop

https://github.com/python/cpython/issues/83065 seems to be the bug we are hitting in cpython

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
