### PR TITLE
Add empty line after module docstring [tests q-s]

### DIFF
--- a/tests/components/qbittorrent/conftest.py
+++ b/tests/components/qbittorrent/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for testing qBittorrent component."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/qingping/test_binary_sensor.py
+++ b/tests/components/qingping/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test the Qingping binary sensors."""
+
 from datetime import timedelta
 import time
 

--- a/tests/components/qingping/test_config_flow.py
+++ b/tests/components/qingping/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Qingping config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/qingping/test_sensor.py
+++ b/tests/components/qingping/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the Qingping sensors."""
+
 from datetime import timedelta
 import time
 

--- a/tests/components/qnap/conftest.py
+++ b/tests/components/qnap/conftest.py
@@ -1,4 +1,5 @@
 """Setup the QNAP tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/qnap/test_config_flow.py
+++ b/tests/components/qnap/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the QNAP config flow."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/rabbitair/test_config_flow.py
+++ b/tests/components/rabbitair/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the RabbitAir config flow."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/rachio/test_config_flow.py
+++ b/tests/components/rachio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Rachio config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/radarr/test_calendar.py
+++ b/tests/components/radarr/test_calendar.py
@@ -1,4 +1,5 @@
 """The tests for Radarr calendar platform."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/radarr/test_config_flow.py
+++ b/tests/components/radarr/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Radarr config flow."""
+
 from unittest.mock import patch
 
 from aiopyarr import exceptions

--- a/tests/components/radio_browser/conftest.py
+++ b/tests/components/radio_browser/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Radio Browser integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/radio_browser/test_config_flow.py
+++ b/tests/components/radio_browser/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Radio Browser config flow."""
+
 from unittest.mock import AsyncMock
 
 from homeassistant.components.radio_browser.const import DOMAIN

--- a/tests/components/rainforest_eagle/conftest.py
+++ b/tests/components/rainforest_eagle/conftest.py
@@ -1,4 +1,5 @@
 """Conftest for rainforest_eagle."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest

--- a/tests/components/rainforest_eagle/test_config_flow.py
+++ b/tests/components/rainforest_eagle/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Rainforest Eagle config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/rainforest_eagle/test_diagnostics.py
+++ b/tests/components/rainforest_eagle/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test the Rainforest Eagle diagnostics."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.rainforest_eagle.const import (
     CONF_CLOUD_ID,

--- a/tests/components/rainforest_eagle/test_sensor.py
+++ b/tests/components/rainforest_eagle/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for rainforest eagle sensors."""
+
 from homeassistant.components.rainforest_eagle.const import DOMAIN
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/rainforest_raven/test_config_flow.py
+++ b/tests/components/rainforest_raven/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Rainforest RAVEn config flow."""
+
 from unittest.mock import patch
 
 from aioraven.device import RAVEnConnectionError

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -1,4 +1,5 @@
 """Tests for the Rainforest RAVEn data coordinator."""
+
 from aioraven.device import RAVEnConnectionError
 import pytest
 

--- a/tests/components/rainforest_raven/test_diagnostics.py
+++ b/tests/components/rainforest_raven/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test the Rainforest Eagle diagnostics."""
+
 from dataclasses import asdict
 
 import pytest

--- a/tests/components/rainmachine/test_config_flow.py
+++ b/tests/components/rainmachine/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the OpenUV config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/rainmachine/test_diagnostics.py
+++ b/tests/components/rainmachine/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test RainMachine diagnostics."""
+
 from regenmaschine.errors import RainMachineError
 
 from homeassistant.components.diagnostics import REDACTED

--- a/tests/components/random/test_binary_sensor.py
+++ b/tests/components/random/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Random binary sensor platform."""
+
 from unittest.mock import patch
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/random/test_config_flow.py
+++ b/tests/components/random/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Random config flow."""
+
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/components/random/test_sensor.py
+++ b/tests/components/random/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the random number sensor platform."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/rapt_ble/test_config_flow.py
+++ b/tests/components/rapt_ble/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the RAPT config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/raspberry_pi/test_config_flow.py
+++ b/tests/components/raspberry_pi/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Raspberry Pi config flow."""
+
 from unittest.mock import patch
 
 from homeassistant.components.raspberry_pi.const import DOMAIN

--- a/tests/components/raspberry_pi/test_hardware.py
+++ b/tests/components/raspberry_pi/test_hardware.py
@@ -1,4 +1,5 @@
 """Test the Raspberry Pi hardware platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/raspberry_pi/test_init.py
+++ b/tests/components/raspberry_pi/test_init.py
@@ -1,4 +1,5 @@
 """Test the Raspberry Pi integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/rdw/conftest.py
+++ b/tests/components/rdw/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for RDW integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/rdw/test_binary_sensor.py
+++ b/tests/components/rdw/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the RDW integration."""
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.rdw.const import DOMAIN
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME, ATTR_ICON

--- a/tests/components/rdw/test_diagnostics.py
+++ b/tests/components/rdw/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the RDW integration."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/rdw/test_init.py
+++ b/tests/components/rdw/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the RDW integration."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.rdw.const import DOMAIN

--- a/tests/components/rdw/test_sensor.py
+++ b/tests/components/rdw/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the RDW integration."""
+
 from homeassistant.components.rdw.const import DOMAIN
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorDeviceClass
 from homeassistant.const import (

--- a/tests/components/recollect_waste/conftest.py
+++ b/tests/components/recollect_waste/conftest.py
@@ -1,4 +1,5 @@
 """Define test fixtures for ReCollect Waste."""
+
 from datetime import date
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/components/recollect_waste/test_config_flow.py
+++ b/tests/components/recollect_waste/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the ReCollect Waste config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from aiorecollect.errors import RecollectError

--- a/tests/components/recollect_waste/test_diagnostics.py
+++ b/tests/components/recollect_waste/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test ReCollect Waste diagnostics."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
+++ b/tests/components/recorder/auto_repairs/statistics/test_duplicates.py
@@ -1,4 +1,5 @@
 """Test removing statistics duplicates."""
+
 from collections.abc import Callable
 import importlib
 from pathlib import Path

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -1,4 +1,5 @@
 """Common test utils for working with recorder."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/recorder/db_schema_23.py
+++ b/tests/components/recorder/db_schema_23.py
@@ -5,6 +5,7 @@ used by Home Assistant Core 2021.11.0, which adds the name column
 to statistics_meta.
 It is used to test the schema migration logic.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/recorder/db_schema_23_with_newer_columns.py
+++ b/tests/components/recorder/db_schema_23_with_newer_columns.py
@@ -9,6 +9,7 @@ allow the recorder to startup successfully.
 
 It is used to test the schema migration logic.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/recorder/db_schema_25.py
+++ b/tests/components/recorder/db_schema_25.py
@@ -1,4 +1,5 @@
 """Models for SQLAlchemy."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/recorder/db_schema_28.py
+++ b/tests/components/recorder/db_schema_28.py
@@ -3,6 +3,7 @@
 This file contains the model definitions for schema version 28.
 It is used to test the schema migration logic.
 """
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/recorder/db_schema_30.py
+++ b/tests/components/recorder/db_schema_30.py
@@ -3,6 +3,7 @@
 This file contains the model definitions for schema version 30.
 It is used to test the schema migration logic.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/recorder/db_schema_32.py
+++ b/tests/components/recorder/db_schema_32.py
@@ -3,6 +3,7 @@
 This file contains the model definitions for schema version 30.
 It is used to test the schema migration logic.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/recorder/table_managers/test_recorder_runs.py
+++ b/tests/components/recorder/table_managers/test_recorder_runs.py
@@ -1,4 +1,5 @@
 """Test recorder runs table manager."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/recorder/table_managers/test_statistics_meta.py
+++ b/tests/components/recorder/table_managers/test_statistics_meta.py
@@ -1,4 +1,5 @@
 """The tests for the Recorder component."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/recorder/test_backup.py
+++ b/tests/components/recorder/test_backup.py
@@ -1,4 +1,5 @@
 """Test backup platform for the Recorder integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/recorder/test_entity_registry.py
+++ b/tests/components/recorder/test_entity_registry.py
@@ -1,4 +1,5 @@
 """The tests for sensor recorder platform."""
+
 from collections.abc import Callable
 
 import pytest

--- a/tests/components/recorder/test_history.py
+++ b/tests/components/recorder/test_history.py
@@ -1,4 +1,5 @@
 """The tests the History component."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/recorder/test_history_db_schema_30.py
+++ b/tests/components/recorder/test_history_db_schema_30.py
@@ -1,4 +1,5 @@
 """The tests the History component."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/recorder/test_history_db_schema_32.py
+++ b/tests/components/recorder/test_history_db_schema_32.py
@@ -1,4 +1,5 @@
 """The tests the History component."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Recorder component."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/recorder/test_models.py
+++ b/tests/components/recorder/test_models.py
@@ -1,4 +1,5 @@
 """The tests for the Recorder component."""
+
 from datetime import datetime, timedelta
 from unittest.mock import PropertyMock
 

--- a/tests/components/recorder/test_models_legacy.py
+++ b/tests/components/recorder/test_models_legacy.py
@@ -1,4 +1,5 @@
 """The tests for the Recorder component legacy models."""
+
 from datetime import datetime, timedelta
 from unittest.mock import PropertyMock
 

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -1,4 +1,5 @@
 """Test data purging."""
+
 from datetime import datetime, timedelta
 import json
 import sqlite3

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -1,4 +1,5 @@
 """The tests for sensor recorder platform."""
+
 from collections.abc import Callable
 from datetime import timedelta
 from unittest.mock import patch

--- a/tests/components/recorder/test_statistics_v23_migration.py
+++ b/tests/components/recorder/test_statistics_v23_migration.py
@@ -3,6 +3,7 @@
 The v23 schema used for these tests has been slightly modified to add the
 EventData table to allow the recorder to startup successfully.
 """
+
 from functools import partial
 import importlib
 import json

--- a/tests/components/recorder/test_system_health.py
+++ b/tests/components/recorder/test_system_health.py
@@ -1,4 +1,5 @@
 """Test recorder system health."""
+
 from unittest.mock import ANY, Mock, patch
 
 import pytest

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -1,4 +1,5 @@
 """Test util methods."""
+
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 import os

--- a/tests/components/recorder/test_v32_migration.py
+++ b/tests/components/recorder/test_v32_migration.py
@@ -1,4 +1,5 @@
 """The tests for recorder platform migrating data from v30."""
+
 from datetime import timedelta
 import importlib
 from pathlib import Path

--- a/tests/components/recovery_mode/test_init.py
+++ b/tests/components/recovery_mode/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Recovery Mode integration."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/refoss/conftest.py
+++ b/tests/components/refoss/conftest.py
@@ -1,4 +1,5 @@
 """Pytest module configuration."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/refoss/test_config_flow.py
+++ b/tests/components/refoss/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the refoss Integration."""
+
 from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/remember_the_milk/test_init.py
+++ b/tests/components/remember_the_milk/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Remember The Milk component."""
+
 from unittest.mock import Mock, mock_open, patch
 
 import homeassistant.components.remember_the_milk as rtm

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -1,4 +1,5 @@
 """The test for remote device automation."""
+
 from datetime import timedelta
 
 from freezegun import freeze_time

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for remote device automation."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/remote/test_significant_change.py
+++ b/tests/components/remote/test_significant_change.py
@@ -1,4 +1,5 @@
 """Test the Remote significant change platform."""
+
 from homeassistant.components.remote import ATTR_ACTIVITY_LIST, ATTR_CURRENT_ACTIVITY
 from homeassistant.components.remote.significant_change import (
     async_check_significant_change,

--- a/tests/components/renault/conftest.py
+++ b/tests/components/renault/conftest.py
@@ -1,4 +1,5 @@
 """Provide common Renault fixtures."""
+
 from collections.abc import Generator
 import contextlib
 from types import MappingProxyType

--- a/tests/components/renault/const.py
+++ b/tests/components/renault/const.py
@@ -1,4 +1,5 @@
 """Constants for the Renault integration tests."""
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.renault.const import (
     CONF_KAMEREON_ACCOUNT_ID,

--- a/tests/components/renault/test_binary_sensor.py
+++ b/tests/components/renault/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Renault binary sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/renault/test_button.py
+++ b/tests/components/renault/test_button.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/renault/test_config_flow.py
+++ b/tests/components/renault/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Renault config flow."""
+
 from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest

--- a/tests/components/renault/test_device_tracker.py
+++ b/tests/components/renault/test_device_tracker.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/renault/test_init.py
+++ b/tests/components/renault/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Renault setup process."""
+
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import Mock, patch

--- a/tests/components/renault/test_select.py
+++ b/tests/components/renault/test_select.py
@@ -1,4 +1,5 @@
 """Tests for Renault selects."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/renault/test_sensor.py
+++ b/tests/components/renault/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/renault/test_services.py
+++ b/tests/components/renault/test_services.py
@@ -1,4 +1,5 @@
 """Tests for Renault sensors."""
+
 from collections.abc import Generator
 from datetime import datetime
 from unittest.mock import patch

--- a/tests/components/renson/test_config_flow.py
+++ b/tests/components/renson/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Renson config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -1,4 +1,5 @@
 """Setup the Reolink tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Reolink config flow."""
+
 from datetime import timedelta
 import json
 from typing import Any

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -1,4 +1,5 @@
 """Test the Reolink init."""
+
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -1,4 +1,5 @@
 """Tests for the Reolink media_source platform."""
+
 from datetime import datetime, timedelta
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -1,4 +1,5 @@
 """Test the repairs websocket API."""
+
 from unittest.mock import AsyncMock, Mock
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Test the repairs websocket API."""
+
 from __future__ import annotations
 
 from http import HTTPStatus

--- a/tests/components/rest/test_notify.py
+++ b/tests/components/rest/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the rest.notify platform."""
+
 from unittest.mock import patch
 
 import respx

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the REST sensor platform."""
+
 from http import HTTPStatus
 import ssl
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/rest/test_switch.py
+++ b/tests/components/rest/test_switch.py
@@ -1,4 +1,5 @@
 """The tests for the REST switch platform."""
+
 from http import HTTPStatus
 
 import httpx

--- a/tests/components/rest_command/conftest.py
+++ b/tests/components/rest_command/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the trend component tests."""
+
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/tests/components/rflink/conftest.py
+++ b/tests/components/rflink/conftest.py
@@ -1,2 +1,3 @@
 """rflink conftest."""
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401

--- a/tests/components/rflink/test_binary_sensor.py
+++ b/tests/components/rflink/test_binary_sensor.py
@@ -3,6 +3,7 @@
 Test setup of rflink sensor component/platform. Verify manual and
 automatic sensor creation.
 """
+
 from datetime import timedelta
 
 from freezegun import freeze_time

--- a/tests/components/rflink/test_cover.py
+++ b/tests/components/rflink/test_cover.py
@@ -4,6 +4,7 @@ Test setup of RFLink covers component/platform. State tracking and
 control of RFLink cover devices.
 
 """
+
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID,

--- a/tests/components/rflink/test_sensor.py
+++ b/tests/components/rflink/test_sensor.py
@@ -4,6 +4,7 @@ Test setup of rflink sensor component/platform. Verify manual and
 automatic sensor creation.
 
 """
+
 from homeassistant.components.rflink import (
     CONF_RECONNECT_INTERVAL,
     DATA_ENTITY_LOOKUP,

--- a/tests/components/rflink/test_switch.py
+++ b/tests/components/rflink/test_switch.py
@@ -4,6 +4,7 @@ Test setup of rflink switch component/platform. State tracking and
 control of Rflink switch devices.
 
 """
+
 from homeassistant.components.rflink import EVENT_BUTTON_PRESSED
 from homeassistant.const import (
     ATTR_ENTITY_ID,

--- a/tests/components/rflink/test_utils.py
+++ b/tests/components/rflink/test_utils.py
@@ -1,4 +1,5 @@
 """Test for RFLink utils methods."""
+
 from homeassistant.components.rflink.utils import (
     brightness_to_rflink,
     rflink_to_brightness,

--- a/tests/components/rfxtrx/conftest.py
+++ b/tests/components/rfxtrx/conftest.py
@@ -1,4 +1,5 @@
 """Common test tools."""
+
 from __future__ import annotations
 
 from unittest.mock import Mock, patch

--- a/tests/components/rfxtrx/test_cover.py
+++ b/tests/components/rfxtrx/test_cover.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx cover platform."""
+
 from unittest.mock import call
 
 import pytest

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -1,4 +1,5 @@
 """The tests for RFXCOM RFXtrx device actions."""
+
 from __future__ import annotations
 
 from typing import Any, NamedTuple

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for RFXCOM RFXtrx device triggers."""
+
 from __future__ import annotations
 
 from typing import Any, NamedTuple

--- a/tests/components/rfxtrx/test_event.py
+++ b/tests/components/rfxtrx/test_event.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx sensor platform."""
+
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx component."""
+
 from __future__ import annotations
 
 from unittest.mock import ANY, call

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx light platform."""
+
 from unittest.mock import call
 
 import pytest

--- a/tests/components/rfxtrx/test_siren.py
+++ b/tests/components/rfxtrx/test_siren.py
@@ -1,4 +1,5 @@
 """The tests for the Rfxtrx siren platform."""
+
 from unittest.mock import call
 
 from homeassistant.components.rfxtrx import DOMAIN

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -1,4 +1,5 @@
 """The tests for the RFXtrx switch platform."""
+
 from unittest.mock import call
 
 import pytest

--- a/tests/components/rhasspy/test_config_flow.py
+++ b/tests/components/rhasspy/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Rhasspy config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/rhasspy/test_init.py
+++ b/tests/components/rhasspy/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Rhasspy integration."""
+
 from homeassistant.components.rhasspy.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/ridwell/conftest.py
+++ b/tests/components/ridwell/conftest.py
@@ -1,4 +1,5 @@
 """Define test fixtures for Ridwell."""
+
 from datetime import date
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/components/ridwell/test_config_flow.py
+++ b/tests/components/ridwell/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ridwell config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from aioridwell.errors import InvalidCredentialsError, RidwellError

--- a/tests/components/ridwell/test_diagnostics.py
+++ b/tests/components/ridwell/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test Ridwell diagnostics."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/ring/common.py
+++ b/tests/components/ring/common.py
@@ -1,4 +1,5 @@
 """Common methods used across the tests for ring devices."""
+
 from unittest.mock import patch
 
 from homeassistant.components.ring import DOMAIN

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Ring tests."""
+
 from collections.abc import Generator
 import re
 from unittest.mock import AsyncMock, Mock, patch

--- a/tests/components/ring/test_binary_sensor.py
+++ b/tests/components/ring/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Ring binary sensor platform."""
+
 from time import time
 from unittest.mock import patch
 

--- a/tests/components/ring/test_config_flow.py
+++ b/tests/components/ring/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ring config flow."""
+
 from unittest.mock import AsyncMock, Mock
 
 import pytest

--- a/tests/components/risco/conftest.py
+++ b/tests/components/risco/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Risco tests."""
+
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -1,4 +1,5 @@
 """Tests for the Risco alarm control panel device."""
+
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Risco binary sensors."""
+
 from unittest.mock import PropertyMock, patch
 
 import pytest

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Risco config flow."""
+
 from unittest.mock import PropertyMock, patch
 
 import pytest

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Risco event sensors."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock, PropertyMock, patch
 

--- a/tests/components/risco/test_switch.py
+++ b/tests/components/risco/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the Risco binary sensors."""
+
 from unittest.mock import PropertyMock, patch
 
 import pytest

--- a/tests/components/risco/util.py
+++ b/tests/components/risco/util.py
@@ -1,4 +1,5 @@
 """Utilities for Risco tests."""
+
 from unittest.mock import AsyncMock, MagicMock
 
 TEST_SITE_UUID = "test-site-uuid"

--- a/tests/components/rituals_perfume_genie/common.py
+++ b/tests/components/rituals_perfume_genie/common.py
@@ -1,4 +1,5 @@
 """Common methods used across tests for Rituals Perfume Genie."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/rituals_perfume_genie/test_binary_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Rituals Perfume Genie binary sensor platform."""
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_ON, EntityCategory
 from homeassistant.core import HomeAssistant

--- a/tests/components/rituals_perfume_genie/test_config_flow.py
+++ b/tests/components/rituals_perfume_genie/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Rituals Perfume Genie config flow."""
+
 from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/rituals_perfume_genie/test_diagnostics.py
+++ b/tests/components/rituals_perfume_genie/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Rituals Perfume Genie integration."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/rituals_perfume_genie/test_init.py
+++ b/tests/components/rituals_perfume_genie/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Rituals Perfume Genie integration."""
+
 from unittest.mock import patch
 
 import aiohttp

--- a/tests/components/rituals_perfume_genie/test_number.py
+++ b/tests/components/rituals_perfume_genie/test_number.py
@@ -1,4 +1,5 @@
 """Tests for the Rituals Perfume Genie number platform."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/rituals_perfume_genie/test_sensor.py
+++ b/tests/components/rituals_perfume_genie/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Rituals Perfume Genie sensor platform."""
+
 from homeassistant.components.rituals_perfume_genie.sensor import SensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,

--- a/tests/components/rituals_perfume_genie/test_switch.py
+++ b/tests/components/rituals_perfume_genie/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the Rituals Perfume Genie switch platform."""
+
 from __future__ import annotations
 
 from homeassistant.components.homeassistant import SERVICE_UPDATE_ENTITY

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -1,4 +1,5 @@
 """Global fixtures for Roborock integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/roborock/mock_data.py
+++ b/tests/components/roborock/mock_data.py
@@ -1,4 +1,5 @@
 """Mock data for Roborock tests."""
+
 from __future__ import annotations
 
 from PIL import Image

--- a/tests/components/roborock/test_button.py
+++ b/tests/components/roborock/test_button.py
@@ -1,4 +1,5 @@
 """Test Roborock Button platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/roborock/test_config_flow.py
+++ b/tests/components/roborock/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Roborock config flow."""
+
 from copy import deepcopy
 from unittest.mock import patch
 

--- a/tests/components/roborock/test_init.py
+++ b/tests/components/roborock/test_init.py
@@ -1,4 +1,5 @@
 """Test for Roborock init."""
+
 from unittest.mock import patch
 
 from roborock import RoborockException, RoborockInvalidCredentials

--- a/tests/components/roborock/test_number.py
+++ b/tests/components/roborock/test_number.py
@@ -1,4 +1,5 @@
 """Test Roborock Number platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -1,4 +1,5 @@
 """Test Roborock Select platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/roborock/test_sensor.py
+++ b/tests/components/roborock/test_sensor.py
@@ -1,4 +1,5 @@
 """Test Roborock Sensors."""
+
 from unittest.mock import patch
 
 from roborock import DeviceData, HomeDataDevice

--- a/tests/components/roborock/test_switch.py
+++ b/tests/components/roborock/test_switch.py
@@ -1,4 +1,5 @@
 """Test Roborock Switch platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/roborock/test_time.py
+++ b/tests/components/roborock/test_time.py
@@ -1,4 +1,5 @@
 """Test Roborock Time platform."""
+
 from datetime import time
 from unittest.mock import patch
 

--- a/tests/components/roku/conftest.py
+++ b/tests/components/roku/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Roku integration tests."""
+
 from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch

--- a/tests/components/roku/test_binary_sensor.py
+++ b/tests/components/roku/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the Roku integration."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/roku/test_diagnostics.py
+++ b/tests/components/roku/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Roku integration."""
+
 from rokuecp import Device as RokuDevice
 from syrupy import SnapshotAssertion
 

--- a/tests/components/roku/test_init.py
+++ b/tests/components/roku/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Roku integration."""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from rokuecp import RokuConnectionError

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -1,4 +1,5 @@
 """Tests for the Roku Media Player platform."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/roku/test_remote.py
+++ b/tests/components/roku/test_remote.py
@@ -1,4 +1,5 @@
 """The tests for the Roku remote platform."""
+
 from unittest.mock import MagicMock
 
 from homeassistant.components.remote import (

--- a/tests/components/roku/test_select.py
+++ b/tests/components/roku/test_select.py
@@ -1,4 +1,5 @@
 """Tests for the Roku select platform."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/roku/test_sensor.py
+++ b/tests/components/roku/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the Roku integration."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/romy/test_config_flow.py
+++ b/tests/components/romy/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the ROMY config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import Mock, PropertyMock, patch
 

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the iRobot Roomba config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import MagicMock, PropertyMock, patch
 

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the roon config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/rpi_power/test_binary_sensor.py
+++ b/tests/components/rpi_power/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for rpi_power binary sensor."""
+
 from datetime import timedelta
 import logging
 from unittest.mock import MagicMock

--- a/tests/components/rpi_power/test_config_flow.py
+++ b/tests/components/rpi_power/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for rpi_power config flow."""
+
 from unittest.mock import MagicMock
 
 from homeassistant.components.rpi_power.const import DOMAIN

--- a/tests/components/rss_feed_template/test_init.py
+++ b/tests/components/rss_feed_template/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the rss_feed_api component."""
+
 from http import HTTPStatus
 
 from defusedxml import ElementTree

--- a/tests/components/rtsp_to_webrtc/test_diagnostics.py
+++ b/tests/components/rtsp_to_webrtc/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test nest diagnostics."""
+
 from typing import Any
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/ruckus_unleashed/test_config_flow.py
+++ b/tests/components/ruckus_unleashed/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ruckus Unleashed config flow."""
+
 from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -1,4 +1,5 @@
 """The sensor tests for the Ruckus Unleashed platform."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock
 

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -1,4 +1,5 @@
 """Test the Ruckus Unleashed config flow."""
+
 from unittest.mock import AsyncMock
 
 from aioruckus.const import ERROR_CONNECT_TIMEOUT, ERROR_LOGIN_INCORRECT

--- a/tests/components/ruuvi_gateway/consts.py
+++ b/tests/components/ruuvi_gateway/consts.py
@@ -1,4 +1,5 @@
 """Constants for ruuvi_gateway tests."""
+
 from __future__ import annotations
 
 ASYNC_SETUP_ENTRY = "homeassistant.components.ruuvi_gateway.async_setup_entry"

--- a/tests/components/ruuvi_gateway/test_config_flow.py
+++ b/tests/components/ruuvi_gateway/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ruuvi Gateway config flow."""
+
 from unittest.mock import patch
 
 from aioruuvigateway.excs import CannotConnect, InvalidAuth

--- a/tests/components/ruuvi_gateway/utils.py
+++ b/tests/components/ruuvi_gateway/utils.py
@@ -1,4 +1,5 @@
 """Utilities for ruuvi_gateway tests."""
+
 from __future__ import annotations
 
 import time

--- a/tests/components/ruuvitag_ble/fixtures.py
+++ b/tests/components/ruuvitag_ble/fixtures.py
@@ -1,4 +1,5 @@
 """Fixtures for testing RuuviTag BLE."""
+
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 NOT_RUUVITAG_SERVICE_INFO = BluetoothServiceInfo(

--- a/tests/components/ruuvitag_ble/test_config_flow.py
+++ b/tests/components/ruuvitag_ble/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ruuvitag config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/rympro/test_config_flow.py
+++ b/tests/components/rympro/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Read Your Meter Pro config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sabnzbd/conftest.py
+++ b/tests/components/sabnzbd/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Sabnzbd tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/sabnzbd/test_config_flow.py
+++ b/tests/components/sabnzbd/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the Sabnzbd config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from pysabnzbd import SabnzbdApiException

--- a/tests/components/sabnzbd/test_init.py
+++ b/tests/components/sabnzbd/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the SABnzbd Integration."""
+
 from unittest.mock import patch
 
 from homeassistant.components.sabnzbd import DEFAULT_NAME, DOMAIN, OLD_SENSOR_KEYS

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Samsung TV."""
+
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Generator

--- a/tests/components/samsungtv/const.py
+++ b/tests/components/samsungtv/const.py
@@ -1,4 +1,5 @@
 """Constants for the samsungtv tests."""
+
 from samsungtvws.event import ED_INSTALLED_APP_EVENT
 
 from homeassistant.components import ssdp

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Samsung TV config flow."""
+
 from copy import deepcopy
 from ipaddress import ip_address
 from unittest.mock import ANY, AsyncMock, Mock, call, patch

--- a/tests/components/samsungtv/test_diagnostics.py
+++ b/tests/components/samsungtv/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test samsungtv diagnostics."""
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Samsung TV Integration."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -1,4 +1,5 @@
 """Tests for samsungtv component."""
+
 from copy import deepcopy
 from datetime import datetime, timedelta
 import logging

--- a/tests/components/samsungtv/test_remote.py
+++ b/tests/components/samsungtv/test_remote.py
@@ -1,4 +1,5 @@
 """The tests for the SamsungTV remote platform."""
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/components/samsungtv/test_trigger.py
+++ b/tests/components/samsungtv/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for WebOS TV automation triggers."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/scene/common.py
+++ b/tests/components/scene/common.py
@@ -3,6 +3,7 @@
 All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
+
 from homeassistant.components.scene import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_ON
 from homeassistant.loader import bind_hass

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -1,4 +1,5 @@
 """Test for the Schedule integration."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/tests/components/schedule/test_recorder.py
+++ b/tests/components/schedule/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for recorder platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/schlage/conftest.py
+++ b/tests/components/schlage/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Schlage tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, create_autospec, patch
 

--- a/tests/components/schlage/test_config_flow.py
+++ b/tests/components/schlage/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Schlage config flow."""
+
 from unittest.mock import AsyncMock, Mock
 
 from pyschlage.exceptions import Error as PyschlageError, NotAuthorizedError

--- a/tests/components/schlage/test_switch.py
+++ b/tests/components/schlage/test_switch.py
@@ -1,4 +1,5 @@
 """Test schlage switch."""
+
 from unittest.mock import Mock
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN

--- a/tests/components/scrape/conftest.py
+++ b/tests/components/scrape/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Scrape integration."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/scrape/test_config_flow.py
+++ b/tests/components/scrape/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Scrape config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -1,4 +1,5 @@
 """Test Scrape component setup process."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/scrape/test_sensor.py
+++ b/tests/components/scrape/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Scrape sensor platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Pentair ScreenLogic config flow."""
+
 from unittest.mock import patch
 
 from screenlogicpy import ScreenLogicError

--- a/tests/components/screenlogic/test_data.py
+++ b/tests/components/screenlogic/test_data.py
@@ -1,4 +1,5 @@
 """Tests for ScreenLogic integration data processing."""
+
 from unittest.mock import DEFAULT, patch
 
 from screenlogicpy import ScreenLogicGateway

--- a/tests/components/screenlogic/test_diagnostics.py
+++ b/tests/components/screenlogic/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Testing for ScreenLogic diagnostics."""
+
 from unittest.mock import DEFAULT, patch
 
 from screenlogicpy import ScreenLogicGateway

--- a/tests/components/screenlogic/test_init.py
+++ b/tests/components/screenlogic/test_init.py
@@ -1,4 +1,5 @@
 """Tests for ScreenLogic integration init."""
+
 from dataclasses import dataclass
 from unittest.mock import DEFAULT, patch
 

--- a/tests/components/script/test_recorder.py
+++ b/tests/components/script/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for script recorder."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/season/conftest.py
+++ b/tests/components/season/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Season integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/season/test_config_flow.py
+++ b/tests/components/season/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Season config flow."""
+
 from unittest.mock import MagicMock
 
 from homeassistant.components.season.const import DOMAIN, TYPE_ASTRONOMICAL

--- a/tests/components/season/test_init.py
+++ b/tests/components/season/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Season integration."""
+
 from homeassistant.components.season.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/season/test_sensor.py
+++ b/tests/components/season/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Season integration."""
+
 from datetime import datetime
 
 from freezegun import freeze_time

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -1,4 +1,5 @@
 """The tests for Select device conditions."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for Select device triggers."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/select/test_init.py
+++ b/tests/components/select/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Select component."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/select/test_recorder.py
+++ b/tests/components/select/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for select recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/select/test_significant_change.py
+++ b/tests/components/select/test_significant_change.py
@@ -1,4 +1,5 @@
 """Test the select significant change platform."""
+
 from homeassistant.components.select.significant_change import (
     async_check_significant_change,
 )

--- a/tests/components/sense/test_config_flow.py
+++ b/tests/components/sense/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Sense config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/sensibo/conftest.py
+++ b/tests/components/sensibo/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Sensibo integration."""
+
 from __future__ import annotations
 
 import json

--- a/tests/components/sensibo/test_binary_sensor.py
+++ b/tests/components/sensibo/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the sensibo binary sensor platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_button.py
+++ b/tests/components/sensibo/test_button.py
@@ -1,4 +1,5 @@
 """The test for the sensibo button platform."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/sensibo/test_climate.py
+++ b/tests/components/sensibo/test_climate.py
@@ -1,4 +1,5 @@
 """The test for the sensibo binary sensor platform."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/sensibo/test_config_flow.py
+++ b/tests/components/sensibo/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Sensibo config flow."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/components/sensibo/test_coordinator.py
+++ b/tests/components/sensibo/test_coordinator.py
@@ -1,4 +1,5 @@
 """The test for the sensibo coordinator."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_diagnostics.py
+++ b/tests/components/sensibo/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test Sensibo diagnostics."""
+
 from __future__ import annotations
 
 from syrupy.assertion import SnapshotAssertion

--- a/tests/components/sensibo/test_entity.py
+++ b/tests/components/sensibo/test_entity.py
@@ -1,4 +1,5 @@
 """The test for the sensibo entity."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/sensibo/test_init.py
+++ b/tests/components/sensibo/test_init.py
@@ -1,4 +1,5 @@
 """Test for Sensibo component Init."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/sensibo/test_number.py
+++ b/tests/components/sensibo/test_number.py
@@ -1,4 +1,5 @@
 """The test for the sensibo number platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_select.py
+++ b/tests/components/sensibo/test_select.py
@@ -1,4 +1,5 @@
 """The test for the sensibo select platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_sensor.py
+++ b/tests/components/sensibo/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the sensibo select platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_switch.py
+++ b/tests/components/sensibo/test_switch.py
@@ -1,4 +1,5 @@
 """The test for the sensibo switch platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensibo/test_update.py
+++ b/tests/components/sensibo/test_update.py
@@ -1,4 +1,5 @@
 """The test for the sensibo update platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sensirion_ble/fixtures.py
+++ b/tests/components/sensirion_ble/fixtures.py
@@ -1,4 +1,5 @@
 """Fixtures for testing Sensirion BLE."""
+
 from homeassistant.helpers.service_info.bluetooth import BluetoothServiceInfo
 
 NOT_SENSIRION_SERVICE_INFO = BluetoothServiceInfo(

--- a/tests/components/sensirion_ble/test_config_flow.py
+++ b/tests/components/sensirion_ble/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Sensirion config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for sensor device automation."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -1,4 +1,5 @@
 """The test for sensor entity."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for sensor recorder platform."""
+
 from collections.abc import Callable
 from datetime import datetime, timedelta
 import math

--- a/tests/components/sensor/test_recorder_missing_stats.py
+++ b/tests/components/sensor/test_recorder_missing_stats.py
@@ -1,4 +1,5 @@
 """The tests for sensor recorder platform can catch up."""
+
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/components/sensor/test_websocket_api.py
+++ b/tests/components/sensor/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Test the sensor websocket API."""
+
 from pytest_unordered import unordered
 
 from homeassistant.components.sensor.const import (

--- a/tests/components/sensorpro/test_config_flow.py
+++ b/tests/components/sensorpro/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SensorPro config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/sensorpro/test_sensor.py
+++ b/tests/components/sensorpro/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the SensorPro sensors."""
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.sensorpro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT

--- a/tests/components/sensorpush/test_config_flow.py
+++ b/tests/components/sensorpush/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SensorPush config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/sensorpush/test_sensor.py
+++ b/tests/components/sensorpush/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the SensorPush sensors."""
+
 from datetime import timedelta
 import time
 

--- a/tests/components/sentry/conftest.py
+++ b/tests/components/sentry/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Sentry tests."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/components/senz/test_config_flow.py
+++ b/tests/components/senz/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SENZ config flow."""
+
 from unittest.mock import patch
 
 from aiosenz import AUTHORIZATION_ENDPOINT, TOKEN_ENDPOINT

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the seventeentrack sensor."""
+
 from __future__ import annotations
 
 import datetime

--- a/tests/components/sfr_box/conftest.py
+++ b/tests/components/sfr_box/conftest.py
@@ -1,4 +1,5 @@
 """Provide common SFR Box fixtures."""
+
 from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, patch

--- a/tests/components/sfr_box/test_binary_sensor.py
+++ b/tests/components/sfr_box/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test the SFR Box binary sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/sfr_box/test_button.py
+++ b/tests/components/sfr_box/test_button.py
@@ -1,4 +1,5 @@
 """Test the SFR Box buttons."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/sfr_box/test_diagnostics.py
+++ b/tests/components/sfr_box/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test the SFR Box diagnostics."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/sfr_box/test_init.py
+++ b/tests/components/sfr_box/test_init.py
@@ -1,4 +1,5 @@
 """Test the SFR Box setup process."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/sfr_box/test_sensor.py
+++ b/tests/components/sfr_box/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the SFR Box sensors."""
+
 from collections.abc import Generator
 from unittest.mock import patch
 

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Shark IQ config flow."""
+
 from unittest.mock import patch
 
 import aiohttp

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -1,4 +1,5 @@
 """Test the Shark IQ vacuum entity."""
+
 from __future__ import annotations
 
 from collections.abc import Iterable

--- a/tests/components/shell_command/test_init.py
+++ b/tests/components/shell_command/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Shell command component."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/shelly/bluetooth/test_scanner.py
+++ b/tests/components/shelly/bluetooth/test_scanner.py
@@ -1,4 +1,5 @@
 """Test the shelly bluetooth scanner."""
+
 from __future__ import annotations
 
 from aioshelly.ble.const import BLE_SCAN_RESULT_EVENT

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration for Shelly."""
+
 from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from aioshelly.block_device import BlockDevice, BlockUpdateType

--- a/tests/components/shelly/test_binary_sensor.py
+++ b/tests/components/shelly/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Shelly binary sensor platform."""
+
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_MOTION

--- a/tests/components/shelly/test_button.py
+++ b/tests/components/shelly/test_button.py
@@ -1,4 +1,5 @@
 """Tests for Shelly button platform."""
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -1,4 +1,5 @@
 """Tests for Shelly climate platform."""
+
 from copy import deepcopy
 from unittest.mock import AsyncMock, Mock, PropertyMock
 

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Shelly config flow."""
+
 from dataclasses import replace
 from ipaddress import ip_address
 from typing import Any

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -1,4 +1,5 @@
 """Tests for Shelly coordinator."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/components/shelly/test_cover.py
+++ b/tests/components/shelly/test_cover.py
@@ -1,4 +1,5 @@
 """Tests for Shelly cover platform."""
+
 from unittest.mock import Mock
 
 import pytest

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for Shelly device triggers."""
+
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_BUTTON1

--- a/tests/components/shelly/test_diagnostics.py
+++ b/tests/components/shelly/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for Shelly diagnostics platform."""
+
 from unittest.mock import ANY, Mock
 
 from aioshelly.ble.const import BLE_SCAN_RESULT_EVENT

--- a/tests/components/shelly/test_event.py
+++ b/tests/components/shelly/test_event.py
@@ -1,4 +1,5 @@
 """Tests for Shelly button platform."""
+
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_I3

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -1,4 +1,5 @@
 """Test cases for the Shelly component."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 from aioshelly.exceptions import (

--- a/tests/components/shelly/test_light.py
+++ b/tests/components/shelly/test_light.py
@@ -1,4 +1,5 @@
 """Tests for Shelly light platform."""
+
 from unittest.mock import AsyncMock, Mock
 
 from aioshelly.const import (

--- a/tests/components/shelly/test_logbook.py
+++ b/tests/components/shelly/test_logbook.py
@@ -1,4 +1,5 @@
 """The tests for Shelly logbook."""
+
 from unittest.mock import Mock
 
 from homeassistant.components.shelly.const import (

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -1,4 +1,5 @@
 """Tests for Shelly number platform."""
+
 from unittest.mock import AsyncMock, Mock
 
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError

--- a/tests/components/shelly/test_sensor.py
+++ b/tests/components/shelly/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Shelly sensor platform."""
+
 from copy import deepcopy
 from unittest.mock import Mock
 

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for Shelly switch platform."""
+
 from copy import deepcopy
 from unittest.mock import AsyncMock, Mock
 

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -1,4 +1,5 @@
 """Tests for Shelly update platform."""
+
 from unittest.mock import AsyncMock, Mock
 
 from aioshelly.exceptions import DeviceConnectionError, InvalidAuthError, RpcCallError

--- a/tests/components/shelly/test_utils.py
+++ b/tests/components/shelly/test_utils.py
@@ -1,4 +1,5 @@
 """Tests for Shelly utils."""
+
 from typing import Any
 from unittest.mock import Mock
 

--- a/tests/components/shelly/test_valve.py
+++ b/tests/components/shelly/test_valve.py
@@ -1,4 +1,5 @@
 """Tests for Shelly valve platform."""
+
 from unittest.mock import Mock
 
 from aioshelly.const import MODEL_GAS

--- a/tests/components/shopping_list/conftest.py
+++ b/tests/components/shopping_list/conftest.py
@@ -1,4 +1,5 @@
 """Shopping list test helpers."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/shopping_list/test_config_flow.py
+++ b/tests/components/shopping_list/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow."""
+
 from homeassistant.components.shopping_list.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.core import HomeAssistant

--- a/tests/components/shopping_list/test_init.py
+++ b/tests/components/shopping_list/test_init.py
@@ -1,4 +1,5 @@
 """Test shopping list component."""
+
 from http import HTTPStatus
 
 import pytest

--- a/tests/components/shopping_list/test_intent.py
+++ b/tests/components/shopping_list/test_intent.py
@@ -1,4 +1,5 @@
 """Test Shopping List intents."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import intent
 

--- a/tests/components/sia/test_config_flow.py
+++ b/tests/components/sia/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the sia config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sigfox/test_sensor.py
+++ b/tests/components/sigfox/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sigfox sensor."""
+
 from http import HTTPStatus
 import re
 

--- a/tests/components/sighthound/test_image_processing.py
+++ b/tests/components/sighthound/test_image_processing.py
@@ -1,4 +1,5 @@
 """Tests for the Sighthound integration."""
+
 from copy import deepcopy
 import datetime
 import os

--- a/tests/components/signal_messenger/conftest.py
+++ b/tests/components/signal_messenger/conftest.py
@@ -1,4 +1,5 @@
 """Signal notification test helpers."""
+
 from http import HTTPStatus
 
 from pysignalclirestapi import SignalCliRestApi

--- a/tests/components/simplepush/test_config_flow.py
+++ b/tests/components/simplepush/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Simplepush config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/simplisafe/test_diagnostics.py
+++ b/tests/components/simplisafe/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test SimpliSafe diagnostics."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/simplisafe/test_init.py
+++ b/tests/components/simplisafe/test_init.py
@@ -1,4 +1,5 @@
 """Define tests for SimpliSafe setup."""
+
 from unittest.mock import patch
 
 from homeassistant.components.simplisafe import DOMAIN

--- a/tests/components/simulated/test_sensor.py
+++ b/tests/components/simulated/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the simulated sensor."""
+
 from homeassistant.components.simulated.sensor import (
     CONF_AMP,
     CONF_FWHM,

--- a/tests/components/siren/test_init.py
+++ b/tests/components/siren/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the siren component."""
+
 from types import ModuleType
 from unittest.mock import MagicMock
 

--- a/tests/components/siren/test_recorder.py
+++ b/tests/components/siren/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for siren recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/skybell/conftest.py
+++ b/tests/components/skybell/conftest.py
@@ -1,4 +1,5 @@
 """Configure pytest for Skybell tests."""
+
 from unittest.mock import AsyncMock, patch
 
 from aioskybell import Skybell, SkybellDevice

--- a/tests/components/skybell/test_binary_sensor.py
+++ b/tests/components/skybell/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Binary sensor tests for the Skybell integration."""
+
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import ATTR_DEVICE_CLASS, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant

--- a/tests/components/skybell/test_config_flow.py
+++ b/tests/components/skybell/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test SkyBell config flow."""
+
 from unittest.mock import patch
 
 from aioskybell import exceptions

--- a/tests/components/slack/test_config_flow.py
+++ b/tests/components/slack/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Slack config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/slack/test_init.py
+++ b/tests/components/slack/test_init.py
@@ -1,4 +1,5 @@
 """Test Slack integration."""
+
 from homeassistant.components.slack.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -1,4 +1,5 @@
 """Test slack notifications."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock

--- a/tests/components/sleepiq/conftest.py
+++ b/tests/components/sleepiq/conftest.py
@@ -1,4 +1,5 @@
 """Common methods for SleepIQ."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/sleepiq/test_binary_sensor.py
+++ b/tests/components/sleepiq/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ binary sensor platform."""
+
 from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceClass
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,

--- a/tests/components/sleepiq/test_button.py
+++ b/tests/components/sleepiq/test_button.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ binary sensor platform."""
+
 from homeassistant.components.button import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant

--- a/tests/components/sleepiq/test_config_flow.py
+++ b/tests/components/sleepiq/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the SleepIQ config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from asyncsleepiq import SleepIQLoginException, SleepIQTimeoutException

--- a/tests/components/sleepiq/test_init.py
+++ b/tests/components/sleepiq/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the SleepIQ integration."""
+
 from asyncsleepiq import (
     SleepIQAPIException,
     SleepIQLoginException,

--- a/tests/components/sleepiq/test_light.py
+++ b/tests/components/sleepiq/test_light.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ light platform."""
+
 from homeassistant.components.light import DOMAIN
 from homeassistant.components.sleepiq.coordinator import LONGER_UPDATE_INTERVAL
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON

--- a/tests/components/sleepiq/test_number.py
+++ b/tests/components/sleepiq/test_number.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ number platform."""
+
 from homeassistant.components.number import (
     ATTR_MAX,
     ATTR_MIN,

--- a/tests/components/sleepiq/test_select.py
+++ b/tests/components/sleepiq/test_select.py
@@ -1,4 +1,5 @@
 """Tests for the SleepIQ select platform."""
+
 from unittest.mock import MagicMock
 
 from asyncsleepiq import FootWarmingTemps

--- a/tests/components/sleepiq/test_sensor.py
+++ b/tests/components/sleepiq/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ sensor platform."""
+
 from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON
 from homeassistant.core import HomeAssistant

--- a/tests/components/sleepiq/test_switch.py
+++ b/tests/components/sleepiq/test_switch.py
@@ -1,4 +1,5 @@
 """The tests for SleepIQ switch platform."""
+
 from homeassistant.components.sleepiq.coordinator import LONGER_UPDATE_INTERVAL
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON

--- a/tests/components/slimproto/conftest.py
+++ b/tests/components/slimproto/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the SlimProto Player integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/slimproto/test_config_flow.py
+++ b/tests/components/slimproto/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SlimProto Player config flow."""
+
 from unittest.mock import AsyncMock
 
 from homeassistant.components.slimproto.const import DEFAULT_NAME, DOMAIN

--- a/tests/components/sma/conftest.py
+++ b/tests/components/sma/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for sma tests."""
+
 from unittest.mock import patch
 
 from pysma.const import GENERIC_SENSORS

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the sma config flow."""
+
 from unittest.mock import patch
 
 from pysma.exceptions import (

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the sma sensor platform."""
+
 from pysma.const import (
     ENERGY_METER_VIA_INVERTER,
     GENERIC_SENSORS,

--- a/tests/components/smappee/test_config_flow.py
+++ b/tests/components/smappee/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Smappee component config flow module."""
+
 from http import HTTPStatus
 from ipaddress import ip_address
 from unittest.mock import patch

--- a/tests/components/smappee/test_init.py
+++ b/tests/components/smappee/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Smappee component init module."""
+
 from unittest.mock import patch
 
 from homeassistant.components.smappee.const import DOMAIN

--- a/tests/components/smart_meter_texas/conftest.py
+++ b/tests/components/smart_meter_texas/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration and mocks for Smart Meter Texas."""
+
 from http import HTTPStatus
 import json
 

--- a/tests/components/smart_meter_texas/test_config_flow.py
+++ b/tests/components/smart_meter_texas/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Smart Meter Texas config flow."""
+
 from unittest.mock import patch
 
 from aiohttp import ClientError

--- a/tests/components/smart_meter_texas/test_init.py
+++ b/tests/components/smart_meter_texas/test_init.py
@@ -1,4 +1,5 @@
 """Test the Smart Meter Texas module."""
+
 from unittest.mock import patch
 
 from homeassistant.components.homeassistant import (

--- a/tests/components/smart_meter_texas/test_sensor.py
+++ b/tests/components/smart_meter_texas/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the Smart Meter Texas sensor entity."""
+
 from unittest.mock import patch
 
 from homeassistant.components.homeassistant import (

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
 from homeassistant.components.binary_sensor import (

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 from pysmartthings.device import Status
 import pytest

--- a/tests/components/smartthings/test_config_flow.py
+++ b/tests/components/smartthings/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the SmartThings config flow module."""
+
 from http import HTTPStatus
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 
 from homeassistant.components.cover import (

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 
 from homeassistant.components.fan import (

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the SmartThings component init module."""
+
 from http import HTTPStatus
 from unittest.mock import Mock, patch
 from uuid import uuid4

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 import pytest
 

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 from pysmartthings.device import Status
 

--- a/tests/components/smartthings/test_scene.py
+++ b/tests/components/smartthings/test_scene.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNAVAILABLE

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import ATTRIBUTES, CAPABILITIES, Attribute, Capability
 
 from homeassistant.components.sensor import (

--- a/tests/components/smartthings/test_smartapp.py
+++ b/tests/components/smartthings/test_smartapp.py
@@ -1,4 +1,5 @@
 """Tests for the smartapp module."""
+
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
 

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -3,6 +3,7 @@
 The only mocking required is of the underlying SmartThings API object so
 real HTTP calls are not initiated during testing.
 """
+
 from pysmartthings import Attribute, Capability
 
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE

--- a/tests/components/smarttub/test_binary_sensor.py
+++ b/tests/components/smarttub/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test the SmartTub binary sensor platform."""
+
 from datetime import datetime
 from unittest.mock import create_autospec
 

--- a/tests/components/smarttub/test_config_flow.py
+++ b/tests/components/smarttub/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the smarttub config flow."""
+
 from unittest.mock import patch
 
 from smarttub import LoginFailed

--- a/tests/components/smarttub/test_init.py
+++ b/tests/components/smarttub/test_init.py
@@ -1,4 +1,5 @@
 """Test smarttub setup process."""
+
 from unittest.mock import patch
 
 from smarttub import LoginFailed

--- a/tests/components/smhi/common.py
+++ b/tests/components/smhi/common.py
@@ -1,4 +1,5 @@
 """Common test utilities."""
+
 from unittest.mock import Mock
 
 

--- a/tests/components/smhi/test_config_flow.py
+++ b/tests/components/smhi/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Smhi config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/smhi/test_init.py
+++ b/tests/components/smhi/test_init.py
@@ -1,4 +1,5 @@
 """Test SMHI component setup process."""
+
 from unittest.mock import patch
 
 from smhi.smhi_lib import APIURL_TEMPLATE

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -1,4 +1,5 @@
 """Test for the smhi weather entity."""
+
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the notify smtp platform."""
+
 from pathlib import Path
 import re
 from unittest.mock import patch

--- a/tests/components/snapcast/conftest.py
+++ b/tests/components/snapcast/conftest.py
@@ -1,4 +1,5 @@
 """Test the snapcast config flow."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/snooz/conftest.py
+++ b/tests/components/snooz/conftest.py
@@ -1,4 +1,5 @@
 """Snooz test fixtures and configuration."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/snooz/test_config_flow.py
+++ b/tests/components/snooz/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Snooz config flow."""
+
 from __future__ import annotations
 
 from asyncio import Event

--- a/tests/components/snooz/test_fan.py
+++ b/tests/components/snooz/test_fan.py
@@ -1,4 +1,5 @@
 """Test Snooz fan entity."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/snooz/test_init.py
+++ b/tests/components/snooz/test_init.py
@@ -1,4 +1,5 @@
 """Test Snooz configuration."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/solaredge/test_config_flow.py
+++ b/tests/components/solaredge/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the SolarEdge config flow."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/solaredge/test_coordinator.py
+++ b/tests/components/solaredge/test_coordinator.py
@@ -1,4 +1,5 @@
 """Tests for the SolarEdge coordinator services."""
+
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/solarlog/test_config_flow.py
+++ b/tests/components/solarlog/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the solarlog config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the solax config flow."""
+
 from unittest.mock import patch
 
 from solax import RealTimeAPI

--- a/tests/components/soma/test_config_flow.py
+++ b/tests/components/soma/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Soma config flow."""
+
 from unittest.mock import patch
 
 from api.soma_api import SomaApi

--- a/tests/components/somfy_mylink/test_config_flow.py
+++ b/tests/components/somfy_mylink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Somfy MyLink config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sonarr/conftest.py
+++ b/tests/components/sonarr/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Sonarr integration tests."""
+
 from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch

--- a/tests/components/sonarr/test_config_flow.py
+++ b/tests/components/sonarr/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Sonarr config flow."""
+
 from unittest.mock import MagicMock, patch
 
 from aiopyarr import ArrAuthenticationException, ArrException

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Sonsrr integration."""
+
 from unittest.mock import MagicMock, patch
 
 from aiopyarr import ArrAuthenticationException, ArrException

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Sonarr sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/components/songpal/test_init.py
+++ b/tests/components/songpal/test_init.py
@@ -1,4 +1,5 @@
 """Tests songpal setup."""
+
 from unittest.mock import patch
 
 from homeassistant.components import songpal

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -1,4 +1,5 @@
 """Test songpal media_player."""
+
 from datetime import timedelta
 import logging
 from unittest.mock import AsyncMock, MagicMock, call, patch

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Sonos tests."""
+
 from copy import copy
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock, patch

--- a/tests/components/sonos/test_config_flow.py
+++ b/tests/components/sonos/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the sonos config flow."""
+
 from __future__ import annotations
 
 from ipaddress import ip_address

--- a/tests/components/sonos/test_helpers.py
+++ b/tests/components/sonos/test_helpers.py
@@ -1,4 +1,5 @@
 """Test the sonos config flow."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,4 +1,5 @@
 """Tests for the Sonos Media Player platform."""
+
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import (

--- a/tests/components/sonos/test_number.py
+++ b/tests/components/sonos/test_number.py
@@ -1,4 +1,5 @@
 """Tests for the Sonos number platform."""
+
 from unittest.mock import PropertyMock, patch
 
 from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN, SERVICE_SET_VALUE

--- a/tests/components/sonos/test_repairs.py
+++ b/tests/components/sonos/test_repairs.py
@@ -1,4 +1,5 @@
 """Test repairs handling for Sonos."""
+
 from unittest.mock import Mock
 
 from homeassistant.components.sonos.const import (

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Sonos battery sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import PropertyMock, patch
 

--- a/tests/components/sonos/test_services.py
+++ b/tests/components/sonos/test_services.py
@@ -1,4 +1,5 @@
 """Tests for Sonos services."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/sonos/test_speaker.py
+++ b/tests/components/sonos/test_speaker.py
@@ -1,4 +1,5 @@
 """Tests for common SonosSpeaker behavior."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sonos/test_statistics.py
+++ b/tests/components/sonos/test_statistics.py
@@ -1,4 +1,5 @@
 """Tests for the Sonos statistics."""
+
 from homeassistant.components.sonos.const import DATA_SONOS
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the Sonos Alarm switch platform."""
+
 from copy import copy
 from datetime import timedelta
 from unittest.mock import patch

--- a/tests/components/soundtouch/test_config_flow.py
+++ b/tests/components/soundtouch/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/soundtouch/test_media_player.py
+++ b/tests/components/soundtouch/test_media_player.py
@@ -1,4 +1,5 @@
 """Test the SoundTouch component."""
+
 from datetime import timedelta
 from typing import Any
 

--- a/tests/components/spaceapi/test_init.py
+++ b/tests/components/spaceapi/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Home Assistant SpaceAPI component."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/spc/test_init.py
+++ b/tests/components/spc/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Vanderbilt SPC component."""
+
 from unittest.mock import Mock, PropertyMock, patch
 
 from homeassistant.bootstrap import async_setup_component

--- a/tests/components/speedtestdotnet/conftest.py
+++ b/tests/components/speedtestdotnet/conftest.py
@@ -1,4 +1,5 @@
 """Conftest for speedtestdotnet."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/speedtestdotnet/test_config_flow.py
+++ b/tests/components/speedtestdotnet/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for SpeedTest config flow."""
+
 from unittest.mock import MagicMock
 
 from homeassistant import config_entries

--- a/tests/components/speedtestdotnet/test_sensor.py
+++ b/tests/components/speedtestdotnet/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for SpeedTest sensors."""
+
 from unittest.mock import MagicMock
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN

--- a/tests/components/spider/test_config_flow.py
+++ b/tests/components/spider/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Spider config flow."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/spotify/test_config_flow.py
+++ b/tests/components/spotify/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Spotify config flow."""
+
 from http import HTTPStatus
 from ipaddress import ip_address
 from unittest.mock import patch

--- a/tests/components/sql/test_config_flow.py
+++ b/tests/components/sql/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SQL config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -1,4 +1,5 @@
 """Test for SQL component Init."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/sql/test_sensor.py
+++ b/tests/components/sql/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the sql sensor platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sql/test_util.py
+++ b/tests/components/sql/test_util.py
@@ -1,4 +1,5 @@
 """Test the sql utils."""
+
 from homeassistant.components.recorder import Recorder, get_instance
 from homeassistant.components.sql.util import resolve_db_url
 from homeassistant.core import HomeAssistant

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Logitech Squeezebox config flow."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/srp_energy/conftest.py
+++ b/tests/components/srp_energy/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Srp Energy integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SRP Energy config flow."""
+
 from unittest.mock import MagicMock, patch
 
 from homeassistant.components.srp_energy.const import CONF_IS_TOU, DOMAIN

--- a/tests/components/srp_energy/test_init.py
+++ b/tests/components/srp_energy/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Srp Energy component Init."""
+
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/ssdp/conftest.py
+++ b/tests/components/ssdp/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for SSDP tests."""
+
 from unittest.mock import AsyncMock, patch
 
 from async_upnp_client.server import UpnpServer

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,4 +1,5 @@
 """Test the SSDP integration."""
+
 from datetime import datetime
 from ipaddress import IPv4Address
 from unittest.mock import ANY, AsyncMock, patch

--- a/tests/components/starlink/test_config_flow.py
+++ b/tests/components/starlink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Starlink config flow."""
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.starlink.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER

--- a/tests/components/starlink/test_diagnostics.py
+++ b/tests/components/starlink/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for Starlink diagnostics."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.starlink.const import DOMAIN

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -1,4 +1,5 @@
 """Tests Starlink integration init/unload."""
+
 from homeassistant.components.starlink.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS

--- a/tests/components/startca/test_sensor.py
+++ b/tests/components/startca/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Start.ca sensor platform."""
+
 from http import HTTPStatus
 
 from homeassistant.bootstrap import async_setup_component

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the statistics sensor platform."""
+
 from __future__ import annotations
 
 from collections.abc import Sequence

--- a/tests/components/statsd/test_init.py
+++ b/tests/components/statsd/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the StatsD feeder."""
+
 from unittest import mock
 from unittest.mock import patch
 

--- a/tests/components/steam_online/test_config_flow.py
+++ b/tests/components/steam_online/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Steam config flow."""
+
 from unittest.mock import patch
 
 import steam

--- a/tests/components/steamist/test_config_flow.py
+++ b/tests/components/steamist/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Steamist config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the steamist component."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/steamist/test_sensor.py
+++ b/tests/components/steamist/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the steamist sensos."""
+
 from __future__ import annotations
 
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, UnitOfTemperature, UnitOfTime

--- a/tests/components/steamist/test_switch.py
+++ b/tests/components/steamist/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the steamist switch."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/stookalert/test_config_flow.py
+++ b/tests/components/stookalert/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Stookalert config flow."""
+
 from unittest.mock import patch
 
 from homeassistant.components.stookalert.const import CONF_PROVINCE, DOMAIN

--- a/tests/components/stookwijzer/test_config_flow.py
+++ b/tests/components/stookwijzer/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Stookwijzer config flow."""
+
 from unittest.mock import patch
 
 from homeassistant.components.stookwijzer.const import DOMAIN

--- a/tests/components/stream/common.py
+++ b/tests/components/stream/common.py
@@ -1,4 +1,5 @@
 """Collection of test helpers."""
+
 from fractions import Fraction
 import functools
 from functools import partial

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -9,6 +9,7 @@ nothing for the test to verify. The solution is the WorkerSync class that
 allows the tests to pause the worker thread before finalizing the stream
 so that it can inspect the output.
 """
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -1,4 +1,5 @@
 """The tests for hls streams."""
+
 from datetime import timedelta
 from http import HTTPStatus
 import logging

--- a/tests/components/streamlabswater/conftest.py
+++ b/tests/components/streamlabswater/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the StreamLabs tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/streamlabswater/test_binary_sensor.py
+++ b/tests/components/streamlabswater/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Streamlabs Water binary sensor platform."""
+
 from unittest.mock import AsyncMock, patch
 
 from syrupy import SnapshotAssertion

--- a/tests/components/streamlabswater/test_config_flow.py
+++ b/tests/components/streamlabswater/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the StreamLabs config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from homeassistant import config_entries

--- a/tests/components/streamlabswater/test_sensor.py
+++ b/tests/components/streamlabswater/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Streamlabs Water sensor platform."""
+
 from unittest.mock import AsyncMock, patch
 
 from syrupy import SnapshotAssertion

--- a/tests/components/stt/common.py
+++ b/tests/components/stt/common.py
@@ -1,4 +1,5 @@
 """Provide common test tools for STT."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -1,4 +1,5 @@
 """Test STT component setup."""
+
 from collections.abc import AsyncIterable, Generator
 from http import HTTPStatus
 from pathlib import Path

--- a/tests/components/stt/test_legacy.py
+++ b/tests/components/stt/test_legacy.py
@@ -1,4 +1,5 @@
 """Test the legacy stt setup."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/tests/components/subaru/conftest.py
+++ b/tests/components/subaru/conftest.py
@@ -1,4 +1,5 @@
 """Common functions needed to setup tests for Subaru component."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Subaru component config flow."""
+
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import PropertyMock, patch

--- a/tests/components/subaru/test_device_tracker.py
+++ b/tests/components/subaru/test_device_tracker.py
@@ -1,4 +1,5 @@
 """Test Subaru device tracker."""
+
 from copy import deepcopy
 from unittest.mock import patch
 

--- a/tests/components/subaru/test_init.py
+++ b/tests/components/subaru/test_init.py
@@ -1,4 +1,5 @@
 """Test Subaru component setup and updates."""
+
 from unittest.mock import patch
 
 from subarulink import InvalidCredentials, SubaruException

--- a/tests/components/subaru/test_lock.py
+++ b/tests/components/subaru/test_lock.py
@@ -1,4 +1,5 @@
 """Test Subaru locks."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/subaru/test_sensor.py
+++ b/tests/components/subaru/test_sensor.py
@@ -1,4 +1,5 @@
 """Test Subaru sensors."""
+
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/components/suez_water/conftest.py
+++ b/tests/components/suez_water/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Suez Water tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/suez_water/test_config_flow.py
+++ b/tests/components/suez_water/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Suez Water config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from pysuez.client import PySuezError

--- a/tests/components/sun/test_config_flow.py
+++ b/tests/components/sun/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Sun config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Sun component."""
+
 from datetime import datetime, timedelta
 from unittest.mock import patch
 

--- a/tests/components/sun/test_recorder.py
+++ b/tests/components/sun/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for sun recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/sun/test_sensor.py
+++ b/tests/components/sun/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Sun sensor platform."""
+
 from datetime import datetime, timedelta
 
 from astral import LocationInfo

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for the sun automation."""
+
 from datetime import datetime
 
 from freezegun import freeze_time

--- a/tests/components/sunweg/test_config_flow.py
+++ b/tests/components/sunweg/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Sun WEG server config flow."""
+
 from unittest.mock import patch
 
 from sunweg.api import APIHelper

--- a/tests/components/surepetcare/conftest.py
+++ b/tests/components/surepetcare/conftest.py
@@ -1,4 +1,5 @@
 """Define fixtures available for all tests."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Sure Petcare binary sensor platform."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 

--- a/tests/components/surepetcare/test_config_flow.py
+++ b/tests/components/surepetcare/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Sure Petcare config flow."""
+
 from unittest.mock import NonCallableMagicMock, patch
 
 from surepy.exceptions import SurePetcareAuthenticationError, SurePetcareError

--- a/tests/components/surepetcare/test_sensor.py
+++ b/tests/components/surepetcare/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the surepetcare sensor platform."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 

--- a/tests/components/swiss_public_transport/conftest.py
+++ b/tests/components/swiss_public_transport/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the swiss_public_transport tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/swiss_public_transport/test_config_flow.py
+++ b/tests/components/swiss_public_transport/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the swiss_public_transport config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from opendata_transport.exceptions import (

--- a/tests/components/swiss_public_transport/test_init.py
+++ b/tests/components/swiss_public_transport/test_init.py
@@ -1,4 +1,5 @@
 """Test the swiss_public_transport config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.swiss_public_transport.const import (

--- a/tests/components/switch/common.py
+++ b/tests/components/switch/common.py
@@ -3,6 +3,7 @@
 All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
+
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,

--- a/tests/components/switch/conftest.py
+++ b/tests/components/switch/conftest.py
@@ -1,2 +1,3 @@
 """switch conftest."""
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -1,4 +1,5 @@
 """The test for switch device automation."""
+
 from datetime import timedelta
 
 from freezegun import freeze_time

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for switch device automation."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/switch/test_significant_change.py
+++ b/tests/components/switch/test_significant_change.py
@@ -1,4 +1,5 @@
 """Test the sensor significant change platform."""
+
 from homeassistant.components.switch.significant_change import (
     async_check_significant_change,
 )

--- a/tests/components/switch_as_x/conftest.py
+++ b/tests/components/switch_as_x/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Switch as X integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Switch as X config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock

--- a/tests/components/switch_as_x/test_fan.py
+++ b/tests/components/switch_as_x/test_fan.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X Fan platform."""
+
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/switch_as_x/test_light.py
+++ b/tests/components/switch_as_x/test_light.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X Light platform."""
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,

--- a/tests/components/switch_as_x/test_lock.py
+++ b/tests/components/switch_as_x/test_lock.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X Lock platform."""
+
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler

--- a/tests/components/switch_as_x/test_siren.py
+++ b/tests/components/switch_as_x/test_siren.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X Siren platform."""
+
 from homeassistant.components.siren import DOMAIN as SIREN_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler

--- a/tests/components/switch_as_x/test_valve.py
+++ b/tests/components/switch_as_x/test_valve.py
@@ -1,4 +1,5 @@
 """Tests for the Switch as X Valve platform."""
+
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch_as_x.config_flow import SwitchAsXConfigFlowHandler
 from homeassistant.components.switch_as_x.const import (

--- a/tests/components/switchbot/test_config_flow.py
+++ b/tests/components/switchbot/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the switchbot config flow."""
+
 from unittest.mock import patch
 
 from switchbot import SwitchbotAccountConnectionError, SwitchbotAuthenticationError

--- a/tests/components/switchbot_cloud/conftest.py
+++ b/tests/components/switchbot_cloud/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the SwitchBot via API tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/switchbot_cloud/test_config_flow.py
+++ b/tests/components/switchbot_cloud/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the SwitchBot via API config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures and objects for the Switcher integration tests."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest

--- a/tests/components/switcher_kis/test_button.py
+++ b/tests/components/switcher_kis/test_button.py
@@ -1,4 +1,5 @@
 """Tests for Switcher button platform."""
+
 from unittest.mock import ANY, patch
 
 from aioswitcher.api import DeviceState, SwitcherBaseResponse, ThermostatSwing

--- a/tests/components/switcher_kis/test_climate.py
+++ b/tests/components/switcher_kis/test_climate.py
@@ -1,4 +1,5 @@
 """Test the Switcher climate platform."""
+
 from unittest.mock import ANY, patch
 
 from aioswitcher.api import SwitcherBaseResponse

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Switcher config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/switcher_kis/test_cover.py
+++ b/tests/components/switcher_kis/test_cover.py
@@ -1,4 +1,5 @@
 """Test the Switcher cover platform."""
+
 from unittest.mock import patch
 
 from aioswitcher.api import SwitcherBaseResponse

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,4 +1,5 @@
 """Test cases for the switcher_kis component."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/switcher_kis/test_services.py
+++ b/tests/components/switcher_kis/test_services.py
@@ -1,4 +1,5 @@
 """Test the services for the Switcher integration."""
+
 from unittest.mock import patch
 
 from aioswitcher.api import Command

--- a/tests/components/switcher_kis/test_switch.py
+++ b/tests/components/switcher_kis/test_switch.py
@@ -1,4 +1,5 @@
 """Test the Switcher switch platform."""
+
 from unittest.mock import patch
 
 from aioswitcher.api import Command, SwitcherBaseResponse

--- a/tests/components/syncthing/test_config_flow.py
+++ b/tests/components/syncthing/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for syncthing config flow."""
+
 from unittest.mock import patch
 
 from aiosyncthing.exceptions import UnauthorizedError

--- a/tests/components/synology_dsm/conftest.py
+++ b/tests/components/synology_dsm/conftest.py
@@ -1,4 +1,5 @@
 """Configure Synology DSM tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Synology DSM config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 

--- a/tests/components/synology_dsm/test_init.py
+++ b/tests/components/synology_dsm/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Synology DSM component."""
+
 from unittest.mock import MagicMock, patch
 
 from synology_dsm.exceptions import SynologyDSMLoginInvalidException

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the System Bridge config flow."""
+
 from unittest.mock import patch
 
 from systembridgeconnector.exceptions import (

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the system health component init."""
+
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.client_exceptions import ClientError

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -1,4 +1,5 @@
 """Test system log component."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/systemmonitor/conftest.py
+++ b/tests/components/systemmonitor/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the System Monitor integration."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/systemmonitor/test_binary_sensor.py
+++ b/tests/components/systemmonitor/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test System Monitor binary sensor."""
+
 from datetime import timedelta
 from unittest.mock import Mock, patch
 

--- a/tests/components/systemmonitor/test_config_flow.py
+++ b/tests/components/systemmonitor/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the System Monitor config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock

--- a/tests/components/systemmonitor/test_diagnostics.py
+++ b/tests/components/systemmonitor/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the System Monitor integration."""
+
 from unittest.mock import Mock
 
 from syrupy import SnapshotAssertion

--- a/tests/components/systemmonitor/test_init.py
+++ b/tests/components/systemmonitor/test_init.py
@@ -1,4 +1,5 @@
 """Test for System Monitor init."""
+
 from __future__ import annotations
 
 from unittest.mock import Mock


### PR DESCRIPTION
## Proposed change
Formatting change required for ruff `0.3.1`. See #112690
Created with regex substitution
```diff
-"""\nfrom
+"""\n\nfrom
```

_Please feel free to merge directly after ruff checks pass to prevent accidental merge conflicts._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
