### PR TITLE
Update aioairzone-cloud to v0.4.6

### DIFF
--- a/homeassistant/components/airzone_cloud/coordinator.py
+++ b/homeassistant/components/airzone_cloud/coordinator.py
@@ -25,6 +25,7 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def __init__(self, hass: HomeAssistant, airzone: AirzoneCloudApi) -> None:
         """Initialize."""
         self.airzone = airzone
+        self.airzone.set_update_callback(self.async_set_updated_data)
 
         super().__init__(
             hass,

--- a/homeassistant/components/airzone_cloud/manifest.json
+++ b/homeassistant/components/airzone_cloud/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": ["@Noltari"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/airzone_cloud",
-  "iot_class": "cloud_polling",
+  "iot_class": "cloud_push",
   "loggers": ["aioairzone_cloud"],
-  "requirements": ["aioairzone-cloud==0.4.5"]
+  "requirements": ["aioairzone-cloud==0.4.6"]
 }

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -168,7 +168,7 @@
         "airzone_cloud": {
           "integration_type": "hub",
           "config_flow": true,
-          "iot_class": "cloud_polling",
+          "iot_class": "cloud_push",
           "name": "Airzone Cloud"
         }
       }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -188,7 +188,7 @@ aio-georss-gdacs==0.9
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.4.5
+aioairzone-cloud==0.4.6
 
 # homeassistant.components.airzone
 aioairzone==0.7.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -167,7 +167,7 @@ aio-georss-gdacs==0.9
 aioairq==0.3.2
 
 # homeassistant.components.airzone_cloud
-aioairzone-cloud==0.4.5
+aioairzone-cloud==0.4.6
 
 # homeassistant.components.airzone
 aioairzone==0.7.5

--- a/tests/components/airzone_cloud/conftest.py
+++ b/tests/components/airzone_cloud/conftest.py
@@ -11,5 +11,8 @@ def airzone_cloud_no_websockets():
     with patch(
         "homeassistant.components.airzone_cloud.AirzoneCloudApi._update_websockets",
         return_value=False,
-    ), patch("aioairzone_cloud.websockets.AirzoneCloudIWS.connect", return_value=True):
+    ), patch(
+        "homeassistant.components.airzone_cloud.AirzoneCloudApi.connect_installation_websockets",
+        return_value=None,
+    ):
         yield


### PR DESCRIPTION
## Proposed change
Update aioairzone-cloud to [v0.4.6](https://github.com/Noltari/aioairzone-cloud/compare/0.4.5...0.4.6).

Since this adds the remaining Cloud Push functionality, the integration is now Cloud Push instead of Cloud Polling.

Releases:
- https://github.com/Noltari/aioairzone-cloud/releases/tag/0.4.6

Git compare: https://github.com/Noltari/aioairzone-cloud/compare/0.4.5...0.4.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31728

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
