### PR TITLE
Add pylint plugin to check for async_add_entities not using list comprehensions

### DIFF
--- a/pylint/plugins/hass_enforce_non_list_comprehensions.py
+++ b/pylint/plugins/hass_enforce_non_list_comprehensions.py
@@ -36,10 +36,9 @@ class HassEnforceNonListComprehensionsChecker(BaseChecker):
             if len(node.args) > 1:
                 return
 
-            for arg in node.args:
-                if isinstance(arg, nodes.ListComp):
-                    self.add_message("hass-enforce-non-list-comprehensions", node=node)
-                    return
+            if isinstance(node.args[0], nodes.ListComp):
+                self.add_message("hass-enforce-non-list-comprehensions", node=node)
+                return
 
 
 def register(linter: PyLinter) -> None:

--- a/pylint/plugins/hass_enforce_non_list_comprehensions.py
+++ b/pylint/plugins/hass_enforce_non_list_comprehensions.py
@@ -1,0 +1,36 @@
+"""Plugin for checking sorted platforms list."""
+from __future__ import annotations
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+
+class HassEnforceNonListComprehensionsChecker(BaseChecker):
+    """Checker for async_add_entities not using list comprehensions."""
+
+    name = "hass_enforce_non_list_comprehensions"
+    priority = -1
+    msgs = {
+        "W7461": (
+            "Call to async_add_entities should not use of list comprehensions. "
+            "Unwrap and use the generator expression directly.",
+            "hass-enforce-non-list-comprehensions",
+            "Used when async_add_entities should not use list comprehensions.",
+        ),
+    }
+    options = ()
+
+    def visit_call(self, node: nodes.Call) -> None:
+        """Check if async_add_entities call is not using list comprehensions."""
+        func_name = node.func.as_string()
+        if func_name == "async_add_entities":
+            for arg in node.args:
+                if isinstance(arg, nodes.ListComp):
+                    self.add_message("hass-enforce-non-list-comprehensions", node=node)
+                    return
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(HassEnforceNonListComprehensionsChecker(linter))

--- a/pylint/plugins/hass_enforce_non_list_comprehensions.py
+++ b/pylint/plugins/hass_enforce_non_list_comprehensions.py
@@ -13,7 +13,7 @@ class HassEnforceNonListComprehensionsChecker(BaseChecker):
     priority = -1
     msgs = {
         "W7461": (
-            "Call to async_add_entities should not use of list comprehensions. "
+            "Call to async_add_entities should not use list comprehensions. "
             "Unwrap and use the generator expression directly.",
             "hass-enforce-non-list-comprehensions",
             "Used when async_add_entities should not use list comprehensions.",

--- a/pylint/plugins/hass_enforce_non_list_comprehensions.py
+++ b/pylint/plugins/hass_enforce_non_list_comprehensions.py
@@ -23,8 +23,19 @@ class HassEnforceNonListComprehensionsChecker(BaseChecker):
 
     def visit_call(self, node: nodes.Call) -> None:
         """Check if async_add_entities call is not using list comprehensions."""
+        root_name = node.root().name
+
+        # we only need to check components
+        if not root_name.startswith("homeassistant.components"):
+            return
+
         func_name = node.func.as_string()
         if func_name == "async_add_entities":
+            # we only want to check calls where
+            # update_before_add is not set
+            if len(node.args) > 1:
+                return
+
             for arg in node.args:
                 if isinstance(arg, nodes.ListComp):
                     self.add_message("hass-enforce-non-list-comprehensions", node=node)

--- a/pylint/plugins/hass_enforce_non_list_comprehensions.py
+++ b/pylint/plugins/hass_enforce_non_list_comprehensions.py
@@ -1,4 +1,4 @@
-"""Plugin for checking sorted platforms list."""
+"""Plugin for checking async_add_entities not using list comprehensions."""
 from __future__ import annotations
 
 from astroid import nodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ load-plugins = [
     "pylint.extensions.code_style",
     "pylint.extensions.typing",
     "hass_enforce_coordinator_module",
+    "hass_enforce_non_list_comprehensions",
     "hass_enforce_sorted_platforms",
     "hass_enforce_super_call",
     "hass_enforce_type_hints",

--- a/tests/pylint/conftest.py
+++ b/tests/pylint/conftest.py
@@ -122,3 +122,28 @@ def enforce_coordinator_module_fixture(
     )
     enforce_coordinator_module_checker.module = "homeassistant.components.pylint_test"
     return enforce_coordinator_module_checker
+
+
+@pytest.fixture(name="hass_enforce_non_list_comprehensions", scope="session")
+def hass_enforce_non_list_comprehensions_fixture() -> ModuleType:
+    """Fixture to the content for the hass_enforce_non_list_comprehensions check."""
+    return _load_plugin_from_file(
+        "hass_enforce_non_list_comprehensions",
+        "pylint/plugins/hass_enforce_non_list_comprehensions.py",
+    )
+
+
+@pytest.fixture(name="enforce_non_list_comprehensions_checker")
+def enforce_non_list_comprehensions_fixture(
+    hass_enforce_non_list_comprehensions, linter
+) -> BaseChecker:
+    """Fixture to provide a hass_enforce_non_list_comprehensions checker."""
+    enforce_non_list_comprehensions_checker = (
+        hass_enforce_non_list_comprehensions.HassEnforceNonListComprehensionsChecker(
+            linter
+        )
+    )
+    enforce_non_list_comprehensions_checker.module = (
+        "homeassistant.components.pylint_test"
+    )
+    return enforce_non_list_comprehensions_checker

--- a/tests/pylint/test_enforce_non_list_comprehensions.py
+++ b/tests/pylint/test_enforce_non_list_comprehensions.py
@@ -1,0 +1,76 @@
+"""Tests for pylint hass enforce non list comprehensions plugin."""
+import astroid
+from pylint.checkers import BaseChecker
+from pylint.interfaces import UNDEFINED
+from pylint.testutils import MessageTest, UnittestLinter
+from pylint.utils import ASTWalker
+import pytest
+
+from . import assert_adds_messages, assert_no_messages
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        pytest.param(
+            """
+        async_add_entities(entity for entity in entities)
+        """,
+            id="generator_expression",
+        ),
+        pytest.param(
+            """
+        entities: list[Sensor] = []
+
+        async_add_entities(entities)
+        """,
+            id="passing_list",
+        ),
+        pytest.param(
+            """
+        async_add_entities([entity for entity in entities], True)
+        """,
+            id="list_comprehension_with_update_before_add",
+        ),
+    ],
+)
+def test_enforce_sorted_platforms(
+    linter: UnittestLinter,
+    enforce_non_list_comprehensions_checker: BaseChecker,
+    code: str,
+) -> None:
+    """Good test cases."""
+    root_node = astroid.parse(code, "homeassistant.components.pylint_test")
+    walker = ASTWalker(linter)
+    walker.add_checker(enforce_non_list_comprehensions_checker)
+
+    with assert_no_messages(linter):
+        walker.walk(root_node)
+
+
+def test_enforce_sorted_platforms_bad(
+    linter: UnittestLinter,
+    enforce_non_list_comprehensions_checker: BaseChecker,
+) -> None:
+    """Bad test case."""
+    call_node = astroid.extract_node(
+        """
+    async_add_entities([entity for entity in entities])
+    """,
+        "homeassistant.components.pylint_test",
+    )
+
+    with assert_adds_messages(
+        linter,
+        MessageTest(
+            msg_id="hass-enforce-non-list-comprehensions",
+            line=2,
+            node=call_node,
+            args=None,
+            confidence=UNDEFINED,
+            col_offset=0,
+            end_line=2,
+            end_col_offset=51,
+        ),
+    ):
+        enforce_non_list_comprehensions_checker.visit_call(call_node)


### PR DESCRIPTION
## Proposed change
Add a Pylint plugin that checks whether calls to `async_add_entities` use a list comprehension, but could use the generator directly. We currently have to pay attention to this during the review.

Thanks @joostlek for the idea 🚀 

~TODO: Tests~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
