### PR TITLE
Update reporting for media_source.async_resolve_media

### DIFF
--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -148,7 +148,11 @@ async def async_resolve_media(
         raise Unresolvable("Media Source not loaded")
 
     if target_media_player is UNDEFINED:
-        report("calls media_source.async_resolve_media without passing an entity_id")
+        report(
+            "calls media_source.async_resolve_media without passing an entity_id",
+            {DOMAIN},
+            error_if_core=True,
+        )
         target_media_player = None
 
     try:

--- a/homeassistant/components/media_source/__init__.py
+++ b/homeassistant/components/media_source/__init__.py
@@ -151,7 +151,6 @@ async def async_resolve_media(
         report(
             "calls media_source.async_resolve_media without passing an entity_id",
             {DOMAIN},
-            error_if_core=True,
         )
         target_media_player = None
 

--- a/tests/components/jellyfin/test_media_source.py
+++ b/tests/components/jellyfin/test_media_source.py
@@ -40,7 +40,9 @@ async def test_resolve(
     mock_api.get_item.side_effect = None
     mock_api.get_item.return_value = load_json_fixture("track.json")
 
-    play_media = await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/TRACK-UUID")
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/TRACK-UUID", "media_player.jellyfin_device"
+    )
 
     assert play_media.mime_type == "audio/flac"
     assert play_media.url == snapshot
@@ -49,7 +51,9 @@ async def test_resolve(
     mock_api.get_item.side_effect = None
     mock_api.get_item.return_value = load_json_fixture("movie.json")
 
-    play_media = await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/MOVIE-UUID")
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/MOVIE-UUID", "media_player.jellyfin_device"
+    )
 
     assert play_media.mime_type == "video/mp4"
     assert play_media.url == snapshot
@@ -59,7 +63,11 @@ async def test_resolve(
     mock_api.get_item.return_value = load_json_fixture("unsupported-item.json")
 
     with pytest.raises(BrowseError):
-        await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/UNSUPPORTED-ITEM-UUID")
+        await async_resolve_media(
+            hass,
+            f"{URI_SCHEME}{DOMAIN}/UNSUPPORTED-ITEM-UUID",
+            "media_player.jellyfin_device",
+        )
 
 
 async def test_root(

--- a/tests/components/media_source/test_init.py
+++ b/tests/components/media_source/test_init.py
@@ -121,17 +121,13 @@ async def test_async_resolve_media_no_entity(
     assert await async_setup_component(hass, media_source.DOMAIN, {})
     await hass.async_block_till_done()
 
-    media = await media_source.async_resolve_media(
-        hass,
-        media_source.generate_media_source_id(media_source.DOMAIN, "local/test.mp3"),
-    )
-    assert isinstance(media, media_source.models.PlayMedia)
-    assert media.url == "/media/local/test.mp3"
-    assert media.mime_type == "audio/mpeg"
-    assert (
-        "calls media_source.async_resolve_media without passing an entity_id"
-        in caplog.text
-    )
+    with pytest.raises(RuntimeError):
+        await media_source.async_resolve_media(
+            hass,
+            media_source.generate_media_source_id(
+                media_source.DOMAIN, "local/test.mp3"
+            ),
+        )
 
 
 async def test_async_unresolve_media(hass: HomeAssistant) -> None:

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -81,7 +81,9 @@ async def test_resolve(
         f"FILE|{config_entry.entry_id}|{TEST_CHANNEL}|{TEST_STREAM}|{TEST_FILE_NAME}"
     )
 
-    play_media = await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/{file_id}")
+    play_media = await async_resolve_media(
+        hass, f"{URI_SCHEME}{DOMAIN}/{file_id}", None
+    )
 
     assert play_media.mime_type == TEST_MIME_TYPE
 
@@ -245,7 +247,7 @@ async def test_browsing_errors(
     with pytest.raises(Unresolvable):
         await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}/UNKNOWN")
     with pytest.raises(Unresolvable):
-        await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/UNKNOWN")
+        await async_resolve_media(hass, f"{URI_SCHEME}{DOMAIN}/UNKNOWN", None)
 
 
 async def test_browsing_not_loaded(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes media_source reporting on itself. We also shouldn't do this anymore in core, so let' raise if that happens.
```
Detected that integration 'media_source' calls media_source.async_resolve_media without passing an entity_id at homeassistant/components/media_source/__init__.py, line 151: report("calls media_source.async_resolve_media without passing an entity_id"), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+media_source%22
```

Fixes https://github.com/home-assistant/core/issues/111978
Fixes https://github.com/home-assistant/core/issues/111979

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
