### PR TITLE
Remove hourly weather entity from met_eireann

### DIFF
--- a/homeassistant/components/met_eireann/weather.py
+++ b/homeassistant/components/met_eireann/weather.py
@@ -53,17 +53,15 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     entity_registry = er.async_get(hass)
 
-    entities = [MetEireannWeather(coordinator, config_entry.data, False)]
-
-    # Add hourly entity to legacy config entries
-    if entity_registry.async_get_entity_id(
+    # Remove hourly entity from legacy config entries
+    if entity_id := entity_registry.async_get_entity_id(
         WEATHER_DOMAIN,
         DOMAIN,
         _calculate_unique_id(config_entry.data, True),
     ):
-        entities.append(MetEireannWeather(coordinator, config_entry.data, True))
+        entity_registry.async_remove(entity_id)
 
-    async_add_entities(entities)
+    async_add_entities([MetEireannWeather(coordinator, config_entry.data)])
 
 
 def _calculate_unique_id(config: MappingProxyType[str, Any], hourly: bool) -> str:
@@ -93,19 +91,15 @@ class MetEireannWeather(
         self,
         coordinator: DataUpdateCoordinator[MetEireannWeatherData],
         config: MappingProxyType[str, Any],
-        hourly: bool,
     ) -> None:
         """Initialise the platform with a data instance and site."""
         super().__init__(coordinator)
-        self._attr_unique_id = _calculate_unique_id(config, hourly)
+        self._attr_unique_id = _calculate_unique_id(config, False)
         self._config = config
-        self._hourly = hourly
-        name_appendix = " Hourly" if hourly else ""
         if (name := self._config.get(CONF_NAME)) is not None:
-            self._attr_name = f"{name}{name_appendix}"
+            self._attr_name = name
         else:
-            self._attr_name = f"{DEFAULT_NAME}{name_appendix}"
-        self._attr_entity_registry_enabled_default = not hourly
+            self._attr_name = DEFAULT_NAME
         self._attr_device_info = DeviceInfo(
             name="Forecast",
             entry_type=DeviceEntryType.SERVICE,
@@ -182,7 +176,7 @@ class MetEireannWeather(
     @property
     def forecast(self) -> list[Forecast]:
         """Return the forecast array."""
-        return self._forecast(self._hourly)
+        return self._forecast(False)
 
     @callback
     def _async_forecast_daily(self) -> list[Forecast]:

--- a/tests/components/met_eireann/test_weather.py
+++ b/tests/components/met_eireann/test_weather.py
@@ -45,22 +45,6 @@ async def test_new_config_entry(
     assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 1
 
 
-async def test_legacy_config_entry(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_weather
-) -> None:
-    """Test the expected entities are created."""
-    entity_registry.async_get_or_create(
-        WEATHER_DOMAIN,
-        DOMAIN,
-        "10-20-hourly",
-    )
-    await setup_config_entry(hass)
-    assert len(hass.states.async_entity_ids("weather")) == 2
-
-    entry = hass.config_entries.async_entries()[0]
-    assert len(er.async_entries_for_config_entry(entity_registry, entry.entry_id)) == 2
-
-
 async def test_weather(hass: HomeAssistant, mock_weather) -> None:
     """Test weather entity."""
     await setup_config_entry(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `met_eireann` integration previously created two entities for each configured location, one entity which provided daily weather forecasts and one entity which provided hourly forecasts. The `met_eireann` integration now only creates a single entity which provides both daily and hourly weather forecasts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the hourly weather entity from `met_eireann` and instead provide hourly + daily forecasts in one entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
