### PR TITLE
Limit rainbird aiohttp client session to a single connection

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -11,11 +11,10 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
 
 from .const import CONF_SERIAL_NUMBER
-from .coordinator import RainbirdData
+from .coordinator import RainbirdData, async_create_clientsession
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,9 +35,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
+    clientsession = async_create_clientsession()
+    entry.async_on_unload(clientsession.close)
     controller = AsyncRainbirdController(
         AsyncRainbirdClient(
-            async_get_clientsession(hass),
+            clientsession,
             entry.data[CONF_HOST],
             entry.data[CONF_PASSWORD],
         )

--- a/homeassistant/components/rainbird/coordinator.py
+++ b/homeassistant/components/rainbird/coordinator.py
@@ -9,6 +9,7 @@ from functools import cached_property
 import logging
 from typing import TypeVar
 
+import aiohttp
 from pyrainbird.async_client import (
     AsyncRainbirdController,
     RainbirdApiException,
@@ -28,6 +29,9 @@ UPDATE_INTERVAL = datetime.timedelta(minutes=1)
 # changes, so we refresh it less often.
 CALENDAR_UPDATE_INTERVAL = datetime.timedelta(minutes=15)
 
+# Rainbird devices can only accept a single request at a time
+CONECTION_LIMIT = 1
+
 _LOGGER = logging.getLogger(__name__)
 
 _T = TypeVar("_T")
@@ -41,6 +45,13 @@ class RainbirdDeviceState:
     active_zones: set[int]
     rain: bool
     rain_delay: int
+
+
+def async_create_clientsession() -> aiohttp.ClientSession:
+    """Create a rainbird async_create_clientsession with a connection limit."""
+    return aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(limit=CONECTION_LIMIT),
+    )
 
 
 class RainbirdUpdateCoordinator(DataUpdateCoordinator[RainbirdDeviceState]):

--- a/tests/components/rainbird/conftest.py
+++ b/tests/components/rainbird/conftest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from http import HTTPStatus
 import json
 from typing import Any
@@ -15,7 +16,7 @@ from homeassistant.components.rainbird.const import (
     ATTR_DURATION,
     DEFAULT_TRIGGER_TIME_MINUTES,
 )
-from homeassistant.const import Platform
+from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, Platform
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -153,6 +154,31 @@ def setup_platforms(
 
     with patch(f"homeassistant.components.{DOMAIN}.PLATFORMS", platforms):
         yield
+
+
+@pytest.fixture(autouse=True)
+def aioclient_mock(hass: HomeAssistant) -> Generator[AiohttpClientMocker, None, None]:
+    """Context manager to mock aiohttp client."""
+    mocker = AiohttpClientMocker()
+
+    def create_session():
+        session = mocker.create_session(hass.loop)
+
+        async def close_session(event):
+            """Close session."""
+            await session.close()
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, close_session)
+        return session
+
+    with patch(
+        "homeassistant.components.rainbird.async_create_clientsession",
+        side_effect=create_session,
+    ), patch(
+        "homeassistant.components.rainbird.config_flow.async_create_clientsession",
+        side_effect=create_session,
+    ):
+        yield mocker
 
 
 def rainbird_json_response(result: dict[str, str]) -> bytes:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Limit rainbird aiohttp client session to a single connection so that any concurrent requests are queued rather than issued in parallel. This should fix any issues with rainbird stability due to concurrent requests either from the data coordinator, UI, or automations.

Manually tested:
- Without this change: If you spam the sprinkler switch on and off over and over again it will fail with an error due to the device being busy
- With the change:  If you spam the sprinkler switch on and off over and over again it always succeeds.

Additionally manually tested config flows, adding and removing/disabling the config entries, etc and verifying all connections are closed properly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #111708
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
