### PR TITLE
Fix LingeringTask after test completion in enphase_envoy

### DIFF
--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -28,6 +28,7 @@ async def test_form(hass: HomeAssistant, config, setup_enphase_envoy) -> None:
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy 1234"
     assert result2["data"] == {
@@ -57,6 +58,7 @@ async def test_user_no_serial_number(
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
@@ -86,6 +88,7 @@ async def test_user_fetching_serial_fails(
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy"
     assert result2["data"] == {
@@ -115,6 +118,7 @@ async def test_form_invalid_auth(hass: HomeAssistant, setup_enphase_envoy) -> No
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "invalid_auth"}
 
@@ -136,6 +140,7 @@ async def test_form_cannot_connect(hass: HomeAssistant, setup_enphase_envoy) -> 
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
 
@@ -157,6 +162,7 @@ async def test_form_unknown_error(hass: HomeAssistant, setup_enphase_envoy) -> N
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "unknown"}
 
@@ -199,6 +205,7 @@ async def test_zeroconf_pre_token_firmware(
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy 1234"
     assert result2["result"].unique_id == "1234"
@@ -239,6 +246,7 @@ async def test_zeroconf_token_firmware(
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Envoy 1234"
     assert result2["result"].unique_id == "1234"
@@ -330,6 +338,7 @@ async def test_zeroconf_serial_already_exists(
             type="mock_type",
         ),
     )
+    await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
 
@@ -353,6 +362,7 @@ async def test_zeroconf_serial_already_exists_ignores_ipv6(
             type="mock_type",
         ),
     )
+    await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "not_ipv4_address"
 
@@ -377,6 +387,7 @@ async def test_zeroconf_host_already_exists(
             type="mock_type",
         ),
     )
+    await hass.async_block_till_done()
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
 
@@ -401,6 +412,7 @@ async def test_reauth(hass: HomeAssistant, config_entry, setup_enphase_envoy) ->
             "password": "test-password",
         },
     )
+    await hass.async_block_till_done()
     assert result2["type"] == "abort"
     assert result2["reason"] == "reauth_successful"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Test reports `FAILED tests/components/enphase_envoy/test_config_flow.py::test_zeroconf_serial_already_exists - Failed: Lingering task`. Fix by inserting await hass.async_block_till_done() before final asserts as in #111165.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
