### PR TITLE
Avoid using coordinator in config flow of APCUPSD

### DIFF
--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN
+from .const import DOMAIN
 from .coordinator import APCUPSdCoordinator
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/apcupsd/binary_sensor.py
+++ b/homeassistant/components/apcupsd/binary_sensor.py
@@ -13,7 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN, APCUPSdCoordinator
+from . import DOMAIN
+from .coordinator import APCUPSdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 _DESCRIPTION = BinarySensorEntityDescription(
@@ -53,7 +54,7 @@ class OnlineStatus(CoordinatorEntity[APCUPSdCoordinator], BinarySensorEntity):
         super().__init__(coordinator, context=description.key.upper())
 
         # Set up unique id and device info if serial number is available.
-        if (serial_no := coordinator.ups_serial_no) is not None:
+        if (serial_no := coordinator.data.serial_no) is not None:
             self._attr_unique_id = f"{serial_no}_{description.key}"
         self.entity_description = description
         self._attr_device_info = coordinator.device_info

--- a/homeassistant/components/apcupsd/config_flow.py
+++ b/homeassistant/components/apcupsd/config_flow.py
@@ -1,17 +1,19 @@
 """Config flow for APCUPSd integration."""
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
+import aioapcaccess
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers import selector
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from . import DOMAIN, APCUPSdCoordinator
+from .const import CONNECTION_TIMEOUT, DOMAIN
+from .coordinator import APCUPSdData
 
 _PORT_SELECTOR = vol.All(
     selector.NumberSelector(
@@ -49,32 +51,22 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self._async_abort_entries_match({CONF_HOST: host, CONF_PORT: port})
 
         # Test the connection to the host and get the current status for serial number.
-        coordinator = APCUPSdCoordinator(self.hass, host, port)
-        await coordinator.async_request_refresh()
-
-        if isinstance(coordinator.last_exception, (UpdateFailed, TimeoutError)):
+        try:
+            async with asyncio.timeout(CONNECTION_TIMEOUT):
+                data = APCUPSdData(await aioapcaccess.request_status(host, port))
+        except (OSError, asyncio.IncompleteReadError, TimeoutError):
             errors = {"base": "cannot_connect"}
             return self.async_show_form(
                 step_id="user", data_schema=_SCHEMA, errors=errors
             )
 
-        if not coordinator.data:
+        if not data:
             return self.async_abort(reason="no_status")
 
         # We _try_ to use the serial number of the UPS as the unique id since this field
         # is not guaranteed to exist on all APC UPS models.
-        await self.async_set_unique_id(coordinator.ups_serial_no)
+        await self.async_set_unique_id(data.serial_no)
         self._abort_if_unique_id_configured()
 
-        title = "APC UPS"
-        if coordinator.ups_name is not None:
-            title = coordinator.ups_name
-        elif coordinator.ups_model is not None:
-            title = coordinator.ups_model
-        elif coordinator.ups_serial_no is not None:
-            title = coordinator.ups_serial_no
-
-        return self.async_create_entry(
-            title=title,
-            data=user_input,
-        )
+        title = data.name or data.model or data.serial_no or "APC UPS"
+        return self.async_create_entry(title=title, data=user_input)

--- a/homeassistant/components/apcupsd/const.py
+++ b/homeassistant/components/apcupsd/const.py
@@ -2,3 +2,4 @@
 from typing import Final
 
 DOMAIN: Final = "apcupsd"
+CONNECTION_TIMEOUT: int = 10

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -39,7 +39,7 @@ class APCUPSdData(OrderedDict[str, str]):
         """Return the model of the UPS, if available."""
         # Different UPS models may report slightly different keys for model, here we
         # try them all.
-        return self.get("APCMODEL", self.get("MODEL"))
+        return self.get("APCMODEL") or self.get("MODEL")
 
     @property
     def serial_no(self) -> str | None:

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from collections import OrderedDict
 from datetime import timedelta
 import logging
 from typing import Final
@@ -26,7 +25,7 @@ UPDATE_INTERVAL: Final = timedelta(seconds=60)
 REQUEST_REFRESH_COOLDOWN: Final = 5
 
 
-class APCUPSdData(OrderedDict[str, str]):
+class APCUPSdData(dict[str, str]):
     """Store data about an APCUPSd and provide a few helper methods for easier accesses."""
 
     @property

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -39,10 +39,7 @@ class APCUPSdData(OrderedDict[str, str]):
         """Return the model of the UPS, if available."""
         # Different UPS models may report slightly different keys for model, here we
         # try them all.
-        for model_key in ("APCMODEL", "MODEL"):
-            if model_key in self:
-                return self[model_key]
-        return None
+        return self.get("APCMODEL", self.get("MODEL"))
 
     @property
     def serial_no(self) -> str | None:

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -80,7 +80,7 @@ class APCUPSdCoordinator(DataUpdateCoordinator[APCUPSdData]):
             identifiers={(DOMAIN, self.data.serial_no or self.config_entry.entry_id)},
             model=self.data.model,
             manufacturer="APC",
-            name=self.data.name if self.data.name else "APC UPS",
+            name=self.data.name or "APC UPS",
             hw_version=self.data.get("FIRMWARE"),
             sw_version=self.data.get("VERSION"),
         )

--- a/homeassistant/components/apcupsd/coordinator.py
+++ b/homeassistant/components/apcupsd/coordinator.py
@@ -19,14 +19,38 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .const import DOMAIN
+from .const import CONNECTION_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 UPDATE_INTERVAL: Final = timedelta(seconds=60)
 REQUEST_REFRESH_COOLDOWN: Final = 5
 
 
-class APCUPSdCoordinator(DataUpdateCoordinator[OrderedDict[str, str]]):
+class APCUPSdData(OrderedDict[str, str]):
+    """Store data about an APCUPSd and provide a few helper methods for easier accesses."""
+
+    @property
+    def name(self) -> str | None:
+        """Return the name of the UPS, if available."""
+        return self.get("UPSNAME")
+
+    @property
+    def model(self) -> str | None:
+        """Return the model of the UPS, if available."""
+        # Different UPS models may report slightly different keys for model, here we
+        # try them all.
+        for model_key in ("APCMODEL", "MODEL"):
+            if model_key in self:
+                return self[model_key]
+        return None
+
+    @property
+    def serial_no(self) -> str | None:
+        """Return the unique serial number of the UPS, if available."""
+        return self.get("SERIALNO")
+
+
+class APCUPSdCoordinator(DataUpdateCoordinator[APCUPSdData]):
     """Store and coordinate the data retrieved from APCUPSd for all sensors.
 
     For each entity to use, acts as the single point responsible for fetching
@@ -53,45 +77,26 @@ class APCUPSdCoordinator(DataUpdateCoordinator[OrderedDict[str, str]]):
         self._port = port
 
     @property
-    def ups_name(self) -> str | None:
-        """Return the name of the UPS, if available."""
-        return self.data.get("UPSNAME")
-
-    @property
-    def ups_model(self) -> str | None:
-        """Return the model of the UPS, if available."""
-        # Different UPS models may report slightly different keys for model, here we
-        # try them all.
-        for model_key in ("APCMODEL", "MODEL"):
-            if model_key in self.data:
-                return self.data[model_key]
-        return None
-
-    @property
-    def ups_serial_no(self) -> str | None:
-        """Return the unique serial number of the UPS, if available."""
-        return self.data.get("SERIALNO")
-
-    @property
     def device_info(self) -> DeviceInfo:
         """Return the DeviceInfo of this APC UPS, if serial number is available."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self.ups_serial_no or self.config_entry.entry_id)},
-            model=self.ups_model,
+            identifiers={(DOMAIN, self.data.serial_no or self.config_entry.entry_id)},
+            model=self.data.model,
             manufacturer="APC",
-            name=self.ups_name if self.ups_name else "APC UPS",
+            name=self.data.name if self.data.name else "APC UPS",
             hw_version=self.data.get("FIRMWARE"),
             sw_version=self.data.get("VERSION"),
         )
 
-    async def _async_update_data(self) -> OrderedDict[str, str]:
+    async def _async_update_data(self) -> APCUPSdData:
         """Fetch the latest status from APCUPSd.
 
         Note that the result dict uses upper case for each resource, where our
         integration uses lower cases as keys internally.
         """
-        async with asyncio.timeout(10):
+        async with asyncio.timeout(CONNECTION_TIMEOUT):
             try:
-                return await aioapcaccess.request_status(self._host, self._port)
+                data = await aioapcaccess.request_status(self._host, self._port)
+                return APCUPSdData(data)
             except (OSError, asyncio.IncompleteReadError) as error:
                 raise UpdateFailed(error) from error

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -24,7 +24,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN, APCUPSdCoordinator
+from .const import DOMAIN
+from .coordinator import APCUPSdCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -493,7 +493,7 @@ class APCUPSdSensor(CoordinatorEntity[APCUPSdCoordinator], SensorEntity):
         super().__init__(coordinator=coordinator, context=description.key.upper())
 
         # Set up unique id and device info if serial number is available.
-        if (serial_no := coordinator.ups_serial_no) is not None:
+        if (serial_no := coordinator.data.serial_no) is not None:
             self._attr_unique_id = f"{serial_no}_{description.key}"
 
         self.entity_description = description


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In PR #108931 @bdraco rightfully pointed out that it would be a good idea to avoid using coordinators inside config flows and instead we should just do a bare request and catch the exceptions there.

This PR first decouples the data class (along with its helper methods) from the coordinator to make it reusable both in coordinator and config flow, then refactors the config flow to do the bare request instead.

We also take this opportunity to apply a code simplification and a few import fixes (they were importing from `.` instead of directly importing from the corresponding modules).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
