### PR TITLE
Avoid expensive inspect calls in config validators

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -10,7 +10,7 @@ from datetime import (
     timedelta,
 )
 from enum import Enum, StrEnum
-import inspect
+from functools import partial
 import logging
 from numbers import Number
 import os
@@ -103,6 +103,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.util.yaml.objects import NodeStrClass
 
 from . import script_variables as script_variables_helper, template as template_helper
+from .frame import get_logger
 
 TIME_PERIOD_ERROR = "offset {} should be format 'HH:MM', 'HH:MM:SS' or 'HH:MM:SS.F'"
 
@@ -890,28 +891,20 @@ def _deprecated_or_removed(
         - No warning if neither key nor replacement_key are provided
             - Adds replacement_key with default value in this case
     """
-    module = inspect.getmodule(inspect.stack(context=0)[2].frame)
-    if module is not None:
-        module_name = module.__name__
-    else:
-        # If Python is unable to access the sources files, the call stack frame
-        # will be missing information, so let's guard.
-        # https://github.com/home-assistant/core/issues/24982
-        module_name = __name__
+    logger_func: Callable | None = None
     if option_removed:
-        logger_func = logging.getLogger(module_name).error
         option_status = "has been removed"
     else:
-        logger_func = logging.getLogger(module_name).warning
         option_status = "is deprecated"
 
     def validator(config: dict) -> dict:
         """Check if key is in config and log warning or error."""
+        nonlocal logger_func
         if key in config:
             try:
                 near = (
                     f"near {config.__config_file__}"  # type: ignore[attr-defined]
-                    f":{config.__line__} "
+                    f":{config.__line__} "  # type: ignore[attr-defined]
                 )
             except AttributeError:
                 near = ""
@@ -927,6 +920,10 @@ def _deprecated_or_removed(
 
             if raise_if_present:
                 raise vol.Invalid(warning % arguments)
+
+            if logger_func is None:
+                level = logging.WARNING if option_removed else logging.ERROR
+                logger_func = partial(get_logger(__name__).log, level)
 
             logger_func(warning, *arguments)
             value = config[key]
@@ -1112,19 +1109,9 @@ def expand_condition_shorthand(value: Any | None) -> Any:
 def empty_config_schema(domain: str) -> Callable[[dict], dict]:
     """Return a config schema which logs if there are configuration parameters."""
 
-    module = inspect.getmodule(inspect.stack(context=0)[2].frame)
-    if module is not None:
-        module_name = module.__name__
-    else:
-        # If Python is unable to access the sources files, the call stack frame
-        # will be missing information, so let's guard.
-        # https://github.com/home-assistant/core/issues/24982
-        module_name = __name__
-    logger_func = logging.getLogger(module_name).error
-
     def validator(config: dict) -> dict:
         if domain in config and config[domain]:
-            logger_func(
+            get_logger(__name__).error(
                 (
                     "The %s integration does not support any configuration parameters, "
                     "got %s. Please remove the configuration parameters from your "
@@ -1146,16 +1133,6 @@ def _no_yaml_config_schema(
 ) -> Callable[[dict], dict]:
     """Return a config schema which logs if attempted to setup from YAML."""
 
-    module = inspect.getmodule(inspect.stack(context=0)[2].frame)
-    if module is not None:
-        module_name = module.__name__
-    else:
-        # If Python is unable to access the sources files, the call stack frame
-        # will be missing information, so let's guard.
-        # https://github.com/home-assistant/core/issues/24982
-        module_name = __name__
-    logger_func = logging.getLogger(module_name).error
-
     def raise_issue() -> None:
         # pylint: disable-next=import-outside-toplevel
         from .issue_registry import IssueSeverity, async_create_issue
@@ -1176,7 +1153,7 @@ def _no_yaml_config_schema(
 
     def validator(config: dict) -> dict:
         if domain in config:
-            logger_func(
+            get_logger(__name__).error(
                 (
                     "The %s integration does not support YAML setup, please remove it "
                     "from your configuration file"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -102,7 +102,7 @@ import homeassistant.util.dt as dt_util
 from homeassistant.util.yaml.objects import NodeStrClass
 
 from . import script_variables as script_variables_helper, template as template_helper
-from .frame import get_logger
+from .frame import get_integration_logger
 
 TIME_PERIOD_ERROR = "offset {} should be format 'HH:MM', 'HH:MM:SS' or 'HH:MM:SS.F'"
 
@@ -921,7 +921,7 @@ def _deprecated_or_removed(
             if raise_if_present:
                 raise vol.Invalid(warning % arguments)
 
-            get_logger(__name__).log(level, warning, *arguments)
+            get_integration_logger(__name__).log(level, warning, *arguments)
             value = config[key]
             if replacement_key or option_removed:
                 config.pop(key)
@@ -1107,7 +1107,7 @@ def empty_config_schema(domain: str) -> Callable[[dict], dict]:
 
     def validator(config: dict) -> dict:
         if domain in config and config[domain]:
-            get_logger(__name__).error(
+            get_integration_logger(__name__).error(
                 (
                     "The %s integration does not support any configuration parameters, "
                     "got %s. Please remove the configuration parameters from your "
@@ -1149,7 +1149,7 @@ def _no_yaml_config_schema(
 
     def validator(config: dict) -> dict:
         if domain in config:
-            get_logger(__name__).error(
+            get_integration_logger(__name__).error(
                 (
                     "The %s integration does not support YAML setup, please remove it "
                     "from your configuration file"

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -904,7 +904,7 @@ def _deprecated_or_removed(
             try:
                 near = (
                     f"near {config.__config_file__}"  # type: ignore[attr-defined]
-                    f":{config.__line__} "  # type: ignore[attr-defined]
+                    f":{config.__line__} "
                 )
             except AttributeError:
                 near = ""

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -34,7 +34,7 @@ class IntegrationFrame:
     relative_filename: str
 
 
-def get_logger(fallback_name: str) -> logging.Logger:
+def get_integration_logger(fallback_name: str) -> logging.Logger:
     """Return a logger by checking the current integration frame.
 
     If Python is unable to access the sources files, the call stack frame

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -34,6 +34,26 @@ class IntegrationFrame:
     relative_filename: str
 
 
+def get_logger(fallback_name: str) -> logging.Logger:
+    """Return a logger by checking the current integration frame.
+
+    If Python is unable to access the sources files, the call stack frame
+    will be missing information, so let's guard by requiring a fallback name.
+    https://github.com/home-assistant/core/issues/24982
+    """
+    try:
+        integration_frame = get_integration_frame()
+    except MissingIntegrationFrame:
+        return logging.getLogger(fallback_name)
+
+    if integration_frame.custom_integration:
+        logger_name = f"custom_components.{integration_frame.integration}"
+    else:
+        logger_name = f"homeassistant.components.{integration_frame.integration}"
+
+    return logging.getLogger(logger_name)
+
+
 def get_integration_frame(exclude_integrations: set | None = None) -> IntegrationFrame:
     """Return the frame, integration and integration path of the current stack frame."""
     found_frame = None

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -988,7 +988,7 @@ def test_deprecated_with_default(caplog: pytest.LogCaptureFixture, schema) -> No
 
     test_data = {"mars": True}
     with patch(
-        "homeassistant.helpers.config_validation.get_logger",
+        "homeassistant.helpers.config_validation.get_integration_logger",
         return_value=logging.getLogger(__name__),
     ):
         output = deprecated_schema(test_data.copy())

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -2,6 +2,7 @@
 from collections import OrderedDict
 from datetime import date, datetime, timedelta
 import enum
+import logging
 import os
 from socket import _GLOBAL_DEFAULT_TIMEOUT
 from unittest.mock import Mock, patch
@@ -986,7 +987,11 @@ def test_deprecated_with_default(caplog: pytest.LogCaptureFixture, schema) -> No
     deprecated_schema = vol.All(cv.deprecated("mars", default=False), schema)
 
     test_data = {"mars": True}
-    output = deprecated_schema(test_data.copy())
+    with patch(
+        "homeassistant.helpers.config_validation.get_logger",
+        return_value=logging.getLogger(__name__),
+    ):
+        output = deprecated_schema(test_data.copy())
     assert len(caplog.records) == 1
     assert caplog.records[0].name == __name__
     assert (
@@ -1062,21 +1067,19 @@ def test_deprecated_with_replacement_key_and_default(
 
 
 def test_deprecated_cant_find_module() -> None:
-    """Test if the current module cannot be inspected."""
-    with patch("inspect.getmodule", return_value=None):
-        # This used to raise.
-        cv.deprecated(
-            "mars",
-            replacement_key="jupiter",
-            default=False,
-        )
+    """Test if the current module cannot be found."""
+    # This used to raise.
+    cv.deprecated(
+        "mars",
+        replacement_key="jupiter",
+        default=False,
+    )
 
-    with patch("inspect.getmodule", return_value=None):
-        # This used to raise.
-        cv.removed(
-            "mars",
-            default=False,
-        )
+    # This used to raise.
+    cv.removed(
+        "mars",
+        default=False,
+    )
 
 
 def test_deprecated_or_removed_logger_with_config_attributes(
@@ -1551,8 +1554,7 @@ def test_empty_schema(caplog: pytest.LogCaptureFixture) -> None:
 
 def test_empty_schema_cant_find_module() -> None:
     """Test if the current module cannot be inspected."""
-    with patch("inspect.getmodule", return_value=None):
-        cv.empty_config_schema("test_domain")({"test_domain": {"foo": "bar"}})
+    cv.empty_config_schema("test_domain")({"test_domain": {"foo": "bar"}})
 
 
 def test_config_entry_only_schema(
@@ -1582,10 +1584,7 @@ def test_config_entry_only_schema(
 
 def test_config_entry_only_schema_cant_find_module() -> None:
     """Test if the current module cannot be inspected."""
-    with patch("inspect.getmodule", return_value=None):
-        cv.config_entry_only_config_schema("test_domain")(
-            {"test_domain": {"foo": "bar"}}
-        )
+    cv.config_entry_only_config_schema("test_domain")({"test_domain": {"foo": "bar"}})
 
 
 def test_config_entry_only_schema_no_hass(

--- a/tests/helpers/test_frame.py
+++ b/tests/helpers/test_frame.py
@@ -22,11 +22,11 @@ async def test_extract_frame_integration(
     )
 
 
-async def test_get_logging(
+async def test_get_integration_logger(
     caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
-    """Test extracting the current frame to get the loggger."""
-    logger = frame.get_logger(__name__)
+    """Test extracting the current frame to get the logger."""
+    logger = frame.get_integration_logger(__name__)
     assert logger.name == "homeassistant.components.hue"
 
 
@@ -47,13 +47,13 @@ async def test_extract_frame_resolve_module(
     )
 
 
-async def test_get_logger_resolve_module(
+async def test_get_integration_logger_resolve_module(
     hass: HomeAssistant, enable_custom_integrations
 ) -> None:
     """Test getting the logger from integration context."""
-    from custom_components.test_integration_frame import call_get_logger
+    from custom_components.test_integration_frame import call_get_integration_logger
 
-    logger = call_get_logger(__name__)
+    logger = call_get_integration_logger(__name__)
 
     assert logger.name == "custom_components.test_integration_frame"
 
@@ -121,7 +121,9 @@ async def test_extract_frame_no_integration(caplog: pytest.LogCaptureFixture) ->
         frame.get_integration_frame()
 
 
-async def test_get_logger_no_integration(caplog: pytest.LogCaptureFixture) -> None:
+async def test_get_integration_logger_no_integration(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test getting fallback logger without integration context."""
     with patch(
         "homeassistant.helpers.frame.extract_stack",
@@ -138,7 +140,7 @@ async def test_get_logger_no_integration(caplog: pytest.LogCaptureFixture) -> No
             ),
         ],
     ):
-        logger = frame.get_logger(__name__)
+        logger = frame.get_integration_logger(__name__)
 
     assert logger.name == __name__
 

--- a/tests/testing_config/custom_components/test_integration_frame/__init__.py
+++ b/tests/testing_config/custom_components/test_integration_frame/__init__.py
@@ -1,6 +1,13 @@
 """An integration which calls helpers.frame.get_integration_frame."""
 
+import logging
+
 from homeassistant.helpers import frame
+
+
+def call_get_logger(fallback_name: str) -> logging.Logger:
+    """Call get_logger."""
+    return frame.get_logger(fallback_name)
 
 
 def call_get_integration_frame() -> frame.IntegrationFrame:

--- a/tests/testing_config/custom_components/test_integration_frame/__init__.py
+++ b/tests/testing_config/custom_components/test_integration_frame/__init__.py
@@ -5,9 +5,9 @@ import logging
 from homeassistant.helpers import frame
 
 
-def call_get_logger(fallback_name: str) -> logging.Logger:
-    """Call get_logger."""
-    return frame.get_logger(fallback_name)
+def call_get_integration_logger(fallback_name: str) -> logging.Logger:
+    """Call get_integration_logger."""
+    return frame.get_integration_logger(fallback_name)
 
 
 def call_get_integration_frame() -> frame.IntegrationFrame:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`inspect.getmodule` has a performance problem https://github.com/python/cpython/issues/92041 which is significant enough to generate asyncio warnings at startup

We now avoid getting the logger unless we are going to log as this affected startup time for a large chunk of integrations that used these validators

<img width="1648" alt="Screenshot 2024-03-02 at 3 34 08 PM" src="https://github.com/home-assistant/core/assets/663432/5e498d4d-20de-4b3b-9a3c-675b052e8f52">
<img width="1628" alt="Screenshot 2024-03-02 at 3 34 23 PM" src="https://github.com/home-assistant/core/assets/663432/4d6aed3a-ac14-457b-9463-1470a5da1aeb">
<img width="1652" alt="Screenshot 2024-03-02 at 3 34 32 PM" src="https://github.com/home-assistant/core/assets/663432/25e0005a-0ed1-43bc-b68b-8742ad2180b8">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
