### PR TITLE
Add icon translations to TP-Link Omada

### DIFF
--- a/homeassistant/components/tplink_omada/icons.json
+++ b/homeassistant/components/tplink_omada/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "switch": {
+      "poe_control": {
+        "default": "mdi:ethernet"
+      }
+    }
+  }
+}

--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -17,8 +17,6 @@ from .const import DOMAIN
 from .controller import OmadaSiteController, OmadaSwitchPortCoordinator
 from .entity import OmadaDeviceEntity
 
-POE_SWITCH_ICON = "mdi:ethernet"
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -62,8 +60,8 @@ class OmadaNetworkSwitchPortPoEControl(
     """Representation of a PoE control toggle on a single network port on a switch."""
 
     _attr_has_entity_name = True
+    _attr_translation_key = "poe_control"
     _attr_entity_category = EntityCategory.CONFIG
-    _attr_icon = POE_SWITCH_ICON
 
     def __init__(
         self,
@@ -74,8 +72,8 @@ class OmadaNetworkSwitchPortPoEControl(
         """Initialize the PoE switch."""
         super().__init__(coordinator, device)
         self.port_id = port_id
-        self.port_details = self.coordinator.data[port_id]
-        self.omada_client = self.coordinator.omada_client
+        self.port_details = coordinator.data[port_id]
+        self.omada_client = coordinator.omada_client
         self._attr_unique_id = f"{device.mac}_{port_id}_poe"
 
         self._attr_name = f"{get_port_base_name(self.port_details)} PoE"

--- a/tests/components/tplink_omada/snapshots/test_switch.ambr
+++ b/tests/components/tplink_omada/snapshots/test_switch.ambr
@@ -3,7 +3,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 1 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_1_poe',
@@ -35,12 +34,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 1 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000001_poe',
     'unit_of_measurement': None,
   })
@@ -49,7 +48,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 6 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_6_poe',
@@ -81,12 +79,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 6 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000006_poe',
     'unit_of_measurement': None,
   })
@@ -95,7 +93,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 7 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_7_poe',
@@ -127,12 +124,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 7 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000007_poe',
     'unit_of_measurement': None,
   })
@@ -141,7 +138,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 8 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_8_poe',
@@ -173,12 +169,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 8 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000008_poe',
     'unit_of_measurement': None,
   })
@@ -187,7 +183,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 2 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_2_poe',
@@ -219,12 +214,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 2 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000002_poe',
     'unit_of_measurement': None,
   })
@@ -233,7 +228,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 3 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_3_poe',
@@ -265,12 +259,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 3 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000003_poe',
     'unit_of_measurement': None,
   })
@@ -279,7 +273,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 4 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_4_poe',
@@ -311,12 +304,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 4 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000004_poe',
     'unit_of_measurement': None,
   })
@@ -325,7 +318,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'friendly_name': 'Test PoE Switch Port 5 PoE',
-      'icon': 'mdi:ethernet',
     }),
     'context': <ANY>,
     'entity_id': 'switch.test_poe_switch_port_5_poe',
@@ -357,12 +349,12 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:ethernet',
+    'original_icon': None,
     'original_name': 'Port 5 PoE',
     'platform': 'tplink_omada',
     'previous_unique_id': None,
     'supported_features': 0,
-    'translation_key': None,
+    'translation_key': 'poe_control',
     'unique_id': '54-AF-97-00-00-01_000000000000000000000005_poe',
     'unit_of_measurement': None,
   })


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add icon translations to TP-Link Omada

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr