### PR TITLE
Fix pylint/mypy on elmax integration

### DIFF
--- a/homeassistant/components/elmax/config_flow.py
+++ b/homeassistant/components/elmax/config_flow.py
@@ -13,7 +13,6 @@ import voluptuous as vol
 
 from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
@@ -118,13 +117,13 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the flow initiated by the user."""
         return await self.async_step_choose_mode(user_input=user_input)
 
     async def async_step_choose_mode(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle local vs cloud mode selection step."""
         return self.async_show_menu(
             step_id="choose_mode",
@@ -136,7 +135,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _handle_direct_and_create_entry(
         self, fallback_step_id: str, schema: vol.Schema
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         return await self._test_direct_and_create_entry()
 
     async def _test_direct_and_create_entry(self):
@@ -202,7 +201,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_direct(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_direct(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Handle the direct setup step."""
         self._selected_mode = CONF_ELMAX_MODE_CLOUD
         if user_input is None:
@@ -236,7 +235,9 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
             fallback_step_id=CONF_ELMAX_MODE_DIRECT, schema=tmp_schema
         )
 
-    async def async_step_zeroconf_setup(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_zeroconf_setup(
+        self, user_input: dict[str, Any]
+    ) -> ConfigFlowResult:
         """Handle the direct setup step triggered via zeroconf."""
         if user_input is None:
             return self.async_show_form(
@@ -265,7 +266,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _check_unique_and_create_entry(
         self, unique_id: str, title: str, data: Mapping[str, Any]
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         # Make sure this is the only Elmax integration for this specific panel id.
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
@@ -275,7 +276,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
             data=data,
         )
 
-    async def async_step_cloud(self, user_input: dict[str, Any]) -> FlowResult:
+    async def async_step_cloud(self, user_input: dict[str, Any]) -> ConfigFlowResult:
         """Handle the cloud setup flow."""
         self._selected_mode = CONF_ELMAX_MODE_CLOUD
 
@@ -463,7 +464,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
         host: str,
         https_port: int,
         http_port: int,
-    ) -> FlowResult | None:
+    ) -> ConfigFlowResult | None:
         # Look for another entry with the same PANEL_ID (local or remote).
         # If there already is a matching panel, take the change to notify the Coordinator
         # so that it uses the newly discovered IP address. This mitigates the issues
@@ -496,7 +497,7 @@ class ElmaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(
         self, discovery_info: ZeroconfServiceInfo
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle device found via zeroconf."""
         host = discovery_info.host
         https_port = (


### PR DESCRIPTION
## Proposed change
Remove incorrect usage of FlowResult from https://github.com/home-assistant/core/pull/94392.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
