### PR TITLE
Remove the deprecated YAML support for Aftership

### DIFF
--- a/homeassistant/components/aftership/config_flow.py
+++ b/homeassistant/components/aftership/config_flow.py
@@ -8,10 +8,8 @@ from pyaftership import AfterShip, AfterShipException
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_API_KEY, CONF_NAME
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN
+from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import DOMAIN
 
@@ -46,27 +44,4 @@ class AfterShipConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema({vol.Required(CONF_API_KEY): str}),
             errors=errors,
-        )
-
-    async def async_step_import(self, config: dict[str, Any]) -> ConfigFlowResult:
-        """Import configuration from yaml."""
-        async_create_issue(
-            self.hass,
-            HOMEASSISTANT_DOMAIN,
-            f"deprecated_yaml_{DOMAIN}",
-            breaks_in_ha_version="2024.4.0",
-            is_fixable=False,
-            issue_domain=DOMAIN,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_yaml",
-            translation_placeholders={
-                "domain": DOMAIN,
-                "integration_title": "AfterShip",
-            },
-        )
-
-        self._async_abort_entries_match({CONF_API_KEY: config[CONF_API_KEY]})
-        return self.async_create_entry(
-            title=config.get(CONF_NAME, "AfterShip"),
-            data={CONF_API_KEY: config[CONF_API_KEY]},
         )

--- a/homeassistant/components/aftership/sensor.py
+++ b/homeassistant/components/aftership/sensor.py
@@ -5,24 +5,16 @@ import logging
 from typing import Any, Final
 
 from pyaftership import AfterShip, AfterShipException
-import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    PLATFORM_SCHEMA as BASE_PLATFORM_SCHEMA,
-    SensorEntity,
-)
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_NAME
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import Throttle
 
 from .const import (
@@ -33,7 +25,6 @@ from .const import (
     CONF_SLUG,
     CONF_TITLE,
     CONF_TRACKING_NUMBER,
-    DEFAULT_NAME,
     DOMAIN,
     MIN_TIME_BETWEEN_UPDATES,
     REMOVE_TRACKING_SERVICE_SCHEMA,
@@ -44,47 +35,7 @@ from .const import (
 
 _LOGGER: Final = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA: Final = BASE_PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_API_KEY): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
-
-
-async def async_setup_platform(
-    hass: HomeAssistant,
-    config: ConfigType,
-    async_add_entities: AddEntitiesCallback,
-    discovery_info: DiscoveryInfoType | None = None,
-) -> None:
-    """Set up the AfterShip sensor platform."""
-    aftership = AfterShip(
-        api_key=config[CONF_API_KEY], session=async_get_clientsession(hass)
-    )
-    try:
-        await aftership.trackings.list()
-    except AfterShipException:
-        async_create_issue(
-            hass,
-            DOMAIN,
-            "deprecated_yaml_import_issue_cannot_connect",
-            breaks_in_ha_version="2024.4.0",
-            is_fixable=False,
-            issue_domain=DOMAIN,
-            severity=IssueSeverity.WARNING,
-            translation_key="deprecated_yaml_import_issue_cannot_connect",
-            translation_placeholders={
-                "integration_title": "AfterShip",
-                "url": "/config/integrations/dashboard/add?domain=aftership",
-            },
-        )
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
-        )
-    )
+PLATFORM_SCHEMA: Final = cv.removed(DOMAIN, raise_if_present=False)
 
 
 async def async_setup_entry(

--- a/tests/components/aftership/test_config_flow.py
+++ b/tests/components/aftership/test_config_flow.py
@@ -4,13 +4,10 @@ from unittest.mock import AsyncMock, patch
 from pyaftership import AfterShipException
 
 from homeassistant.components.aftership.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import issue_registry as ir
-
-from tests.common import MockConfigEntry
 
 
 async def test_full_user_flow(hass: HomeAssistant, mock_setup_entry) -> None:
@@ -75,40 +72,3 @@ async def test_flow_cannot_connect(hass: HomeAssistant, mock_setup_entry) -> Non
         assert result["data"] == {
             CONF_API_KEY: "mock-api-key",
         }
-
-
-async def test_import_flow(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry, mock_setup_entry
-) -> None:
-    """Test importing yaml config."""
-
-    with patch(
-        "homeassistant.components.aftership.config_flow.AfterShip",
-        return_value=AsyncMock(),
-    ) as mock_aftership:
-        mock_aftership.return_value.trackings.return_value.list.return_value = {}
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_API_KEY: "yaml-api-key"},
-        )
-        assert result["type"] == FlowResultType.CREATE_ENTRY
-        assert result["title"] == "AfterShip"
-        assert result["data"] == {
-            CONF_API_KEY: "yaml-api-key",
-        }
-    assert len(issue_registry.issues) == 1
-
-
-async def test_import_flow_already_exists(
-    hass: HomeAssistant, issue_registry: ir.IssueRegistry
-) -> None:
-    """Test importing yaml config where entry already exists."""
-    entry = MockConfigEntry(domain=DOMAIN, data={CONF_API_KEY: "yaml-api-key"})
-    entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data={CONF_API_KEY: "yaml-api-key"}
-    )
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert len(issue_registry.issues) == 1


### PR DESCRIPTION
## Breaking change
The YAML configuration was deprecated in release 2023.10. Support for it has now been completely removed. If you still have `aftership` in your YAML configuration, you should remove it completely.

## Proposed change
Remove the YAML config support for Aftership

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
