### PR TITLE
Speed up importing mqtt platforms

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -40,6 +40,7 @@ from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
+from homeassistant.util.async_ import create_eager_task
 
 # Loading the config flow file will register the flow
 from . import debug_info, discovery
@@ -449,14 +450,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Forward the entry setup to the MQTT platforms
         await asyncio.gather(
             *(
-                [
-                    device_automation.async_setup_entry(hass, config_entry),
-                    tag.async_setup_entry(hass, config_entry),
-                ]
-                + [
-                    hass.config_entries.async_forward_entry_setup(entry, component)
-                    for component in PLATFORMS
-                ]
+                create_eager_task(
+                    device_automation.async_setup_entry(hass, config_entry)
+                ),
+                create_eager_task(tag.async_setup_entry(hass, config_entry)),
+                create_eager_task(
+                    hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+                ),
             )
         )
         # Setup discovery


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `async_forward_entry_setups` so platforms can be loaded in a single executor job instead of many

Currently they all have to create a seperate job because it did not use `async_forward_entry_setups` which knows how to preload them in a single job: https://github.com/home-assistant/core/blob/d2effd869343b924e2d25e12c050d4359444287c/homeassistant/config_entries.py#L1865

```
2024-03-08 08:29:29.819 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[light] loop=[] took 12.12s
2024-03-08 08:29:29.822 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[number] loop=[] took 12.12s
2024-03-08 08:29:29.826 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[scene] loop=[] took 12.13s
2024-03-08 08:29:29.829 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[select] loop=[] took 12.13s
2024-03-08 08:29:29.833 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[sensor] loop=[] took 12.14s
2024-03-08 08:29:30.882 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[update] loop=[] took 13.18s
2024-03-08 08:29:30.948 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[button] loop=[] took 13.18s
2024-03-08 08:29:30.949 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[climate] loop=[] took 13.19s
2024-03-08 08:29:31.012 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[fan] loop=[] took 13.25s
2024-03-08 08:29:31.019 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[humidifier] loop=[] took 13.25s
2024-03-08 08:29:31.024 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[image] loop=[] took 13.26s
2024-03-08 08:29:31.034 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[lock] loop=[] took 13.27s
2024-03-08 08:29:31.045 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[vacuum] loop=[] took 13.28s
2024-03-08 08:29:31.050 DEBUG (MainThread) [homeassistant.loader] Importing platforms for mqtt executor=[valve] loop=[] took 13.28s
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
