### PR TITLE
Import template in the executor to avoid blocking the event loop

### DIFF
--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -5,6 +5,7 @@
   "codeowners": ["@PhracturedBlue", "@tetienne", "@home-assistant/core"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/template",
+  "import_executor": true,
   "integration_type": "helper",
   "iot_class": "local_push",
   "quality_scale": "internal"


### PR DESCRIPTION
~~needs https://github.com/home-assistant/core/pull/112071~~

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Importing template has a very long dep tree because it imports so many other things. One alternative would be to import `httpx` sooner in the setup process since unlikely `aiohttp` which is loaded early, `httpx` is usually loaded a lot later, and its a very heavy dep

```
>>> import sys
>>> before = set(sys.modules)
>>> from homeassistant.components.template import config
>>> after = set(sys.modules)
>>> after-before
{jwt.types, homeassistant.components.template.button, homeassistant.components.websocket_api.connection, _cffi_backend, stringprep, importlib.metadata._collections, requests.packages.urllib3.connectionpool, email._encoded_words, ctypes.macholib.dyld, httpcore._async.connection, multidict, jwt.api_jwt, aiohttp.web_ws, http, homeassistant.helpers.http, homeassistant.components, _hashlib, quopri, httpx._compat, heapq, homeassistant.components.template.const, cryptography.hazmat.primitives.asymmetric.utils, asyncio.base_events, homeassistant.components.template.sensor, threading, pycares, aiohttp.compression_utils, yaml.representer, httpcore._backends.base, pycares._cares, click, aiohttp.multipart, homeassistant.components.websocket_api.commands, cryptography.x509.extensions, multidict._multidict_base, urllib3.exceptions, pkgutil, cryptography.hazmat.primitives.asymmetric.dsa, homeassistant.helpers.update_coordinator, requests, yaml.scanner, homeassistant.components.network.util, rich._wrap, mimetypes, jinja2.lexer, cryptography.hazmat.primitives._cipheralgorithm, rich.themes, homeassistant.util.yaml.loader, homeassistant.components.http.ban, rich.emoji, logging.handlers, cryptography.hazmat.primitives.asymmetric, httpcore._models, trio._deprecate, httpcore._sync.http11, simplejson.decoder, homeassistant.components.network.models, yaml.error, jinja2.sandbox, requests.packages.urllib3.contrib, asyncio.tasks, _openssl.lib, netrc, aiohttp._helpers, typing_extensions, idna.intranges, yarl._quoting_c, _zoneinfo, homeassistant.util.frozen_dataclass_compat, urllib3.connectionpool, awesomeversion, typing, homeassistant.util.executor, httpx._status_codes, ifaddr, anyio.streams, homeassistant.components.weather.websocket_api, homeassistant.auth.permissions.models, requests.packages.urllib3.util.response, anyio._core._resources, __future__, jwt.api_jwk, _multibytecodec, email.message, httpx._transports.mock, homeassistant.auth.permissions.types, rich.panel, cryptography.hazmat.primitives.asymmetric.rsa, rich.markup, rich.color_triplet, http.client, certifi.core, anyio.lowlevel, httpcore._sync.http_proxy, h2.config, trio._core._traps, packaging._structures, homeassistant.data_entry_flow, trio._unix_pipes, jwt.utils, homeassistant.generated.config_flows, trio._core._local, anyio.streams.stapled, trio._version, _cares.lib, cryptography.hazmat.primitives.ciphers.algorithms, homeassistant.components.button.const, aiohttp._websocket, _ssl, yaml.loader, homeassistant.components.weather.const, hyperframe.flags, jwt.warnings, requests.packages.urllib3.filepost, trio._core._mock_clock, rich._palettes, pygments.token, homeassistant.components.template.trigger_entity, yaml.reader, trio._core._generated_instrumentation, attr._compat, rich._lru_cache, asyncio.trsock, concurrent.futures.thread, h2.errors, homeassistant.generated.countries, bz2, cryptography.x509.base, yaml.serializer, trio._socket, aiohttp.connector, attr, voluptuous.util, homeassistant.util.unit_system, gc, rich.text, httpcore, pygments.styles._mapping, bisect, urllib3.util.retry, socks, aiohttp.http_websocket, asyncio, aiohttp_fast_url_dispatcher, packaging._tokenizer, simplejson.scanner, cython_runtime, sniffio._impl, homeassistant.util.yaml, simplejson.errors, rich.repr, math, homeassistant.helpers.script, jwt.jwk_set_cache, homeassistant.helpers.group, packaging.specifiers, homeassistant.helpers.restore_state, homeassistant.helpers.translation, asyncio.log, h2.connection, cryptography.hazmat, hpack.struct, jwt.algorithms, httpx._transports, asyncio.unix_events, voluptuous.humanize, trio.lowlevel, jwt.jwks_client, rich.palette, frozenlist._frozenlist, cryptography.hazmat.primitives.ciphers.modes, jinja2.bccache, homeassistant.components.template.binary_sensor, cryptography.hazmat.primitives.asymmetric.ed448, requests.packages.urllib3.contrib._appengine_environ, yaml.parser, homeassistant.requirements, rich.scope, email.iterators, homeassistant.components.template.image, urllib3._version, homeassistant.util.package, homeassistant.components.template.number, yaml.resolver, http.cookiejar, yarl._quoting, packaging._musllinux, homeassistant, email._parseaddr, homeassistant.helpers.script_variables, fcntl, _openssl, _locale, aiohttp.web_server, requests.packages.urllib3._version, click.core, click.formatting, rich.padding, ifaddr._shared, anyio._core._eventloop, cryptography.hazmat.primitives.serialization.base, homeassistant.util.network, hyperframe.frame, outcome._impl, homeassistant.util.yaml.const, homeassistant.helpers.frame, csv, isal, homeassistant.components.sensor, rich._ratio, attr.filters, logging, requests.exceptions, homeassistant.components.sensor.helpers, cryptography.hazmat.primitives.constant_time, concurrent.futures, rich.spinner, aiohttp.log, voluptuous, voluptuous.schema_builder, requests.packages.urllib3.packages.six.moves, platform, homeassistant.components.template.coordinator, h2.windows, hpack.table, cryptography.hazmat._oid, sortedcontainers.sorteddict, click.types, anyio._core._tasks, homeassistant.components.http.auth, homeassistant.components.number.websocket_api, urllib3.packages.six.moves.urllib, h11._version, errno, aiohttp.payload, uuid, hyperframe.exceptions, ctypes.macholib.dylib, _heapq, homeassistant.components.websocket_api.error, jinja2, httpx._urls, yarl, homeassistant.components.http.security_filter, httpcore._sync, homeassistant.util.color, homeassistant.helpers.debounce, email.charset, homeassistant.helpers.storage, rich.syntax, packaging._manylinux, h2.utilities, yaml._yaml, _cares, requests.packages.urllib3.util.timeout, cryptography.hazmat.primitives.serialization, hpack, aiohttp.web_request, urllib3.util.proxy, aiohttp.web_urldispatcher, homeassistant.util.yaml.objects, anyio._core._testing, httpcore._sync.interfaces, rich.cells, homeassistant.util.enum, charset_normalizer.cd, httpx._content, anyio._core._synchronization, asyncio.selector_events, idna.core, binascii, anyio._core._subprocesses, homeassistant.components.device_automation.exceptions, requests.structures, urllib3.util, requests.packages.urllib3.util.wait, selectors, homeassistant.helpers.reload, h11._writers, cryptography.x509.name, awesomeversion.awesomeversion, gzip, queue, outcome._version, pygments.modeline, slugify.special, ntpath, importlib.resources.readers, asyncio.taskgroups, jinja2.compiler, requests.packages.urllib3.fields, cryptography.hazmat.primitives, idna.package_data, aiohttp.hdrs, urllib.request, brotli, anyio._core._exceptions, struct, aiohttp.payload_streamer, homeassistant.block_async_io, cryptography.x509, urllib3.util.ssl_match_hostname, sortedcontainers.sortedlist, homeassistant.backports.functools, aiohttp.locks, _csv, homeassistant.generated.application_credentials, homeassistant.helpers.issue_registry, homeassistant.components.template, email.base64mime, attr.exceptions, homeassistant.components.weather, _cython_3_0_5, asyncio.runners, ulid_transform._ulid_impl, markupsafe, homeassistant.exceptions, requests.packages.urllib3.util.queue, anyio._core._fileio, _scproxy, asyncio.sslproto, voluptuous_serialize, trio._ssl, cryptography.hazmat.bindings, asyncio.streams, rich._cell_widths, lru, importlib.resources._adapters, aiohttp.client_exceptions, decimal, hyperframe, homeassistant.helpers.area_registry, ctypes.macholib, anyio.streams.tls, requests.packages.urllib3.util.url, httpcore._backends.auto, homeassistant.util.read_only_dict, jwt.api_jws, trio._subprocess_platform, h11._headers, cryptography.utils, importlib.metadata._text, cryptography.hazmat.primitives.asymmetric.x448, trio._core, homeassistant.helpers.trigger, pygments.util, simplejson.compat, rich.measure, trio._core._run, multidict._abc, simplejson, requests.packages.idna.core, urllib3.filepost, homeassistant.util.thread, requests.models, socket, sortedcontainers.sortedset, packaging._elffile, attr._make, jwt, urllib3.connection, anyio.abc._subprocesses, requests.packages.urllib3.response, trio._path, ssl, _sysconfigdata__darwin_darwin, yaml.composer, zipfile._path.glob, packaging.version, homeassistant.auth.const, locale, homeassistant.util.ssl, argparse, aiohttp.helpers, zipfile._path, httpx._urlparse, colorsys, jinja2.optimizer, packaging.utils, trio._core._thread_cache, httpcore._async.connection_pool, asyncio.base_subprocess, aiodns, homeassistant.components.number.const, requests.packages.urllib3.util.retry, trio._core._generated_run, homeassistant.auth.models, h11._connection, aiodns.error, homeassistant.generated.mqtt, anyio._core._streams, trio._highlevel_open_tcp_listeners, yaml.tokens, homeassistant.helpers.entity, _queue, h11._events, h2.stream, requests.status_codes, urllib3.response, homeassistant.helpers.condition, pygments.lexers, json.encoder, importlib.resources._legacy, requests.packages.urllib3.util.proxy, httpcore._async.http2, rich.default_styles, rich.terminal_theme, homeassistant.helpers.entity_component, homeassistant.loader, homeassistant.auth.permissions.entities, aiohttp.formdata, aiohttp.web_app, sniffio, email, httpcore._backends.sync, trio._core._generated_io_kqueue, cryptography.hazmat.primitives.asymmetric.types, rich.control, charset_normalizer.utils, requests.packages.urllib3.util.connection, _cython_3_0_0rc1, copy, jinja2.exceptions, httpcore._async.http11, homeassistant.components.sensor.websocket_api, pycares.errno, cryptography.x509.certificate_transparency, click.decorators, rich.containers, packaging._parser, aiohttp.tcp_helpers, urllib3.contrib, asyncio.events, homeassistant.generated.languages, requests.packages.idna, asyncio.base_tasks, _posixsubprocess, trio._core._concat_tb, email.utils, importlib.metadata._itertools, requests.packages.urllib3._collections, cryptography.hazmat.backends, jinja2.runtime, aiohttp.web_runner, homeassistant.helpers.config_validation, rich.segment, _compat_pickle, requests.packages.urllib3.request, asyncio.timeouts, anyio._core._sockets, charset_normalizer.legacy, jwt.exceptions, requests._internal_utils, rich.pager, homeassistant.util.logging, pycares.utils, awesomeversion.utils.validate, click.utils, lzma, cryptography.hazmat.primitives.ciphers, homeassistant.components.scene, trio.socket, homeassistant.auth, trio._core._parking_lot, aiohttp.web_exceptions, importlib.resources, aiohttp.web_protocol, jinja2.environment, aiohttp.client_ws, packaging.requirements, _lzma, concurrent.futures._base, slugify.slugify, rich.jupyter, homeassistant.helpers.location, trio._threads, isal.igzip_lib, concurrent, hpack.huffman_table, requests.packages.urllib3.packages, yaml.dumper, aiohttp, cryptography.__about__, awesomeversion.comparehandlers.simple, trio._core._entry_queue, h2.frame_buffer, rich.theme, rich.box, jinja2.tests, idna.idnadata, urllib3.packages.six, rich.live, email.encoders, homeassistant.generated.usb, h11._abnf, anyio.abc._sockets, aiohttp.web_fileresponse, homeassistant.util.uuid, aiohttp.typedefs, homeassistant.components.light, jinja2.idtracking, ctypes.util, trio._core._ki, homeassistant.helpers.typing, sysconfig, _typing, attr._funcs, pygments.plugin, attr._cmp, httpx._config, yaml.events, urllib3.util.ssl_, homeassistant.generated.bluetooth, httpcore._sync.connection, attr.setters, ulid_transform, requests.certs, homeassistant.generated.dhcp, homeassistant.auth.permissions, requests.packages, sortedcontainers, aiohttp.web, trio._core._unbounded_queue, requests.packages.urllib3.util.request, trio._highlevel_open_tcp_stream, httpcore._backends.mock, click._compat, homeassistant.util.unit_conversion, trio._core._instrumentation, homeassistant.auth.auth_store, _datetime, jinja2.parser, voluptuous.error, homeassistant.components.network.network, urllib3.util.ssltransport, signal, importlib.metadata._adapters, pprint, httpx._models, anyio.from_thread, homeassistant.helpers.entity_registry, json, cryptography, requests.packages.urllib3.packages.six.moves.urllib, h2.exceptions, isal._isal, homeassistant.helpers.ratelimit, cryptography.x509.general_name, _brotli, asyncio.exceptions, text_unidecode, anyio._core._signals, homeassistant.components.websocket_api.const, getpass, trio._core._wakeup_socketpair, homeassistant.auth.permissions.util, httpx.__version__, aiohttp.web_middlewares, asyncio.protocols, h11._state, shutil, homeassistant.util.timeout, _decimal, jinja2.nodes, click.globals, email.feedparser, rich.style, rich.highlighter, frozenlist, awesomeversion.comparehandlers, homeassistant.components.http.headers, rich.errors, awesomeversion.comparehandlers.modifier, homeassistant.auth.permissions.const, homeassistant.util.decorator, slugify.__version__, cryptography.hazmat.primitives.ciphers.base, unicodedata, httpx._main, asyncio.futures, pathlib, aiohttp.http_parser, aiohttp.http_writer, attr._config, urllib3.util.timeout, homeassistant.generated.zeroconf, awesomeversion.exceptions, pygments.styles, httpx._transports.wsgi, charset_normalizer.api, homeassistant.helpers.json, statistics, trio._signals, aiohttp.tracing, homeassistant.helpers.discovery, anyio.abc._resources, cryptography.hazmat.primitives.serialization.ssh, ctypes._endian, subprocess, homeassistant.auth.permissions.merge, trio._core._asyncgens, zoneinfo._tzpath, asyncio.mixins, textwrap, atomicwrites, importlib.resources.abc, homeassistant.components.http.web_runner, rich.progress, pycares._version, httpcore._backends.trio, requests.utils, slugify, urllib.error, string, bcrypt._bcrypt, homeassistant.util.yaml.input, certifi, anyio.abc._streams, homeassistant.components.select.const, requests.packages.urllib3, homeassistant.generated.ssdp, h2, _cython_3_0_6, _bz2, homeassistant.components.image.const, cryptography.hazmat.primitives.hashes, trio._highlevel_generic, homeassistant.helpers.entity_values, json.scanner, rich.region, asyncio.coroutines, homeassistant.auth.jwt_wrapper, urllib3.contrib._appengine_environ, select, timeit, homeassistant.components.template.select, orjson.orjson, idna, homeassistant.generated, zipfile, homeassistant.helpers.dispatcher, fractions, homeassistant.helpers.service, cryptography.x509.oid, httpcore._exceptions, trio._highlevel_serve_listeners, httpcore._api, homeassistant.components.websocket_api.decorators, jinja2.visitor, homeassistant.components.logger.const, requests.packages.urllib3.packages.six.moves.http_client, importlib.metadata, requests.cookies, requests.__version__, rich._spinners, homeassistant.backports, attr.validators, markupsafe._speedups, homeassistant.components.websocket_api.auth, outcome._util, homeassistant.components.http.static, _statistics, homeassistant.components.network.const, homeassistant.helpers.selector, homeassistant.helpers.deprecation, urllib3.fields, trio._core._io_kqueue, awesomeversion.comparehandlers.sections, yarl._url, homeassistant.util.ulid, asyncio.base_futures, requests.packages.urllib3.util.ssl_match_hostname, requests.packages.idna.idnadata, homeassistant.helpers.sun, homeassistant.components.device_automation.action, httpx._types, urllib3.util.response, numbers, cryptography.exceptions, rich.table, httpcore._async.http_proxy, homeassistant.components.select, homeassistant.components.websocket_api, array, lru._lru, anyio._core._typedattr, homeassistant.components.template.config, homeassistant.auth.providers, homeassistant.components.device_automation.helpers, requests.compat, httpx._auth, calendar, requests.hooks, httpcore._sync.connection_pool, urllib3.util.url, homeassistant.util.async_, jinja2.filters, _contextvars, _asyncio, httpx._utils, trio._util, httpcore._trace, homeassistant.components.logger.websocket_api, encodings.idna, trio._dtls, _uuid, requests.auth, homeassistant.components.device_automation, aiohttp.abc, homeassistant.util, requests.sessions, aiohttp.cookiejar, requests.packages.idna.intranges, homeassistant.components.websocket_api.http, homeassistant.components.template.weather, ifaddr._posix, urllib.parse, asyncio.locks, yaml.nodes, requests.api, homeassistant.components.http.view, asyncio.subprocess, charset_normalizer.models, urllib3, httpx._client, multidict._multidict, voluptuous.validators, importlib.metadata._meta, email.quoprimime, homeassistant.util.json, isal.isal_zlib, urllib3.packages, httpx._transports.default, homeassistant.components.zone.const, requests.packages.urllib3.connection, hpack.huffman, trio._abc, yaml.cyaml, rich, rich._emoji_codes, secrets, click.termui, jinja2._identifier, asyncio.constants, traceback, aiosignal, httpx._decoders, rich.file_proxy, charset_normalizer.version, httpcore._synchronization, zoneinfo._common, urllib3.poolmanager, cryptography.hazmat.primitives._serialization, anyio._core, trio._core._exceptions, cryptography.hazmat.primitives.asymmetric.ec, homeassistant.util.yaml.dumper, homeassistant.components.http.cors, simplejson.raw_json, attr.converters, homeassistant.auth.permissions.system_policies, anyio.abc._eventloop, homeassistant.components.logger, pygments.style, urllib3._collections, urllib3.util.connection, jinja2.ext, homeassistant.auth.permissions.events, requests.packages.urllib3.util.ssltransport, requests.packages.urllib3.util.ssl_, jinja2.defaults, homeassistant.helpers.start, aiohttp.resolver, attr._next_gen, base64, requests.packages.urllib3.util, anyio, zlib, jinja2.async_utils, rich.filesize, homeassistant.helpers.entity_platform, httpcore._async.interfaces, homeassistant.helpers.collection, homeassistant.components.template.template_entity, _struct, rich.abc, trio._file_io, ctypes.macholib.framework, async_interrupt, multidict._compat, homeassistant.helpers.template, homeassistant.components.sensor.const, outcome, ulid_transform.ulid_impl, homeassistant.helpers.trigger_template_entity, click.parser, datetime, aiohttp._http_parser, homeassistant.helpers.event, trio._channel, email.header, httpx._transports.base, homeassistant.components.button, importlib.resources._itertools, anyio.abc._testing, click.exceptions, aiohttp.base_protocol, homeassistant.config, trio._subprocess, homeassistant.util.dt, homeassistant.components.http.request_context, homeassistant.components.persistent_notification, homeassistant.helpers.normalized_name_base_registry, charset_normalizer.assets, cryptography.hazmat.primitives._asymmetric, asyncio.threads, requests.packages.urllib3.packages.six.moves.urllib.parse, urllib3.util.wait, ipaddress, requests.packages.urllib3.poolmanager, typing.io, aiohttp.http, random, anyio.to_thread, anyio.abc._tasks, awesomeversion.utils, homeassistant.generated.currencies, homeassistant.config_entries, trio._sync, urllib3.packages.six.moves, yaml.emitter, trio._highlevel_ssl_helpers, rich._extension, zoneinfo, simplejson._speedups, aiohttp.streams, homeassistant.components.websocket_api.util, homeassistant.components.http.const, asyncio.queues, _json, h11._receivebuffer, trio._subprocess_platform.kqueue, _ctypes, homeassistant.helpers, homeassistant.components.number, homeassistant.helpers.trace, httpcore._utils, tempfile, _bisect, _socket, trio, _osx_support, _string, homeassistant.components.device_automation.const, ctypes, httpx._api, rich.console, trio._highlevel_socket, httpx._exceptions, packaging.markers, packaging, h11, httpcore._backends.anyio, rich._pick, homeassistant.components.http.forwarded, termios, h11._util, h2.events, urllib3.packages.six.moves.urllib.parse, orjson, rich.screen, httpcore._async, rich.color, homeassistant.auth.mfa_modules, httpx._transports.asgi, homeassistant.util.scaling, h11._readers, importlib.resources._common, pygments.lexers._mapping, rich.constrain, dataclasses, charset_normalizer, homeassistant.helpers.network, awesomeversion.strategy, cryptography.x509.verification, rich._log_render, aiohttp.web_routedef, hpack.huffman_constants, aiohttp.http_exceptions, httpcore._backends, yaml, cryptography.hazmat.primitives.asymmetric.x25519, bcrypt, aiohttp.client_reqrep, pickle, aiohttp.client, charset_normalizer.constant, aiohttp.web_response, ciso8601, yaml.constructor, importlib.readers, email.errors, packaging.tags, homeassistant.core, homeassistant.util.file, rich.live_render, homeassistant.components.logger.helpers, hashlib, awesomeversion.utils.regex, importlib.abc, http.cookies, urllib3.packages.six.moves.http_client, aiohttp.client_proto, trio._highlevel_open_unix_stream, awesomeversion.comparehandlers.container, httpx, urllib, typing.re, rich.protocol, homeassistant.components.zone, contextvars, simplejson.encoder, _pickle, rich.align, json.decoder, rich.pretty, aiohttp_zlib_ng, homeassistant.components.binary_sensor, homeassistant.helpers.device_registry, charset_normalizer.md, urllib.response, cryptography.hazmat.bindings._rust, jinja2.utils, aiohttp._http_writer, html, importlib.metadata._functools, urllib3.util.queue, cryptography.hazmat.primitives.asymmetric.dh, pygments, _random, httpcore._sync.http2, rich.ansi, asyncio.transports, html.entities, hpack.hpack, configparser, requests.packages.urllib3.packages.six, homeassistant.components.image, cryptography.hazmat.primitives.asymmetric.ed25519, trio.to_thread, homeassistant.components.http, homeassistant.components.http.decorators, trio.from_thread, urllib3.request, rich.progress_bar, trio._timeouts, fnmatch, rich.styled, asyncio.staggered, aiohttp.web_log, cryptography.hazmat.primitives.asymmetric.padding, _compression, homeassistant.components.websocket_api.messages, homeassistant.util.location, requests.adapters, requests.packages.chardet, requests.packages.idna.package_data, h2.settings, urllib3.contrib.socks, hpack.exceptions, jinja2.loaders, anyio.abc, httpcore._ssl, homeassistant.helpers.httpx_client, email._policybase, attr._version_info, homeassistant.components.network, homeassistant.setup, homeassistant.const, _blake2, _sha2, homeassistant.helpers.singleton, urllib3.util.request, requests.packages.urllib3.exceptions, email.parser, asyncio.format_helpers, hmac, anyio.streams.memory, gettext, trio.abc, rich._emoji_replace, httpx._multipart, rich._loop, sniffio._version}
>>>
```

<img width="1635" alt="Screenshot 2024-03-02 at 11 37 49 AM" src="https://github.com/home-assistant/core/assets/663432/5d83ddb6-cf79-4811-a5de-3cfc3ee13e93">




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
