### PR TITLE
Allow duplicate names in different modbus entities

### DIFF
--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -301,13 +301,14 @@ def check_config(config: dict) -> dict:
 
     def validate_entity(
         hub_name: str,
+        component: str,
         entity: dict,
         minimum_scan_interval: int,
         ent_names: set,
         ent_addr: set,
     ) -> bool:
         """Validate entity."""
-        name = entity[CONF_NAME]
+        name = f"{component}.{entity[CONF_NAME]}"
         addr = f"{hub_name}{entity[CONF_ADDRESS]}"
         scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         if 0 < scan_interval < 5:
@@ -368,7 +369,7 @@ def check_config(config: dict) -> dict:
         if not validate_modbus(hub, hub_name_inx):
             del config[hub_inx]
             continue
-        for _component, conf_key in PLATFORMS:
+        for component, conf_key in PLATFORMS:
             if conf_key not in hub:
                 continue
             entity_inx = 0
@@ -377,6 +378,7 @@ def check_config(config: dict) -> dict:
             while entity_inx < len(entities):
                 if not validate_entity(
                     hub[CONF_NAME],
+                    component,
                     entities[entity_inx],
                     minimum_scan_interval,
                     ent_names,

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -858,6 +858,30 @@ async def test_duplicate_fan_mode_validator(do_config) -> None:
             ],
             2,
         ),
+        (
+            [
+                {
+                    CONF_NAME: TEST_MODBUS_NAME,
+                    CONF_TYPE: TCP,
+                    CONF_HOST: TEST_MODBUS_HOST,
+                    CONF_PORT: TEST_PORT_TCP,
+                    CONF_TIMEOUT: 3,
+                    CONF_SENSORS: [
+                        {
+                            CONF_NAME: TEST_ENTITY_NAME,
+                            CONF_ADDRESS: 117,
+                            CONF_SLAVE: 0,
+                        },
+                        {
+                            CONF_NAME: TEST_ENTITY_NAME,
+                            CONF_ADDRESS: 1179,
+                            CONF_SLAVE: 0,
+                        },
+                    ],
+                },
+            ],
+            1,
+        ),
     ],
 )
 async def test_duplicate_addresses(do_config, sensor_cnt) -> None:
@@ -865,6 +889,41 @@ async def test_duplicate_addresses(do_config, sensor_cnt) -> None:
     check_config(do_config)
     use_inx = len(do_config) - 1
     assert len(do_config[use_inx][CONF_SENSORS]) == sensor_cnt
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        [
+            {
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_TYPE: TCP,
+                CONF_HOST: TEST_MODBUS_HOST,
+                CONF_PORT: TEST_PORT_TCP,
+                CONF_TIMEOUT: 3,
+                CONF_SENSORS: [
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME,
+                        CONF_ADDRESS: 117,
+                        CONF_SLAVE: 0,
+                    },
+                ],
+                CONF_BINARY_SENSORS: [
+                    {
+                        CONF_NAME: TEST_ENTITY_NAME + "1",
+                        CONF_ADDRESS: 1179,
+                        CONF_SLAVE: 0,
+                    },
+                ],
+            },
+        ],
+    ],
+)
+async def test_no_duplicate_names(do_config) -> None:
+    """Test duplicate entity validator."""
+    check_config(do_config)
+    assert len(do_config[0][CONF_SENSORS]) == 1
+    assert len(do_config[0][CONF_BINARY_SENSORS]) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Modbus integration checks for duplicate entity names, which avoids problems, however duplicates are only within
the same entity, e.g.

```
    sensor.entity1
    binary_sensor.entity1
```
Is not a duplicate and should be allowed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
fixes #112645
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
