### PR TITLE
Preload config flow if it exists when loading a component

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -908,6 +908,15 @@ class Integration:
             with suppress(ImportError):
                 self.get_platform("config")
 
+        if self.config_flow:
+            # If there is a config flow, we will cache it as well since
+            # config entry setup always has to load the flow to get the
+            # major/minor version for migrations. Since we may be running
+            # in the executor we will use this opportunity to cache the
+            # config_flow as well.
+            with suppress(ImportError):
+                self.get_platform("config_flow")
+
         return cache[self.domain]
 
     async def async_get_platform(self, platform_name: str) -> ModuleType:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1038,10 +1038,10 @@ async def test_hass_components_use_reported(
         ) in caplog.text
 
 
-async def test_async_get_component_preloads_config(
+async def test_async_get_component_preloads_config_and_config_flow(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Verify async_get_component will try to preload the config platform."""
+    """Verify async_get_component will try to preload the config and config_flow platform."""
     executor_import_integration = _get_test_integration(
         hass, "executor_import", True, import_executor=True
     )
@@ -1058,7 +1058,7 @@ async def test_async_get_component_preloads_config(
         await executor_import_integration.async_get_component()
 
     assert mock_platform_exists.call_count == 1
-    assert mock_import.call_count == 2
+    assert mock_import.call_count == 3
     assert (
         mock_import.call_args_list[0][0][0]
         == "homeassistant.components.executor_import"
@@ -1066,6 +1066,10 @@ async def test_async_get_component_preloads_config(
     assert (
         mock_import.call_args_list[1][0][0]
         == "homeassistant.components.executor_import.config"
+    )
+    assert (
+        mock_import.call_args_list[2][0][0]
+        == "homeassistant.components.executor_import.config_flow"
     )
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since `config_entries` [always require](https://github.com/home-assistant/core/blob/68f17b5eab88b375ce208d392805b6124d8ac854/homeassistant/config_entries.py#L509) the `config_flow` to be loaded to check for migrations, load it if we know it exists when loading the underlying integration



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
