### PR TITLE
Schedule polling as periodic tasks

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -868,7 +868,7 @@ async def _async_set_up_integrations(
     _LOGGER.debug("Waiting for startup to wrap up")
     try:
         async with hass.timeout.async_timeout(WRAP_UP_TIMEOUT, cool_down=COOLDOWN_TIME):
-            await hass.async_block_till_done()
+            await hass.async_block_till_done(wait_periodic_tasks=False)
     except TimeoutError:
         _LOGGER.warning("Setup timed out for bootstrap - moving forward")
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1028,7 +1028,7 @@ class ConfigEntry:
 
         Background tasks are automatically canceled when config entry is unloaded.
 
-        This is a background task which is different from a normal task:
+        A background task is different from a normal task:
 
           - Will not block startup
           - Will be automatically cancelled on shutdown
@@ -1057,7 +1057,7 @@ class ConfigEntry:
 
         This type of task is typically used for polling.
 
-        This is a periodic task which is different from a normal task:
+        A periodic task is different from a normal task:
 
           - Will not block startup
           - Will be automatically cancelled on shutdown

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1054,14 +1054,13 @@ class ConfigEntry:
     ) -> asyncio.Task[_R]:
         """Create a periodic task tied to the config entry lifecycle.
 
-        This type of task is for background tasks that usually run for
-        the lifetime of Home Assistant or an integration's setup.
+        This type of task is typically used for polling.
 
-        This is a background task which is different from a normal task:
+        This is a periodic task which is different from a normal task:
 
           - Will not block startup
           - Will be automatically cancelled on shutdown
-          - Calls to async_block_till_done will not wait for completion
+          - Calls to async_block_till_done will wait for completion by default
 
         This method must be run in the event loop.
         """

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1026,8 +1026,7 @@ class ConfigEntry:
     ) -> asyncio.Task[_R]:
         """Create a background task tied to the config entry lifecycle.
 
-        This type of task is for background tasks that usually run for
-        the lifetime of Home Assistant or an integration's setup.
+        Background tasks are automatically canceled when config entry is unloaded.
 
         This is a background task which is different from a normal task:
 
@@ -1053,6 +1052,8 @@ class ConfigEntry:
         eager_start: bool = False,
     ) -> asyncio.Task[_R]:
         """Create a periodic task tied to the config entry lifecycle.
+
+        Periodic tasks are automatically canceled when config entry is unloaded.
 
         This type of task is typically used for polling.
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1024,7 +1024,7 @@ class ConfigEntry:
         name: str,
         eager_start: bool = False,
     ) -> asyncio.Task[_R]:
-        """Create a task from within the event loop.
+        """Create a background task tied to the config entry lifecycle.
 
         This type of task is for background tasks that usually run for
         the lifetime of Home Assistant or an integration's setup.
@@ -1052,7 +1052,7 @@ class ConfigEntry:
         name: str,
         eager_start: bool = False,
     ) -> asyncio.Task[_R]:
-        """Create a task from within the event loop.
+        """Create a periodic task tied to the config entry lifecycle.
 
         This type of task is for background tasks that usually run for
         the lifetime of Home Assistant or an integration's setup.

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -674,7 +674,7 @@ class HomeAssistant:
         This type of task is for background tasks that usually run for
         the lifetime of Home Assistant or an integration's setup.
 
-        This is a background task which is different from a normal task:
+        A background task is different from a normal task:
 
           - Will not block startup
           - Will be automatically cancelled on shutdown
@@ -705,7 +705,7 @@ class HomeAssistant:
 
         This type of task is typically used for polling.
 
-        This is a periodic task which is different from a normal task:
+        A periodic task is different from a normal task:
 
           - Will not block startup
           - Will be automatically cancelled on shutdown

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -703,8 +703,7 @@ class HomeAssistant:
     ) -> asyncio.Task[_R]:
         """Create a task from within the event loop.
 
-        This type of tasks is for periodic updates such as polling
-        entities.
+        This type of task is typically used for polling.
 
         This is a periodic task which is different from a normal task:
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -641,11 +641,19 @@ class EntityPlatform:
     @callback
     def _async_handle_interval_callback(self, now: datetime) -> None:
         """Update all the entity states in a single platform."""
-        self.hass.async_create_periodic_task(
-            self._update_entity_states(now),
-            name=f"EntityPlatform poll {self.domain}.{self.platform_name}",
-            eager_start=True,
-        )
+        if self.config_entry:
+            self.config_entry.async_create_periodic_task(
+                self.hass,
+                self._update_entity_states(now),
+                name=f"EntityPlatform poll {self.domain}.{self.platform_name}",
+                eager_start=True,
+            )
+        else:
+            self.hass.async_create_periodic_task(
+                self._update_entity_states(now),
+                name=f"EntityPlatform poll {self.domain}.{self.platform_name}",
+                eager_start=True,
+            )
 
     def _entity_id_already_exists(self, entity_id: str) -> tuple[bool, bool]:
         """Check if an entity_id already exists.

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -641,7 +641,11 @@ class EntityPlatform:
     @callback
     def _async_handle_interval_callback(self, now: datetime) -> None:
         """Update all the entity states in a single platform."""
-        self.hass.async_create_task(self._update_entity_states(now), eager_start=True)
+        self.hass.async_create_periodic_task(
+            self._update_entity_states(now),
+            name=f"EntityPlatform poll {self.domain}.{self.platform_name}",
+            eager_start=True,
+        )
 
     def _entity_id_already_exists(self, entity_id: str) -> tuple[bool, bool]:
         """Check if an entity_id already exists.

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1609,7 +1609,15 @@ class _TrackTimeInterval:
             self._track_job,
             hass.loop.time() + self.seconds,
         )
-        hass.async_run_hass_job(self._run_job, now)
+        if self._run_job.job_type is HassJobType.Coroutinefunction:
+            hass.async_create_periodic_task(
+                # mypy does not know we just checked for the job type
+                self.action(now),  # type: ignore[arg-type]
+                f"track time interval {self.seconds}",
+                eager_start=True,
+            )
+        else:
+            hass.async_run_hass_job(self._run_job, now)
 
     @callback
     def async_cancel(self) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1609,15 +1609,7 @@ class _TrackTimeInterval:
             self._track_job,
             hass.loop.time() + self.seconds,
         )
-        if self._run_job.job_type is HassJobType.Coroutinefunction:
-            hass.async_create_periodic_task(
-                # mypy does not know we just checked for the job type
-                self.action(now),  # type: ignore[arg-type]
-                f"track time interval {self.seconds}",
-                eager_start=True,
-            )
-        else:
-            hass.async_run_hass_job(self._run_job, now)
+        hass.async_run_periodic_hass_job(self._run_job, now)
 
     @callback
     def async_cancel(self) -> None:

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1694,7 +1694,7 @@ class SunListener:
         """Handle solar event."""
         self._unsub_sun = None
         self._listen_next_sun_event()
-        self.hass.async_run_hass_job(self.job)
+        self.hass.async_run_periodic_hass_job(self.job)
 
     @callback
     def _handle_config_event(self, _event: Any) -> None:
@@ -1780,7 +1780,7 @@ class _TrackUTCTimeChange:
         # time when the timer was scheduled
         utc_now = time_tracker_utcnow()
         localized_now = dt_util.as_local(utc_now) if self.local else utc_now
-        hass.async_run_hass_job(self.job, localized_now)
+        hass.async_run_periodic_hass_job(self.job, localized_now)
         if TYPE_CHECKING:
             assert self._pattern_time_change_listener_job is not None
         self._cancel_callback = async_track_point_in_utc_time(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -1694,7 +1694,7 @@ class SunListener:
         """Handle solar event."""
         self._unsub_sun = None
         self._listen_next_sun_event()
-        self.hass.async_run_periodic_hass_job(self.job)
+        self.hass.async_run_hass_job(self.job)
 
     @callback
     def _handle_config_event(self, _event: Any) -> None:
@@ -1780,7 +1780,7 @@ class _TrackUTCTimeChange:
         # time when the timer was scheduled
         utc_now = time_tracker_utcnow()
         localized_now = dt_util.as_local(utc_now) if self.local else utc_now
-        hass.async_run_periodic_hass_job(self.job, localized_now)
+        hass.async_run_hass_job(self.job, localized_now)
         if TYPE_CHECKING:
             assert self._pattern_time_change_listener_job is not None
         self._cancel_callback = async_track_point_in_utc_time(

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -254,14 +254,14 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
     def __wrap_handle_refresh_interval(self) -> None:
         """Handle a refresh interval occurrence."""
         if self.config_entry:
-            self.config_entry.async_create_background_task(
+            self.config_entry.async_create_periodic_task(
                 self.hass,
                 self._handle_refresh_interval(),
                 name=f"{self.name} - {self.config_entry.title} - refresh",
                 eager_start=True,
             )
         else:
-            self.hass.async_create_background_task(
+            self.hass.async_create_periodic_task(
                 self._handle_refresh_interval(),
                 name=f"{self.name} - refresh",
                 eager_start=True,

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -253,7 +253,19 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
     @callback
     def __wrap_handle_refresh_interval(self) -> None:
         """Handle a refresh interval occurrence."""
-        self.hass.async_create_task(self._handle_refresh_interval(), eager_start=True)
+        if self.config_entry:
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self._handle_refresh_interval(),
+                name=f"{self.name} - {self.config_entry.title} - refresh",
+                eager_start=True,
+            )
+        else:
+            self.hass.async_create_background_task(
+                self._handle_refresh_interval(),
+                name=f"{self.name} - refresh",
+                eager_start=True,
+            )
 
     async def _handle_refresh_interval(self, _now: datetime | None = None) -> None:
         """Handle a refresh interval occurrence."""

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -3,14 +3,17 @@ from datetime import timedelta
 import os
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant import config_entries
 from homeassistant.components.hassio import (
     DOMAIN,
     HASSIO_UPDATE_INTERVAL,
     HassioAPIError,
 )
 from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -264,6 +267,7 @@ async def test_sensor(
         ("sensor.test_memory_percent", "4.59"),
     ],
 )
+@patch.dict(os.environ, MOCK_ENVIRON)
 async def test_stats_addon_sensor(
     hass: HomeAssistant,
     entity_id,
@@ -271,18 +275,17 @@ async def test_stats_addon_sensor(
     aioclient_mock: AiohttpClientMocker,
     entity_registry: er.EntityRegistry,
     caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test stats addons sensor."""
     config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
     config_entry.add_to_hass(hass)
 
-    with patch.dict(os.environ, MOCK_ENVIRON):
-        result = await async_setup_component(
-            hass,
-            "hassio",
-            {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
-        )
-        assert result
+    assert await async_setup_component(
+        hass,
+        "hassio",
+        {"http": {"server_port": 9999, "server_host": "127.0.0.1"}, "hassio": {}},
+    )
     await hass.async_block_till_done()
 
     # Verify that the entity is disabled by default.
@@ -292,9 +295,8 @@ async def test_stats_addon_sensor(
     _install_default_mocks(aioclient_mock)
     _install_test_addon_stats_failure_mock(aioclient_mock)
 
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
-    )
+    freezer.tick(HASSIO_UPDATE_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert "Could not fetch stats" not in caplog.text
@@ -303,22 +305,31 @@ async def test_stats_addon_sensor(
     _install_default_mocks(aioclient_mock)
     _install_test_addon_stats_mock(aioclient_mock)
 
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
-    )
+    freezer.tick(HASSIO_UPDATE_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # Enable the entity.
+    assert "Could not fetch stats" not in caplog.text
+
+    # Enable the entity and wait for the reload to complete.
     entity_registry.async_update_entity(entity_id, disabled_by=None)
-    await hass.config_entries.async_reload(config_entry.entry_id)
+    freezer.tick(config_entries.RELOAD_AFTER_UPDATE_DELAY)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+    # Verify the entity is still enabled
+    assert entity_registry.async_get(entity_id).disabled_by is None
+
+    # The config entry just reloaded, so we need to wait for the next update
+    freezer.tick(HASSIO_UPDATE_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    # There is a REQUEST_REFRESH_DELAYs cooldown on the debouncer
-    async_fire_time_changed(
-        hass, dt_util.now() + timedelta(seconds=REQUEST_REFRESH_DELAY)
-    )
-    await hass.async_block_till_done()
+    assert hass.states.get(entity_id) is not None
 
+    freezer.tick(HASSIO_UPDATE_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
     # Verify that the entity have the expected state.
     state = hass.states.get(entity_id)
     assert state.state == expected
@@ -327,9 +338,10 @@ async def test_stats_addon_sensor(
     _install_default_mocks(aioclient_mock)
     _install_test_addon_stats_failure_mock(aioclient_mock)
 
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + HASSIO_UPDATE_INTERVAL + timedelta(seconds=1)
-    )
+    freezer.tick(HASSIO_UPDATE_INTERVAL + timedelta(seconds=1))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_UNAVAILABLE
     assert "Could not fetch stats" in caplog.text

--- a/tests/components/homewizard/test_sensor.py
+++ b/tests/components/homewizard/test_sensor.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock
 
-from homewizard_energy.errors import DisabledError, RequestError
+from homewizard_energy.errors import RequestError
 from homewizard_energy.models import Data
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -375,7 +375,7 @@ async def test_disabled_by_default_sensors(
         assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
-@pytest.mark.parametrize("exception", [RequestError, DisabledError])
+@pytest.mark.parametrize("exception", [RequestError])
 async def test_sensors_unreachable(
     hass: HomeAssistant,
     mock_homewizardenergy: MagicMock,

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -192,7 +192,7 @@ async def test_switch_entities(
 
 
 @pytest.mark.parametrize("device_fixture", ["HWE-SKT"])
-@pytest.mark.parametrize("exception", [RequestError, DisabledError, UnsupportedError])
+@pytest.mark.parametrize("exception", [RequestError, UnsupportedError])
 @pytest.mark.parametrize(
     ("entity_id", "method"),
     [

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -200,7 +200,7 @@ async def test_set_scan_interval_via_platform(
 
     component = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    component.setup({DOMAIN: {"platform": "platform"}})
+    await component.async_setup({DOMAIN: {"platform": "platform"}})
 
     await hass.async_block_till_done()
     assert mock_track.called

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -4329,10 +4329,23 @@ async def test_task_tracking(hass: HomeAssistant) -> None:
     entry.async_create_background_task(
         hass, test_task(), "background-task-name", eager_start=False
     )
+    entry.async_create_periodic_task(
+        hass, test_task(), "periodic-task-name", eager_start=False
+    )
+    entry.async_create_periodic_task(
+        hass, test_task(), "periodic-task-name", eager_start=True
+    )
     await asyncio.sleep(0)
     hass.loop.call_soon(event.set)
     await entry._async_process_on_unload(hass)
-    assert results == ["on_unload", "background", "background", "normal"]
+    assert results == [
+        "on_unload",
+        "background",
+        "background",
+        "background",
+        "background",
+        "normal",
+    ]
 
 
 async def test_preview_supported(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -514,7 +514,7 @@ async def test_shutdown_calls_block_till_done_after_shutdown_run_callback_thread
     """Ensure shutdown_run_callback_threadsafe is called before the final async_block_till_done."""
     stop_calls = []
 
-    async def _record_block_till_done():
+    async def _record_block_till_done(wait_periodic_tasks: bool = True):
         nonlocal stop_calls
         stop_calls.append("async_block_till_done")
 
@@ -2098,9 +2098,9 @@ async def test_chained_logging_hits_log_timeout(
             return
         hass.async_create_task(_task_chain_1())
 
-    with patch.object(ha, "BLOCK_LOG_TIMEOUT", 0.0001):
+    with patch.object(ha, "BLOCK_LOG_TIMEOUT", 0.0):
         hass.async_create_task(_task_chain_1())
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_periodic_tasks=False)
 
     assert "_task_chain_" in caplog.text
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the coordinator/entity platform periodically refreshes and scheduled track time intervals delay startup because the startup waits for them to finish. 

Often, startup takes long enough for the periodic interval to fire (some only have 5s polling periods). Another coordinator's scheduled refresh will usually be fired on many systems, further delaying the startup. This chain of events results in the startup taking a long time and hitting the safety timeout because too many coordinator refresh/platforms polls/time interval tasks are running, and there is never a window where one is not.

After this change, I can no longer get my production instances stuck on `Waiting for startup to wrap up`. Before this change, they often had to wait for ~10s to find a window where all the tasks were not running. My systems are generally more ideal conditions than a typical user would experience because my choice of integrations is carefully curated. I started looking at this problem because of user logs where the time spent at `Waiting for startup to wrap up` was significantly longer.

Note: This PR was reverted and replaced by https://github.com/home-assistant/core/pull/112726

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
