### PR TITLE
Remove hourly weather entity from NWS

### DIFF
--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -84,17 +84,15 @@ async def async_setup_entry(
     entity_registry = er.async_get(hass)
     nws_data: NWSData = hass.data[DOMAIN][entry.entry_id]
 
-    entities = [NWSWeather(entry.data, nws_data, DAYNIGHT)]
-
-    # Add hourly entity to legacy config entries
-    if entity_registry.async_get_entity_id(
+    # Remove hourly entity from legacy config entries
+    if entity_id := entity_registry.async_get_entity_id(
         WEATHER_DOMAIN,
         DOMAIN,
         _calculate_unique_id(entry.data, HOURLY),
     ):
-        entities.append(NWSWeather(entry.data, nws_data, HOURLY))
+        entity_registry.async_remove(entity_id)
 
-    async_add_entities(entities, False)
+    async_add_entities([NWSWeather(entry.data, nws_data)], False)
 
 
 if TYPE_CHECKING:
@@ -129,7 +127,6 @@ class NWSWeather(CoordinatorWeatherEntity):
         self,
         entry_data: MappingProxyType[str, Any],
         nws_data: NWSData,
-        mode: str,
     ) -> None:
         """Initialise the platform with a data instance and station name."""
         super().__init__(
@@ -142,23 +139,17 @@ class NWSWeather(CoordinatorWeatherEntity):
         self.nws = nws_data.api
         latitude = entry_data[CONF_LATITUDE]
         longitude = entry_data[CONF_LONGITUDE]
-        if mode == DAYNIGHT:
-            self.coordinator_forecast_legacy = nws_data.coordinator_forecast
-        else:
-            self.coordinator_forecast_legacy = nws_data.coordinator_forecast_hourly
+        self.coordinator_forecast_legacy = nws_data.coordinator_forecast
         self.station = self.nws.station
-
-        self.mode = mode
-        self._attr_entity_registry_enabled_default = mode == DAYNIGHT
 
         self.observation: dict[str, Any] | None = None
         self._forecast_hourly: list[dict[str, Any]] | None = None
         self._forecast_legacy: list[dict[str, Any]] | None = None
         self._forecast_twice_daily: list[dict[str, Any]] | None = None
 
-        self._attr_unique_id = _calculate_unique_id(entry_data, mode)
+        self._attr_unique_id = _calculate_unique_id(entry_data, DAYNIGHT)
         self._attr_device_info = device_info(latitude, longitude)
-        self._attr_name = f"{self.station} {self.mode.title()}"
+        self._attr_name = f"{self.station} {DAYNIGHT.title()}"
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener and load data."""
@@ -193,10 +184,7 @@ class NWSWeather(CoordinatorWeatherEntity):
     @callback
     def _handle_legacy_forecast_coordinator_update(self) -> None:
         """Handle updated data from the legacy forecast coordinator."""
-        if self.mode == DAYNIGHT:
-            self._forecast_legacy = self.nws.forecast
-        else:
-            self._forecast_legacy = self.nws.forecast_hourly
+        self._forecast_legacy = self.nws.forecast
         self.async_write_ha_state()
 
     @property
@@ -313,7 +301,7 @@ class NWSWeather(CoordinatorWeatherEntity):
     @property
     def forecast(self) -> list[Forecast] | None:
         """Return forecast."""
-        return self._forecast(self._forecast_legacy, self.mode)
+        return self._forecast(self._forecast_legacy, DAYNIGHT)
 
     @callback
     def _async_forecast_hourly(self) -> list[Forecast] | None:

--- a/homeassistant/components/nws/weather.py
+++ b/homeassistant/components/nws/weather.py
@@ -149,7 +149,7 @@ class NWSWeather(CoordinatorWeatherEntity):
 
         self._attr_unique_id = _calculate_unique_id(entry_data, DAYNIGHT)
         self._attr_device_info = device_info(latitude, longitude)
-        self._attr_name = f"{self.station} {DAYNIGHT.title()}"
+        self._attr_name = self.station
 
     async def async_added_to_hass(self) -> None:
         """Set up a listener and load data."""

--- a/tests/components/nws/snapshots/test_weather.ambr
+++ b/tests/components/nws/snapshots/test_weather.ambr
@@ -1,213 +1,4 @@
 # serializer version: 1
-# name: test_forecast_service
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'is_daytime': False,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service.1
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service.2
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'is_daytime': False,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service.3
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service.4
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service.5
-  dict({
-    'forecast': list([
-      dict({
-        'condition': 'lightning-rainy',
-        'datetime': '2019-08-12T20:00:00-04:00',
-        'detailed_description': 'A detailed forecast.',
-        'dew_point': -15.6,
-        'humidity': 75,
-        'precipitation_probability': 89,
-        'temperature': -12.2,
-        'wind_bearing': 180,
-        'wind_speed': 16.09,
-      }),
-    ]),
-  })
-# ---
-# name: test_forecast_service[forecast]
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-        dict({
-          'condition': 'lightning-rainy',
-          'datetime': '2019-08-12T20:00:00-04:00',
-          'detailed_description': 'A detailed forecast.',
-          'dew_point': -15.6,
-          'humidity': 75,
-          'is_daytime': False,
-          'precipitation_probability': 89,
-          'temperature': -12.2,
-          'wind_bearing': 180,
-          'wind_speed': 16.09,
-        }),
-      ]),
-    }),
-  })
-# ---
-# name: test_forecast_service[forecast].1
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-        dict({
-          'condition': 'lightning-rainy',
-          'datetime': '2019-08-12T20:00:00-04:00',
-          'detailed_description': 'A detailed forecast.',
-          'dew_point': -15.6,
-          'humidity': 75,
-          'precipitation_probability': 89,
-          'temperature': -12.2,
-          'wind_bearing': 180,
-          'wind_speed': 16.09,
-        }),
-      ]),
-    }),
-  })
-# ---
-# name: test_forecast_service[forecast].2
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-        dict({
-          'condition': 'lightning-rainy',
-          'datetime': '2019-08-12T20:00:00-04:00',
-          'detailed_description': 'A detailed forecast.',
-          'dew_point': -15.6,
-          'humidity': 75,
-          'is_daytime': False,
-          'precipitation_probability': 89,
-          'temperature': -12.2,
-          'wind_bearing': 180,
-          'wind_speed': 16.09,
-        }),
-      ]),
-    }),
-  })
-# ---
-# name: test_forecast_service[forecast].3
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-        dict({
-          'condition': 'lightning-rainy',
-          'datetime': '2019-08-12T20:00:00-04:00',
-          'detailed_description': 'A detailed forecast.',
-          'dew_point': -15.6,
-          'humidity': 75,
-          'precipitation_probability': 89,
-          'temperature': -12.2,
-          'wind_bearing': 180,
-          'wind_speed': 16.09,
-        }),
-      ]),
-    }),
-  })
-# ---
-# name: test_forecast_service[forecast].4
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-        dict({
-          'condition': 'lightning-rainy',
-          'datetime': '2019-08-12T20:00:00-04:00',
-          'detailed_description': 'A detailed forecast.',
-          'dew_point': -15.6,
-          'humidity': 75,
-          'precipitation_probability': 89,
-          'temperature': -12.2,
-          'wind_bearing': 180,
-          'wind_speed': 16.09,
-        }),
-      ]),
-    }),
-  })
-# ---
-# name: test_forecast_service[forecast].5
-  dict({
-    'weather.abc_daynight': dict({
-      'forecast': list([
-      ]),
-    }),
-  })
-# ---
 # name: test_forecast_service[get_forecast]
   dict({
     'forecast': list([
@@ -303,7 +94,7 @@
 # ---
 # name: test_forecast_service[get_forecasts]
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
         dict({
           'condition': 'lightning-rainy',
@@ -323,7 +114,7 @@
 # ---
 # name: test_forecast_service[get_forecasts].1
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
         dict({
           'condition': 'lightning-rainy',
@@ -342,7 +133,7 @@
 # ---
 # name: test_forecast_service[get_forecasts].2
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
         dict({
           'condition': 'lightning-rainy',
@@ -362,7 +153,7 @@
 # ---
 # name: test_forecast_service[get_forecasts].3
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
         dict({
           'condition': 'lightning-rainy',
@@ -381,7 +172,7 @@
 # ---
 # name: test_forecast_service[get_forecasts].4
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
         dict({
           'condition': 'lightning-rainy',
@@ -400,13 +191,13 @@
 # ---
 # name: test_forecast_service[get_forecasts].5
   dict({
-    'weather.abc_daynight': dict({
+    'weather.abc': dict({
       'forecast': list([
       ]),
     }),
   })
 # ---
-# name: test_forecast_subscription[hourly-weather.abc_daynight]
+# name: test_forecast_subscription[hourly-weather.abc]
   list([
     dict({
       'condition': 'lightning-rainy',
@@ -421,7 +212,7 @@
     }),
   ])
 # ---
-# name: test_forecast_subscription[hourly-weather.abc_daynight].1
+# name: test_forecast_subscription[hourly-weather.abc].1
   list([
     dict({
       'condition': 'lightning-rainy',
@@ -429,100 +220,6 @@
       'detailed_description': 'A detailed forecast.',
       'dew_point': -15.6,
       'humidity': 75,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[hourly]
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[hourly].1
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[twice_daily-weather.abc_hourly]
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'is_daytime': False,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[twice_daily-weather.abc_hourly].1
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'is_daytime': False,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[twice_daily]
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'is_daytime': False,
-      'precipitation_probability': 89,
-      'temperature': -12.2,
-      'wind_bearing': 180,
-      'wind_speed': 16.09,
-    }),
-  ])
-# ---
-# name: test_forecast_subscription[twice_daily].1
-  list([
-    dict({
-      'condition': 'lightning-rainy',
-      'datetime': '2019-08-12T20:00:00-04:00',
-      'detailed_description': 'A detailed forecast.',
-      'dew_point': -15.6,
-      'humidity': 75,
-      'is_daytime': False,
       'precipitation_probability': 89,
       'temperature': -12.2,
       'wind_bearing': 180,

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -67,7 +67,7 @@ async def test_imperial_metric(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
 
     assert state
     assert state.state == ATTR_CONDITION_SUNNY
@@ -94,7 +94,7 @@ async def test_night_clear(hass: HomeAssistant, mock_simple_nws, no_sensor) -> N
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
     assert state.state == ATTR_CONDITION_CLEAR_NIGHT
 
 
@@ -112,7 +112,7 @@ async def test_none_values(hass: HomeAssistant, mock_simple_nws, no_sensor) -> N
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
     assert state.state == STATE_UNKNOWN
     data = state.attributes
     for key in WEATHER_EXPECTED_OBSERVATION_IMPERIAL:
@@ -137,7 +137,7 @@ async def test_none(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
     assert state
     assert state.state == STATE_UNKNOWN
 
@@ -163,8 +163,7 @@ async def test_error_station(hass: HomeAssistant, mock_simple_nws, no_sensor) ->
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert hass.states.get("weather.abc_hourly") is None
-    assert hass.states.get("weather.abc_daynight") is None
+    assert hass.states.get("weather.abc") is None
 
 
 async def test_entity_refresh(hass: HomeAssistant, mock_simple_nws, no_sensor) -> None:
@@ -187,7 +186,7 @@ async def test_entity_refresh(hass: HomeAssistant, mock_simple_nws, no_sensor) -
     await hass.services.async_call(
         "homeassistant",
         "update_entity",
-        {"entity_id": "weather.abc_daynight"},
+        {"entity_id": "weather.abc"},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -226,7 +225,7 @@ async def test_error_observation(
 
         instance.update_observation.assert_called_once()
 
-        state = hass.states.get("weather.abc_daynight")
+        state = hass.states.get("weather.abc")
         assert state
         assert state.state == STATE_UNAVAILABLE
 
@@ -237,7 +236,7 @@ async def test_error_observation(
 
         assert instance.update_observation.call_count == 2
 
-        state = hass.states.get("weather.abc_daynight")
+        state = hass.states.get("weather.abc")
         assert state
         assert state.state == ATTR_CONDITION_SUNNY
 
@@ -249,7 +248,7 @@ async def test_error_observation(
 
         assert instance.update_observation.call_count == 3
 
-        state = hass.states.get("weather.abc_daynight")
+        state = hass.states.get("weather.abc")
         assert state
         assert state.state == ATTR_CONDITION_SUNNY
 
@@ -257,7 +256,7 @@ async def test_error_observation(
         increment_time(timedelta(minutes=10))
         await hass.async_block_till_done()
 
-        state = hass.states.get("weather.abc_daynight")
+        state = hass.states.get("weather.abc")
         assert state
         assert state.state == STATE_UNAVAILABLE
 
@@ -277,7 +276,7 @@ async def test_error_forecast(hass: HomeAssistant, mock_simple_nws, no_sensor) -
 
     instance.update_forecast.assert_called_once()
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
     assert state
     assert state.state == STATE_UNAVAILABLE
 
@@ -288,7 +287,7 @@ async def test_error_forecast(hass: HomeAssistant, mock_simple_nws, no_sensor) -
 
     assert instance.update_forecast.call_count == 2
 
-    state = hass.states.get("weather.abc_daynight")
+    state = hass.states.get("weather.abc")
     assert state
     assert state.state == ATTR_CONDITION_SUNNY
 
@@ -346,7 +345,7 @@ async def test_forecast_service(
             WEATHER_DOMAIN,
             service,
             {
-                "entity_id": "weather.abc_daynight",
+                "entity_id": "weather.abc",
                 "type": forecast_type,
             },
             blocking=True,
@@ -373,7 +372,7 @@ async def test_forecast_service(
             WEATHER_DOMAIN,
             service,
             {
-                "entity_id": "weather.abc_daynight",
+                "entity_id": "weather.abc",
                 "type": forecast_type,
             },
             blocking=True,
@@ -396,7 +395,7 @@ async def test_forecast_service(
         WEATHER_DOMAIN,
         service,
         {
-            "entity_id": "weather.abc_daynight",
+            "entity_id": "weather.abc",
             "type": "hourly",
         },
         blocking=True,
@@ -413,7 +412,7 @@ async def test_forecast_service(
         WEATHER_DOMAIN,
         service,
         {
-            "entity_id": "weather.abc_daynight",
+            "entity_id": "weather.abc",
             "type": "hourly",
         },
         blocking=True,
@@ -424,7 +423,7 @@ async def test_forecast_service(
 
 @pytest.mark.parametrize(
     ("forecast_type", "entity_id"),
-    [("hourly", "weather.abc_daynight")],
+    [("hourly", "weather.abc")],
 )
 async def test_forecast_subscription(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `nws` integration previously created two entities for each configured location, one entity which provided daily weather forecasts and one entity which provided hourly forecasts. The `nws` integration now only creates a single entity which provides both daily and hourly weather forecasts.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove the hourly weather entity from `nws` and instead provide hourly + daily forecasts in one entity

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
