### PR TITLE
Defensively validate ZHA quirks v2 supplied entity metadata 

### DIFF
--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -88,6 +88,18 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
         super()._init_from_quirks_metadata(entity_metadata)
         binary_sensor_metadata: BinarySensorMetadata = entity_metadata.entity_metadata
         self._attribute_name = binary_sensor_metadata.attribute_name
+        if binary_sensor_metadata.device_class is not None:
+            try:
+                self._attr_device_class = BinarySensorDeviceClass(
+                    binary_sensor_metadata.device_class.value
+                )
+            except ValueError as ex:
+                self.warning(
+                    "Quirks provided an invalid device class: %s for entity %s: %s",
+                    binary_sensor_metadata.device_class,
+                    self.entity_id,
+                    ex,
+                )
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -95,9 +95,9 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
                 )
             except ValueError as ex:
                 self.warning(
-                    "Quirks provided an invalid device class: %s for entity %s: %s",
+                    "Quirks provided an invalid device class: %s for platform %s: %s",
                     binary_sensor_metadata.device_class,
-                    self.entity_id,
+                    Platform.BINARY_SENSOR.value,
                     ex,
                 )
 

--- a/homeassistant/components/zha/binary_sensor.py
+++ b/homeassistant/components/zha/binary_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import functools
 import logging
 
-from zigpy.quirks.v2 import BinarySensorMetadata, EntityMetadata
+from zigpy.quirks.v2 import BinarySensorMetadata
 import zigpy.types as t
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasZone
@@ -28,7 +28,7 @@ from .core.const import (
     CLUSTER_HANDLER_OCCUPANCY,
     CLUSTER_HANDLER_ON_OFF,
     CLUSTER_HANDLER_ZONE,
-    QUIRK_METADATA,
+    ENTITY_METADATA,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
 )
@@ -82,19 +82,18 @@ class BinarySensor(ZhaEntity, BinarySensorEntity):
     def __init__(self, unique_id, zha_device, cluster_handlers, **kwargs) -> None:
         """Initialize the ZHA binary sensor."""
         self._cluster_handler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(self, entity_metadata: BinarySensorMetadata) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        binary_sensor_metadata: BinarySensorMetadata = entity_metadata.entity_metadata
-        self._attribute_name = binary_sensor_metadata.attribute_name
-        if binary_sensor_metadata.device_class is not None:
+        self._attribute_name = entity_metadata.attribute_name
+        if entity_metadata.device_class is not None:
             self._attr_device_class = validate_device_class(
                 BinarySensorDeviceClass,
-                binary_sensor_metadata.device_class,
+                entity_metadata.device_class,
                 Platform.BINARY_SENSOR.value,
                 _LOGGER,
             )

--- a/homeassistant/components/zha/button.py
+++ b/homeassistant/components/zha/button.py
@@ -6,11 +6,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
-from zigpy.quirks.v2 import (
-    EntityMetadata,
-    WriteAttributeButtonMetadata,
-    ZCLCommandButtonMetadata,
-)
+from zigpy.quirks.v2 import WriteAttributeButtonMetadata, ZCLCommandButtonMetadata
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
@@ -20,7 +16,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .core import discovery
-from .core.const import CLUSTER_HANDLER_IDENTIFY, QUIRK_METADATA, SIGNAL_ADD_ENTITIES
+from .core.const import CLUSTER_HANDLER_IDENTIFY, ENTITY_METADATA, SIGNAL_ADD_ENTITIES
 from .core.helpers import get_zha_data
 from .core.registries import ZHA_ENTITIES
 from .entity import ZhaEntity
@@ -76,17 +72,18 @@ class ZHAButton(ZhaEntity, ButtonEntity):
     ) -> None:
         """Init this button."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(
+        self, entity_metadata: ZCLCommandButtonMetadata
+    ) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        button_metadata: ZCLCommandButtonMetadata = entity_metadata.entity_metadata
-        self._command_name = button_metadata.command_name
-        self._args = button_metadata.args
-        self._kwargs = button_metadata.kwargs
+        self._command_name = entity_metadata.command_name
+        self._args = entity_metadata.args
+        self._kwargs = entity_metadata.kwargs
 
     def get_args(self) -> list[Any]:
         """Return the arguments to use in the command."""
@@ -148,16 +145,17 @@ class ZHAAttributeButton(ZhaEntity, ButtonEntity):
     ) -> None:
         """Init this button."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(
+        self, entity_metadata: WriteAttributeButtonMetadata
+    ) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        button_metadata: WriteAttributeButtonMetadata = entity_metadata.entity_metadata
-        self._attribute_name = button_metadata.attribute_name
-        self._attribute_value = button_metadata.attribute_value
+        self._attribute_name = entity_metadata.attribute_name
+        self._attribute_value = entity_metadata.attribute_value
 
     async def async_press(self) -> None:
         """Write attribute with defined value."""

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -220,6 +220,8 @@ DISCOVERY_KEY = "zha_discovery_info"
 
 DOMAIN = "zha"
 
+ENTITY_METADATA = "entity_metadata"
+
 GROUP_ID = "group_id"
 GROUP_IDS = "group_ids"
 GROUP_NAME = "group_name"
@@ -232,8 +234,6 @@ POWER_BATTERY_OR_UNKNOWN = "Battery or Unknown"
 PRESET_SCHEDULE = "Schedule"
 PRESET_COMPLEX = "Complex"
 PRESET_TEMP_MANUAL = "Temporary manual"
-
-QUIRK_METADATA = "quirk_metadata"
 
 ZCL_INIT_ATTRS = "ZCL_INIT_ATTRS"
 

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -85,12 +85,18 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
         WriteAttributeButtonMetadata,
         EntityType.CONFIG,
     ): button.ZHAAttributeButton,
+    (
+        Platform.BUTTON,
+        WriteAttributeButtonMetadata,
+        EntityType.STANDARD,
+    ): button.ZHAAttributeButton,
     (Platform.BUTTON, ZCLCommandButtonMetadata, EntityType.CONFIG): button.ZHAButton,
     (
         Platform.BUTTON,
         ZCLCommandButtonMetadata,
         EntityType.DIAGNOSTIC,
     ): button.ZHAButton,
+    (Platform.BUTTON, ZCLCommandButtonMetadata, EntityType.STANDARD): button.ZHAButton,
     (
         Platform.BINARY_SENSOR,
         BinarySensorMetadata,
@@ -111,6 +117,7 @@ QUIRKS_ENTITY_META_TO_ENTITY_CLASS = {
     (Platform.SENSOR, ZCLSensorMetadata, EntityType.DIAGNOSTIC): sensor.Sensor,
     (Platform.SENSOR, ZCLSensorMetadata, EntityType.STANDARD): sensor.Sensor,
     (Platform.SELECT, ZCLEnumMetadata, EntityType.CONFIG): select.ZCLEnumSelectEntity,
+    (Platform.SELECT, ZCLEnumMetadata, EntityType.STANDARD): select.ZCLEnumSelectEntity,
     (
         Platform.SELECT,
         ZCLEnumMetadata,

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -300,9 +300,9 @@ class ProbeEndpoint:
                     not in cluster_handler.ZCL_INIT_ATTRS
                 ):
                     init_attrs = cluster_handler.ZCL_INIT_ATTRS.copy()
-                    init_attrs[
-                        entity_metadata.attribute_name
-                    ] = entity_metadata.attribute_initialized_from_cache
+                    init_attrs[entity_metadata.attribute_name] = (
+                        entity_metadata.attribute_initialized_from_cache
+                    )
                     cluster_handler.__dict__[zha_const.ZCL_INIT_ATTRS] = init_attrs
 
                 endpoint.async_new_entity(

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -224,7 +224,7 @@ class ProbeEndpoint:
 
         for (
             cluster_details,
-            quirk_metadata_list,
+            entity_metadata_list,
         ) in zigpy_device.exposes_metadata.items():
             endpoint_id, cluster_id, cluster_type = cluster_details
 
@@ -265,11 +265,11 @@ class ProbeEndpoint:
             )
             assert cluster_handler
 
-            for quirk_metadata in quirk_metadata_list:
-                platform = Platform(quirk_metadata.entity_platform.value)
-                metadata_type = type(quirk_metadata.entity_metadata)
+            for entity_metadata in entity_metadata_list:
+                platform = Platform(entity_metadata.entity_platform.value)
+                metadata_type = type(entity_metadata)
                 entity_class = QUIRKS_ENTITY_META_TO_ENTITY_CLASS.get(
-                    (platform, metadata_type, quirk_metadata.entity_type)
+                    (platform, metadata_type, entity_metadata.entity_type)
                 )
 
                 if entity_class is None:
@@ -280,7 +280,7 @@ class ProbeEndpoint:
                         device.name,
                         {
                             zha_const.CLUSTER_DETAILS: cluster_details,
-                            zha_const.QUIRK_METADATA: quirk_metadata,
+                            zha_const.ENTITY_METADATA: entity_metadata,
                         },
                     )
                     continue
@@ -288,14 +288,14 @@ class ProbeEndpoint:
                 # automatically add the attribute to ZCL_INIT_ATTRS for the cluster
                 # handler if it is not already in the list
                 if (
-                    hasattr(quirk_metadata.entity_metadata, "attribute_name")
-                    and quirk_metadata.entity_metadata.attribute_name
+                    hasattr(entity_metadata, "attribute_name")
+                    and entity_metadata.attribute_name
                     not in cluster_handler.ZCL_INIT_ATTRS
                 ):
                     init_attrs = cluster_handler.ZCL_INIT_ATTRS.copy()
-                    init_attrs[quirk_metadata.entity_metadata.attribute_name] = (
-                        quirk_metadata.attribute_initialized_from_cache
-                    )
+                    init_attrs[
+                        entity_metadata.attribute_name
+                    ] = entity_metadata.attribute_initialized_from_cache
                     cluster_handler.__dict__[zha_const.ZCL_INIT_ATTRS] = init_attrs
 
                 endpoint.async_new_entity(
@@ -303,7 +303,7 @@ class ProbeEndpoint:
                     entity_class,
                     endpoint.unique_id,
                     [cluster_handler],
-                    quirk_metadata=quirk_metadata,
+                    entity_metadata=entity_metadata,
                 )
 
                 _LOGGER.debug(

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -25,7 +25,29 @@ from zigpy.zcl.foundation import CommandSchema
 import zigpy.zdo.types as zdo_types
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import (
+    Platform,
+    UnitOfApparentPower,
+    UnitOfDataRate,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfInformation,
+    UnitOfIrradiance,
+    UnitOfLength,
+    UnitOfMass,
+    UnitOfPower,
+    UnitOfPrecipitationDepth,
+    UnitOfPressure,
+    UnitOfSoundPressure,
+    UnitOfSpeed,
+    UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
+    UnitOfVolumeFlowRate,
+    UnitOfVolumetricFlux,
+)
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.typing import ConfigType
@@ -218,7 +240,7 @@ def async_get_zha_config_value(
     )
 
 
-def async_cluster_exists(hass, cluster_id, skip_coordinator=True):
+def async_cluster_exists(hass: HomeAssistant, cluster_id, skip_coordinator=True):
     """Determine if a device containing the specified in cluster is paired."""
     zha_gateway = get_zha_gateway(hass)
     zha_devices = zha_gateway.devices.values()
@@ -424,3 +446,32 @@ def get_zha_gateway(hass: HomeAssistant) -> ZHAGateway:
         raise ValueError("No gateway object exists")
 
     return zha_gateway
+
+
+UNITS_OF_MEASURE = {
+    UnitOfApparentPower.__name__: UnitOfApparentPower,
+    UnitOfPower.__name__: UnitOfPower,
+    UnitOfEnergy.__name__: UnitOfEnergy,
+    UnitOfElectricCurrent.__name__: UnitOfElectricCurrent,
+    UnitOfElectricPotential.__name__: UnitOfElectricPotential,
+    UnitOfTemperature.__name__: UnitOfTemperature,
+    UnitOfTime.__name__: UnitOfTime,
+    UnitOfLength.__name__: UnitOfLength,
+    UnitOfFrequency.__name__: UnitOfFrequency,
+    UnitOfPressure.__name__: UnitOfPressure,
+    UnitOfSoundPressure.__name__: UnitOfSoundPressure,
+    UnitOfVolume.__name__: UnitOfVolume,
+    UnitOfVolumeFlowRate.__name__: UnitOfVolumeFlowRate,
+    UnitOfMass.__name__: UnitOfMass,
+    UnitOfIrradiance.__name__: UnitOfIrradiance,
+    UnitOfVolumetricFlux.__name__: UnitOfVolumetricFlux,
+    UnitOfPrecipitationDepth.__name__: UnitOfPrecipitationDepth,
+    UnitOfSpeed.__name__: UnitOfSpeed,
+    UnitOfInformation.__name__: UnitOfInformation,
+    UnitOfDataRate.__name__: UnitOfDataRate,
+}
+
+
+def validate_unit(quirks_unit: enum.Enum) -> enum.Enum:
+    """Validate and return a unit of measure."""
+    return UNITS_OF_MEASURE[type(quirks_unit).__name__](quirks_unit.value)

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -486,8 +486,7 @@ def validate_device_class(
     metadata_value,
     platform: str,
     logger: logging.Logger,
-) -> BinarySensorDeviceClass | None:
-    ...
+) -> BinarySensorDeviceClass | None: ...
 
 
 @overload
@@ -496,8 +495,7 @@ def validate_device_class(
     metadata_value,
     platform: str,
     logger: logging.Logger,
-) -> SensorDeviceClass | None:
-    ...
+) -> SensorDeviceClass | None: ...
 
 
 @overload
@@ -506,8 +504,7 @@ def validate_device_class(
     metadata_value,
     platform: str,
     logger: logging.Logger,
-) -> NumberDeviceClass | None:
-    ...
+) -> NumberDeviceClass | None: ...
 
 
 def validate_device_class(

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -202,6 +202,8 @@ class ZhaEntity(BaseZhaEntity, RestoreEntity):
             self._attr_entity_category = EntityCategory.CONFIG
         elif entity_metadata.entity_type is EntityType.DIAGNOSTIC:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        else:
+            self._attr_entity_category = None
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -182,20 +182,25 @@ class ZhaEntity(BaseZhaEntity, RestoreEntity):
         if entity_metadata.initially_disabled:
             self._attr_entity_registry_enabled_default = False
 
-        if entity_metadata.translation_key:
-            self._attr_translation_key = entity_metadata.translation_key
-
-        if hasattr(entity_metadata.entity_metadata, "attribute_name"):
-            if not entity_metadata.translation_key:
+        has_device_class = hasattr(entity_metadata.entity_metadata, "device_class")
+        has_attribute_name = hasattr(entity_metadata.entity_metadata, "attribute_name")
+        has_command_name = hasattr(entity_metadata.entity_metadata, "command_name")
+        if not has_device_class or (
+            has_device_class and entity_metadata.entity_metadata.device_class is None
+        ):
+            if entity_metadata.translation_key:
+                self._attr_translation_key = entity_metadata.translation_key
+            elif has_attribute_name:
                 self._attr_translation_key = (
                     entity_metadata.entity_metadata.attribute_name
                 )
-            self._unique_id_suffix = entity_metadata.entity_metadata.attribute_name
-        elif hasattr(entity_metadata.entity_metadata, "command_name"):
-            if not entity_metadata.translation_key:
+            elif has_command_name:
                 self._attr_translation_key = (
                     entity_metadata.entity_metadata.command_name
                 )
+        if has_attribute_name:
+            self._unique_id_suffix = entity_metadata.entity_metadata.attribute_name
+        elif has_command_name:
             self._unique_id_suffix = entity_metadata.entity_metadata.command_name
         if entity_metadata.entity_type is EntityType.CONFIG:
             self._attr_entity_category = EntityCategory.CONFIG

--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -182,26 +182,22 @@ class ZhaEntity(BaseZhaEntity, RestoreEntity):
         if entity_metadata.initially_disabled:
             self._attr_entity_registry_enabled_default = False
 
-        has_device_class = hasattr(entity_metadata.entity_metadata, "device_class")
-        has_attribute_name = hasattr(entity_metadata.entity_metadata, "attribute_name")
-        has_command_name = hasattr(entity_metadata.entity_metadata, "command_name")
+        has_device_class = hasattr(entity_metadata, "device_class")
+        has_attribute_name = hasattr(entity_metadata, "attribute_name")
+        has_command_name = hasattr(entity_metadata, "command_name")
         if not has_device_class or (
-            has_device_class and entity_metadata.entity_metadata.device_class is None
+            has_device_class and entity_metadata.device_class is None
         ):
             if entity_metadata.translation_key:
                 self._attr_translation_key = entity_metadata.translation_key
             elif has_attribute_name:
-                self._attr_translation_key = (
-                    entity_metadata.entity_metadata.attribute_name
-                )
+                self._attr_translation_key = entity_metadata.attribute_name
             elif has_command_name:
-                self._attr_translation_key = (
-                    entity_metadata.entity_metadata.command_name
-                )
+                self._attr_translation_key = entity_metadata.command_name
         if has_attribute_name:
-            self._unique_id_suffix = entity_metadata.entity_metadata.attribute_name
+            self._unique_id_suffix = entity_metadata.attribute_name
         elif has_command_name:
-            self._unique_id_suffix = entity_metadata.entity_metadata.command_name
+            self._unique_id_suffix = entity_metadata.command_name
         if entity_metadata.entity_type is EntityType.CONFIG:
             self._attr_entity_category = EntityCategory.CONFIG
         elif entity_metadata.entity_type is EntityType.DIAGNOSTIC:

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -26,7 +26,7 @@
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.112",
     "zigpy-deconz==0.23.1",
-    "zigpy==0.63.4",
+    "zigpy==0.63.5",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -456,9 +456,9 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
                 )
             except ValueError as ex:
                 self.warning(
-                    "Quirks provided an invalid device class: %s for entity %s: %s",
+                    "Quirks provided an invalid device class: %s for platform %s: %s",
                     number_metadata.device_class,
-                    self.entity_id,
+                    Platform.NUMBER.value,
                     ex,
                 )
 

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -6,7 +6,7 @@ import functools
 import logging
 from typing import TYPE_CHECKING, Any, Self
 
-from zigpy.quirks.v2 import EntityMetadata, NumberMetadata
+from zigpy.quirks.v2 import NumberMetadata
 from zigpy.zcl.clusters.hvac import Thermostat
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
@@ -26,7 +26,7 @@ from .core.const import (
     CLUSTER_HANDLER_LEVEL,
     CLUSTER_HANDLER_OCCUPANCY,
     CLUSTER_HANDLER_THERMOSTAT,
-    QUIRK_METADATA,
+    ENTITY_METADATA,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
 )
@@ -403,7 +403,7 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
         Return entity if it is a supported configuration, otherwise return None
         """
         cluster_handler = cluster_handlers[0]
-        if QUIRK_METADATA not in kwargs and (
+        if ENTITY_METADATA not in kwargs and (
             cls._attribute_name in cluster_handler.cluster.unsupported_attributes
             or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
             or cluster_handler.cluster.get(cls._attribute_name) is None
@@ -426,34 +426,33 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
     ) -> None:
         """Init this number configuration entity."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(self, entity_metadata: NumberMetadata) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        number_metadata: NumberMetadata = entity_metadata.entity_metadata
-        self._attribute_name = number_metadata.attribute_name
+        self._attribute_name = entity_metadata.attribute_name
 
-        if number_metadata.min is not None:
-            self._attr_native_min_value = number_metadata.min
-        if number_metadata.max is not None:
-            self._attr_native_max_value = number_metadata.max
-        if number_metadata.step is not None:
-            self._attr_native_step = number_metadata.step
-        if number_metadata.multiplier is not None:
-            self._attr_multiplier = number_metadata.multiplier
-        if number_metadata.device_class is not None:
+        if entity_metadata.min is not None:
+            self._attr_native_min_value = entity_metadata.min
+        if entity_metadata.max is not None:
+            self._attr_native_max_value = entity_metadata.max
+        if entity_metadata.step is not None:
+            self._attr_native_step = entity_metadata.step
+        if entity_metadata.multiplier is not None:
+            self._attr_multiplier = entity_metadata.multiplier
+        if entity_metadata.device_class is not None:
             self._attr_device_class = validate_device_class(
                 NumberDeviceClass,
-                number_metadata.device_class,
+                entity_metadata.device_class,
                 Platform.NUMBER.value,
                 _LOGGER,
             )
-        if number_metadata.device_class is None and number_metadata.unit is not None:
+        if entity_metadata.device_class is None and entity_metadata.unit is not None:
             self._attr_native_unit_of_measurement = validate_unit(
-                number_metadata.unit
+                entity_metadata.unit
             ).value
 
     @property

--- a/homeassistant/components/zha/number.py
+++ b/homeassistant/components/zha/number.py
@@ -30,7 +30,7 @@ from .core.const import (
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
 )
-from .core.helpers import get_zha_data, validate_unit
+from .core.helpers import get_zha_data, validate_device_class, validate_unit
 from .core.registries import ZHA_ENTITIES
 from .entity import ZhaEntity
 
@@ -442,25 +442,19 @@ class ZHANumberConfigurationEntity(ZhaEntity, NumberEntity):
             self._attr_native_max_value = number_metadata.max
         if number_metadata.step is not None:
             self._attr_native_step = number_metadata.step
-        if number_metadata.unit is not None:
+        if number_metadata.multiplier is not None:
+            self._attr_multiplier = number_metadata.multiplier
+        if number_metadata.device_class is not None:
+            self._attr_device_class = validate_device_class(
+                NumberDeviceClass,
+                number_metadata.device_class,
+                Platform.NUMBER.value,
+                _LOGGER,
+            )
+        if number_metadata.device_class is None and number_metadata.unit is not None:
             self._attr_native_unit_of_measurement = validate_unit(
                 number_metadata.unit
             ).value
-        if number_metadata.multiplier is not None:
-            self._attr_multiplier = number_metadata.multiplier
-
-        if number_metadata.device_class is not None:
-            try:
-                self._attr_device_class = NumberDeviceClass(
-                    number_metadata.device_class.value
-                )
-            except ValueError as ex:
-                self.warning(
-                    "Quirks provided an invalid device class: %s for platform %s: %s",
-                    number_metadata.device_class,
-                    Platform.NUMBER.value,
-                    ex,
-                )
 
     @property
     def native_value(self) -> float:

--- a/homeassistant/components/zha/select.py
+++ b/homeassistant/components/zha/select.py
@@ -11,7 +11,7 @@ from zhaquirks.quirk_ids import TUYA_PLUG_MANUFACTURER, TUYA_PLUG_ONOFF
 from zhaquirks.xiaomi.aqara.magnet_ac01 import OppleCluster as MagnetAC01OppleCluster
 from zhaquirks.xiaomi.aqara.switch_acn047 import OppleCluster as T2RelayOppleCluster
 from zigpy import types
-from zigpy.quirks.v2 import EntityMetadata, ZCLEnumMetadata
+from zigpy.quirks.v2 import ZCLEnumMetadata
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.clusters.security import IasWd
 
@@ -29,7 +29,7 @@ from .core.const import (
     CLUSTER_HANDLER_INOVELLI,
     CLUSTER_HANDLER_OCCUPANCY,
     CLUSTER_HANDLER_ON_OFF,
-    QUIRK_METADATA,
+    ENTITY_METADATA,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
     Strobe,
@@ -179,7 +179,7 @@ class ZCLEnumSelectEntity(ZhaEntity, SelectEntity):
         Return entity if it is a supported configuration, otherwise return None
         """
         cluster_handler = cluster_handlers[0]
-        if QUIRK_METADATA not in kwargs and (
+        if ENTITY_METADATA not in kwargs and (
             cls._attribute_name in cluster_handler.cluster.unsupported_attributes
             or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
             or cluster_handler.cluster.get(cls._attribute_name) is None
@@ -202,17 +202,16 @@ class ZCLEnumSelectEntity(ZhaEntity, SelectEntity):
     ) -> None:
         """Init this select entity."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         self._attr_options = [entry.name.replace("_", " ") for entry in self._enum]
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(self, entity_metadata: ZCLEnumMetadata) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        zcl_enum_metadata: ZCLEnumMetadata = entity_metadata.entity_metadata
-        self._attribute_name = zcl_enum_metadata.attribute_name
-        self._enum = zcl_enum_metadata.enum
+        self._attribute_name = entity_metadata.attribute_name
+        self._enum = entity_metadata.enum
 
     @property
     def current_option(self) -> str | None:

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -75,7 +75,7 @@ from .core.const import (
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
 )
-from .core.helpers import get_zha_data, validate_unit
+from .core.helpers import get_zha_data, validate_device_class, validate_unit
 from .core.registries import SMARTTHINGS_HUMIDITY_CLUSTER, ZHA_ENTITIES
 from .entity import BaseZhaEntity, ZhaEntity
 
@@ -189,22 +189,17 @@ class Sensor(ZhaEntity, SensorEntity):
             self._divisor = sensor_metadata.divisor
         if sensor_metadata.multiplier is not None:
             self._multiplier = sensor_metadata.multiplier
-        if sensor_metadata.unit is not None:
+        if sensor_metadata.device_class is not None:
+            self._attr_device_class = validate_device_class(
+                SensorDeviceClass,
+                sensor_metadata.device_class,
+                Platform.SENSOR.value,
+                _LOGGER,
+            )
+        if sensor_metadata.device_class is None and sensor_metadata.unit is not None:
             self._attr_native_unit_of_measurement = validate_unit(
                 sensor_metadata.unit
             ).value
-        if sensor_metadata.device_class is not None:
-            try:
-                self._attr_device_class = SensorDeviceClass(
-                    sensor_metadata.device_class.value
-                )
-            except ValueError as ex:
-                self.warning(
-                    "Quirks provided an invalid device class: %s for platform %s: %s",
-                    sensor_metadata.device_class,
-                    Platform.SENSOR.value,
-                    ex,
-                )
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -200,9 +200,9 @@ class Sensor(ZhaEntity, SensorEntity):
                 )
             except ValueError as ex:
                 self.warning(
-                    "Quirks provided an invalid device class: %s for entity %s: %s",
+                    "Quirks provided an invalid device class: %s for platform %s: %s",
                     sensor_metadata.device_class,
-                    self.entity_id,
+                    Platform.SENSOR.value,
                     ex,
                 )
 

--- a/homeassistant/components/zha/switch.py
+++ b/homeassistant/components/zha/switch.py
@@ -7,7 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Self
 
 from zhaquirks.quirk_ids import TUYA_PLUG_ONOFF
-from zigpy.quirks.v2 import EntityMetadata, SwitchMetadata
+from zigpy.quirks.v2 import SwitchMetadata
 from zigpy.zcl.clusters.closures import ConfigStatus, WindowCovering, WindowCoveringMode
 from zigpy.zcl.clusters.general import OnOff
 from zigpy.zcl.foundation import Status
@@ -25,7 +25,7 @@ from .core.const import (
     CLUSTER_HANDLER_COVER,
     CLUSTER_HANDLER_INOVELLI,
     CLUSTER_HANDLER_ON_OFF,
-    QUIRK_METADATA,
+    ENTITY_METADATA,
     SIGNAL_ADD_ENTITIES,
     SIGNAL_ATTR_UPDATED,
 )
@@ -192,7 +192,7 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
         Return entity if it is a supported configuration, otherwise return None
         """
         cluster_handler = cluster_handlers[0]
-        if QUIRK_METADATA not in kwargs and (
+        if ENTITY_METADATA not in kwargs and (
             cls._attribute_name in cluster_handler.cluster.unsupported_attributes
             or cls._attribute_name not in cluster_handler.cluster.attributes_by_name
             or cluster_handler.cluster.get(cls._attribute_name) is None
@@ -215,21 +215,20 @@ class ZHASwitchConfigurationEntity(ZhaEntity, SwitchEntity):
     ) -> None:
         """Init this number configuration entity."""
         self._cluster_handler: ClusterHandler = cluster_handlers[0]
-        if QUIRK_METADATA in kwargs:
-            self._init_from_quirks_metadata(kwargs[QUIRK_METADATA])
+        if ENTITY_METADATA in kwargs:
+            self._init_from_quirks_metadata(kwargs[ENTITY_METADATA])
         super().__init__(unique_id, zha_device, cluster_handlers, **kwargs)
 
-    def _init_from_quirks_metadata(self, entity_metadata: EntityMetadata) -> None:
+    def _init_from_quirks_metadata(self, entity_metadata: SwitchMetadata) -> None:
         """Init this entity from the quirks metadata."""
         super()._init_from_quirks_metadata(entity_metadata)
-        switch_metadata: SwitchMetadata = entity_metadata.entity_metadata
-        self._attribute_name = switch_metadata.attribute_name
-        if switch_metadata.invert_attribute_name:
-            self._inverter_attribute_name = switch_metadata.invert_attribute_name
-        if switch_metadata.force_inverted:
-            self._force_inverted = switch_metadata.force_inverted
-        self._off_value = switch_metadata.off_value
-        self._on_value = switch_metadata.on_value
+        self._attribute_name = entity_metadata.attribute_name
+        if entity_metadata.invert_attribute_name:
+            self._inverter_attribute_name = entity_metadata.invert_attribute_name
+        if entity_metadata.force_inverted:
+            self._force_inverted = entity_metadata.force_inverted
+        self._off_value = entity_metadata.off_value
+        self._on_value = entity_metadata.on_value
 
     async def async_added_to_hass(self) -> None:
         """Run when about to be added to hass."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2952,7 +2952,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.63.4
+zigpy==0.63.5
 
 # homeassistant.components.zoneminder
 zm-py==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2281,7 +2281,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.63.4
+zigpy==0.63.5
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.55.3

--- a/tests/components/zha/test_helpers.py
+++ b/tests/components/zha/test_helpers.py
@@ -1,11 +1,13 @@
 """Tests for ZHA helpers."""
 
+import enum
 import logging
 from unittest.mock import patch
 
 import pytest
 import voluptuous_serialize
 import zigpy.profiles.zha as zha
+from zigpy.quirks.v2.homeassistant import UnitOfPower as QuirksUnitOfPower
 from zigpy.types.basic import uint16_t
 import zigpy.zcl.clusters.general as general
 import zigpy.zcl.clusters.lighting as lighting
@@ -13,8 +15,9 @@ import zigpy.zcl.clusters.lighting as lighting
 from homeassistant.components.zha.core.helpers import (
     cluster_command_schema_to_vol_schema,
     convert_to_zcl_values,
+    validate_unit,
 )
-from homeassistant.const import Platform
+from homeassistant.const import Platform, UnitOfPower
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 
@@ -40,7 +43,7 @@ def light_platform_only():
 
 
 @pytest.fixture
-async def device_light(hass, zigpy_device_mock, zha_device_joined):
+async def device_light(hass: HomeAssistant, zigpy_device_mock, zha_device_joined):
     """Test light."""
 
     zigpy_device = zigpy_device_mock(
@@ -211,3 +214,25 @@ async def test_zcl_schema_conversions(hass: HomeAssistant, device_light) -> None
 
     # No flags are passed through
     assert converted_data["update_flags"] == 0
+
+
+def test_unit_validation() -> None:
+    """Test unit validation."""
+
+    assert validate_unit(QuirksUnitOfPower.WATT) == UnitOfPower.WATT
+
+    class FooUnit(enum.Enum):
+        """Foo unit."""
+
+        BAR = "bar"
+
+    class UnitOfMass(enum.Enum):
+        """UnitOfMass."""
+
+        BAR = "bar"
+
+    with pytest.raises(KeyError):
+        validate_unit(FooUnit.BAR)
+
+    with pytest.raises(ValueError):
+        validate_unit(UnitOfMass.BAR)

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -435,7 +435,7 @@ async def test_on_off_select_attribute_report(
         "motion_sensitivity_disabled",
         AqaraMotionSensitivities,
         MotionSensitivityQuirk.OppleCluster.cluster_id,
-        translation_key="motion_sensitivity_translation_key",
+        translation_key="motion_sensitivity",
         initially_disabled=True,
     )
 )
@@ -491,9 +491,8 @@ async def test_on_off_select_attribute_report_v2(
     assert hass.states.get(entity_id).state == AqaraMotionSensitivities.Low.name
 
     entity_registry = er.async_get(hass)
-    # none in id because the translation key does not exist
-    entity_entry = entity_registry.async_get("select.fake_manufacturer_fake_model_none")
+    entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry
     assert entity_entry.entity_category == EntityCategory.CONFIG
-    assert entity_entry.disabled is True
-    assert entity_entry.translation_key == "motion_sensitivity_translation_key"
+    assert entity_entry.disabled is False
+    assert entity_entry.translation_key == "motion_sensitivity"

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1260,10 +1260,10 @@ async def test_last_feeding_size_sensor_v2(
     assert entity_id is not None
 
     await send_attributes_report(hass, cluster, {0x010C: 1})
-    assert_state(hass, entity_id, "1.0", UnitOfMass.GRAMS)
+    assert_state(hass, entity_id, "1.0", UnitOfMass.GRAMS.value)
 
     await send_attributes_report(hass, cluster, {0x010C: 5})
-    assert_state(hass, entity_id, "5.0", UnitOfMass.GRAMS)
+    assert_state(hass, entity_id, "5.0", UnitOfMass.GRAMS.value)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR addresses concerns raised in discussions on #111176. It adds validation for all HA specific entity metadata items and tests for invalid combinations of these items as well. 

*EDIT* 

I also pulled a Zigpy update into this because the code was starting to get confusing. There was a lot of `entity_metadata.entity_metadata` references that have been fixed / cleaned up.

Zigpy 0.63.5: https://github.com/zigpy/zigpy/releases/tag/0.63.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
