### PR TITLE
Use MockConfigEntry in hue tests

### DIFF
--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -1,6 +1,6 @@
 """Test Hue bridge."""
 import asyncio
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import patch
 
 from aiohttp import client_exceptions
 from aiohue.errors import Unauthorized
@@ -12,16 +12,21 @@ from homeassistant.components.hue import bridge
 from homeassistant.components.hue.const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
+    DOMAIN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from tests.common import MockConfigEntry
+
 
 async def test_bridge_setup_v1(hass: HomeAssistant, mock_api_v1) -> None:
     """Test a successful setup for V1 bridge."""
-    config_entry = Mock()
-    config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
-    config_entry.options = {CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
+        options={CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False},
+    )
 
     with patch.object(bridge, "HueBridgeV1", return_value=mock_api_v1), patch.object(
         hass.config_entries, "async_forward_entry_setup"
@@ -39,8 +44,10 @@ async def test_bridge_setup_v1(hass: HomeAssistant, mock_api_v1) -> None:
 
 async def test_bridge_setup_v2(hass: HomeAssistant, mock_api_v2) -> None:
     """Test a successful setup for V2 bridge."""
-    config_entry = Mock()
-    config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 2}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 2},
+    )
 
     with patch.object(bridge, "HueBridgeV2", return_value=mock_api_v2), patch.object(
         hass.config_entries, "async_forward_entry_setup"
@@ -65,9 +72,11 @@ async def test_bridge_setup_v2(hass: HomeAssistant, mock_api_v2) -> None:
 
 async def test_bridge_setup_invalid_api_key(hass: HomeAssistant) -> None:
     """Test we start config flow if username is no longer whitelisted."""
-    entry = Mock()
-    entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
-    entry.options = {CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
+        options={CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False},
+    )
     hue_bridge = bridge.HueBridge(hass, entry)
 
     with patch.object(
@@ -81,9 +90,11 @@ async def test_bridge_setup_invalid_api_key(hass: HomeAssistant) -> None:
 
 async def test_bridge_setup_timeout(hass: HomeAssistant) -> None:
     """Test we retry to connect if we cannot connect."""
-    entry = Mock()
-    entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
-    entry.options = {CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False}
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
+        options={CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False},
+    )
     hue_bridge = bridge.HueBridge(hass, entry)
 
     with patch.object(
@@ -96,9 +107,11 @@ async def test_bridge_setup_timeout(hass: HomeAssistant) -> None:
 
 async def test_reset_unloads_entry_if_setup(hass: HomeAssistant, mock_api_v1) -> None:
     """Test calling reset while the entry has been setup."""
-    config_entry = Mock()
-    config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
-    config_entry.options = {CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
+        options={CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False},
+    )
 
     with patch.object(bridge, "HueBridgeV1", return_value=mock_api_v1), patch.object(
         hass.config_entries, "async_forward_entry_setup"
@@ -122,9 +135,11 @@ async def test_reset_unloads_entry_if_setup(hass: HomeAssistant, mock_api_v1) ->
 
 async def test_handle_unauthorized(hass: HomeAssistant, mock_api_v1) -> None:
     """Test handling an unauthorized error on update."""
-    config_entry = Mock(async_setup=AsyncMock())
-    config_entry.data = {"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1}
-    config_entry.options = {CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False}
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
+        options={CONF_ALLOW_HUE_GROUPS: False, CONF_ALLOW_UNREACHABLE: False},
+    )
 
     with patch.object(bridge, "HueBridgeV1", return_value=mock_api_v1):
         hue_bridge = bridge.HueBridge(hass, config_entry)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use MockConfigEntry in hue tests
needed for https://github.com/home-assistant/core/pull/112141


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
