### PR TITLE
Add HassClimateSetTemperature intent

### DIFF
--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -139,9 +139,6 @@ class SetTemperatureIntent(intent.ServiceIntentHandler):
         target_temperature_slot = slots.get("temperature", {})
         target_temperature = target_temperature_slot.get("value")
 
-        if target_temperature is None:
-            raise intent.IntentHandleError("Target temperature missing")
-
         assert target_temperature is not None
 
         service_call_data = {ATTR_ENTITY_ID: state.entity_id}

--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -4,18 +4,31 @@ from __future__ import annotations
 
 import voluptuous as vol
 
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_TEMPERATURE,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import intent
 from homeassistant.helpers.entity_component import EntityComponent
 
 from . import DOMAIN, ClimateEntity
+from .const import (
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    SERVICE_SET_TEMPERATURE,
+    ClimateEntityFeature,
+)
 
 INTENT_GET_TEMPERATURE = "HassClimateGetTemperature"
+INTENT_SET_TEMPERATURE = "HassClimateSetTemperature"
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the climate intents."""
     intent.async_register(hass, GetTemperatureIntent())
+    intent.async_register(hass, SetTemperatureIntent())
 
 
 class GetTemperatureIntent(intent.IntentHandler):
@@ -100,3 +113,61 @@ class GetTemperatureIntent(intent.IntentHandler):
         response.response_type = intent.IntentResponseType.QUERY_ANSWER
         response.async_set_states(matched_states=[climate_state])
         return response
+
+
+class SetTemperatureIntent(intent.ServiceIntentHandler):
+    """Intent handler for setting the temperature of a climate entity."""
+
+    intent_type = INTENT_SET_TEMPERATURE
+
+    def __init__(self) -> None:
+        """Create set position handler."""
+        super().__init__(
+            INTENT_SET_TEMPERATURE,
+            DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            extra_slots={ATTR_TEMPERATURE: vol.All(vol.Range(min=-100, max=200))},
+        )
+
+    async def async_call_service(
+        self, domain: str, service: str, intent_obj: intent.Intent, state: State
+    ) -> None:
+        """Call service on entity with handling for special cases."""
+        hass = intent_obj.hass
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        target_temperature_slot = slots.get("temperature", {})
+        target_temperature = target_temperature_slot.get("value")
+
+        if target_temperature is None:
+            raise intent.IntentHandleError("Target temperature missing")
+
+        assert target_temperature is not None
+
+        service_call_data = {ATTR_ENTITY_ID: state.entity_id}
+
+        if ClimateEntityFeature.TARGET_TEMPERATURE in state.attributes.get(
+            ATTR_SUPPORTED_FEATURES, []
+        ):
+            service_call_data.update({ATTR_TEMPERATURE: target_temperature})
+        elif ClimateEntityFeature.TARGET_TEMPERATURE_RANGE in state.attributes.get(
+            ATTR_SUPPORTED_FEATURES, []
+        ):
+            service_call_data.update(
+                {
+                    ATTR_TARGET_TEMP_LOW: target_temperature,
+                    ATTR_TARGET_TEMP_HIGH: target_temperature,
+                }
+            )
+
+        await self._run_then_background(
+            hass.async_create_task(
+                hass.services.async_call(
+                    DOMAIN,
+                    SERVICE_SET_TEMPERATURE,
+                    service_call_data,
+                    context=intent_obj.context,
+                    blocking=True,
+                )
+            )
+        )

--- a/homeassistant/components/climate/intent.py
+++ b/homeassistant/components/climate/intent.py
@@ -126,7 +126,7 @@ class SetTemperatureIntent(intent.ServiceIntentHandler):
             INTENT_SET_TEMPERATURE,
             DOMAIN,
             SERVICE_SET_TEMPERATURE,
-            extra_slots={ATTR_TEMPERATURE: vol.All(vol.Range(min=-100, max=200))},
+            required_slots={ATTR_TEMPERATURE: vol.All(vol.Range(min=-100, max=200))},
         )
 
     async def async_call_service(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
NO

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `HassClimateSetTemperature` intent which sets the temperature of a `climate` entity. It works regardless of whether the thermostat supports single temperature setpoint or min/max temperature ranges.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
