### PR TITLE
Migrate remaining calls in config modules to async_get_component

### DIFF
--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1083,7 +1083,7 @@ async def merge_packages_config(
                 integration = await async_get_integration_with_requirements(
                     hass, domain
                 )
-                component = integration.get_component()
+                component = await integration.async_get_component()
             except LOAD_EXCEPTIONS as exc:
                 _log_pkg_error(
                     hass,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -490,7 +490,7 @@ class ConfigEntry:
                 hass, self.domain
             )
         try:
-            component = integration.get_component()
+            component = await integration.async_get_component()
         except ImportError as err:
             _LOGGER.error(
                 "Error importing integration %s to set up %s configuration entry: %s",
@@ -677,7 +677,7 @@ class ConfigEntry:
                 self._async_set_state(hass, ConfigEntryState.NOT_LOADED, None)
                 return True
 
-        component = integration.get_component()
+        component = await integration.async_get_component()
 
         if integration.domain == self.domain:
             if not self.state.recoverable:
@@ -734,7 +734,7 @@ class ConfigEntry:
                 # entry.
                 return
 
-        component = integration.get_component()
+        component = await integration.async_get_component()
         if not hasattr(component, "async_remove_entry"):
             return
         try:
@@ -783,7 +783,7 @@ class ConfigEntry:
 
         if not (integration := self._integration_for_domain):
             integration = await loader.async_get_integration(hass, self.domain)
-        component = integration.get_component()
+        component = await integration.async_get_component()
         supports_migrate = hasattr(component, "async_migrate_entry")
         if not supports_migrate:
             if same_major_version:
@@ -2497,14 +2497,14 @@ def _handle_entry_updated_filter(event: Event) -> bool:
 async def support_entry_unload(hass: HomeAssistant, domain: str) -> bool:
     """Test if a domain supports entry unloading."""
     integration = await loader.async_get_integration(hass, domain)
-    component = integration.get_component()
+    component = await integration.async_get_component()
     return hasattr(component, "async_unload_entry")
 
 
 async def support_remove_from_device(hass: HomeAssistant, domain: str) -> bool:
     """Test if a domain supports being removed from a device."""
     integration = await loader.async_get_integration(hass, domain)
-    component = integration.get_component()
+    component = await integration.async_get_component()
     return hasattr(component, "async_remove_config_entry_device")
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1179,10 +1179,9 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
 
-    # Everything is there so we should load in the event loop
-    # since it will all be cached
-    assert "loaded_executor=False" in caplog.text
-    assert "loaded_executor=True" not in caplog.text
+    # Everything is already in the integration cache
+    # so it should not have to call the load
+    assert "loaded_executor" not in caplog.text
     assert module is module_mock
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -617,7 +617,7 @@ async def test_async_when_setup_or_start_already_loaded(hass: HomeAssistant) -> 
 async def test_setup_import_blows_up(hass: HomeAssistant) -> None:
     """Test that we handle it correctly when importing integration blows up."""
     with patch(
-        "homeassistant.loader.Integration.get_component", side_effect=ImportError
+        "homeassistant.loader.Integration.async_get_component", side_effect=ImportError
     ):
         assert not await setup.async_setup_component(hass, "sun", {})
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There were a few cases that were still using get_component that could have done blocking I/O in the event loop, although it was unlikely.

The caching check in async_get_component has been moved up to avoid creating the future if the module is already in the cache

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
