### PR TITLE
Log waiting tasks in bootstrap that are delaying startup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -606,7 +606,10 @@ class _WatchPendingSetups:
             domain: (now - start_time)
             for domain, start_time in self._setup_started.items()
         }
-        _LOGGER.debug("Integration remaining: %s", remaining_with_setup_started)
+        if remaining_with_setup_started:
+            _LOGGER.debug("Integration remaining: %s", remaining_with_setup_started)
+        elif waiting_tasks := self._hass._active_tasks:  # pylint: disable=protected-access
+            _LOGGER.debug("Waiting on tasks: %s", waiting_tasks)
         self._async_dispatch(remaining_with_setup_started)
         if (
             self._setup_started

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -852,7 +852,10 @@ async def _async_set_up_integrations(
             ):
                 await async_setup_multi_components(hass, stage_1_domains, config)
         except TimeoutError:
-            _LOGGER.warning("Setup timed out for stage 1 - moving forward")
+            _LOGGER.warning(
+                "Setup timed out for stage 1 waiting on %s - moving forward",
+                hass._active_tasks,  # pylint: disable=protected-access
+            )
 
     # Add after dependencies when setting up stage 2 domains
     async_set_domains_to_be_loaded(hass, stage_2_domains)
@@ -865,7 +868,10 @@ async def _async_set_up_integrations(
             ):
                 await async_setup_multi_components(hass, stage_2_domains, config)
         except TimeoutError:
-            _LOGGER.warning("Setup timed out for stage 2 - moving forward")
+            _LOGGER.warning(
+                "Setup timed out for stage 2 waiting on %s - moving forward",
+                hass._active_tasks,  # pylint: disable=protected-access
+            )
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
@@ -873,7 +879,10 @@ async def _async_set_up_integrations(
         async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
             await hass.async_block_till_done()
     except TimeoutError:
-        _LOGGER.warning("Setup timed out for bootstrap - moving forward")
+        _LOGGER.warning(
+            "Setup timed out for bootstrap waiting on %s - moving forward",
+            hass._active_tasks,  # pylint: disable=protected-access
+        )
 
     watcher.async_stop()
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -402,6 +402,18 @@ class HomeAssistant:
             max_workers=1, thread_name_prefix="ImportExecutor"
         )
 
+    @property
+    def _active_tasks(self) -> set[asyncio.Future[Any]]:
+        """Return all active tasks.
+
+        This property is used in bootstrap to log all active tasks
+        so we can identify what is blocking startup.
+
+        This property is marked as private to avoid accidental use
+        as it is not guaranteed to be present in future versions.
+        """
+        return self._tasks
+
     @cached_property
     def is_running(self) -> bool:
         """Return if Home Assistant is running."""

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -871,6 +871,83 @@ async def test_warning_logged_on_wrap_up_timeout(
 
 
 @pytest.mark.parametrize("load_registries", [False])
+async def test_tasks_logged_that_block_stage_1(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test we log tasks that delay stage 1 startup."""
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            async def _not_marked_background_task():
+                await asyncio.sleep(0.2)
+
+            hass.async_create_task(_not_marked_background_task())
+            await asyncio.sleep(0.1)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain="normal_integration",
+            async_setup=gen_domain_setup("normal_integration"),
+            partial_manifest={},
+        ),
+    )
+
+    original_stage_1 = bootstrap.STAGE_1_INTEGRATIONS
+    with patch.object(bootstrap, "STAGE_1_TIMEOUT", 0), patch.object(
+        bootstrap, "COOLDOWN_TIME", 0
+    ), patch.object(
+        bootstrap, "STAGE_1_INTEGRATIONS", [*original_stage_1, "normal_integration"]
+    ):
+        await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
+        await hass.async_block_till_done()
+
+    assert "Setup timed out for stage 1 waiting on" in caplog.text
+    assert "waiting on" in caplog.text
+    assert "_not_marked_background_task" in caplog.text
+
+
+@pytest.mark.parametrize("load_registries", [False])
+async def test_tasks_logged_that_block_stage_2(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test we log tasks that delay stage 2 startup."""
+
+    def gen_domain_setup(domain):
+        async def async_setup(hass, config):
+            async def _not_marked_background_task():
+                await asyncio.sleep(0.2)
+
+            hass.async_create_task(_not_marked_background_task())
+            await asyncio.sleep(0.1)
+            return True
+
+        return async_setup
+
+    mock_integration(
+        hass,
+        MockModule(
+            domain="normal_integration",
+            async_setup=gen_domain_setup("normal_integration"),
+            partial_manifest={},
+        ),
+    )
+
+    with patch.object(bootstrap, "STAGE_2_TIMEOUT", 0), patch.object(
+        bootstrap, "COOLDOWN_TIME", 0
+    ):
+        await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
+        await hass.async_block_till_done()
+
+    assert "Setup timed out for stage 2 waiting on" in caplog.text
+    assert "waiting on" in caplog.text
+    assert "_not_marked_background_task" in caplog.text
+
+
+@pytest.mark.parametrize("load_registries", [False])
 async def test_bootstrap_is_cancellation_safe(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -844,10 +844,10 @@ async def test_warning_logged_on_wrap_up_timeout(
 
     def gen_domain_setup(domain):
         async def async_setup(hass, config):
-            async def _background_task():
+            async def _not_marked_background_task():
                 await asyncio.sleep(0.2)
 
-            hass.async_create_task(_background_task())
+            hass.async_create_task(_not_marked_background_task())
             return True
 
         return async_setup
@@ -865,7 +865,9 @@ async def test_warning_logged_on_wrap_up_timeout(
         await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
         await hass.async_block_till_done()
 
-    assert "Setup timed out for bootstrap - moving forward" in caplog.text
+    assert "Setup timed out for bootstrap" in caplog.text
+    assert "waiting on" in caplog.text
+    assert "_not_marked_background_task" in caplog.text
 
 
 @pytest.mark.parametrize("load_registries", [False])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Followup to https://github.com/home-assistant/core/pull/112542 to log the tasks at each stage instead of once all the delays have been hit because the user may pull the power by the time they got there to try again (this is not a good idea but it obviously happens).

The log currently looks like
```
2024-03-07 16:12:48.555 DEBUG (MainThread) [homeassistant.bootstrap] Waiting for startup to wrap up
2024-03-07 16:12:49.237 DEBUG (MainThread) [homeassistant.bootstrap] Integration remaining: {}
2024-03-07 16:12:49.238 DEBUG (MainThread) [homeassistant.bootstrap] Running timeout Zones: {}
2024-03-07 16:12:50.239 DEBUG (MainThread) [homeassistant.bootstrap] Integration remaining: {}
2024-03-07 16:12:50.239 DEBUG (MainThread) [homeassistant.bootstrap] Running timeout Zones: {}
...
```

This is not very helpful for users and devs who are trying track down which tasks we are waiting for.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
