### PR TITLE
Avoid multiple executor jobs with concurrent calls to async_get_component

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -848,6 +848,7 @@ class Integration:
 
         if debug := _LOGGER.isEnabledFor(logging.DEBUG):
             start = time.perf_counter()
+
         domain = self.domain
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
@@ -855,24 +856,26 @@ class Integration:
             self.pkg_path not in sys.modules
             or (self.config_flow and f"{self.pkg_path}.config_flow" not in sys.modules)
         )
+        if not load_executor:
+            comp = self.get_component()
+            if debug:
+                _LOGGER.debug(
+                    "Component %s import took %.3f seconds (loaded_executor=False)",
+                    domain,
+                    time.perf_counter() - start,
+                )
+            return comp
+
         self._component_future = self.hass.loop.create_future()
         try:
-            if load_executor:
-                try:
-                    comp = await self.hass.async_add_import_executor_job(
-                        self.get_component
-                    )
-                except ImportError as ex:
-                    load_executor = False
-                    _LOGGER.debug(
-                        "Failed to import %s in executor", domain, exc_info=ex
-                    )
-                    # If importing in the executor deadlocks because there is a circular
-                    # dependency, we fall back to the event loop.
-                    comp = self.get_component()
-            else:
+            try:
+                comp = await self.hass.async_add_import_executor_job(self.get_component)
+            except ImportError as ex:
+                load_executor = False
+                _LOGGER.debug("Failed to import %s in executor", domain, exc_info=ex)
+                # If importing in the executor deadlocks because there is a circular
+                # dependency, we fall back to the event loop.
                 comp = self.get_component()
-
             self._component_future.set_result(comp)
         except BaseException as ex:
             self._component_future.set_exception(ex)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -661,6 +661,7 @@ class Integration:
             self._all_dependencies_resolved = True
             self._all_dependencies = set()
 
+        self._component_future: asyncio.Future[ComponentProtocol] | None = None
         self._import_futures: dict[str, asyncio.Future[ModuleType]] = {}
         _LOGGER.info("Loaded %s from %s", self.domain, pkg_path)
 
@@ -842,25 +843,47 @@ class Integration:
         and will check if import_executor is set and load it in the executor,
         otherwise it will load it in the event loop.
         """
+        if self._component_future:
+            return await self._component_future
+
         if debug := _LOGGER.isEnabledFor(logging.DEBUG):
             start = time.perf_counter()
         domain = self.domain
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
-        load_executor = (
-            self.import_executor and f"{self.pkg_path}.{domain}" not in sys.modules
+        load_executor = self.import_executor and (
+            self.pkg_path not in sys.modules
+            or (self.config_flow and f"{self.pkg_path}.config_flow" not in sys.modules)
         )
-        if load_executor:
-            try:
-                comp = await self.hass.async_add_import_executor_job(self.get_component)
-            except ImportError as ex:
-                load_executor = False
-                _LOGGER.debug("Failed to import %s in executor", domain, exc_info=ex)
-                # If importing in the executor deadlocks because there is a circular
-                # dependency, we fall back to the event loop.
+        self._component_future = self.hass.loop.create_future()
+        try:
+            if load_executor:
+                try:
+                    comp = await self.hass.async_add_import_executor_job(
+                        self.get_component
+                    )
+                except ImportError as ex:
+                    load_executor = False
+                    _LOGGER.debug(
+                        "Failed to import %s in executor", domain, exc_info=ex
+                    )
+                    # If importing in the executor deadlocks because there is a circular
+                    # dependency, we fall back to the event loop.
+                    comp = self.get_component()
+            else:
                 comp = self.get_component()
-        else:
-            comp = self.get_component()
+
+            self._component_future.set_result(comp)
+        except BaseException as ex:
+            self._component_future.set_exception(ex)
+            with suppress(BaseException):
+                # Set the exception retrieved flag on the future since
+                # it will never be retrieved unless there
+                # are concurrent calls to async_get_component
+                self._component_future.result()
+            raise
+        finally:
+            self._component_future = None
 
         if debug:
             _LOGGER.debug(
@@ -869,6 +892,7 @@ class Integration:
                 time.perf_counter() - start,
                 load_executor,
             )
+
         return comp
 
     def get_component(self) -> ComponentProtocol:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -849,7 +849,6 @@ class Integration:
         if debug := _LOGGER.isEnabledFor(logging.DEBUG):
             start = time.perf_counter()
 
-        domain = self.domain
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
         load_executor = self.import_executor and (
@@ -861,7 +860,7 @@ class Integration:
             if debug:
                 _LOGGER.debug(
                     "Component %s import took %.3f seconds (loaded_executor=False)",
-                    domain,
+                    self.domain,
                     time.perf_counter() - start,
                 )
             return comp
@@ -872,7 +871,9 @@ class Integration:
                 comp = await self.hass.async_add_import_executor_job(self.get_component)
             except ImportError as ex:
                 load_executor = False
-                _LOGGER.debug("Failed to import %s in executor", domain, exc_info=ex)
+                _LOGGER.debug(
+                    "Failed to import %s in executor", self.domain, exc_info=ex
+                )
                 # If importing in the executor deadlocks because there is a circular
                 # dependency, we fall back to the event loop.
                 comp = self.get_component()
@@ -891,7 +892,7 @@ class Integration:
         if debug:
             _LOGGER.debug(
                 "Component %s import took %.3f seconds (loaded_executor=%s)",
-                domain,
+                self.domain,
                 time.perf_counter() - start,
                 load_executor,
             )

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@
 import asyncio
 import os
 import sys
+import threading
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1086,8 +1087,8 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     assert integration.import_executor is True
     assert integration.config_flow is True
 
-    assert "executor_import" not in hass.config.components
-    assert "executor_import.config_flow" not in hass.config.components
+    assert "test_package_loaded_executor" not in hass.config.components
+    assert "test_package_loaded_executor.config_flow" not in hass.config.components
 
     config_flow_module_name = f"{integration.pkg_path}.config_flow"
     module_mock = MagicMock()
@@ -1131,6 +1132,64 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     assert "loaded_executor=False" in caplog.text
     assert "loaded_executor=True" not in caplog.text
     assert module is module_mock
+
+
+async def test_async_get_component_concurrent_loads(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    enable_custom_integrations: None,
+) -> None:
+    """Verify async_get_component waits if the first load if called again when still in progress."""
+    integration = await loader.async_get_integration(
+        hass, "test_package_loaded_executor"
+    )
+    assert integration.pkg_path == "custom_components.test_package_loaded_executor"
+    assert integration.import_executor is True
+    assert integration.config_flow is True
+
+    assert "test_package_loaded_executor" not in hass.config.components
+    assert "test_package_loaded_executor.config_flow" not in hass.config.components
+
+    config_flow_module_name = f"{integration.pkg_path}.config_flow"
+    module_mock = MagicMock()
+    config_flow_module_mock = MagicMock()
+    imports = []
+    start_event = threading.Event()
+    import_event = asyncio.Event()
+
+    def import_module(name: str) -> Any:
+        hass.loop.call_soon_threadsafe(import_event.set)
+        imports.append(name)
+        start_event.wait()
+        if name == integration.pkg_path:
+            return module_mock
+        if name == config_flow_module_name:
+            return config_flow_module_mock
+        raise ImportError
+
+    modules_without_integration = {
+        k: v
+        for k, v in sys.modules.items()
+        if k != config_flow_module_name and k != integration.pkg_path
+    }
+    with patch.dict(
+        "sys.modules",
+        {**modules_without_integration},
+        clear=True,
+    ), patch("homeassistant.loader.importlib.import_module", import_module):
+        load_task1 = asyncio.create_task(integration.async_get_component())
+        load_task2 = asyncio.create_task(integration.async_get_component())
+        await import_event.wait()  # make sure the import is started
+        assert not integration._component_future.done()
+        start_event.set()
+        comp1 = await load_task1
+        comp2 = await load_task2
+        assert integration._component_future is None
+
+    assert comp1 is module_mock
+    assert comp2 is module_mock
+
+    assert imports == [integration.pkg_path, config_flow_module_name]
 
 
 async def test_async_get_component_deadlock_fallback(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Return a future that can be awaited if the component is currently being loaded.  This can happen from platform setup.

```
2024-03-03 17:17:09.184 DEBUG (MainThread) [homeassistant.loader] Component ping import took 0.010 seconds (loaded_executor=True)
2024-03-03 17:17:09.184 DEBUG (MainThread) [homeassistant.loader] Component ping import took 0.000 seconds (loaded_executor=False)
2024-03-03 17:17:09.186 DEBUG (MainThread) [homeassistant.loader] Component ping import took 0.012 seconds (loaded_executor=True)
2024-03-03 17:17:09.186 DEBUG (MainThread) [homeassistant.loader] Component ping import took 0.012 seconds (loaded_executor=True)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
