### PR TITLE
Fix deCONZ light entity might not report a supported color mode

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -204,11 +204,10 @@ class DeconzBaseLight(DeconzDevice[_LightDeviceT], LightEntity):
             if device.model_id in ("HG06467", "TS0601"):
                 self._attr_effect_list = XMAS_LIGHT_EFFECTS
 
-        # Make a best guess effort to provide a reasonable color mode as a start,
-        # this is only used as a fallback in self.color_mode to always report a
+        # This is only used as a fallback in self.color_mode to always report a
         # supported color mode as otherwise self._attr_color_mode could be None
         if not self.is_on and self.color_mode not in self._attr_supported_color_modes:
-            self._attr_color_mode = next(iter(self._attr_supported_color_modes))
+            self._attr_color_mode = ColorMode.UNKNOWN
 
     @property
     def color_mode(self) -> str | None:

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -204,6 +204,12 @@ class DeconzBaseLight(DeconzDevice[_LightDeviceT], LightEntity):
             if device.model_id in ("HG06467", "TS0601"):
                 self._attr_effect_list = XMAS_LIGHT_EFFECTS
 
+        # Make a best guess effort to provide a reasonable color mode as a start,
+        # this is only used as a fallback in self.color_mode to always report a
+        # supported color mode as otherwise self._attr_color_mode could be None
+        if not self.is_on and self.color_mode not in self._attr_supported_color_modes:
+            self._attr_color_mode = next(iter(self._attr_supported_color_modes))
+
     @property
     def color_mode(self) -> str | None:
         """Return the color mode of the light."""

--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -165,6 +165,7 @@ class DeconzBaseLight(DeconzDevice[_LightDeviceT], LightEntity):
     """Representation of a deCONZ light."""
 
     TYPE = DOMAIN
+    _attr_color_mode = ColorMode.UNKNOWN
 
     def __init__(self, device: _LightDeviceT, gateway: DeconzGateway) -> None:
         """Set up light."""
@@ -203,11 +204,6 @@ class DeconzBaseLight(DeconzDevice[_LightDeviceT], LightEntity):
             self._attr_effect_list = [EFFECT_COLORLOOP]
             if device.model_id in ("HG06467", "TS0601"):
                 self._attr_effect_list = XMAS_LIGHT_EFFECTS
-
-        # This is only used as a fallback in self.color_mode to always report a
-        # supported color mode as otherwise self._attr_color_mode could be None
-        if not self.is_on and self.color_mode not in self._attr_supported_color_modes:
-            self._attr_color_mode = ColorMode.UNKNOWN
 
     @property
     def color_mode(self) -> str | None:

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -1523,4 +1523,4 @@ async def test_verify_group_color_mode_fallback(
     )
     group_state = hass.states.get("light.opbergruimte")
     assert group_state.state == STATE_ON
-    assert group_state.attributes[ATTR_COLOR_MODE] is ColorMode.BRIGHTNESS
+    assert group_state.attributes[ATTR_COLOR_MODE] is ColorMode.UNKNOWN

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -1380,10 +1380,147 @@ async def test_verify_group_supported_features(
 
     assert len(hass.states.async_all()) == 4
 
-    assert hass.states.get("light.group").state == STATE_ON
+    group_state = hass.states.get("light.group")
+    assert group_state.state == STATE_ON
+    assert group_state.attributes[ATTR_COLOR_MODE] == ColorMode.COLOR_TEMP
     assert (
-        hass.states.get("light.group").attributes[ATTR_SUPPORTED_FEATURES]
+        group_state.attributes[ATTR_SUPPORTED_FEATURES]
         == LightEntityFeature.TRANSITION
         | LightEntityFeature.FLASH
         | LightEntityFeature.EFFECT
     )
+
+
+async def test_verify_group_color_mode_fallback(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, mock_deconz_websocket
+) -> None:
+    """Test that group supported features reflect what included lights support."""
+    data = {
+        "groups": {
+            "43": {
+                "action": {
+                    "alert": "none",
+                    "bri": 127,
+                    "colormode": "hs",
+                    "ct": 0,
+                    "effect": "none",
+                    "hue": 0,
+                    "on": True,
+                    "sat": 127,
+                    "scene": "4",
+                    "xy": [0, 0],
+                },
+                "devicemembership": [],
+                "etag": "4548e982c4cfff942f7af80958abb2a0",
+                "id": "43",
+                "lights": ["13"],
+                "name": "Opbergruimte",
+                "scenes": [
+                    {
+                        "id": "1",
+                        "lightcount": 1,
+                        "name": "Scene Normaal deCONZ",
+                        "transitiontime": 10,
+                    },
+                    {
+                        "id": "2",
+                        "lightcount": 1,
+                        "name": "Scene Fel deCONZ",
+                        "transitiontime": 10,
+                    },
+                    {
+                        "id": "3",
+                        "lightcount": 1,
+                        "name": "Scene Gedimd deCONZ",
+                        "transitiontime": 10,
+                    },
+                    {
+                        "id": "4",
+                        "lightcount": 1,
+                        "name": "Scene Uit deCONZ",
+                        "transitiontime": 10,
+                    },
+                ],
+                "state": {"all_on": False, "any_on": False},
+                "type": "LightGroup",
+            },
+        },
+        "lights": {
+            "13": {
+                "capabilities": {
+                    "alerts": [
+                        "none",
+                        "select",
+                        "lselect",
+                        "blink",
+                        "breathe",
+                        "okay",
+                        "channelchange",
+                        "finish",
+                        "stop",
+                    ],
+                    "bri": {"min_dim_level": 5},
+                },
+                "config": {
+                    "bri": {"execute_if_off": True, "startup": "previous"},
+                    "groups": ["43"],
+                    "on": {"startup": "previous"},
+                },
+                "etag": "ca0ed7763eca37f5e6b24f6d46f8a518",
+                "hascolor": False,
+                "lastannounced": None,
+                "lastseen": "2024-03-02T20:08Z",
+                "manufacturername": "Signify Netherlands B.V.",
+                "modelid": "LWA001",
+                "name": "Opbergruimte Lamp Plafond",
+                "productid": "Philips-LWA001-1-A19DLv5",
+                "productname": "Hue white lamp",
+                "state": {
+                    "alert": "none",
+                    "bri": 76,
+                    "effect": "none",
+                    "on": False,
+                    "reachable": True,
+                },
+                "swconfigid": "87169548",
+                "swversion": "1.104.2",
+                "type": "Dimmable light",
+                "uniqueid": "00:17:88:01:08:11:22:33-01",
+            },
+        },
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    group_state = hass.states.get("light.opbergruimte")
+    assert group_state.state == STATE_OFF
+    assert group_state.attributes[ATTR_COLOR_MODE] is None
+
+    await mock_deconz_websocket(
+        data={
+            "e": "changed",
+            "id": "13",
+            "r": "lights",
+            "state": {
+                "alert": "none",
+                "bri": 76,
+                "effect": "none",
+                "on": True,
+                "reachable": True,
+            },
+            "t": "event",
+            "uniqueid": "00:17:88:01:08:11:22:33-01",
+        }
+    )
+    await mock_deconz_websocket(
+        data={
+            "e": "changed",
+            "id": "43",
+            "r": "groups",
+            "state": {"all_on": True, "any_on": True},
+            "t": "event",
+        }
+    )
+    group_state = hass.states.get("light.opbergruimte")
+    assert group_state.state == STATE_ON
+    assert group_state.attributes[ATTR_COLOR_MODE] is ColorMode.BRIGHTNESS


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix case where self._attr_color_mode is None and a light or group changes to "on" and the group reports a wrongful color_mode (in test case, "HS") thus causing self.color_mode to fall back to the previous self._attr_color_mode value then being None causing the "does not report a color mode" warning.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112061
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
