### PR TITLE
Use description key instead of name for Tibber RT unique ID

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -60,6 +60,35 @@ MIN_TIME_BETWEEN_UPDATES = timedelta(minutes=5)
 PARALLEL_UPDATES = 0
 
 
+RT_SENSORS_UNIQUE_ID_MIGRATION = {
+    "accumulated_consumption_last_hour": "accumulated consumption current hour",
+    "accumulated_production_last_hour": "accumulated production current hour",
+    "current_l1": "current L1",
+    "current_l2": "current L2",
+    "current_l3": "current L3",
+    "estimated_hour_consumption": "Estimated consumption current hour",
+}
+
+RT_SENSORS_UNIQUE_ID_MIGRATION_SIMPLE = {
+    # simple migration can be done by replacing " " with "_"
+    "accumulated_consumption",
+    "accumulated_cost",
+    "accumulated_production",
+    "accumulated_reward",
+    "average_power",
+    "last_meter_consumption",
+    "last_meter_production",
+    "max_power",
+    "min_power",
+    "power_factor",
+    "power_production",
+    "signal_strength",
+    "voltage_phase1",
+    "voltage_phase2",
+    "voltage_phase3",
+}
+
+
 RT_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="averagePower",
@@ -525,12 +554,50 @@ class TibberRtDataCoordinator(DataUpdateCoordinator):  # pylint: disable=hass-en
         self._async_remove_device_updates_handler = self.async_add_listener(
             self._add_sensors
         )
+        self.entity_registry = async_get_entity_reg(hass)
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
 
     @callback
     def _handle_ha_stop(self, _event: Event) -> None:
         """Handle Home Assistant stopping."""
         self._async_remove_device_updates_handler()
+
+    @callback
+    def _migrate_unique_id(self, sensor_description: SensorEntityDescription) -> None:
+        """Migrate unique id if needed."""
+        translation_key = sensor_description.translation_key
+        entity_id: str | None = None
+        if translation_key in RT_SENSORS_UNIQUE_ID_MIGRATION_SIMPLE:
+            entity_id = self.entity_registry.async_get_entity_id(
+                "sensor",
+                TIBBER_DOMAIN,
+                f"{self._tibber_home.home_id}_rt_{translation_key.replace('_', ' ')}",
+            )
+        elif translation_key in RT_SENSORS_UNIQUE_ID_MIGRATION:
+            entity_id = self.entity_registry.async_get_entity_id(
+                "sensor",
+                TIBBER_DOMAIN,
+                f"{self._tibber_home.home_id}_rt_{RT_SENSORS_UNIQUE_ID_MIGRATION[translation_key]}",
+            )
+
+        if entity_id is None:
+            return
+
+        new_unique_id = (
+            f"{self._tibber_home.home_id}_rt_{sensor_description.translation_key}"
+        )
+
+        _LOGGER.debug(
+            "Migrating unique id for %s to %s",
+            sensor_description.translation_key,
+            new_unique_id,
+        )
+        try:
+            self.entity_registry.async_update_entity(
+                entity_id, new_unique_id=new_unique_id
+            )
+        except ValueError as err:
+            _LOGGER.error(err)
 
     @callback
     def _add_sensors(self) -> None:
@@ -545,6 +612,8 @@ class TibberRtDataCoordinator(DataUpdateCoordinator):  # pylint: disable=hass-en
             state = live_measurement.get(sensor_description.key)
             if state is None:
                 continue
+
+            self._migrate_unique_id(sensor_description)
             entity = TibberSensorRT(
                 self._tibber_home,
                 sensor_description,

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -454,7 +454,9 @@ class TibberSensorRT(TibberSensor, CoordinatorEntity["TibberRtDataCoordinator"])
         self._device_name = f"{self._model} {self._home_name}"
 
         self._attr_native_value = initial_state
-        self._attr_unique_id = f"{self._tibber_home.home_id}_rt_{description.name}"
+        self._attr_unique_id = (
+            f"{self._tibber_home.home_id}_rt_{description.translation_key}"
+        )
 
         if description.key in ("accumulatedCost", "accumulatedReward"):
             self._attr_native_unit_of_measurement = tibber_home.currency


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

<https://github.com/home-assistant/core/pull/108797/files> removed the name key, which was used to generate unique IDs for real-time sensors.

This PR moves it to to see the description key instead.
As this key is not a 1:1 in most entities, a migration has been added.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #111826
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
