### PR TITLE
Fix async_get_component loading in the executor when the module is already loaded

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -847,9 +847,7 @@ class Integration:
         domain = self.domain
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
-        load_executor = (
-            self.import_executor and f"{self.pkg_path}.{domain}" not in sys.modules
-        )
+        load_executor = self.import_executor and self.pkg_path not in sys.modules
         if load_executor:
             try:
                 comp = await self.hass.async_add_import_executor_job(self.get_component)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -847,7 +847,10 @@ class Integration:
         domain = self.domain
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
-        load_executor = self.import_executor and self.pkg_path not in sys.modules
+        load_executor = self.import_executor and (
+            self.pkg_path not in sys.modules
+            or (self.config_flow and f"{self.pkg_path}.config_flow" not in sys.modules)
+        )
         if load_executor:
             try:
                 comp = await self.hass.async_add_import_executor_job(self.get_component)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1069,6 +1069,29 @@ async def test_async_get_component_preloads_config(
     )
 
 
+async def test_async_get_component_loads_loop_if_already_in_sys_modules(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
+    """Verify async_get_component does not create an executor job if the module is already in sys.modules."""
+    integration = await loader.async_get_integration(
+        hass, "test_package_loaded_executor"
+    )
+    assert integration.pkg_path == "custom_components.test_package_loaded_executor"
+    assert integration.import_executor is True
+    module_mock = MagicMock()
+    assert "executor_import" not in hass.config.components
+    with patch.dict("sys.modules", {integration.pkg_path: module_mock}), patch(
+        "homeassistant.loader.importlib.import_module", return_value=module_mock
+    ) as mock_import:
+        module = await integration.async_get_component()
+
+    assert mock_import.call_count == 1
+    assert "loaded_executor=False" in caplog.text
+    assert module is module_mock
+
+
 async def test_async_get_component_deadlock_fallback(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1084,16 +1084,53 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     )
     assert integration.pkg_path == "custom_components.test_package_loaded_executor"
     assert integration.import_executor is True
-    module_mock = MagicMock()
+    assert integration.config_flow is True
+
     assert "executor_import" not in hass.config.components
-    with patch.dict("sys.modules", {integration.pkg_path: module_mock}), patch(
-        "homeassistant.loader.importlib.import_module", return_value=module_mock
-    ) as mock_import:
+    assert "executor_import.config_flow" not in hass.config.components
+
+    config_flow_module_name = f"{integration.pkg_path}.config_flow"
+    module_mock = MagicMock()
+    config_flow_module_mock = MagicMock()
+
+    def import_module(name: str) -> Any:
+        if name == integration.pkg_path:
+            return module_mock
+        if name == config_flow_module_name:
+            return config_flow_module_mock
+        raise ImportError
+
+    caplog.clear()
+    modules_without_config_flow = {
+        k: v for k, v in sys.modules.items() if k != config_flow_module_name
+    }
+    with patch.dict(
+        "sys.modules",
+        {**modules_without_config_flow, integration.pkg_path: module_mock},
+        clear=True,
+    ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
 
-    assert mock_import.call_count == 1
+    # The config flow is missing so we should load
+    # in the executor
+    assert "loaded_executor=True" in caplog.text
+    assert module is module_mock
+
+    with patch.dict(
+        "sys.modules",
+        {
+            integration.pkg_path: module_mock,
+            config_flow_module_name: config_flow_module_mock,
+        },
+    ), patch("homeassistant.loader.importlib.import_module", import_module):
+        module = await integration.async_get_component()
+
+    # Everything is there so we should load in the event loop
+    # since it will all be cached
     assert "loaded_executor=False" in caplog.text
     assert module is module_mock
+
+    caplog.clear()
 
 
 async def test_async_get_component_deadlock_fallback(

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1100,7 +1100,6 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
             return config_flow_module_mock
         raise ImportError
 
-    caplog.clear()
     modules_without_config_flow = {
         k: v for k, v in sys.modules.items() if k != config_flow_module_name
     }
@@ -1114,7 +1113,9 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     # The config flow is missing so we should load
     # in the executor
     assert "loaded_executor=True" in caplog.text
+    assert "loaded_executor=False" not in caplog.text
     assert module is module_mock
+    caplog.clear()
 
     with patch.dict(
         "sys.modules",
@@ -1128,9 +1129,8 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     # Everything is there so we should load in the event loop
     # since it will all be cached
     assert "loaded_executor=False" in caplog.text
+    assert "loaded_executor=True" not in caplog.text
     assert module is module_mock
-
-    caplog.clear()
 
 
 async def test_async_get_component_deadlock_fallback(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


The sys.modules check was incorrect (only on dev -- it works as expected in `rc`) so it was slower than it needed to be


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
