### PR TITLE
Fix places not changed to hub in Axis tests

### DIFF
--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -8,6 +8,7 @@ import pytest
 
 from homeassistant.components import axis, zeroconf
 from homeassistant.components.axis.const import DOMAIN as AXIS_DOMAIN
+from homeassistant.components.axis.hub import AxisHub
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.config_entries import SOURCE_ZEROCONF
 from homeassistant.const import (
@@ -48,12 +49,12 @@ async def test_device_setup(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Successful setup."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
+    hub = AxisHub.get_hub(hass, setup_config_entry)
 
-    assert device.api.vapix.firmware_version == "9.10.1"
-    assert device.api.vapix.product_number == "M1065-LW"
-    assert device.api.vapix.product_type == "Network Camera"
-    assert device.api.vapix.serial_number == "00408C123456"
+    assert hub.api.vapix.firmware_version == "9.10.1"
+    assert hub.api.vapix.product_number == "M1065-LW"
+    assert hub.api.vapix.product_type == "Network Camera"
+    assert hub.api.vapix.serial_number == "00408C123456"
 
     assert len(forward_entry_setup.mock_calls) == 4
     assert forward_entry_setup.mock_calls[0][1][1] == "binary_sensor"
@@ -61,27 +62,27 @@ async def test_device_setup(
     assert forward_entry_setup.mock_calls[2][1][1] == "light"
     assert forward_entry_setup.mock_calls[3][1][1] == "switch"
 
-    assert device.host == config[CONF_HOST]
-    assert device.model == config[CONF_MODEL]
-    assert device.name == config[CONF_NAME]
-    assert device.unique_id == FORMATTED_MAC
+    assert hub.host == config[CONF_HOST]
+    assert hub.model == config[CONF_MODEL]
+    assert hub.name == config[CONF_NAME]
+    assert hub.unique_id == FORMATTED_MAC
 
     device_entry = device_registry.async_get_device(
-        identifiers={(AXIS_DOMAIN, device.unique_id)}
+        identifiers={(AXIS_DOMAIN, hub.unique_id)}
     )
 
-    assert device_entry.configuration_url == device.api.config.url
+    assert device_entry.configuration_url == hub.api.config.url
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_BASIC_DEVICE_INFO])
 async def test_device_info(hass: HomeAssistant, setup_config_entry) -> None:
     """Verify other path of device information works."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
+    hub = AxisHub.get_hub(hass, setup_config_entry)
 
-    assert device.api.vapix.firmware_version == "9.80.1"
-    assert device.api.vapix.product_number == "M1065-LW"
-    assert device.api.vapix.product_type == "Network Camera"
-    assert device.api.vapix.serial_number == "00408C123456"
+    assert hub.api.vapix.firmware_version == "9.80.1"
+    assert hub.api.vapix.product_number == "M1065-LW"
+    assert hub.api.vapix.product_type == "Network Camera"
+    assert hub.api.vapix.serial_number == "00408C123456"
 
 
 @pytest.mark.parametrize("api_discovery_items", [API_DISCOVERY_MQTT])
@@ -111,8 +112,8 @@ async def test_update_address(
     hass: HomeAssistant, setup_config_entry, mock_vapix_requests
 ) -> None:
     """Test update address works."""
-    device = hass.data[AXIS_DOMAIN][setup_config_entry.entry_id]
-    assert device.api.config.host == "1.2.3.4"
+    hub = AxisHub.get_hub(hass, setup_config_entry)
+    assert hub.api.config.host == "1.2.3.4"
 
     with patch(
         "homeassistant.components.axis.async_setup_entry", return_value=True
@@ -133,7 +134,7 @@ async def test_update_address(
         )
         await hass.async_block_till_done()
 
-    assert device.api.config.host == "2.3.4.5"
+    assert hub.api.config.host == "2.3.4.5"
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Missed some places still referring to "device" rather than "hub"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
