### PR TITLE
Add test to ensure bootstrap continues if an integraton raises CancelledError

### DIFF
--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
@@ -1,0 +1,7 @@
+"""Provide a mock package component."""
+import asyncio
+
+
+async def async_setup(hass, config):
+    """Mock a successful setup."""
+    raise asyncio.CancelledError("Make sure this does not leak upward")

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error/__init__.py
@@ -4,4 +4,5 @@ import asyncio
 
 async def async_setup(hass, config):
     """Mock a successful setup."""
-    raise asyncio.CancelledError("Make sure this does not leak upward")
+    asyncio.current_task().cancel()
+    await asyncio.sleep(0)

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error/manifest.json
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "test_package_raises_cancelled_error",
+  "name": "Test Package that raises asyncio.CancelledError",
+  "documentation": "http://test-package.io",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": [],
+  "config_flow": false,
+  "version": "1.2.3"
+}

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
@@ -1,0 +1,12 @@
+"""Provide a mock package component."""
+import asyncio
+
+
+async def async_setup(hass, config):
+    """Mock a successful setup."""
+    return True
+
+
+async def async_setup_entry(hass, entry):
+    """Mock an unsuccessful entry setup."""
+    raise asyncio.CancelledError("Make sure this does not leak upward")

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/__init__.py
@@ -9,4 +9,5 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Mock an unsuccessful entry setup."""
-    raise asyncio.CancelledError("Make sure this does not leak upward")
+    asyncio.current_task().cancel()
+    await asyncio.sleep(0)

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/config_flow.py
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/config_flow.py
@@ -1,0 +1,17 @@
+"""Config flow."""
+
+from homeassistant.config_entries import ConfigFlow
+from homeassistant.core import HomeAssistant
+
+
+class MockConfigFlow(
+    ConfigFlow, domain="test_package_raises_cancelled_error_config_entry"
+):
+    """Mock config flow."""
+
+    pass
+
+
+async def _async_has_devices(hass: HomeAssistant) -> bool:
+    """Return if there are devices that can be discovered."""
+    return True

--- a/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/manifest.json
+++ b/tests/testing_config/custom_components/test_package_raises_cancelled_error_config_entry/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "test_package_raises_cancelled_error_config_entry",
+  "name": "Test Package that raises asyncio.CancelledError in async_setup_entry",
+  "documentation": "http://test-package.io",
+  "requirements": [],
+  "dependencies": [],
+  "codeowners": [],
+  "config_flow": true,
+  "version": "1.2.3"
+}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I did not find a problem here but this seemed like a case we want to check for

On a side note, we probably consume CancelledError when we should not https://superfastpython.com/asyncio-task-cancellation-best-practices/#Practice_1_Do_Not_Consume_CancelledError but thats the not problem I was looking for



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
