### PR TITLE
Address late review for Ping

### DIFF
--- a/homeassistant/components/ping/binary_sensor.py
+++ b/homeassistant/components/ping/binary_sensor.py
@@ -95,7 +95,7 @@ class PingBinarySensor(PingEntity, BinarySensorEntity):
         self, config_entry: ConfigEntry, coordinator: PingUpdateCoordinator
     ) -> None:
         """Initialize the Ping Binary sensor."""
-        super().__init__(coordinator, config_entry.entry_id)
+        super().__init__(config_entry, coordinator, config_entry.entry_id)
 
         # if this was imported just enable it when it was enabled before
         if CONF_IMPORTED_BY in config_entry.data:

--- a/homeassistant/components/ping/entity.py
+++ b/homeassistant/components/ping/entity.py
@@ -1,4 +1,6 @@
 """Base entity for the Ping component."""
+from config_entries import ConfigEntry
+
 from homeassistant.core import DOMAIN
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -13,6 +15,7 @@ class PingEntity(CoordinatorEntity[PingUpdateCoordinator]):
 
     def __init__(
         self,
+        config_entry: ConfigEntry,
         coordinator: PingUpdateCoordinator,
         unique_id: str,
     ) -> None:
@@ -21,6 +24,6 @@ class PingEntity(CoordinatorEntity[PingUpdateCoordinator]):
 
         self._attr_unique_id = unique_id
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.coordinator.data.ip_address)},
+            identifiers={(DOMAIN, config_entry.entry_id)},
             manufacturer="Ping",
         )

--- a/homeassistant/components/ping/entity.py
+++ b/homeassistant/components/ping/entity.py
@@ -1,6 +1,5 @@
 """Base entity for the Ping component."""
-from config_entries import ConfigEntry
-
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import DOMAIN
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/homeassistant/components/ping/sensor.py
+++ b/homeassistant/components/ping/sensor.py
@@ -101,7 +101,9 @@ class PingSensor(PingEntity, SensorEntity):
         coordinator: PingUpdateCoordinator,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, f"{config_entry.entry_id}-{description.key}")
+        super().__init__(
+            config_entry, coordinator, f"{config_entry.entry_id}-{description.key}"
+        )
 
         self.entity_description = description
 


### PR DESCRIPTION
## Proposed change
Address the late review comment (https://github.com/home-assistant/core/pull/112004#pullrequestreview-1913039656) for Ping

Use the config entry id (I do not have anything beside this) instead of the IP address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
