### PR TITLE
Disable updating ZHA coordinator path from discovery info

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -511,17 +511,16 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
         if current_entry.source != SOURCE_IGNORE:
             self._abort_if_unique_id_configured()
-            return
-
-        # Only update the current entry if it is an ignored discovery
-        self._abort_if_unique_id_configured(
-            updates={
-                CONF_DEVICE: {
-                    **current_entry.data.get(CONF_DEVICE, {}),
-                    CONF_DEVICE_PATH: device_path,
-                },
-            }
-        )
+        else:
+            # Only update the current entry if it is an ignored discovery
+            self._abort_if_unique_id_configured(
+                updates={
+                    CONF_DEVICE: {
+                        **current_entry.data.get(CONF_DEVICE, {}),
+                        CONF_DEVICE_PATH: device_path,
+                    },
+                }
+            )
 
     @staticmethod
     @callback

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -500,15 +500,20 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
     VERSION = 4
 
-    async def _set_unique_id_or_update_path(
+    async def _set_unique_id_and_update_ignored_flow(
         self, unique_id: str, device_path: str
     ) -> None:
-        """Set the flow's unique ID and update the device path if it isn't unique."""
+        """Set the flow's unique ID and update the device path in an ignored flow."""
         current_entry = await self.async_set_unique_id(unique_id)
 
         if not current_entry:
             return
 
+        if current_entry.source != SOURCE_IGNORE:
+            self._abort_if_unique_id_configured()
+            return
+
+        # Only update the current entry if it is an ignored discovery
         self._abort_if_unique_id_configured(
             updates={
                 CONF_DEVICE: {
@@ -586,7 +591,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         description = discovery_info.description
         dev_path = discovery_info.device
 
-        await self._set_unique_id_or_update_path(
+        await self._set_unique_id_and_update_ignored_flow(
             unique_id=f"{vid}:{pid}_{serial_number}_{manufacturer}_{description}",
             device_path=dev_path,
         )
@@ -636,7 +641,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         node_name = local_name.removesuffix(".local")
         device_path = f"socket://{discovery_info.host}:{port}"
 
-        await self._set_unique_id_or_update_path(
+        await self._set_unique_id_and_update_ignored_flow(
             unique_id=node_name,
             device_path=device_path,
         )
@@ -661,7 +666,7 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         device_settings = discovery_data["port"]
         device_path = device_settings[CONF_DEVICE_PATH]
 
-        await self._set_unique_id_or_update_path(
+        await self._set_unique_id_and_update_ignored_flow(
             unique_id=f"{name}_{radio_type.name}_{device_path}",
             device_path=device_path,
         )

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -295,45 +295,6 @@ async def test_efr32_via_zeroconf(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
-async def test_discovery_via_zeroconf_ip_change(hass: HomeAssistant) -> None:
-    """Test zeroconf flow -- radio detected."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="tube_zb_gw_cc2652p2_poe",
-        data={
-            CONF_DEVICE: {
-                CONF_DEVICE_PATH: "socket://192.168.1.5:6638",
-                CONF_BAUDRATE: 115200,
-                CONF_FLOW_CONTROL: None,
-            }
-        },
-    )
-    entry.add_to_hass(hass)
-
-    service_info = zeroconf.ZeroconfServiceInfo(
-        ip_address=ip_address("192.168.1.22"),
-        ip_addresses=[ip_address("192.168.1.22")],
-        hostname="tube_zb_gw_cc2652p2_poe.local.",
-        name="mock_name",
-        port=6053,
-        properties={"address": "tube_zb_gw_cc2652p2_poe.local"},
-        type="mock_type",
-    )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
-    )
-
-    assert result["type"] == FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-    assert entry.data[CONF_DEVICE] == {
-        CONF_DEVICE_PATH: "socket://192.168.1.22:6638",
-        CONF_BAUDRATE: 115200,
-        CONF_FLOW_CONTROL: None,
-    }
-
-
-@patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-@patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
 async def test_discovery_via_zeroconf_ip_change_ignored(hass: HomeAssistant) -> None:
     """Test zeroconf flow that was ignored gets updated."""
     entry = MockConfigEntry(
@@ -547,7 +508,7 @@ async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
 
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
-async def test_discovery_via_usb_path_changes(hass: HomeAssistant) -> None:
+async def test_discovery_via_usb_path_does_not_change(hass: HomeAssistant) -> None:
     """Test usb flow already setup and the path changes."""
 
     entry = MockConfigEntry(
@@ -579,7 +540,7 @@ async def test_discovery_via_usb_path_changes(hass: HomeAssistant) -> None:
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_DEVICE] == {
-        CONF_DEVICE_PATH: "/dev/ttyZIGBEE",
+        CONF_DEVICE_PATH: "/dev/ttyUSB1",
         CONF_BAUDRATE: 115200,
         CONF_FLOW_CONTROL: None,
     }

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -509,7 +509,7 @@ async def test_discovery_via_usb_already_setup(hass: HomeAssistant) -> None:
 
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_discovery_via_usb_path_does_not_change(hass: HomeAssistant) -> None:
-    """Test usb flow already setup and the path changes."""
+    """Test usb flow already set up and the path does not change."""
 
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Coordinators configured over ZeroConf will not update their IP addresses, nor will USB devices passed through with Docker with a non-unique serial port (e.g. `/dev/ttyUSB1` instead of `/dev/serial/by-id/usb-Nabu_Casa_SkyConnect_v1.0_...-if00-port0`).

If your USB coordinator changes paths or IP addresses, you can always update the path by using the ZHA "Migrate Radio" button and then selecting the "Re-configure radio" button.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove updating the coordinator's device path based on config flow discovery.

The ZHA coordinator device is created with its `unique_id` set from discovery data. Unfortunately, this breaks catastrophically when a radio has been migrated: the `unique_id` remains the same after we change the device path so if the original coordinator is ever seen again, the device path will revert.

We currently do not store enough information in the config entry to disambiguate migrated config entries from existing config entries whose USB/hardware info has changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
