### PR TITLE
Pass job type to event listeners when creating entities

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -46,6 +46,7 @@ from homeassistant.const import (
 from homeassistant.core import (
     CALLBACK_TYPE,
     Context,
+    HassJobType,
     HomeAssistant,
     callback,
     get_release_channel,
@@ -1430,7 +1431,10 @@ class Entity(
 
             self.async_on_remove(
                 async_track_entity_registry_updated_event(
-                    self.hass, self.entity_id, self._async_registry_updated
+                    self.hass,
+                    self.entity_id,
+                    self._async_registry_updated,
+                    job_type=HassJobType.Callback,
                 )
             )
             self._async_subscribe_device_updates()
@@ -1545,6 +1549,7 @@ class Entity(
             self.hass,
             device_id,
             self._async_device_registry_updated,
+            job_type=HassJobType.Callback,
         )
         if (
             not self._on_remove

--- a/tests/helpers/test_event.py
+++ b/tests/helpers/test_event.py
@@ -453,7 +453,7 @@ async def test_async_track_state_change_event(hass: HomeAssistant) -> None:
         raise ValueError
 
     unsub_single = async_track_state_change_event(
-        hass, ["light.Bowl"], single_run_callback
+        hass, ["light.Bowl"], single_run_callback, job_type=ha.HassJobType.Callback
     )
     unsub_multi = async_track_state_change_event(
         hass, ["light.Bowl", "switch.kitchen"], multiple_run_callback
@@ -560,7 +560,9 @@ async def test_async_track_state_added_domain(hass: HomeAssistant) -> None:
     def callback_that_throws(event):
         raise ValueError
 
-    unsub_single = async_track_state_added_domain(hass, "light", single_run_callback)
+    unsub_single = async_track_state_added_domain(
+        hass, "light", single_run_callback, job_type=ha.HassJobType.Callback
+    )
     unsub_multi = async_track_state_added_domain(
         hass, ["light", "switch"], multiple_run_callback
     )
@@ -672,7 +674,9 @@ async def test_async_track_state_removed_domain(hass: HomeAssistant) -> None:
     def callback_that_throws(event):
         raise ValueError
 
-    unsub_single = async_track_state_removed_domain(hass, "light", single_run_callback)
+    unsub_single = async_track_state_removed_domain(
+        hass, "light", single_run_callback, job_type=ha.HassJobType.Callback
+    )
     unsub_multi = async_track_state_removed_domain(
         hass, ["light", "switch"], multiple_run_callback
     )
@@ -4602,7 +4606,9 @@ async def test_async_track_entity_registry_updated_event(hass: HomeAssistant) ->
     def run_callback(event):
         event_data.append(event.data)
 
-    unsub1 = async_track_entity_registry_updated_event(hass, entity_id, run_callback)
+    unsub1 = async_track_entity_registry_updated_event(
+        hass, entity_id, run_callback, job_type=ha.HassJobType.Callback
+    )
     unsub2 = async_track_entity_registry_updated_event(
         hass, new_entity_id, run_callback
     )
@@ -4721,7 +4727,10 @@ async def test_async_track_device_registry_updated_event(hass: HomeAssistant) ->
         hass, device_id, single_device_id_callback
     )
     unsub2 = async_track_device_registry_updated_event(
-        hass, [device_id, device_id2], multiple_device_id_callback
+        hass,
+        [device_id, device_id2],
+        multiple_device_id_callback,
+        job_type=ha.HassJobType.Callback,
     )
     hass.bus.async_fire(
         EVENT_DEVICE_REGISTRY_UPDATED, {"action": "create", "device_id": device_id}


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pass job type to event listeners when creating entities

Every entity has to call `async_track_device_registry_updated_event` and `async_track_entity_registry_updated_event` when its added which means expensive run time inspection had to happen on the listener to determine how to run call. Since we already know these will always be callback functions we can pass the job type to avoid needing to work it out 2x per added entity (excluding entities that have no device attached)

`get_hassjob_callable_job_type` was the one of the most expensive calls during startup.

<img width="634" alt="Screenshot 2024-03-06 at 2 23 52 PM" src="https://github.com/home-assistant/core/assets/663432/d7ad4083-355b-4117-b337-de1cb1be6712">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
