### PR TITLE
Remove unnecessary access to UniFi hub object in tests

### DIFF
--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -1,8 +1,13 @@
 """UniFi Network button platform tests."""
 
 from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, ButtonDeviceClass
-from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
-from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, EntityCategory
+from homeassistant.components.unifi.const import CONF_SITE_ID
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    CONF_HOST,
+    STATE_UNAVAILABLE,
+    EntityCategory,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -36,8 +41,6 @@ async def test_restart_device_button(
             }
         ],
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 1
 
     ent_reg_entry = entity_registry.async_get("button.switch_restart")
@@ -52,7 +55,7 @@ async def test_restart_device_button(
     # Send restart device command
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/devmgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(
@@ -120,8 +123,6 @@ async def test_power_cycle_poe(
             }
         ],
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
-
     assert len(hass.states.async_entity_ids(BUTTON_DOMAIN)) == 2
 
     ent_reg_entry = entity_registry.async_get("button.switch_port_1_power_cycle")
@@ -136,7 +137,7 @@ async def test_power_cycle_poe(
     # Send restart device command
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/devmgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -56,7 +56,7 @@ async def test_restart_device_button(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(
@@ -139,7 +139,7 @@ async def test_power_cycle_poe(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_button.py
+++ b/tests/components/unifi/test_button.py
@@ -55,7 +55,8 @@ async def test_restart_device_button(
     # Send restart device command
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(
@@ -137,7 +138,8 @@ async def test_power_cycle_poe(
     # Send restart device command
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -9,11 +9,13 @@ from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_CLIENT_SOURCE,
+    CONF_DETECTION_TIME,
     CONF_IGNORE_WIRED_BUG,
     CONF_SSID_FILTER,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
     CONF_TRACK_WIRED_CLIENTS,
+    DEFAULT_DETECTION_TIME,
     DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
@@ -55,7 +57,6 @@ async def test_tracked_wireless_clients(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[client]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
@@ -70,7 +71,9 @@ async def test_tracked_wireless_clients(
 
     # Change time to mark client as away
 
-    new_time = dt_util.utcnow() + hub.option_detection_time
+    new_time = dt_util.utcnow() + timedelta(
+        seconds=config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
@@ -194,7 +197,7 @@ async def test_tracked_wireless_clients_event_source(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[client]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
     assert hass.states.get("device_tracker.client").state == STATE_NOT_HOME
 
@@ -243,7 +246,14 @@ async def test_tracked_wireless_clients_event_source(
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
     # Change time to mark client as away
-    freezer.tick(hub.option_detection_time + timedelta(seconds=1))
+    freezer.tick(
+        timedelta(
+            seconds=(
+                config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+                + 1
+            )
+        )
+    )
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -282,7 +292,14 @@ async def test_tracked_wireless_clients_event_source(
     assert hass.states.get("device_tracker.client").state == STATE_HOME
 
     # Change time to mark client as away
-    freezer.tick(hub.option_detection_time + timedelta(seconds=1))
+    freezer.tick(
+        timedelta(
+            seconds=(
+                config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+                + 1
+            )
+        )
+    )
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -682,10 +699,8 @@ async def test_option_ssid_filter(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[client, client_on_ssid2]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
-
     assert hass.states.get("device_tracker.client").state == STATE_HOME
     assert hass.states.get("device_tracker.client_on_ssid2").state == STATE_NOT_HOME
 
@@ -711,7 +726,11 @@ async def test_option_ssid_filter(
     mock_unifi_websocket(message=MessageKey.CLIENT, data=client_on_ssid2)
     await hass.async_block_till_done()
 
-    new_time = dt_util.utcnow() + hub.option_detection_time
+    new_time = dt_util.utcnow() + timedelta(
+        seconds=(
+            config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME) + 1
+        )
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
@@ -739,7 +758,11 @@ async def test_option_ssid_filter(
 
     # Time pass to mark client as away
 
-    new_time += hub.option_detection_time
+    new_time += timedelta(
+        seconds=(
+            config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME) + 1
+        )
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
@@ -758,7 +781,9 @@ async def test_option_ssid_filter(
     mock_unifi_websocket(message=MessageKey.CLIENT, data=client_on_ssid2)
     await hass.async_block_till_done()
 
-    new_time += hub.option_detection_time
+    new_time += timedelta(
+        seconds=(config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME))
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
@@ -788,7 +813,6 @@ async def test_wireless_client_go_wired_issue(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=[client]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
 
@@ -807,7 +831,9 @@ async def test_wireless_client_go_wired_issue(
     assert client_state.state == STATE_HOME
 
     # Pass time
-    new_time = dt_util.utcnow() + hub.option_detection_time
+    new_time = dt_util.utcnow() + timedelta(
+        seconds=(config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME))
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()
@@ -859,7 +885,6 @@ async def test_option_ignore_wired_bug(
         options={CONF_IGNORE_WIRED_BUG: True},
         clients_response=[client],
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
 
     # Client is wireless
@@ -876,7 +901,9 @@ async def test_option_ignore_wired_bug(
     assert client_state.state == STATE_HOME
 
     # pass time
-    new_time = dt_util.utcnow() + hub.option_detection_time
+    new_time = dt_util.utcnow() + timedelta(
+        seconds=config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME)
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -18,10 +18,11 @@ from homeassistant.components.sensor import (
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
+    CONF_DETECTION_TIME,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
+    DEFAULT_DETECTION_TIME,
     DEVICE_STATES,
-    DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_UNAVAILABLE, EntityCategory
@@ -395,7 +396,6 @@ async def test_bandwidth_sensors(
 
     # Verify reset sensor after heartbeat expires
 
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
     new_time = dt_util.utcnow()
     wireless_client["last_seen"] = dt_util.as_timestamp(new_time)
 
@@ -409,8 +409,11 @@ async def test_bandwidth_sensors(
     assert hass.states.get("sensor.wireless_client_rx").state == "3456.0"
     assert hass.states.get("sensor.wireless_client_tx").state == "7891.0"
 
-    new_time = new_time + hub.option_detection_time + timedelta(seconds=1)
-
+    new_time += timedelta(
+        seconds=(
+            config_entry.options.get(CONF_DETECTION_TIME, DEFAULT_DETECTION_TIME) + 1
+        )
+    )
     with freeze_time(new_time):
         async_fire_time_changed(hass, new_time)
         await hass.async_block_till_done()

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -70,7 +70,7 @@ async def test_reconnect_client(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -149,7 +149,7 @@ async def test_reconnect_client_hub_unavailable(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -266,7 +266,7 @@ async def test_remove_clients(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -1,13 +1,13 @@
 """deCONZ service tests."""
 from unittest.mock import patch
 
-from homeassistant.components.unifi.const import DOMAIN as UNIFI_DOMAIN
+from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN as UNIFI_DOMAIN
 from homeassistant.components.unifi.services import (
     SERVICE_RECONNECT_CLIENT,
     SERVICE_REMOVE_CLIENTS,
     SUPPORTED_SERVICES,
 )
-from homeassistant.const import ATTR_DEVICE_ID
+from homeassistant.const import ATTR_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -66,11 +66,10 @@ async def test_reconnect_client(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_response=clients
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -148,7 +147,7 @@ async def test_reconnect_client_hub_unavailable(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -261,11 +260,10 @@ async def test_remove_clients(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, clients_all_response=clients
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -69,7 +69,8 @@ async def test_reconnect_client(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -147,7 +148,8 @@ async def test_reconnect_client_hub_unavailable(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     device_entry = device_registry.async_get_or_create(
@@ -263,7 +265,8 @@ async def test_remove_clients(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(UNIFI_DOMAIN, SERVICE_REMOVE_CLIENTS, blocking=True)

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -858,7 +858,8 @@ async def test_switches(
     # Block and unblock client
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -882,7 +883,8 @@ async def test_switches(
     # Enable and disable DPI
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/5f976f62e3c58f018ec7e17d",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/{DPI_APPS[0]["_id"]}",
     )
 
     await hass.services.async_call(
@@ -981,7 +983,8 @@ async def test_block_switches(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -1160,7 +1163,8 @@ async def test_outlet_switches(
     device_id = test_data["device_id"]
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/{device_id}",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/{device_id}",
     )
 
     await hass.services.async_call(
@@ -1370,7 +1374,8 @@ async def test_poe_port_switches(
     # Turn off PoE
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/mock-id",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/mock-id",
     )
 
     await hass.services.async_call(
@@ -1466,8 +1471,8 @@ async def test_wlan_switches(
     # Disable WLAN
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}"
-        + f"/rest/wlanconf/{WLAN['_id']}",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/wlanconf/{WLAN['_id']}",
     )
 
     await hass.services.async_call(
@@ -1546,8 +1551,8 @@ async def test_port_forwarding_switches(
     # Disable port forward
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}"
-        + f"/rest/portforward/{data['_id']}",
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/portforward/{data['_id']}",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -859,7 +859,7 @@ async def test_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -884,7 +884,7 @@ async def test_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/{DPI_APPS[0]["_id"]}",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/{DPI_APPS[0]["_id"]}",
     )
 
     await hass.services.async_call(
@@ -984,7 +984,7 @@ async def test_block_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.post(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -1164,7 +1164,7 @@ async def test_outlet_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/{device_id}",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/{device_id}",
     )
 
     await hass.services.async_call(
@@ -1375,7 +1375,7 @@ async def test_poe_port_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/mock-id",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/mock-id",
     )
 
     await hass.services.async_call(
@@ -1472,7 +1472,7 @@ async def test_wlan_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/wlanconf/{WLAN['_id']}",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/wlanconf/{WLAN['_id']}",
     )
 
     await hass.services.async_call(
@@ -1552,7 +1552,7 @@ async def test_port_forwarding_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/portforward/{data['_id']}",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/portforward/{data['_id']}",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -15,6 +15,7 @@ from homeassistant.components.switch import (
 from homeassistant.components.unifi.const import (
     CONF_BLOCK_CLIENT,
     CONF_DPI_RESTRICTIONS,
+    CONF_SITE_ID,
     CONF_TRACK_CLIENTS,
     CONF_TRACK_DEVICES,
     DOMAIN as UNIFI_DOMAIN,
@@ -23,6 +24,7 @@ from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
+    CONF_HOST,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -829,7 +831,6 @@ async def test_switches(
         dpigroup_response=DPI_GROUPS,
         dpiapp_response=DPI_APPS,
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 3
 
@@ -857,7 +858,7 @@ async def test_switches(
     # Block and unblock client
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -881,7 +882,7 @@ async def test_switches(
     # Enable and disable DPI
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{hub.host}:1234/api/s/{hub.site}/rest/dpiapp/5f976f62e3c58f018ec7e17d",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/5f976f62e3c58f018ec7e17d",
     )
 
     await hass.services.async_call(
@@ -951,7 +952,6 @@ async def test_block_switches(
         clients_response=[UNBLOCKED],
         clients_all_response=[BLOCKED],
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
 
@@ -981,7 +981,7 @@ async def test_block_switches(
 
     aioclient_mock.clear_requests()
     aioclient_mock.post(
-        f"https://{hub.host}:1234/api/s/{hub.site}/cmd/stamgr",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/stamgr",
     )
 
     await hass.services.async_call(
@@ -1142,7 +1142,6 @@ async def test_outlet_switches(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[test_data]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == expected_switches
     # Validate state object
     switch_1 = hass.states.get(f"switch.{entity_id}")
@@ -1161,7 +1160,7 @@ async def test_outlet_switches(
     device_id = test_data["device_id"]
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{hub.host}:1234/api/s/{hub.site}/rest/device/{device_id}",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/{device_id}",
     )
 
     await hass.services.async_call(
@@ -1333,7 +1332,6 @@ async def test_poe_port_switches(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, devices_response=[DEVICE_1]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
@@ -1372,7 +1370,7 @@ async def test_poe_port_switches(
     # Turn off PoE
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{hub.host}:1234/api/s/{hub.site}/rest/device/mock-id",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/rest/device/mock-id",
     )
 
     await hass.services.async_call(
@@ -1445,7 +1443,6 @@ async def test_wlan_switches(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, wlans_response=[WLAN]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
@@ -1469,7 +1466,8 @@ async def test_wlan_switches(
     # Disable WLAN
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{hub.host}:1234/api/s/{hub.site}" + f"/rest/wlanconf/{WLAN['_id']}",
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}"
+        + f"/rest/wlanconf/{WLAN['_id']}",
     )
 
     await hass.services.async_call(
@@ -1525,7 +1523,6 @@ async def test_port_forwarding_switches(
     config_entry = await setup_unifi_integration(
         hass, aioclient_mock, port_forward_response=[_data.copy()]
     )
-    hub = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
@@ -1549,7 +1546,7 @@ async def test_port_forwarding_switches(
     # Disable port forward
     aioclient_mock.clear_requests()
     aioclient_mock.put(
-        f"https://{hub.host}:1234/api/s/{hub.site}"
+        f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}"
         + f"/rest/portforward/{data['_id']}",
     )
 

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -884,7 +884,7 @@ async def test_switches(
     aioclient_mock.clear_requests()
     aioclient_mock.put(
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/{DPI_APPS[0]["_id"]}",
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/rest/dpiapp/{DPI_APPS[0]['_id']}",
     )
 
     await hass.services.async_call(

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -164,7 +164,7 @@ async def test_install(
 
     url = (
         f"https://{config_entry.data[CONF_HOST]}:1234"
-        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr"
+        f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr"
     )
     aioclient_mock.clear_requests()
     aioclient_mock.post(url)

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -162,7 +162,10 @@ async def test_install(
     device_state = hass.states.get("update.device_1")
     assert device_state.state == STATE_ON
 
-    url = f"https://{config_entry.data[CONF_HOST]}:1234/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr"
+    url = (
+        f"https://{config_entry.data[CONF_HOST]}:1234"
+        + f"/api/s/{config_entry.data[CONF_SITE_ID]}/cmd/devmgr"
+    )
     aioclient_mock.clear_requests()
     aioclient_mock.post(url)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is only a bunch of f-strings that get their data from other sources.
Avoid accessing hub to reach data available else where
Late comment from https://github.com/home-assistant/core/pull/104332#discussion_r1432002640

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
