### PR TITLE
Issue warning modbus configuration when modbus configuration is empty

### DIFF
--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -391,7 +391,7 @@ def check_config(config: dict) -> dict:
                 else:
                     entity_inx += 1
         if no_entities:
-            err = f"Modbus {hub[CONF_NAME]} is instable without entities, please add entities!"
+            err = f"There are no entities defined for Modbus {hub[CONF_NAME]}, this will cause the integration to be unstable,  please add at least one entity!"
             _LOGGER.warning(err)
             # Ensure timeout is not started/handled.
             hub[CONF_TIMEOUT] = -1

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -370,12 +370,14 @@ def check_config(config: dict) -> dict:
         if not validate_modbus(hub, hub_name_inx):
             del config[hub_inx]
             continue
-        for component, conf_key in PLATFORMS:
+        minimum_scan_interval = 9999
+        no_entities = True
+        for _component, conf_key in PLATFORMS:
             if conf_key not in hub:
                 continue
+            no_entities = False
             entity_inx = 0
             entities = hub[conf_key]
-            minimum_scan_interval = 9999
             while entity_inx < len(entities):
                 if not validate_entity(
                     hub[CONF_NAME],
@@ -388,7 +390,11 @@ def check_config(config: dict) -> dict:
                     del entities[entity_inx]
                 else:
                     entity_inx += 1
-
+        if no_entities:
+            err = f"Modbus {hub[CONF_NAME]} is instable without entities, please add entities!"
+            _LOGGER.warning(err)
+            # Ensure timeout is not started/handled.
+            hub[CONF_TIMEOUT] = -1
         if hub[CONF_TIMEOUT] >= minimum_scan_interval:
             hub[CONF_TIMEOUT] = minimum_scan_interval - 1
             _LOGGER.warning(

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -372,7 +372,7 @@ def check_config(config: dict) -> dict:
             continue
         minimum_scan_interval = 9999
         no_entities = True
-        for _component, conf_key in PLATFORMS:
+        for component, conf_key in PLATFORMS:
             if conf_key not in hub:
                 continue
             no_entities = False

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -391,7 +391,7 @@ def check_config(config: dict) -> dict:
                 else:
                     entity_inx += 1
         if no_entities:
-            err = f"There are no entities defined for Modbus {hub[CONF_NAME]}, this will cause the integration to be unstable,  please add at least one entity!"
+            err = f"Modbus {hub[CONF_NAME]} contain no entities, this will cause instability,  please add at least one entity!"
             _LOGGER.warning(err)
             # Ensure timeout is not started/handled.
             hub[CONF_TIMEOUT] = -1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The minimum_scan_interval was controlled pr entity type, leading to timeout = -1 when no entities was defined.
this PR calculates the minimum_scan_interval across all entity types and still sets timeout = -1 when no entities is defined.

Seems from HA core POW, it does not makes sense to have modbus defined without any entities and may cause problems (e.g. most devices terminate the connection after a while without communication, but the reconnect logic depend on the entity update method). 

This PR issues a warning when modbus is configured without entities. Some custom components use this configuration to add their own configuration (HIGHLY NOT RECOMMENDED) so currently we issue only a warning.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
