### PR TITLE
Fix ZHA groups page

### DIFF
--- a/homeassistant/components/zha/core/group.py
+++ b/homeassistant/components/zha/core/group.py
@@ -87,6 +87,9 @@ class ZHAGroupMember(LogMixin):
         entity_info = []
 
         for entity_ref in zha_device_registry.get(self.device.ieee):
+            # We have device entities now that don't leverage cluster handlers
+            if not entity_ref.cluster_handlers:
+                continue
             entity = entity_registry.async_get(entity_ref.reference_id)
             handler = list(entity_ref.cluster_handlers.values())[0]
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -25,6 +25,7 @@ from homeassistant.components.zha.core.helpers import get_zha_gateway
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 from homeassistant.setup import async_setup_component
 
@@ -38,6 +39,8 @@ from .common import (
     update_attribute_cache,
 )
 from .conftest import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+
+from tests.common import MockConfigEntry
 
 ON = 1
 OFF = 0
@@ -89,27 +92,6 @@ def zigpy_cover_device(zigpy_device_mock):
         }
     }
     return zigpy_device_mock(endpoints)
-
-
-@pytest.fixture
-async def coordinator(hass, zigpy_device_mock, zha_device_joined):
-    """Test ZHA light platform."""
-
-    zigpy_device = zigpy_device_mock(
-        {
-            1: {
-                SIG_EP_INPUT: [],
-                SIG_EP_OUTPUT: [],
-                SIG_EP_TYPE: zha.DeviceType.COLOR_DIMMABLE_LIGHT,
-            }
-        },
-        ieee="00:15:8d:00:02:32:4f:32",
-        nwk=0x0000,
-        node_descriptor=b"\xf8\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff",
-    )
-    zha_device = await zha_device_joined(zigpy_device)
-    zha_device.available = True
-    return zha_device
 
 
 @pytest.fixture
@@ -300,19 +282,41 @@ async def zigpy_device_tuya(hass, zigpy_device_mock, zha_device_joined):
     new=0,
 )
 async def test_zha_group_switch_entity(
-    hass: HomeAssistant, device_switch_1, device_switch_2, coordinator
+    hass: HomeAssistant,
+    device_switch_1,
+    device_switch_2,
+    entity_registry: er.EntityRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test the switch entity for a ZHA group."""
+
+    # make sure we can still get groups when counter entities exist
+    entity_id = "sensor.coordinator_manufacturer_coordinator_model_counter_1"
+    state = hass.states.get(entity_id)
+    assert state is None
+
+    # Enable the entity.
+    entity_registry.async_update_entity(entity_id, disabled_by=None)
+    await hass.config_entries.async_reload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "1"
+
     zha_gateway = get_zha_gateway(hass)
     assert zha_gateway is not None
-    zha_gateway.coordinator_zha_device = coordinator
-    coordinator._zha_gateway = zha_gateway
     device_switch_1._zha_gateway = zha_gateway
     device_switch_2._zha_gateway = zha_gateway
-    member_ieee_addresses = [device_switch_1.ieee, device_switch_2.ieee]
+    member_ieee_addresses = [
+        device_switch_1.ieee,
+        device_switch_2.ieee,
+        zha_gateway.coordinator_zha_device.ieee,
+    ]
     members = [
         GroupMember(device_switch_1.ieee, 1),
         GroupMember(device_switch_2.ieee, 1),
+        GroupMember(zha_gateway.coordinator_zha_device.ieee, 1),
     ]
 
     # test creating a group with 2 members
@@ -320,7 +324,7 @@ async def test_zha_group_switch_entity(
     await hass.async_block_till_done()
 
     assert zha_group is not None
-    assert len(zha_group.members) == 2
+    assert len(zha_group.members) == 3
     for member in zha_group.members:
         assert member.device.ieee in member_ieee_addresses
         assert member.group == zha_group
@@ -332,12 +336,6 @@ async def test_zha_group_switch_entity(
     group_cluster_on_off = zha_group.endpoint[general.OnOff.cluster_id]
     dev1_cluster_on_off = device_switch_1.device.endpoints[1].on_off
     dev2_cluster_on_off = device_switch_2.device.endpoints[1].on_off
-
-    await async_enable_traffic(hass, [device_switch_1, device_switch_2], enabled=False)
-    await async_wait_for_updates(hass)
-
-    # test that the switches were created and that they are off
-    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     # allow traffic to flow through the gateway and device
     await async_enable_traffic(hass, [device_switch_1, device_switch_2])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix the ZHA groups page. It was inadvertently broken with the addition of the counter entities: https://github.com/home-assistant/core/pull/111175. 

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/decorators.py", line 26, in _handle_async_response
    await func(hass, connection, msg)
  File "/usr/src/homeassistant/homeassistant/components/zha/websocket_api.py", line 426, in websocket_get_groups
    groups = [group.group_info for group in zha_gateway.groups.values()]
              ^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/core/group.py", line 240, in group_info
    group_info["members"] = [member.member_info for member in self.members]
                             ^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/core/group.py", line 78, in member_info
    member_info["entities"] = self.associated_entities
                              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/zha/core/group.py", line 91, in associated_entities
    handler = list(entity_ref.cluster_handlers.values())[0]
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
