### PR TITLE
Avoid writing registries to disk during startup

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -14,6 +14,7 @@ from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryItems,
     normalize_name,
 )
+from .registry import BaseRegistry
 from .storage import Store
 from .typing import UNDEFINED, UndefinedType
 
@@ -22,7 +23,6 @@ EVENT_AREA_REGISTRY_UPDATED = "area_registry_updated"
 STORAGE_KEY = "core.area_registry"
 STORAGE_VERSION_MAJOR = 1
 STORAGE_VERSION_MINOR = 6
-SAVE_DELAY = 10
 
 
 class EventAreaRegistryUpdatedData(TypedDict):
@@ -86,7 +86,7 @@ class AreaRegistryStore(Store[dict[str, list[dict[str, Any]]]]):
         return old_data
 
 
-class AreaRegistry:
+class AreaRegistry(BaseRegistry):
     """Class to hold a registry of areas."""
 
     areas: NormalizedNameBaseRegistryItems[AreaEntry]
@@ -272,11 +272,6 @@ class AreaRegistry:
 
         self.areas = areas
         self._area_data = areas.data
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the area registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -31,6 +31,7 @@ from .deprecation import (
 )
 from .frame import report
 from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes
+from .registry import BaseRegistry
 from .typing import UNDEFINED, UndefinedType
 
 if TYPE_CHECKING:
@@ -45,7 +46,7 @@ EVENT_DEVICE_REGISTRY_UPDATED = "device_registry_updated"
 STORAGE_KEY = "core.device_registry"
 STORAGE_VERSION_MAJOR = 1
 STORAGE_VERSION_MINOR = 5
-SAVE_DELAY = 10
+
 CLEANUP_DELAY = 10
 
 CONNECTION_BLUETOOTH = "bluetooth"
@@ -456,7 +457,7 @@ class DeviceRegistryItems(UserDict[str, _EntryTypeT]):
         return None
 
 
-class DeviceRegistry:
+class DeviceRegistry(BaseRegistry):
     """Class to hold a registry of devices."""
 
     devices: DeviceRegistryItems[DeviceEntry]
@@ -897,11 +898,6 @@ class DeviceRegistry:
         self.devices = devices
         self.deleted_devices = deleted_devices
         self._device_data = devices.data
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the device registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, Any]]]:

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -52,6 +52,7 @@ from homeassistant.util.read_only_dict import ReadOnlyDict
 from . import device_registry as dr, storage
 from .device_registry import EVENT_DEVICE_REGISTRY_UPDATED
 from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes
+from .registry import BaseRegistry
 from .typing import UNDEFINED, UndefinedType
 
 if TYPE_CHECKING:
@@ -61,7 +62,7 @@ T = TypeVar("T")
 
 DATA_REGISTRY = "entity_registry"
 EVENT_ENTITY_REGISTRY_UPDATED = "entity_registry_updated"
-SAVE_DELAY = 10
+
 _LOGGER = logging.getLogger(__name__)
 
 STORAGE_VERSION_MAJOR = 1
@@ -549,7 +550,7 @@ class EntityRegistryItems(UserDict[str, RegistryEntry]):
         return [data[key] for key in self._area_id_index.get(area_id, ())]
 
 
-class EntityRegistry:
+class EntityRegistry(BaseRegistry):
     """Class to hold a registry of entities."""
 
     deleted_entities: dict[tuple[str, str, str], DeletedRegistryEntry]
@@ -1181,11 +1182,6 @@ class EntityRegistry:
         self.deleted_entities = deleted_entities
         self.entities = entities
         self._entities_data = entities.data
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the entity registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, Any]:

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -14,6 +14,7 @@ from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryItems,
     normalize_name,
 )
+from .registry import BaseRegistry
 from .storage import Store
 from .typing import UNDEFINED, EventType, UndefinedType
 
@@ -21,7 +22,6 @@ DATA_REGISTRY = "floor_registry"
 EVENT_FLOOR_REGISTRY_UPDATED = "floor_registry_updated"
 STORAGE_KEY = "core.floor_registry"
 STORAGE_VERSION_MAJOR = 1
-SAVE_DELAY = 10
 
 
 class EventFloorRegistryUpdatedData(TypedDict):
@@ -44,7 +44,7 @@ class FloorEntry(NormalizedNameBaseRegistryEntry):
     level: int = 0
 
 
-class FloorRegistry:
+class FloorRegistry(BaseRegistry):
     """Class to hold a registry of floors."""
 
     floors: NormalizedNameBaseRegistryItems[FloorEntry]
@@ -208,11 +208,6 @@ class FloorRegistry:
 
         self.floors = floors
         self._floor_data = floors.data
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the floor registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, str | int | list[str] | None]]]:

--- a/homeassistant/helpers/issue_registry.py
+++ b/homeassistant/helpers/issue_registry.py
@@ -14,6 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as dt_util
 
+from .registry import BaseRegistry
 from .storage import Store
 
 DATA_REGISTRY = "issue_registry"
@@ -21,7 +22,6 @@ EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED = "repairs_issue_registry_updated"
 STORAGE_KEY = "repairs.issue_registry"
 STORAGE_VERSION_MAJOR = 1
 STORAGE_VERSION_MINOR = 2
-SAVE_DELAY = 10
 
 
 class IssueSeverity(StrEnum):
@@ -92,7 +92,7 @@ class IssueRegistryStore(Store[dict[str, list[dict[str, Any]]]]):
         return old_data
 
 
-class IssueRegistry:
+class IssueRegistry(BaseRegistry):
     """Class to hold a registry of issues."""
 
     def __init__(self, hass: HomeAssistant, *, read_only: bool = False) -> None:
@@ -258,11 +258,6 @@ class IssueRegistry:
                     )
 
         self.issues = issues
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the issue registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, str | None]]]:

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -14,6 +14,7 @@ from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryItems,
     normalize_name,
 )
+from .registry import BaseRegistry
 from .storage import Store
 from .typing import UNDEFINED, EventType, UndefinedType
 
@@ -21,7 +22,6 @@ DATA_REGISTRY = "label_registry"
 EVENT_LABEL_REGISTRY_UPDATED = "label_registry_updated"
 STORAGE_KEY = "core.label_registry"
 STORAGE_VERSION_MAJOR = 1
-SAVE_DELAY = 10
 
 
 class EventLabelRegistryUpdatedData(TypedDict):
@@ -44,7 +44,7 @@ class LabelEntry(NormalizedNameBaseRegistryEntry):
     icon: str | None = None
 
 
-class LabelRegistry:
+class LabelRegistry(BaseRegistry):
     """Class to hold a registry of labels."""
 
     labels: NormalizedNameBaseRegistryItems[LabelEntry]
@@ -204,11 +204,6 @@ class LabelRegistry:
 
         self.labels = labels
         self._label_data = labels.data
-
-    @callback
-    def async_schedule_save(self) -> None:
-        """Schedule saving the label registry."""
-        self._store.async_delay_save(self._data_to_save, SAVE_DELAY)
 
     @callback
     def _data_to_save(self) -> dict[str, list[dict[str, str | None]]]:

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -32,4 +32,4 @@ class BaseRegistry(ABC):
     @callback
     @abstractmethod
     def _data_to_save(self) -> dict[str, Any]:
-        """Return data of entity registry to store in a file."""
+        """Return data of registry to store in a file."""

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -1,0 +1,35 @@
+"""Provide a base implementation for registries."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import CoreState, HomeAssistant, callback
+
+if TYPE_CHECKING:
+    from .storage import Store
+
+SAVE_DELAY = 10
+SAVE_DELAY_STARTING = 300
+
+
+class BaseRegistry(ABC):
+    """Class to implement a registry."""
+
+    hass: HomeAssistant
+    _store: Store
+
+    @callback
+    def async_schedule_save(self) -> None:
+        """Schedule saving the registry."""
+        # Schedule the save past startup to avoid writing
+        # the file while the system is starting.
+        delay = (
+            SAVE_DELAY_STARTING if self.hass.state is CoreState.starting else SAVE_DELAY
+        )
+        self._store.async_delay_save(self._data_to_save, delay)
+
+    @callback
+    @abstractmethod
+    def _data_to_save(self) -> dict[str, Any]:
+        """Return data of entity registry to store in a file."""

--- a/tests/helpers/test_registry.py
+++ b/tests/helpers/test_registry.py
@@ -1,0 +1,48 @@
+"""Tests for the registry."""
+from typing import Any
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.helpers import storage
+from homeassistant.helpers.registry import SAVE_DELAY, SAVE_DELAY_STARTING, BaseRegistry
+
+from tests.common import async_fire_time_changed
+
+
+class SampleRegistry(BaseRegistry):
+    """Class to hold a registry of X."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the registry."""
+        self.hass = hass
+        self._store = storage.Store(hass, 1, "test")
+        self.save_calls = 0
+
+    def _data_to_save(self) -> None:
+        """Return data of registry to save."""
+        self.save_calls += 1
+        return None
+
+
+async def test_async_schedule_save(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, hass_storage: dict[str, Any]
+) -> None:
+    """Test saving the registry."""
+    registry = SampleRegistry(hass)
+    hass.set_state(CoreState.starting)
+
+    registry.async_schedule_save()
+    freezer.tick(SAVE_DELAY)
+    async_fire_time_changed(hass)
+    assert registry.save_calls == 0
+
+    freezer.tick(SAVE_DELAY_STARTING)
+    async_fire_time_changed(hass)
+    assert registry.save_calls == 1
+
+    hass.set_state(CoreState.running)
+    registry.async_schedule_save()
+    freezer.tick(SAVE_DELAY)
+    async_fire_time_changed(hass)
+    assert registry.save_calls == 2

--- a/tests/helpers/test_registry.py
+++ b/tests/helpers/test_registry.py
@@ -35,14 +35,17 @@ async def test_async_schedule_save(
     registry.async_schedule_save()
     freezer.tick(SAVE_DELAY)
     async_fire_time_changed(hass)
+    await hass.async_block_till_done()
     assert registry.save_calls == 0
 
     freezer.tick(SAVE_DELAY_STARTING)
     async_fire_time_changed(hass)
+    await hass.async_block_till_done()
     assert registry.save_calls == 1
 
     hass.set_state(CoreState.running)
     registry.async_schedule_save()
     freezer.tick(SAVE_DELAY)
     async_fire_time_changed(hass)
+    await hass.async_block_till_done()
     assert registry.save_calls == 2


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid writing registries to disk during startup

Registry writes are now scheduled 5 minutes in the future if they are requested during startup to avoid delaying startup and creating more work in an already busy executor during startup.  Storage is smart enough to honor the lowest delay so if a registry requests a shorter delayed save after startup it will supersede the one made during startup and still save in 10 seconds.

Restore state doesn't have this problem because it uses `async_at_start` https://github.com/home-assistant/core/blob/5da629b3e59bca2cf7ca1236ffe82c49e89b85a0/homeassistant/helpers/restore_state.py#L150   I didn't do that here since there is a good chance some of the registries won't do any changes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
