### PR TITLE
Start deprecation of auxiliary heater in ClimateEntity

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -310,7 +310,6 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     _attr_temperature_unit: str
 
     __climate_reported_legacy_aux = False
-    __climate_legacy_aux = False
 
     __mod_supported_features: ClimateEntityFeature = ClimateEntityFeature(0)
     # Integrations should set `_enable_turn_on_off_backwards_compatibility` to False
@@ -339,19 +338,6 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             "_ClimateEntity__mod_supported_features"
         )
 
-    def __init_subclass__(cls, **kwargs: Any) -> None:
-        """Post initialisation processing."""
-        super().__init_subclass__(**kwargs)
-        if (
-            "is_aux_heat" in cls.__dict__
-            or "_attr_is_aux_heat" in cls.__dict__
-            or cls.turn_aux_heat_on is not ClimateEntity.turn_aux_heat_on
-            or cls.async_turn_aux_heat_on is not ClimateEntity.async_turn_aux_heat_on
-            or cls.turn_aux_heat_off is not ClimateEntity.turn_aux_heat_off
-            or cls.async_turn_aux_heat_off is not ClimateEntity.async_turn_aux_heat_off
-        ):
-            cls.__climate_legacy_aux = True
-
     @callback
     def add_to_platform_start(
         self,
@@ -361,10 +347,6 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
     ) -> None:
         """Start adding an entity to a platform."""
         super().add_to_platform_start(hass, platform, parallel_updates)
-
-        module = type(self).__module__
-        if self.__climate_legacy_aux and "custom_components" in module:
-            self._report_legacy_aux(hass)
 
         def _report_turn_on_off(feature: str, method: str) -> None:
             """Log warning not implemented turn on/off feature."""
@@ -424,11 +406,11 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 ClimateEntityFeature.TURN_ON | ClimateEntityFeature.TURN_OFF
             )
 
-    def _report_legacy_aux(self, hass: HomeAssistant) -> None:
+    def _report_legacy_aux(self) -> None:
         """Log warning and create an issue if the entity implements legacy auxiliary heater."""
 
         report_issue = async_suggest_report_issue(
-            hass,
+            self.hass,
             integration_domain=self.platform.platform_name,
             module=type(self).__module__,
         )
@@ -447,7 +429,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         translation_placeholders = {"platform": self.platform.platform_name}
         translation_key = "deprecated_climate_aux_no_url"
         issue_tracker = async_get_issue_tracker(
-            hass,
+            self.hass,
             integration_domain=self.platform.platform_name,
             module=type(self).__module__,
         )
@@ -466,6 +448,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             translation_key=translation_key,
             translation_placeholders=translation_placeholders,
         )
+        self.__climate_reported_legacy_aux = True
 
     @final
     @property
@@ -571,6 +554,11 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
         if ClimateEntityFeature.AUX_HEAT in supported_features:
             data[ATTR_AUX_HEAT] = STATE_ON if self.is_aux_heat else STATE_OFF
+            if (
+                self.__climate_reported_legacy_aux is False
+                and "custom_components" in type(self).__module__
+            ):
+                self._report_legacy_aux()
 
         return data
 

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -362,7 +362,8 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Start adding an entity to a platform."""
         super().add_to_platform_start(hass, platform, parallel_updates)
 
-        if self.__climate_legacy_aux:
+        module = type(self).__module__
+        if self.__climate_legacy_aux and "custom_components" in module:
             self._report_legacy_aux(hass)
 
         def _report_turn_on_off(feature: str, method: str) -> None:

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -453,9 +453,6 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         )
         if issue_tracker:
             translation_placeholders["issue_tracker"] = issue_tracker
-            translation_key = "deprecated_climate_aux_url"
-        if "custom_components" in type(self).__module__ and issue_tracker:
-            translation_placeholders["issue_tracker"] = issue_tracker
             translation_key = "deprecated_climate_aux_url_custom"
         ir.async_create_issue(
             self.hass,

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -239,10 +239,6 @@
     }
   },
   "issues": {
-    "deprecated_climate_aux_url": {
-      "title": "The {platform} integration is using deprecated climate auxiliary heater",
-      "description": "The integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease create a bug report at {issue_tracker}."
-    },
     "deprecated_climate_aux_url_custom": {
       "title": "The {platform} custom integration is using deprecated climate auxiliary heater",
       "description": "The custom integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease create a bug report at {issue_tracker}.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -238,6 +238,20 @@
       }
     }
   },
+  "issues": {
+    "deprecated_climate_aux_url": {
+      "title": "The {platform} integration is using deprecated climate auxiliary heater",
+      "description": "The integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease create a bug report at {issue_tracker}."
+    },
+    "deprecated_climate_aux_url_custom": {
+      "title": "The {platform} custom integration is using deprecated climate auxiliary heater",
+      "description": "The custom integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease create a bug report at {issue_tracker}.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."
+    },
+    "deprecated_climate_aux_no_url": {
+      "title": "[%key:component::climate::issues::deprecated_climate_aux_url_custom::title%]",
+      "description": "The custom integration `{platform}` implements the `is_aux_heat` property or uses the auxiliary heater methods in a subclass of ClimateEntity.\n\nPlease report it to the author of the {platform} integration.\n\nOnce an updated version of `{platform}` is available, install it and restart Home Assistant to fix this issue."
+    }
+  },
   "exceptions": {
     "not_valid_preset_mode": {
       "message": "Preset mode {mode} is not valid. Valid preset modes are: {modes}."

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -28,6 +28,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from tests.common import (
@@ -765,3 +766,192 @@ async def test_sync_toggle(hass: HomeAssistant) -> None:
     await climate.async_toggle()
 
     assert climate.toggle.called
+
+
+ISSUE_TRACKER = "https://blablabla.com"
+
+
+@pytest.mark.parametrize(
+    (
+        "manifest_extra",
+        "translation_key",
+        "translation_placeholders_extra",
+        "report",
+        "module",
+    ),
+    [
+        (
+            {},
+            "deprecated_climate_aux_no_url",
+            {},
+            "report it to the author of the 'test' custom integration",
+            "custom_components.test.climate",
+        ),
+        (
+            {"issue_tracker": ISSUE_TRACKER},
+            "deprecated_climate_aux_url_custom",
+            {"issue_tracker": ISSUE_TRACKER},
+            "create a bug report at https://blablabla.com",
+            "custom_components.test.climate",
+        ),
+        (
+            {"issue_tracker": ISSUE_TRACKER},
+            "deprecated_climate_aux_url",
+            {"issue_tracker": ISSUE_TRACKER},
+            "create a bug report at https://blablabla.com",
+            "homeassistant.components.test.climate",
+        ),
+    ],
+)
+async def test_issue_aux_property_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    config_flow_fixture: None,
+    manifest_extra: dict[str, str],
+    translation_key: str,
+    translation_placeholders_extra: dict[str, str],
+    report: str,
+    module: str,
+) -> None:
+    """Test the issue is raised on deprecated auxiliary heater attributes."""
+
+    class MockClimateEntityWithAux(MockClimateEntity):
+        """Mock climate class with mocked aux heater."""
+
+        _attr_supported_features = ClimateEntityFeature.AUX_HEAT
+
+        @property
+        def is_aux_heat(self) -> bool | None:
+            """Return true if aux heater.
+
+            Requires ClimateEntityFeature.AUX_HEAT.
+            """
+            return True
+
+        async def async_turn_aux_heat_on(self) -> None:
+            """Turn auxiliary heater on."""
+            await self.hass.async_add_executor_job(self.turn_aux_heat_on)
+
+        async def async_turn_aux_heat_off(self) -> None:
+            """Turn auxiliary heater off."""
+            await self.hass.async_add_executor_job(self.turn_aux_heat_off)
+
+    # Fake the module is custom component or built in
+    MockClimateEntityWithAux.__module__ = module
+
+    climate_entity = MockClimateEntityWithAux(
+        name="Testing",
+        entity_id="climate.testing",
+    )
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_climate_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test weather platform via config entry."""
+        async_add_entities([climate_entity])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+            partial_manifest=manifest_extra,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.climate",
+        MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
+    )
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert climate_entity.state == HVACMode.HEAT
+
+    issues = ir.async_get(hass)
+    issue = issues.async_get_issue("climate", "deprecated_climate_aux_test")
+    assert issue
+    assert issue.issue_domain == "test"
+    assert issue.issue_id == "deprecated_climate_aux_test"
+    assert issue.translation_key == translation_key
+    assert (
+        issue.translation_placeholders
+        == {"platform": "test"} | translation_placeholders_extra
+    )
+
+    assert (
+        "test::MockClimateEntityWithAux implements the `is_aux_heat` property or uses "
+        "the auxiliary  heater methods in a subclass of ClimateEntity which is deprecated "
+        f"and will be unsupported from Home Assistant 2024.10. Please {report}"
+    ) in caplog.text
+
+
+async def test_no_issue_no_aux_property(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    config_flow_fixture: None,
+) -> None:
+    """Test the issue is raised on deprecated auxiliary heater attributes."""
+
+    climate_entity = MockClimateEntity(
+        name="Testing",
+        entity_id="climate.testing",
+    )
+
+    async def async_setup_entry_init(
+        hass: HomeAssistant, config_entry: ConfigEntry
+    ) -> bool:
+        """Set up test config entry."""
+        await hass.config_entries.async_forward_entry_setups(config_entry, [DOMAIN])
+        return True
+
+    async def async_setup_entry_climate_platform(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddEntitiesCallback,
+    ) -> None:
+        """Set up test weather platform via config entry."""
+        async_add_entities([climate_entity])
+
+    mock_integration(
+        hass,
+        MockModule(
+            "test",
+            async_setup_entry=async_setup_entry_init,
+        ),
+        built_in=False,
+    )
+    mock_platform(
+        hass,
+        "test.climate",
+        MockPlatform(async_setup_entry=async_setup_entry_climate_platform),
+    )
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert climate_entity.state == HVACMode.HEAT
+
+    issues = ir.async_get(hass)
+    assert len(issues.issues) == 0
+
+    assert (
+        "test::MockClimateEntityWithAux implements the `is_aux_heat` property or uses "
+        "the auxiliary  heater methods in a subclass of ClimateEntity which is deprecated "
+        "and will be unsupported from Home Assistant 2024.10."
+    ) not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As was decided in https://github.com/home-assistant/architecture/discussions/932 this starts the deprecation of auxiliary heater within the `ClimateEntity` which affect both the `is_aux_heat` property as well as the aux heater methods.

Dev docs PR: https://github.com/home-assistant/developers.home-assistant/pull/2109

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
