### PR TITLE
Switch config to use async_get_component/async_get_platform

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1433,7 +1433,7 @@ async def async_process_component_config(  # noqa: C901
     # Check if the integration has a custom config validator
     config_validator = None
     try:
-        config_validator = integration.get_platform("config")
+        config_validator = await integration.async_get_platform("config")
     except ImportError as err:
         # Filter out import error of the config platform.
         # If the config platform contains bad imports, make sure

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1557,7 +1557,7 @@ async def async_process_component_config(  # noqa: C901
             continue
 
         try:
-            platform = p_integration.get_platform(domain)
+            platform = await p_integration.async_get_platform(domain)
         except LOAD_EXCEPTIONS as exc:
             exc_info = ConfigExceptionInfo(
                 exc,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1418,7 +1418,7 @@ async def async_process_component_config(  # noqa: C901
     config_exceptions: list[ConfigExceptionInfo] = []
 
     try:
-        component = integration.get_component()
+        component = await integration.async_get_component()
     except LOAD_EXCEPTIONS as exc:
         exc_info = ConfigExceptionInfo(
             exc,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1430,7 +1430,8 @@ async def test_component_config_exceptions(
     # Config validator
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(
+        async_get_component=AsyncMock(),
+        async_get_platform=AsyncMock(
             return_value=Mock(
                 async_validate_config=AsyncMock(side_effect=ValueError("broken"))
             )
@@ -1455,14 +1456,14 @@ async def test_component_config_exceptions(
 
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(
+        async_get_platform=AsyncMock(
             return_value=Mock(
                 async_validate_config=AsyncMock(
                     side_effect=HomeAssistantError("broken")
                 )
             )
         ),
-        get_component=Mock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
+        async_get_component=AsyncMock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
     )
     caplog.clear()
     assert (
@@ -1482,8 +1483,8 @@ async def test_component_config_exceptions(
     caplog.clear()
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(return_value=None),
-        get_component=Mock(
+        async_get_platform=AsyncMock(return_value=None),
+        async_get_component=AsyncMock(
             return_value=Mock(CONFIG_SCHEMA=Mock(side_effect=ValueError("broken")))
         ),
     )
@@ -1511,8 +1512,8 @@ async def test_component_config_exceptions(
     caplog.clear()
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(return_value=None),
-        get_component=Mock(
+        async_get_platform=AsyncMock(return_value=None),
+        async_get_component=AsyncMock(
             return_value=Mock(
                 spec=["PLATFORM_SCHEMA_BASE"],
                 PLATFORM_SCHEMA_BASE=Mock(side_effect=ValueError("broken")),
@@ -1551,13 +1552,13 @@ async def test_component_config_exceptions(
     caplog.clear()
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(return_value=None),
-        get_component=Mock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
+        async_get_platform=AsyncMock(return_value=None),
+        async_get_component=AsyncMock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
     )
     with patch(
         "homeassistant.config.async_get_integration_with_requirements",
         return_value=Mock(  # integration that owns platform
-            get_platform=Mock(
+            async_get_platform=AsyncMock(
                 return_value=Mock(  # platform
                     PLATFORM_SCHEMA=Mock(side_effect=ValueError("broken"))
                 )
@@ -1640,12 +1641,12 @@ async def test_component_config_exceptions(
             "for test_domain component with PLATFORM_SCHEMA"
         ) in caplog.text
 
-    # get_platform("domain") raising on ImportError
+    # async_get_platform("domain") raising on ImportError
     caplog.clear()
     test_integration = Mock(
         domain="test_domain",
-        get_platform=Mock(return_value=None),
-        get_component=Mock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
+        async_get_platform=AsyncMock(return_value=None),
+        async_get_component=AsyncMock(return_value=Mock(spec=["PLATFORM_SCHEMA_BASE"])),
     )
     import_error = ImportError(
         ("ModuleNotFoundError: No module named 'not_installed_something'"),
@@ -1654,7 +1655,7 @@ async def test_component_config_exceptions(
     with patch(
         "homeassistant.config.async_get_integration_with_requirements",
         return_value=Mock(  # integration that owns platform
-            get_platform=Mock(side_effect=import_error)
+            async_get_platform=AsyncMock(side_effect=import_error)
         ),
     ):
         assert await config_util.async_process_component_and_handle_errors(
@@ -1688,12 +1689,13 @@ async def test_component_config_exceptions(
             "No module named 'not_installed_something'"
         ) in str(ex.value)
 
-    # get_platform("config") raising
+    # async_get_platform("config") raising
     caplog.clear()
     test_integration = Mock(
         pkg_path="homeassistant.components.test_domain",
         domain="test_domain",
-        get_platform=Mock(
+        async_get_component=AsyncMock(),
+        async_get_platform=AsyncMock(
             side_effect=ImportError(
                 ("ModuleNotFoundError: No module named 'not_installed_something'"),
                 name="not_installed_something",
@@ -1729,12 +1731,12 @@ async def test_component_config_exceptions(
         "No module named 'not_installed_something'" in str(ex.value)
     )
 
-    # get_component raising
+    # async_get_component raising
     caplog.clear()
     test_integration = Mock(
         pkg_path="homeassistant.components.test_domain",
         domain="test_domain",
-        get_component=Mock(
+        async_get_component=AsyncMock(
             side_effect=FileNotFoundError("No such file or directory: b'liblibc.a'")
         ),
     )


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This was another path where integrations that were marked to load in the executor
would be loaded in the loop


<img width="1605" alt="Screenshot 2024-03-02 at 12 09 52 PM" src="https://github.com/home-assistant/core/assets/663432/651604c7-ccb0-453e-b1af-d30573aadc6b">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
