### PR TITLE
Fix sonos overloading the executor when there are many devices

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -8,7 +8,7 @@ import datetime
 from functools import partial
 import logging
 import time
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import defusedxml.ElementTree as ET
 from soco.core import SoCo
@@ -64,6 +64,9 @@ from .helpers import soco_error
 from .media import SonosMedia
 from .statistics import ActivityStatistics, EventStatistics
 
+if TYPE_CHECKING:
+    from . import SonosData
+
 NEVER_TIME = -1200.0
 RESUB_COOLDOWN_SECONDS = 10.0
 EVENT_CHARGING = {
@@ -97,6 +100,7 @@ class SonosSpeaker:
     ) -> None:
         """Initialize a SonosSpeaker."""
         self.hass = hass
+        self.data: SonosData = hass.data[DATA_SONOS]
         self.soco = soco
         self.websocket: SonosWebsocket | None = None
         self.household_id: str = soco.household_id
@@ -183,7 +187,7 @@ class SonosSpeaker:
         )
         dispatch_pairs: tuple[tuple[str, Callable[..., Any]], ...] = (
             (SONOS_CHECK_ACTIVITY, self.async_check_activity),
-            (SONOS_SPEAKER_ADDED, self.update_group_for_uid),
+            (SONOS_SPEAKER_ADDED, self.async_update_group_for_uid),
             (f"{SONOS_REBOOTED}-{self.soco.uid}", self.async_rebooted),
             (f"{SONOS_SPEAKER_ACTIVITY}-{self.soco.uid}", self.speaker_activity),
             (f"{SONOS_VANISHED}-{self.soco.uid}", self.async_vanished),
@@ -272,12 +276,12 @@ class SonosSpeaker:
     @property
     def alarms(self) -> SonosAlarms:
         """Return the SonosAlarms instance for this household."""
-        return self.hass.data[DATA_SONOS].alarms[self.household_id]
+        return self.data.alarms[self.household_id]
 
     @property
     def favorites(self) -> SonosFavorites:
         """Return the SonosFavorites instance for this household."""
-        return self.hass.data[DATA_SONOS].favorites[self.household_id]
+        return self.data.favorites[self.household_id]
 
     @property
     def is_coordinator(self) -> bool:
@@ -494,9 +498,7 @@ class SonosSpeaker:
             "x-rincon:"
         ):
             new_coordinator_uid = av_transport_uri.split(":")[-1]
-            if new_coordinator_speaker := self.hass.data[DATA_SONOS].discovered.get(
-                new_coordinator_uid
-            ):
+            if new_coordinator_speaker := self.data.discovered.get(new_coordinator_uid):
                 _LOGGER.debug(
                     "Media update coordinator (%s) received for %s",
                     new_coordinator_speaker.zone_name,
@@ -655,7 +657,7 @@ class SonosSpeaker:
 
         await self.async_unsubscribe()
 
-        self.hass.data[DATA_SONOS].discovery_known.discard(self.soco.uid)
+        self.data.discovery_known.discard(self.soco.uid)
 
     async def async_vanished(self, reason: str) -> None:
         """Handle removal of speaker when marked as vanished."""
@@ -782,15 +784,16 @@ class SonosSpeaker:
         """Update group topology when polling."""
         self.hass.add_job(self.create_update_groups_coro())
 
-    def update_group_for_uid(self, uid: str) -> None:
+    @callback
+    def async_update_group_for_uid(self, uid: str) -> None:
         """Update group topology if uid is missing."""
         if uid not in self._group_members_missing:
             return
-        missing_zone = self.hass.data[DATA_SONOS].discovered[uid].zone_name
+        missing_zone = self.data.discovered[uid].zone_name
         _LOGGER.debug(
             "%s was missing, adding to %s group", missing_zone, self.zone_name
         )
-        self.update_groups()
+        self.hass.async_create_task(self.create_update_groups_coro(), eager_start=True)
 
     @callback
     def async_update_groups(self, event: SonosEvent) -> None:
@@ -864,7 +867,7 @@ class SonosSpeaker:
             sonos_group_entities = []
 
             for uid in group:
-                speaker = self.hass.data[DATA_SONOS].discovered.get(uid)
+                speaker = self.data.discovered.get(uid)
                 if speaker:
                     self._group_members_missing.discard(uid)
                     sonos_group.append(speaker)
@@ -892,10 +895,7 @@ class SonosSpeaker:
             self.async_write_entity_states()
 
             for joined_uid in group[1:]:
-                joined_speaker: SonosSpeaker = self.hass.data[
-                    DATA_SONOS
-                ].discovered.get(joined_uid)
-                if joined_speaker:
+                if joined_speaker := self.data.discovered.get(joined_uid):
                     joined_speaker.coordinator = self
                     joined_speaker.sonos_group = sonos_group
                     joined_speaker.sonos_group_entities = sonos_group_entities
@@ -906,13 +906,13 @@ class SonosSpeaker:
         async def _async_handle_group_event(event: SonosEvent | None) -> None:
             """Get async lock and handle event."""
 
-            async with self.hass.data[DATA_SONOS].topology_condition:
+            async with self.data.topology_condition:
                 group = await _async_extract_group(event)
 
                 if self.soco.uid == group[0]:
                     _async_regroup(group)
 
-                    self.hass.data[DATA_SONOS].topology_condition.notify_all()
+                    self.data.topology_condition.notify_all()
 
         return _async_handle_group_event(event)
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes #112479

It looks like `self.update_group_for_uid` can be called in the event loop since it does not do any I/O and it did not need to run in the executor.

Since it made calls into `hass.data[DATA_SONOS]`, the typing was lost and I had trouble following the code. To make it easier to follow and make sure I didn't make a mistake here, I bound the data to the SonosSpeaker object as `self.data` so it could be typed and was easier to follow the code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
