### PR TITLE
Add empty line after module docstring [tests t-z]

### DIFF
--- a/tests/components/tado/test_binary_sensor.py
+++ b/tests/components/tado/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The sensor tests for the tado platform."""
+
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/tado/test_climate.py
+++ b/tests/components/tado/test_climate.py
@@ -1,4 +1,5 @@
 """The sensor tests for the tado platform."""
+
 from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration

--- a/tests/components/tado/test_config_flow.py
+++ b/tests/components/tado/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tado config flow."""
+
 from http import HTTPStatus
 from ipaddress import ip_address
 from unittest.mock import MagicMock, patch

--- a/tests/components/tado/test_sensor.py
+++ b/tests/components/tado/test_sensor.py
@@ -1,4 +1,5 @@
 """The sensor tests for the tado platform."""
+
 from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration

--- a/tests/components/tado/test_water_heater.py
+++ b/tests/components/tado/test_water_heater.py
@@ -1,4 +1,5 @@
 """The sensor tests for the tado platform."""
+
 from homeassistant.core import HomeAssistant
 
 from .util import async_init_integration

--- a/tests/components/tailscale/conftest.py
+++ b/tests/components/tailscale/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Tailscale integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/tailscale/test_binary_sensor.py
+++ b/tests/components/tailscale/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the Tailscale integration."""
+
 from homeassistant.components.binary_sensor import (
     STATE_OFF,
     STATE_ON,

--- a/tests/components/tailscale/test_diagnostics.py
+++ b/tests/components/tailscale/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Tailscale integration."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/tailscale/test_init.py
+++ b/tests/components/tailscale/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Tailscale integration."""
+
 from unittest.mock import MagicMock
 
 from tailscale import TailscaleAuthenticationError, TailscaleConnectionError

--- a/tests/components/tailscale/test_sensor.py
+++ b/tests/components/tailscale/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the Tailscale integration."""
+
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.tailscale.const import DOMAIN
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_FRIENDLY_NAME, EntityCategory

--- a/tests/components/tailwind/conftest.py
+++ b/tests/components/tailwind/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Tailwind integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/tailwind/test_button.py
+++ b/tests/components/tailwind/test_button.py
@@ -1,4 +1,5 @@
 """Tests for button entities provided by the Tailwind integration."""
+
 from unittest.mock import MagicMock
 
 from gotailwind import TailwindError

--- a/tests/components/tailwind/test_config_flow.py
+++ b/tests/components/tailwind/test_config_flow.py
@@ -1,4 +1,5 @@
 """Configuration flow tests for the Tailwind integration."""
+
 from ipaddress import ip_address
 from unittest.mock import MagicMock
 

--- a/tests/components/tailwind/test_cover.py
+++ b/tests/components/tailwind/test_cover.py
@@ -1,4 +1,5 @@
 """Tests for cover entities provided by the Tailwind integration."""
+
 from unittest.mock import ANY, MagicMock
 
 from gotailwind import (

--- a/tests/components/tailwind/test_init.py
+++ b/tests/components/tailwind/test_init.py
@@ -1,4 +1,5 @@
 """Integration tests for the Tailwind integration."""
+
 from unittest.mock import MagicMock
 
 from gotailwind import TailwindAuthenticationError, TailwindConnectionError

--- a/tests/components/tailwind/test_number.py
+++ b/tests/components/tailwind/test_number.py
@@ -1,4 +1,5 @@
 """Tests for number entities provided by the Tailwind integration."""
+
 from unittest.mock import MagicMock
 
 from gotailwind import TailwindError

--- a/tests/components/tankerkoenig/conftest.py
+++ b/tests/components/tankerkoenig/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Tankerkoenig integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/tankerkoenig/test_config_flow.py
+++ b/tests/components/tankerkoenig/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Tankerkoenig config flow."""
+
 from unittest.mock import patch
 
 from aiotankerkoenig.exceptions import TankerkoenigInvalidKeyError

--- a/tests/components/tankerkoenig/test_coordinator.py
+++ b/tests/components/tankerkoenig/test_coordinator.py
@@ -1,4 +1,5 @@
 """Tests for the Tankerkoening integration."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/tankerkoenig/test_diagnostics.py
+++ b/tests/components/tankerkoenig/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the Tankerkoening integration."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures for Tasmota component."""
+
 from unittest.mock import patch
 
 from hatasmota.discovery import get_status_sensor_entities

--- a/tests/components/tasmota/test_config_flow.py
+++ b/tests/components/tasmota/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow."""
+
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo

--- a/tests/components/tautulli/test_config_flow.py
+++ b/tests/components/tautulli/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test Tautulli config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from pytautulli import exceptions

--- a/tests/components/tcp/test_binary_sensor.py
+++ b/tests/components/tcp/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the TCP binary sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import call, patch
 

--- a/tests/components/tcp/test_sensor.py
+++ b/tests/components/tcp/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the TCP sensor platform."""
+
 from copy import copy
 from unittest.mock import call, patch
 

--- a/tests/components/technove/conftest.py
+++ b/tests/components/technove/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for TechnoVE integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/technove/test_binary_sensor.py
+++ b/tests/components/technove/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the TechnoVE binary sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/components/technove/test_sensor.py
+++ b/tests/components/technove/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the TechnoVE sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/components/technove/test_switch.py
+++ b/tests/components/technove/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the TechnoVE switch platform."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/tedee/conftest.py
+++ b/tests/components/tedee/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Tedee integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/tedee/test_config_flow.py
+++ b/tests/components/tedee/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tedee config flow."""
+
 from unittest.mock import MagicMock
 
 from pytedee_async import (

--- a/tests/components/tedee/test_diagnostics.py
+++ b/tests/components/tedee/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Tedee integration."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/tedee/test_init.py
+++ b/tests/components/tedee/test_init.py
@@ -1,4 +1,5 @@
 """Test initialization of tedee."""
+
 from unittest.mock import MagicMock
 
 from pytedee_async.exception import TedeeAuthException, TedeeClientException

--- a/tests/components/tedee/test_lock.py
+++ b/tests/components/tedee/test_lock.py
@@ -1,4 +1,5 @@
 """Tests for tedee lock."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/components/telegram/test_notify.py
+++ b/tests/components/telegram/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the telegram.notify platform."""
+
 from unittest.mock import patch
 
 from homeassistant import config as hass_config

--- a/tests/components/telegram_bot/conftest.py
+++ b/tests/components/telegram_bot/conftest.py
@@ -1,4 +1,5 @@
 """Tests for the telegram_bot integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/telegram_bot/test_broadcast.py
+++ b/tests/components/telegram_bot/test_broadcast.py
@@ -1,4 +1,5 @@
 """Test Telegram broadcast."""
+
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 

--- a/tests/components/telegram_bot/test_telegram_bot.py
+++ b/tests/components/telegram_bot/test_telegram_bot.py
@@ -1,4 +1,5 @@
 """Tests for the telegram_bot component."""
+
 from unittest.mock import AsyncMock, patch
 
 from telegram import Update

--- a/tests/components/tellduslive/test_config_flow.py
+++ b/tests/components/tellduslive/test_config_flow.py
@@ -1,5 +1,6 @@
 # flake8: noqa pylint: skip-file
 """Tests for the TelldusLive config flow."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/temper/test_sensor.py
+++ b/tests/components/temper/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the temper (USB temperature sensor) component."""
+
 from datetime import timedelta
 from unittest.mock import Mock, patch
 

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Template Binary sensor platform."""
+
 from datetime import UTC, datetime, timedelta
 import logging
 from unittest.mock import patch

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Switch config flow."""
+
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -1,4 +1,5 @@
 """The tests for the Template cover platform."""
+
 from typing import Any
 
 import pytest

--- a/tests/components/template/test_image.py
+++ b/tests/components/template/test_image.py
@@ -1,4 +1,5 @@
 """The tests for the Template image platform."""
+
 from http import HTTPStatus
 from io import BytesIO
 from typing import Any

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -1,4 +1,5 @@
 """The test for the Template sensor platform."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -1,4 +1,5 @@
 """The tests for the Template number platform."""
+
 from homeassistant import setup
 from homeassistant.components.input_number import (
     ATTR_VALUE as INPUT_NUMBER_ATTR_VALUE,

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -1,4 +1,5 @@
 """The tests for the Template select platform."""
+
 from homeassistant import setup
 from homeassistant.components.input_select import (
     ATTR_OPTION as INPUT_SELECT_ATTR_OPTION,

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Template sensor platform."""
+
 from asyncio import Event
 from datetime import datetime, timedelta
 from unittest.mock import ANY, patch

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for the Template automation."""
+
 from datetime import timedelta
 from unittest import mock
 

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -1,4 +1,5 @@
 """The tests for the Template Weather platform."""
+
 from typing import Any
 
 import pytest

--- a/tests/components/tesla_wall_connector/conftest.py
+++ b/tests/components/tesla_wall_connector/conftest.py
@@ -1,4 +1,5 @@
 """Common fixutres with default mocks as well as common test helper methods."""
+
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any

--- a/tests/components/tesla_wall_connector/test_binary_sensor.py
+++ b/tests/components/tesla_wall_connector/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for binary sensors."""
+
 from homeassistant.core import HomeAssistant
 
 from .conftest import (

--- a/tests/components/tesla_wall_connector/test_config_flow.py
+++ b/tests/components/tesla_wall_connector/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tesla Wall Connector config flow."""
+
 from unittest.mock import patch
 
 from tesla_wall_connector.exceptions import WallConnectorConnectionError

--- a/tests/components/tesla_wall_connector/test_init.py
+++ b/tests/components/tesla_wall_connector/test_init.py
@@ -1,4 +1,5 @@
 """Test the Tesla Wall Connector config flow."""
+
 from tesla_wall_connector.exceptions import WallConnectorConnectionError
 
 from homeassistant import config_entries

--- a/tests/components/tesla_wall_connector/test_sensor.py
+++ b/tests/components/tesla_wall_connector/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for sensors."""
+
 from homeassistant.core import HomeAssistant
 
 from .conftest import (

--- a/tests/components/teslemetry/conftest.py
+++ b/tests/components/teslemetry/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Tessie."""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/tests/components/teslemetry/test_sensor.py
+++ b/tests/components/teslemetry/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the Teslemetry sensor platform."""
+
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion

--- a/tests/components/tessie/conftest.py
+++ b/tests/components/tessie/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Tessie."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/tessie/test_button.py
+++ b/tests/components/tessie/test_button.py
@@ -1,4 +1,5 @@
 """Test the Tessie button platform."""
+
 from unittest.mock import patch
 
 from syrupy import SnapshotAssertion

--- a/tests/components/tessie/test_climate.py
+++ b/tests/components/tessie/test_climate.py
@@ -1,4 +1,5 @@
 """Test the Tessie climate platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/tessie/test_coordinator.py
+++ b/tests/components/tessie/test_coordinator.py
@@ -1,4 +1,5 @@
 """Test the Tessie sensor platform."""
+
 from datetime import timedelta
 
 from homeassistant.components.tessie import PLATFORMS

--- a/tests/components/tessie/test_cover.py
+++ b/tests/components/tessie/test_cover.py
@@ -1,4 +1,5 @@
 """Test the Tessie cover platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/tessie/test_select.py
+++ b/tests/components/tessie/test_select.py
@@ -1,4 +1,5 @@
 """Test the Tessie select platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/tessie/test_sensor.py
+++ b/tests/components/tessie/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the Tessie sensor platform."""
+
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy import SnapshotAssertion

--- a/tests/components/tessie/test_switch.py
+++ b/tests/components/tessie/test_switch.py
@@ -1,4 +1,5 @@
 """Test the Tessie switch platform."""
+
 from unittest.mock import patch
 
 from syrupy import SnapshotAssertion

--- a/tests/components/tessie/test_update.py
+++ b/tests/components/tessie/test_update.py
@@ -1,4 +1,5 @@
 """Test the Tessie update platform."""
+
 from unittest.mock import patch
 
 from syrupy import SnapshotAssertion

--- a/tests/components/text/test_init.py
+++ b/tests/components/text/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the text component."""
+
 from typing import Any
 
 import pytest

--- a/tests/components/text/test_recorder.py
+++ b/tests/components/text/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for text recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/thermobeacon/test_config_flow.py
+++ b/tests/components/thermobeacon/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the ThermoBeacon config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/thermobeacon/test_sensor.py
+++ b/tests/components/thermobeacon/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the ThermoBeacon sensors."""
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermobeacon.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT

--- a/tests/components/thermopro/test_config_flow.py
+++ b/tests/components/thermopro/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the ThermoPro config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/thermopro/test_sensor.py
+++ b/tests/components/thermopro/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the ThermoPro config flow."""
+
 from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.components.thermopro.const import DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_UNIT_OF_MEASUREMENT

--- a/tests/components/thread/test_config_flow.py
+++ b/tests/components/thread/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Thread config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/threshold/test_config_flow.py
+++ b/tests/components/threshold/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Threshold config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/tibber/test_config_flow.py
+++ b/tests/components/tibber/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Tibber config flow."""
+
 from asyncio import TimeoutError
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 

--- a/tests/components/tibber/test_diagnostics.py
+++ b/tests/components/tibber/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test the Netatmo diagnostics."""
+
 from unittest.mock import patch
 
 from homeassistant.components.recorder import Recorder

--- a/tests/components/tibber/test_statistics.py
+++ b/tests/components/tibber/test_statistics.py
@@ -1,4 +1,5 @@
 """Test adding external statistics from Tibber."""
+
 from unittest.mock import AsyncMock
 
 from homeassistant.components.recorder import Recorder

--- a/tests/components/tile/test_config_flow.py
+++ b/tests/components/tile/test_config_flow.py
@@ -1,4 +1,5 @@
 """Define tests for the Tile config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/tile/test_diagnostics.py
+++ b/tests/components/tile/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test Tile diagnostics."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/tilt_ble/test_config_flow.py
+++ b/tests/components/tilt_ble/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tilt config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/time/test_init.py
+++ b/tests/components/time/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the time component."""
+
 from datetime import time
 
 from homeassistant.components.time import DOMAIN, SERVICE_SET_VALUE, TimeEntity

--- a/tests/components/time_date/conftest.py
+++ b/tests/components/time_date/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Time & Date integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/time_date/test_config_flow.py
+++ b/tests/components/time_date/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Time & Date config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the timer component."""
+
 from datetime import timedelta
 import logging
 from unittest.mock import patch

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test Times of the Day Binary Sensor."""
+
 from datetime import datetime, timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/tod/test_config_flow.py
+++ b/tests/components/tod/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Times of the Day config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/todoist/conftest.py
+++ b/tests/components/todoist/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the todoist tests."""
+
 from collections.abc import Generator
 from http import HTTPStatus
 from unittest.mock import AsyncMock, patch

--- a/tests/components/todoist/test_calendar.py
+++ b/tests/components/todoist/test_calendar.py
@@ -1,4 +1,5 @@
 """Unit tests for the Todoist calendar platform."""
+
 from datetime import timedelta
 from http import HTTPStatus
 from typing import Any

--- a/tests/components/todoist/test_init.py
+++ b/tests/components/todoist/test_init.py
@@ -1,4 +1,5 @@
 """Unit tests for the Todoist integration."""
+
 from http import HTTPStatus
 from unittest.mock import AsyncMock
 

--- a/tests/components/todoist/test_todo.py
+++ b/tests/components/todoist/test_todo.py
@@ -1,4 +1,5 @@
 """Unit tests for the Todoist todo platform."""
+
 from typing import Any
 from unittest.mock import AsyncMock
 

--- a/tests/components/tolo/test_config_flow.py
+++ b/tests/components/tolo/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the TOLO Sauna config flow."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/tomato/test_device_tracker.py
+++ b/tests/components/tomato/test_device_tracker.py
@@ -1,4 +1,5 @@
 """The tests for the Tomato device tracker platform."""
+
 from unittest import mock
 
 import pytest

--- a/tests/components/tomorrowio/const.py
+++ b/tests/components/tomorrowio/const.py
@@ -1,4 +1,5 @@
 """Constants for tomorrowio tests."""
+
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_LATITUDE,

--- a/tests/components/tomorrowio/test_config_flow.py
+++ b/tests/components/tomorrowio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tomorrow.io config flow."""
+
 from unittest.mock import patch
 
 from pytomorrowio.exceptions import (

--- a/tests/components/tomorrowio/test_init.py
+++ b/tests/components/tomorrowio/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Tomorrow.io init."""
+
 from datetime import timedelta
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/tomorrowio/test_sensor.py
+++ b/tests/components/tomorrowio/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Tomorrow.io sensor entities."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/tomorrowio/test_weather.py
+++ b/tests/components/tomorrowio/test_weather.py
@@ -1,4 +1,5 @@
 """Tests for Tomorrow.io weather entity."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/toon/test_config_flow.py
+++ b/tests/components/toon/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Toon config flow."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -1,4 +1,5 @@
 """Common methods used across tests for TotalConnect."""
+
 from unittest.mock import patch
 
 from total_connect_client import ArmingState, ResultCode, ZoneStatus, ZoneType

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -1,4 +1,5 @@
 """Tests for the TotalConnect alarm control panel device."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/totalconnect/test_binary_sensor.py
+++ b/tests/components/totalconnect/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the TotalConnect binary sensor."""
+
 from unittest.mock import patch
 
 from homeassistant.components.binary_sensor import (

--- a/tests/components/totalconnect/test_config_flow.py
+++ b/tests/components/totalconnect/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the TotalConnect config flow."""
+
 from unittest.mock import patch
 
 from total_connect_client.exceptions import AuthenticationError

--- a/tests/components/totalconnect/test_diagnostics.py
+++ b/tests/components/totalconnect/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test TotalConnect diagnostics."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/totalconnect/test_init.py
+++ b/tests/components/totalconnect/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the TotalConnect init process."""
+
 from unittest.mock import patch
 
 from total_connect_client.exceptions import AuthenticationError

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the tplink config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from kasa import TimeoutException

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the TP-Link component."""
+
 from __future__ import annotations
 
 import copy

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -1,4 +1,5 @@
 """Tests for light platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures for TP-Link Omada integration."""
+
 from collections.abc import Generator
 import json
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/tplink_omada/test_config_flow.py
+++ b/tests/components/tplink_omada/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the TP-Link Omada config flows."""
+
 from unittest.mock import patch
 
 from tplink_omada_client import OmadaSite

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for TP-Link Omada switch entities."""
+
 from unittest.mock import MagicMock
 
 from syrupy.assertion import SnapshotAssertion

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -1,4 +1,5 @@
 """The tests the for Traccar device tracker platform."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/traccar_server/common.py
+++ b/tests/components/traccar_server/common.py
@@ -1,4 +1,5 @@
 """Common test tools for Traccar Server."""
+
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry

--- a/tests/components/traccar_server/conftest.py
+++ b/tests/components/traccar_server/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Traccar Server tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/traccar_server/test_config_flow.py
+++ b/tests/components/traccar_server/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Traccar Server config flow."""
+
 from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock

--- a/tests/components/traccar_server/test_diagnostics.py
+++ b/tests/components/traccar_server/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test Traccar Server diagnostics."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock
 

--- a/tests/components/tractive/test_config_flow.py
+++ b/tests/components/tractive/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the tractive config flow."""
+
 from unittest.mock import patch
 
 import aiotractive

--- a/tests/components/tradfri/common.py
+++ b/tests/components/tradfri/common.py
@@ -1,4 +1,5 @@
 """Common tools used for the Tradfri test suite."""
+
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any

--- a/tests/components/tradfri/conftest.py
+++ b/tests/components/tradfri/conftest.py
@@ -1,4 +1,5 @@
 """Common tradfri test fixtures."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Generator

--- a/tests/components/tradfri/test_config_flow.py
+++ b/tests/components/tradfri/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Tradfri config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/tradfri/test_cover.py
+++ b/tests/components/tradfri/test_cover.py
@@ -1,4 +1,5 @@
 """Tradfri cover (recognised as blinds in the IKEA ecosystem) platform tests."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/components/tradfri/test_diagnostics.py
+++ b/tests/components/tradfri/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for Tradfri diagnostics."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/tradfri/test_fan.py
+++ b/tests/components/tradfri/test_fan.py
@@ -1,4 +1,5 @@
 """Tradfri fan (recognised as air purifiers in the IKEA ecosystem) platform tests."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Tradfri setup."""
+
 from unittest.mock import MagicMock
 
 from homeassistant.components import tradfri

--- a/tests/components/tradfri/test_light.py
+++ b/tests/components/tradfri/test_light.py
@@ -1,4 +1,5 @@
 """Tradfri lights platform tests."""
+
 from typing import Any
 
 import pytest

--- a/tests/components/tradfri/test_sensor.py
+++ b/tests/components/tradfri/test_sensor.py
@@ -1,4 +1,5 @@
 """Tradfri sensor platform tests."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/tradfri/test_switch.py
+++ b/tests/components/tradfri/test_switch.py
@@ -1,4 +1,5 @@
 """Tradfri switch (recognised as sockets in the IKEA ecosystem) platform tests."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/trafikverket_camera/conftest.py
+++ b/tests/components/trafikverket_camera/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Trafikverket Camera integration tests."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/trafikverket_camera/test_binary_sensor.py
+++ b/tests/components/trafikverket_camera/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket binary sensor platform."""
+
 from __future__ import annotations
 
 from pytrafikverket.trafikverket_camera import CameraInfo

--- a/tests/components/trafikverket_camera/test_camera.py
+++ b/tests/components/trafikverket_camera/test_camera.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket camera platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/trafikverket_camera/test_config_flow.py
+++ b/tests/components/trafikverket_camera/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Trafikverket Camera config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_camera/test_coordinator.py
+++ b/tests/components/trafikverket_camera/test_coordinator.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket Camera coordinator."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_camera/test_init.py
+++ b/tests/components/trafikverket_camera/test_init.py
@@ -1,4 +1,5 @@
 """Test for Trafikverket Ferry component Init."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/trafikverket_camera/test_recorder.py
+++ b/tests/components/trafikverket_camera/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for Trafikcerket Camera recorder."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/trafikverket_camera/test_sensor.py
+++ b/tests/components/trafikverket_camera/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket sensor platform."""
+
 from __future__ import annotations
 
 from pytrafikverket.trafikverket_camera import CameraInfo

--- a/tests/components/trafikverket_ferry/conftest.py
+++ b/tests/components/trafikverket_ferry/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Trafikverket Ferry integration tests."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/trafikverket_ferry/test_config_flow.py
+++ b/tests/components/trafikverket_ferry/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Trafikverket Ferry config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_ferry/test_coordinator.py
+++ b/tests/components/trafikverket_ferry/test_coordinator.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket Ferry coordinator."""
+
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta

--- a/tests/components/trafikverket_ferry/test_init.py
+++ b/tests/components/trafikverket_ferry/test_init.py
@@ -1,4 +1,5 @@
 """Test for Trafikverket Ferry component Init."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_ferry/test_sensor.py
+++ b/tests/components/trafikverket_ferry/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket sensor platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/trafikverket_train/conftest.py
+++ b/tests/components/trafikverket_train/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Trafikverket Train integration tests."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/trafikverket_train/test_config_flow.py
+++ b/tests/components/trafikverket_train/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Trafikverket Train config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_train/test_init.py
+++ b/tests/components/trafikverket_train/test_init.py
@@ -1,4 +1,5 @@
 """Test for Trafikverket Train component Init."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/trafikverket_train/test_sensor.py
+++ b/tests/components/trafikverket_train/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket train sensor platform."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/trafikverket_train/test_util.py
+++ b/tests/components/trafikverket_train/test_util.py
@@ -1,4 +1,5 @@
 """The test for the Trafikverket train utils."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/trafikverket_weatherstation/test_config_flow.py
+++ b/tests/components/trafikverket_weatherstation/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Trafikverket weatherstation config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/transmission/test_config_flow.py
+++ b/tests/components/transmission/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Transmission config flow."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/transport_nsw/test_sensor.py
+++ b/tests/components/transport_nsw/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the Transport NSW (AU) sensor platform."""
+
 from unittest.mock import patch
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass

--- a/tests/components/trend/conftest.py
+++ b/tests/components/trend/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the trend component tests."""
+
 from collections.abc import Awaitable, Callable
 from typing import Any
 

--- a/tests/components/trend/test_binary_sensor.py
+++ b/tests/components/trend/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the Trend sensor platform."""
+
 from datetime import timedelta
 import logging
 from typing import Any

--- a/tests/components/trend/test_config_flow.py
+++ b/tests/components/trend/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Trend config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/tts/common.py
+++ b/tests/components/tts/common.py
@@ -1,4 +1,5 @@
 """Provide common tests tools for tts."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/tts/conftest.py
+++ b/tests/components/tts/conftest.py
@@ -2,6 +2,7 @@
 
 From http://doc.pytest.org/en/latest/example/simple.html#making-test-result-information-available-in-fixtures
 """
+
 from collections.abc import Generator
 
 import pytest

--- a/tests/components/tts/test_legacy.py
+++ b/tests/components/tts/test_legacy.py
@@ -1,4 +1,5 @@
 """Test the legacy tts setup."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/components/tts/test_media_source.py
+++ b/tests/components/tts/test_media_source.py
@@ -1,4 +1,5 @@
 """Tests for TTS media source."""
+
 from http import HTTPStatus
 from unittest.mock import MagicMock
 

--- a/tests/components/tts/test_notify.py
+++ b/tests/components/tts/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the TTS component."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/tuya/conftest.py
+++ b/tests/components/tuya/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Tuya integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/tuya/test_config_flow.py
+++ b/tests/components/tuya/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Tuya config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock

--- a/tests/components/twentemilieu/conftest.py
+++ b/tests/components/twentemilieu/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Twente Milieu integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/twentemilieu/test_calendar.py
+++ b/tests/components/twentemilieu/test_calendar.py
@@ -1,4 +1,5 @@
 """Tests for the Twente Milieu calendar."""
+
 from http import HTTPStatus
 
 import pytest

--- a/tests/components/twentemilieu/test_config_flow.py
+++ b/tests/components/twentemilieu/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Twente Milieu config flow."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/twentemilieu/test_diagnostics.py
+++ b/tests/components/twentemilieu/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the TwenteMilieu integration."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/twentemilieu/test_init.py
+++ b/tests/components/twentemilieu/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Twente Milieu integration."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -1,4 +1,5 @@
 """Test the init file of Twilio."""
+
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components import twilio
 from homeassistant.config import async_process_ha_core_config

--- a/tests/components/twinkly/conftest.py
+++ b/tests/components/twinkly/conftest.py
@@ -1,4 +1,5 @@
 """Configure tests for the Twinkly integration."""
+
 from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any
 from unittest.mock import patch

--- a/tests/components/twinkly/test_config_flow.py
+++ b/tests/components/twinkly/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the config_flow of the twinly component."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries

--- a/tests/components/twinkly/test_diagnostics.py
+++ b/tests/components/twinkly/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics of the twinkly component."""
+
 from collections.abc import Awaitable, Callable
 
 from syrupy import SnapshotAssertion

--- a/tests/components/twinkly/test_light.py
+++ b/tests/components/twinkly/test_light.py
@@ -1,4 +1,5 @@
 """Tests for the integration of a twinly device."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/twitch/conftest.py
+++ b/tests/components/twitch/conftest.py
@@ -1,4 +1,5 @@
 """Configure tests for the Twitch integration."""
+
 from collections.abc import Awaitable, Callable, Generator
 import time
 from unittest.mock import AsyncMock, patch

--- a/tests/components/twitch/test_config_flow.py
+++ b/tests/components/twitch/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow for Twitch."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/twitch/test_sensor.py
+++ b/tests/components/twitch/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for an update of the Twitch component."""
+
 from datetime import datetime
 
 import pytest

--- a/tests/components/ukraine_alarm/test_config_flow.py
+++ b/tests/components/ukraine_alarm/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Ukraine Alarm config flow."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for UniFi Network methods."""
+
 from __future__ import annotations
 
 import asyncio

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -1,4 +1,5 @@
 """The tests for the UniFi Network device tracker platform."""
+
 from datetime import timedelta
 
 from aiounifi.models.message import MessageKey

--- a/tests/components/unifi/test_diagnostics.py
+++ b/tests/components/unifi/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test UniFi Network diagnostics."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,

--- a/tests/components/unifi/test_hub.py
+++ b/tests/components/unifi/test_hub.py
@@ -1,4 +1,5 @@
 """Test UniFi Network."""
+
 from copy import deepcopy
 from datetime import timedelta
 from http import HTTPStatus

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -1,4 +1,5 @@
 """Test UniFi Network integration setup process."""
+
 from typing import Any
 from unittest.mock import patch
 

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,4 +1,5 @@
 """UniFi Network sensor platform tests."""
+
 from copy import deepcopy
 from datetime import datetime, timedelta
 from unittest.mock import patch

--- a/tests/components/unifi/test_services.py
+++ b/tests/components/unifi/test_services.py
@@ -1,4 +1,5 @@
 """deCONZ service tests."""
+
 from unittest.mock import patch
 
 from homeassistant.components.unifi.const import CONF_SITE_ID, DOMAIN as UNIFI_DOMAIN

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -1,4 +1,5 @@
 """UniFi Network switch platform tests."""
+
 from copy import deepcopy
 from datetime import timedelta
 

--- a/tests/components/unifi/test_update.py
+++ b/tests/components/unifi/test_update.py
@@ -1,4 +1,5 @@
 """The tests for the UniFi Network update platform."""
+
 from copy import deepcopy
 
 from aiounifi.models.message import MessageKey

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the UniFi Protect config flow."""
+
 from __future__ import annotations
 
 from dataclasses import asdict

--- a/tests/components/unifiprotect/test_diagnostics.py
+++ b/tests/components/unifiprotect/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test UniFi Protect diagnostics."""
+
 from pyunifiprotect.data import NVR, Light
 
 from homeassistant.components.unifiprotect.const import CONF_ALLOW_EA

--- a/tests/components/unifiprotect/test_recorder.py
+++ b/tests/components/unifiprotect/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for unifiprotect recorder."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -1,4 +1,5 @@
 """Test repairs for unifiprotect."""
+
 from __future__ import annotations
 
 from copy import copy

--- a/tests/components/unifiprotect/test_sensor.py
+++ b/tests/components/unifiprotect/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the UniFi Protect sensor platform."""
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1,4 +1,5 @@
 """The tests for the Universal Media player platform."""
+
 from copy import copy
 from unittest.mock import Mock, patch
 

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the UPB Control config flow."""
+
 from unittest.mock import MagicMock, PropertyMock, patch
 
 from homeassistant import config_entries

--- a/tests/components/upcloud/test_config_flow.py
+++ b/tests/components/upcloud/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the UpCloud config flow."""
+
 from unittest.mock import patch
 
 import requests.exceptions

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The test for update device automation."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Update component."""
+
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/update/test_recorder.py
+++ b/tests/components/update/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for update recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/update/test_significant_change.py
+++ b/tests/components/update/test_significant_change.py
@@ -1,4 +1,5 @@
 """Test the update significant change platform."""
+
 from homeassistant.components.update.const import (
     ATTR_IN_PROGRESS,
     ATTR_INSTALLED_VERSION,

--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for SSDP tests."""
+
 from __future__ import annotations
 
 import copy

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -1,4 +1,5 @@
 """Test UPnP/IGD setup process."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock

--- a/tests/components/uptime/conftest.py
+++ b/tests/components/uptime/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Uptime integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/uptime/test_init.py
+++ b/tests/components/uptime/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Uptime integration."""
+
 from homeassistant.components.uptime.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -1,4 +1,5 @@
 """Common constants and functions for UptimeRobot tests."""
+
 from __future__ import annotations
 
 from enum import Enum

--- a/tests/components/uptimerobot/test_config_flow.py
+++ b/tests/components/uptimerobot/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the UptimeRobot config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -1,4 +1,5 @@
 """Test the UptimeRobot init."""
+
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/uptimerobot/test_switch.py
+++ b/tests/components/uptimerobot/test_switch.py
@@ -1,4 +1,5 @@
 """Test UptimeRobot switch."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Utility Meter config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the utility_meter component."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the utility_meter sensor platform."""
+
 from datetime import timedelta
 
 from freezegun import freeze_time

--- a/tests/components/uvc/test_camera.py
+++ b/tests/components/uvc/test_camera.py
@@ -1,4 +1,5 @@
 """The tests for UVC camera module."""
+
 from datetime import UTC, datetime, timedelta
 from unittest.mock import call, patch
 

--- a/tests/components/v2c/conftest.py
+++ b/tests/components/v2c/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the V2C tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/v2c/test_config_flow.py
+++ b/tests/components/v2c/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the V2C config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/vacuum/common.py
+++ b/tests/components/vacuum/common.py
@@ -3,6 +3,7 @@
 All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
+
 from homeassistant.components.vacuum import (
     ATTR_FAN_SPEED,
     ATTR_PARAMS,

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for Vacuum device triggers."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/vacuum/test_init.py
+++ b/tests/components/vacuum/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Vacuum entity integration."""
+
 from __future__ import annotations
 
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature

--- a/tests/components/vacuum/test_recorder.py
+++ b/tests/components/vacuum/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for vacuum recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/vallox/test_binary_sensor.py
+++ b/tests/components/vallox/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for Vallox binary sensor platform."""
+
 from typing import Any
 
 import pytest

--- a/tests/components/vallox/test_config_flow.py
+++ b/tests/components/vallox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Vallox integration config flow."""
+
 from unittest.mock import patch
 
 from vallox_websocket_api import ValloxApiException, ValloxWebsocketException

--- a/tests/components/vallox/test_fan.py
+++ b/tests/components/vallox/test_fan.py
@@ -1,4 +1,5 @@
 """Tests for Vallox fan platform."""
+
 from unittest.mock import call
 
 import pytest

--- a/tests/components/valve/test_init.py
+++ b/tests/components/valve/test_init.py
@@ -1,4 +1,5 @@
 """The tests for Valve."""
+
 from collections.abc import Generator
 
 import pytest

--- a/tests/components/velbus/conftest.py
+++ b/tests/components/velbus/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Velbus tests."""
+
 from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/velbus/test_config_flow.py
+++ b/tests/components/velbus/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Velbus config flow."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Velbus component initialisation."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/velux/conftest.py
+++ b/tests/components/velux/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Velux tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/velux/test_config_flow.py
+++ b/tests/components/velux/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Velux config flow."""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/tests/components/venstar/test_climate.py
+++ b/tests/components/venstar/test_climate.py
@@ -1,4 +1,5 @@
 """The climate tests for the venstar integration."""
+
 from unittest.mock import patch
 
 from homeassistant.components.climate import ClimateEntityFeature

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -1,4 +1,5 @@
 """Tests of the initialization of the venstar integration."""
+
 from unittest.mock import patch
 
 from homeassistant.components.venstar.const import DOMAIN as VENSTAR_DOMAIN

--- a/tests/components/vera/common.py
+++ b/tests/components/vera/common.py
@@ -1,4 +1,5 @@
 """Common code for tests."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/vera/conftest.py
+++ b/tests/components/vera/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for tests."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/vera/test_binary_sensor.py
+++ b/tests/components/vera/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_climate.py
+++ b/tests/components/vera/test_climate.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_common.py
+++ b/tests/components/vera/test_common.py
@@ -1,4 +1,5 @@
 """Tests for common vera code."""
+
 from datetime import timedelta
 from unittest.mock import MagicMock
 

--- a/tests/components/vera/test_config_flow.py
+++ b/tests/components/vera/test_config_flow.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock, patch
 
 from requests.exceptions import RequestException

--- a/tests/components/vera/test_cover.py
+++ b/tests/components/vera/test_cover.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/vera/test_light.py
+++ b/tests/components/vera/test_light.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_lock.py
+++ b/tests/components/vera/test_lock.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_scene.py
+++ b/tests/components/vera/test_scene.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/vera/test_sensor.py
+++ b/tests/components/vera/test_sensor.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from __future__ import annotations
 
 from collections.abc import Callable

--- a/tests/components/vera/test_switch.py
+++ b/tests/components/vera/test_switch.py
@@ -1,4 +1,5 @@
 """Vera tests."""
+
 from unittest.mock import MagicMock
 
 import pyvera as pv

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Verisure integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Verisure config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/version/common.py
+++ b/tests/components/version/common.py
@@ -1,4 +1,5 @@
 """Fixtures for version integration."""
+
 from __future__ import annotations
 
 from typing import Any, Final

--- a/tests/components/version/test_binary_sensor.py
+++ b/tests/components/version/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """The test for the version binary sensor platform."""
+
 from __future__ import annotations
 
 from homeassistant.components.version.const import DEFAULT_CONFIGURATION

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Version config flow."""
+
 from unittest.mock import patch
 
 from pyhaversion.consts import HaVersionChannel, HaVersionSource

--- a/tests/components/version/test_sensor.py
+++ b/tests/components/version/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the version sensor platform."""
+
 from __future__ import annotations
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/vesync/conftest.py
+++ b/tests/components/vesync/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for VeSync tests."""
+
 from __future__ import annotations
 
 from unittest.mock import Mock, patch

--- a/tests/components/vesync/test_config_flow.py
+++ b/tests/components/vesync/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test for vesync config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import data_entry_flow

--- a/tests/components/vesync/test_diagnostics.py
+++ b/tests/components/vesync/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the VeSync integration."""
+
 from unittest.mock import patch
 
 from pyvesync.helpers import Helpers

--- a/tests/components/vesync/test_init.py
+++ b/tests/components/vesync/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the init module."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for ViCare integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import AsyncGenerator, Generator

--- a/tests/components/vicare/test_config_flow.py
+++ b/tests/components/vicare/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the ViCare config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Vilfo Router config flow."""
+
 from unittest.mock import Mock, patch
 
 import vilfo

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -1,4 +1,5 @@
 """Configure py.test."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/vizio/const.py
+++ b/tests/components/vizio/const.py
@@ -1,4 +1,5 @@
 """Constants for the Vizio integration tests."""
+
 from ipaddress import ip_address
 
 from homeassistant.components import zeroconf

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Vizio init."""
+
 from datetime import timedelta
 
 import pytest

--- a/tests/components/vizio/test_media_player.py
+++ b/tests/components/vizio/test_media_player.py
@@ -1,4 +1,5 @@
 """Tests for Vizio config flow."""
+
 from __future__ import annotations
 
 from contextlib import asynccontextmanager

--- a/tests/components/vlc_telnet/test_config_flow.py
+++ b/tests/components/vlc_telnet/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the VLC media player Telnet config flow."""
+
 from __future__ import annotations
 
 from typing import Any

--- a/tests/components/vodafone_station/const.py
+++ b/tests/components/vodafone_station/const.py
@@ -1,4 +1,5 @@
 """Common stuff for Vodafone Station tests."""
+
 from homeassistant.components.vodafone_station.const import DOMAIN
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 

--- a/tests/components/vodafone_station/test_config_flow.py
+++ b/tests/components/vodafone_station/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for Vodafone Station config flow."""
+
 from unittest.mock import patch
 
 from aiovodafone import exceptions as aiovodafone_exceptions

--- a/tests/components/voicerss/test_tts.py
+++ b/tests/components/voicerss/test_tts.py
@@ -1,4 +1,5 @@
 """The tests for the VoiceRSS speech platform."""
+
 from http import HTTPStatus
 
 import pytest

--- a/tests/components/voip/test_binary_sensor.py
+++ b/tests/components/voip/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test VoIP binary sensor devices."""
+
 from homeassistant.components.voip.devices import VoIPDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/tests/components/voip/test_config_flow.py
+++ b/tests/components/voip/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test VoIP config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/voip/test_devices.py
+++ b/tests/components/voip/test_devices.py
@@ -1,4 +1,5 @@
 """Test VoIP devices."""
+
 from __future__ import annotations
 
 from voip_utils import CallInfo

--- a/tests/components/voip/test_init.py
+++ b/tests/components/voip/test_init.py
@@ -1,4 +1,5 @@
 """Test VoIP init."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/voip/test_select.py
+++ b/tests/components/voip/test_select.py
@@ -1,4 +1,5 @@
 """Test VoIP select."""
+
 from homeassistant.components.voip.devices import VoIPDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/tests/components/voip/test_switch.py
+++ b/tests/components/voip/test_switch.py
@@ -1,4 +1,5 @@
 """Test VoIP switch devices."""
+
 from homeassistant.components.voip.devices import VoIPDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Volumio config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/volvooncall/test_config_flow.py
+++ b/tests/components/volvooncall/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Volvo On Call config flow."""
+
 from unittest.mock import Mock, patch
 
 from aiohttp import ClientResponseError

--- a/tests/components/vultr/test_init.py
+++ b/tests/components/vultr/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the Vultr component."""
+
 from copy import deepcopy
 import json
 from unittest.mock import patch

--- a/tests/components/vultr/test_switch.py
+++ b/tests/components/vultr/test_switch.py
@@ -1,4 +1,5 @@
 """Test the Vultr switch platform."""
+
 from __future__ import annotations
 
 import json

--- a/tests/components/wake_on_lan/conftest.py
+++ b/tests/components/wake_on_lan/conftest.py
@@ -1,4 +1,5 @@
 """Test fixtures for Wake on Lan."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/wake_on_lan/test_init.py
+++ b/tests/components/wake_on_lan/test_init.py
@@ -1,4 +1,5 @@
 """Tests for Wake On LAN component."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/wake_on_lan/test_switch.py
+++ b/tests/components/wake_on_lan/test_switch.py
@@ -1,4 +1,5 @@
 """The tests for the wake on lan switch platform."""
+
 from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch

--- a/tests/components/wake_word/common.py
+++ b/tests/components/wake_word/common.py
@@ -1,4 +1,5 @@
 """Provide common test tools for wake-word-detection."""
+
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine

--- a/tests/components/wallbox/test_config_flow.py
+++ b/tests/components/wallbox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Wallbox config flow."""
+
 from http import HTTPStatus
 import json
 

--- a/tests/components/wallbox/test_sensor.py
+++ b/tests/components/wallbox/test_sensor.py
@@ -1,4 +1,5 @@
 """Test Wallbox Switch component."""
+
 from homeassistant.const import CONF_UNIT_OF_MEASUREMENT, UnitOfPower
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/waqi/conftest.py
+++ b/tests/components/waqi/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the World Air Quality Index (WAQI) tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/water_heater/common.py
+++ b/tests/components/water_heater/common.py
@@ -3,6 +3,7 @@
 All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
+
 from homeassistant.components.water_heater import (
     _LOGGER,
     ATTR_AWAY_MODE,

--- a/tests/components/water_heater/conftest.py
+++ b/tests/components/water_heater/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for water heater platform tests."""
+
 from collections.abc import Generator
 
 import pytest

--- a/tests/components/water_heater/test_init.py
+++ b/tests/components/water_heater/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the water heater component."""
+
 from __future__ import annotations
 
 from unittest import mock

--- a/tests/components/water_heater/test_recorder.py
+++ b/tests/components/water_heater/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for water_heater recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/watttime/test_config_flow.py
+++ b/tests/components/watttime/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the WattTime config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from aiowatttime.errors import CoordinatesNotFoundError, InvalidCredentialsError

--- a/tests/components/watttime/test_diagnostics.py
+++ b/tests/components/watttime/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test WattTime diagnostics."""
+
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 

--- a/tests/components/waze_travel_time/conftest.py
+++ b/tests/components/waze_travel_time/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Waze Travel Time tests."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/weather/conftest.py
+++ b/tests/components/weather/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Weather platform tests."""
+
 from collections.abc import Generator
 
 import pytest

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -1,4 +1,5 @@
 """The test for weather entity."""
+
 from datetime import datetime
 
 import pytest

--- a/tests/components/weather/test_intent.py
+++ b/tests/components/weather/test_intent.py
@@ -1,4 +1,5 @@
 """Test weather intents."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/weather/test_recorder.py
+++ b/tests/components/weather/test_recorder.py
@@ -1,4 +1,5 @@
 """The tests for weather recorder."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/weather/test_websocket_api.py
+++ b/tests/components/weather/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Test the weather websocket API."""
+
 from homeassistant.components.weather import Forecast, WeatherEntityFeature
 from homeassistant.components.weather.const import DOMAIN
 from homeassistant.const import UnitOfTemperature

--- a/tests/components/weatherflow_cloud/conftest.py
+++ b/tests/components/weatherflow_cloud/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the WeatherflowCloud tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/components/weatherkit/conftest.py
+++ b/tests/components/weatherkit/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Apple WeatherKit tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/weatherkit/test_config_flow.py
+++ b/tests/components/weatherkit/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Apple WeatherKit config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from apple_weatherkit import DataSetType

--- a/tests/components/weatherkit/test_coordinator.py
+++ b/tests/components/weatherkit/test_coordinator.py
@@ -1,4 +1,5 @@
 """Test WeatherKit data coordinator."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/weatherkit/test_setup.py
+++ b/tests/components/weatherkit/test_setup.py
@@ -1,4 +1,5 @@
 """Test the WeatherKit setup process."""
+
 from unittest.mock import patch
 
 from apple_weatherkit.client import (

--- a/tests/components/webhook/test_init.py
+++ b/tests/components/webhook/test_init.py
@@ -1,4 +1,5 @@
 """Test the webhook component."""
+
 from http import HTTPStatus
 from ipaddress import ip_address
 from unittest.mock import Mock, patch

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for the webhook automation trigger."""
+
 from ipaddress import ip_address
 from unittest.mock import Mock, patch
 

--- a/tests/components/webmin/conftest.py
+++ b/tests/components/webmin/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Webmin integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/webmin/test_config_flow.py
+++ b/tests/components/webmin/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Webmin config flow."""
+
 from __future__ import annotations
 
 from http import HTTPStatus

--- a/tests/components/webmin/test_init.py
+++ b/tests/components/webmin/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Webmin integration."""
+
 from homeassistant.components.webmin.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures and objects for the LG webOS integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/components/webostv/const.py
+++ b/tests/components/webostv/const.py
@@ -1,4 +1,5 @@
 """Constants for LG webOS Smart TV tests."""
+
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
 

--- a/tests/components/webostv/test_diagnostics.py
+++ b/tests/components/webostv/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by LG webOS Smart TV."""
+
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -1,4 +1,5 @@
 """The tests for the LG webOS TV platform."""
+
 from unittest.mock import Mock
 
 from aiowebostv import WebOsTvPairError

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -1,4 +1,5 @@
 """The tests for the LG webOS media player platform."""
+
 from datetime import timedelta
 from http import HTTPStatus
 from unittest.mock import Mock

--- a/tests/components/webostv/test_notify.py
+++ b/tests/components/webostv/test_notify.py
@@ -1,4 +1,5 @@
 """The tests for the WebOS TV notify platform."""
+
 from unittest.mock import Mock, call
 
 from aiowebostv import WebOsTvPairError

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for WebOS TV automation triggers."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/websocket_api/test_auth.py
+++ b/tests/components/websocket_api/test_auth.py
@@ -1,4 +1,5 @@
 """Test auth of websocket API."""
+
 from unittest.mock import patch
 
 import aiohttp

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -1,4 +1,5 @@
 """Test decorators."""
+
 from homeassistant.components import http, websocket_api
 from homeassistant.core import HomeAssistant
 

--- a/tests/components/websocket_api/test_init.py
+++ b/tests/components/websocket_api/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Home Assistant Websocket API."""
+
 from unittest.mock import Mock, patch
 
 from aiohttp import WSMsgType

--- a/tests/components/websocket_api/test_sensor.py
+++ b/tests/components/websocket_api/test_sensor.py
@@ -1,4 +1,5 @@
 """Test cases for the API stream sensor."""
+
 from homeassistant.auth.providers.legacy_api_password import (
     LegacyApiPasswordAuthProvider,
 )

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -1,4 +1,5 @@
 """Tests for the Wemo light entity via the bridge."""
+
 from unittest.mock import create_autospec
 
 import pytest

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Whirlpool Sixth Sense integration tests."""
+
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -1,4 +1,5 @@
 """Test the Whirlpool Sixth Sense climate domain."""
+
 from unittest.mock import MagicMock
 
 from attr import dataclass

--- a/tests/components/whirlpool/test_config_flow.py
+++ b/tests/components/whirlpool/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Whirlpool Sixth Sense config flow."""
+
 from unittest.mock import patch
 
 import aiohttp

--- a/tests/components/whirlpool/test_init.py
+++ b/tests/components/whirlpool/test_init.py
@@ -1,4 +1,5 @@
 """Test the Whirlpool Sixth Sense init."""
+
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp

--- a/tests/components/whirlpool/test_sensor.py
+++ b/tests/components/whirlpool/test_sensor.py
@@ -1,4 +1,5 @@
 """Test the Whirlpool Sensor domain."""
+
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 

--- a/tests/components/whois/conftest.py
+++ b/tests/components/whois/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Whois integration tests."""
+
 from __future__ import annotations
 
 from collections.abc import Generator

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Whois config flow."""
+
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest

--- a/tests/components/whois/test_diagnostics.py
+++ b/tests/components/whois/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Whois integration."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/whois/test_init.py
+++ b/tests/components/whois/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Whois integration."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/whois/test_sensor.py
+++ b/tests/components/whois/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the sensors provided by the Whois integration."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/wiffi/conftest.py
+++ b/tests/components/wiffi/conftest.py
@@ -1,4 +1,5 @@
 """Configuration for Wiffi tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/wilight/conftest.py
+++ b/tests/components/wilight/conftest.py
@@ -1,2 +1,3 @@
 """wilight conftest."""
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401

--- a/tests/components/wilight/test_cover.py
+++ b/tests/components/wilight/test_cover.py
@@ -1,4 +1,5 @@
 """Tests for the WiLight integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/wilight/test_fan.py
+++ b/tests/components/wilight/test_fan.py
@@ -1,4 +1,5 @@
 """Tests for the WiLight integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/wilight/test_init.py
+++ b/tests/components/wilight/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the WiLight integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/wilight/test_light.py
+++ b/tests/components/wilight/test_light.py
@@ -1,4 +1,5 @@
 """Tests for the WiLight integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/wilight/test_switch.py
+++ b/tests/components/wilight/test_switch.py
@@ -1,4 +1,5 @@
 """Tests for the WiLight integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/withings/conftest.py
+++ b/tests/components/withings/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for tests."""
+
 from datetime import timedelta
 import time
 from unittest.mock import AsyncMock, patch

--- a/tests/components/withings/test_binary_sensor.py
+++ b/tests/components/withings/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Withings component."""
+
 from unittest.mock import AsyncMock
 
 from aiohttp.client_exceptions import ClientResponseError

--- a/tests/components/withings/test_calendar.py
+++ b/tests/components/withings/test_calendar.py
@@ -1,4 +1,5 @@
 """Tests for the Withings calendar."""
+
 from datetime import date, timedelta
 from http import HTTPStatus
 from unittest.mock import AsyncMock

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.components.withings.const import DOMAIN

--- a/tests/components/withings/test_diagnostics.py
+++ b/tests/components/withings/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the Withings integration."""
+
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -1,4 +1,5 @@
 """Tests for the Withings component."""
+
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the Withings component."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the WiZ Platform config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/wiz/test_diagnostics.py
+++ b/tests/components/wiz/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test WiZ diagnostics."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/wled/conftest.py
+++ b/tests/components/wled/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for WLED integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/components/wled/test_button.py
+++ b/tests/components/wled/test_button.py
@@ -1,4 +1,5 @@
 """Tests for the WLED button platform."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/wled/test_config_flow.py
+++ b/tests/components/wled/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the WLED config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/components/wled/test_diagnostics.py
+++ b/tests/components/wled/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the WLED integration."""
+
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -1,4 +1,5 @@
 """Tests for the WLED sensor platform."""
+
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 

--- a/tests/components/wled/test_update.py
+++ b/tests/components/wled/test_update.py
@@ -1,4 +1,5 @@
 """Tests for the WLED update platform."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/wolflink/test_config_flow.py
+++ b/tests/components/wolflink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Wolf SmartSet Service config flow."""
+
 from unittest.mock import patch
 
 from httpcore import ConnectError

--- a/tests/components/workday/conftest.py
+++ b/tests/components/workday/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Workday integration tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Tests the Home Assistant workday binary sensor."""
+
 from datetime import date, datetime
 from typing import Any
 

--- a/tests/components/workday/test_config_flow.py
+++ b/tests/components/workday/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Workday config flow."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -1,4 +1,5 @@
 """Test Workday component setup process."""
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/tests/components/ws66i/test_config_flow.py
+++ b/tests/components/ws66i/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the WS66i 6-Zone Amplifier config flow."""
+
 from unittest.mock import patch
 
 from homeassistant import config_entries, data_entry_flow

--- a/tests/components/ws66i/test_init.py
+++ b/tests/components/ws66i/test_init.py
@@ -1,4 +1,5 @@
 """Test the WS66i 6-Zone Amplifier init file."""
+
 from unittest.mock import patch
 
 from homeassistant.components.ws66i.const import DOMAIN

--- a/tests/components/ws66i/test_media_player.py
+++ b/tests/components/ws66i/test_media_player.py
@@ -1,4 +1,5 @@
 """The tests for WS66i Media player platform."""
+
 from collections import defaultdict
 from unittest.mock import patch
 

--- a/tests/components/wsdot/test_sensor.py
+++ b/tests/components/wsdot/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for the WSDOT platform."""
+
 from datetime import datetime, timedelta, timezone
 import re
 

--- a/tests/components/wyoming/conftest.py
+++ b/tests/components/wyoming/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Wyoming tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/wyoming/test_binary_sensor.py
+++ b/tests/components/wyoming/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test Wyoming binary sensor devices."""
+
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON

--- a/tests/components/wyoming/test_config_flow.py
+++ b/tests/components/wyoming/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Wyoming config flow."""
+
 from ipaddress import IPv4Address
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/wyoming/test_devices.py
+++ b/tests/components/wyoming/test_devices.py
@@ -1,4 +1,5 @@
 """Test Wyoming devices."""
+
 from __future__ import annotations
 
 from homeassistant.components.assist_pipeline.select import OPTION_PREFERRED

--- a/tests/components/wyoming/test_init.py
+++ b/tests/components/wyoming/test_init.py
@@ -1,4 +1,5 @@
 """Test init."""
+
 from unittest.mock import patch
 
 from homeassistant.config_entries import ConfigEntry

--- a/tests/components/wyoming/test_number.py
+++ b/tests/components/wyoming/test_number.py
@@ -1,4 +1,5 @@
 """Test Wyoming number."""
+
 from unittest.mock import patch
 
 from homeassistant.components.wyoming.devices import SatelliteDevice

--- a/tests/components/wyoming/test_select.py
+++ b/tests/components/wyoming/test_select.py
@@ -1,4 +1,5 @@
 """Test Wyoming select."""
+
 from unittest.mock import Mock, patch
 
 from homeassistant.components import assist_pipeline

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -1,4 +1,5 @@
 """Test stt."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/wyoming/test_switch.py
+++ b/tests/components/wyoming/test_switch.py
@@ -1,4 +1,5 @@
 """Test Wyoming switch devices."""
+
 from homeassistant.components.wyoming.devices import SatelliteDevice
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -1,4 +1,5 @@
 """Test tts."""
+
 from __future__ import annotations
 
 import io

--- a/tests/components/xbox/test_config_flow.py
+++ b/tests/components/xbox/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the xbox config flow."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/xiaomi/test_device_tracker.py
+++ b/tests/components/xiaomi/test_device_tracker.py
@@ -1,4 +1,5 @@
 """The tests for the Xiaomi router device tracker platform."""
+
 from http import HTTPStatus
 import logging
 from unittest.mock import MagicMock, call, patch

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Xiaomi Aqara config flow."""
+
 from ipaddress import ip_address
 from socket import gaierror
 from unittest.mock import Mock, patch

--- a/tests/components/xiaomi_ble/test_config_flow.py
+++ b/tests/components/xiaomi_ble/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Xiaomi config flow."""
+
 from unittest.mock import patch
 
 from xiaomi_ble import XiaomiBluetoothDeviceData as DeviceData

--- a/tests/components/xiaomi_ble/test_sensor.py
+++ b/tests/components/xiaomi_ble/test_sensor.py
@@ -1,4 +1,5 @@
 """Test Xiaomi BLE sensors."""
+
 from datetime import timedelta
 import time
 

--- a/tests/components/xiaomi_miio/test_button.py
+++ b/tests/components/xiaomi_miio/test_button.py
@@ -1,4 +1,5 @@
 """The tests for the xiaomi_miio button component."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Xiaomi Miio config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import Mock, patch
 

--- a/tests/components/xiaomi_miio/test_vacuum.py
+++ b/tests/components/xiaomi_miio/test_vacuum.py
@@ -1,4 +1,5 @@
 """The tests for the Xiaomi vacuum platform."""
+
 from datetime import datetime, time, timedelta
 from unittest import mock
 from unittest.mock import MagicMock, patch

--- a/tests/components/yale_smart_alarm/conftest.py
+++ b/tests/components/yale_smart_alarm/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for the Yale Smart Living integration."""
+
 from __future__ import annotations
 
 import json

--- a/tests/components/yale_smart_alarm/test_config_flow.py
+++ b/tests/components/yale_smart_alarm/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Yale Smart Living config flow."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/yale_smart_alarm/test_coordinator.py
+++ b/tests/components/yale_smart_alarm/test_coordinator.py
@@ -1,4 +1,5 @@
 """The test for the sensibo coordinator."""
+
 from __future__ import annotations
 
 from datetime import timedelta

--- a/tests/components/yale_smart_alarm/test_diagnostics.py
+++ b/tests/components/yale_smart_alarm/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Test Yale Smart Living diagnostics."""
+
 from __future__ import annotations
 
 from unittest.mock import Mock

--- a/tests/components/yamaha/test_media_player.py
+++ b/tests/components/yamaha/test_media_player.py
@@ -1,4 +1,5 @@
 """The tests for the Yamaha Media player platform."""
+
 from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import pytest

--- a/tests/components/yamaha_musiccast/test_config_flow.py
+++ b/tests/components/yamaha_musiccast/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test config flow."""
+
 from unittest.mock import patch
 
 from aiomusiccast import MusicCastConnectionException

--- a/tests/components/yandextts/test_tts.py
+++ b/tests/components/yandextts/test_tts.py
@@ -1,4 +1,5 @@
 """The tests for the Yandex SpeechKit speech platform."""
+
 from http import HTTPStatus
 
 import pytest

--- a/tests/components/yardian/conftest.py
+++ b/tests/components/yardian/conftest.py
@@ -1,4 +1,5 @@
 """Common fixtures for the Yardian tests."""
+
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/yardian/test_config_flow.py
+++ b/tests/components/yardian/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Yardian config flow."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/yeelight/test_binary_sensor.py
+++ b/tests/components/yeelight/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test the Yeelight binary sensor."""
+
 from unittest.mock import patch
 
 from homeassistant.components.yeelight import DOMAIN

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Yeelight config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -1,4 +1,5 @@
 """Test Yeelight."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -1,4 +1,5 @@
 """Test the Yeelight light."""
+
 from datetime import timedelta
 import logging
 import socket

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test yolink config flow."""
+
 from http import HTTPStatus
 from unittest.mock import patch
 

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -1,4 +1,5 @@
 """Test the youless config flow."""
+
 from unittest.mock import MagicMock, patch
 from urllib.error import URLError
 

--- a/tests/components/youtube/conftest.py
+++ b/tests/components/youtube/conftest.py
@@ -1,4 +1,5 @@
 """Configure tests for the YouTube integration."""
+
 from collections.abc import Awaitable, Callable, Coroutine
 import time
 from typing import Any

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the YouTube config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/youtube/test_diagnostics.py
+++ b/tests/components/youtube/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the YouTube integration."""
+
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.youtube.const import DOMAIN

--- a/tests/components/youtube/test_sensor.py
+++ b/tests/components/youtube/test_sensor.py
@@ -1,4 +1,5 @@
 """Sensor tests for the YouTube integration."""
+
 from datetime import timedelta
 from unittest.mock import patch
 

--- a/tests/components/zamg/conftest.py
+++ b/tests/components/zamg/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for Zamg integration tests."""
+
 from collections.abc import Generator
 import json
 from unittest.mock import MagicMock, patch

--- a/tests/components/zamg/test_config_flow.py
+++ b/tests/components/zamg/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Zamg config flow."""
+
 from unittest.mock import MagicMock
 
 from zamg.exceptions import ZamgApiError

--- a/tests/components/zamg/test_init.py
+++ b/tests/components/zamg/test_init.py
@@ -1,4 +1,5 @@
 """Test Zamg component init."""
+
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,4 +1,5 @@
 """Test Zeroconf component setup process."""
+
 from typing import Any
 from unittest.mock import call, patch
 

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -1,4 +1,5 @@
 """Test Zeroconf multiple instance protection."""
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/components/zerproc/conftest.py
+++ b/tests/components/zerproc/conftest.py
@@ -1,2 +1,3 @@
 """zerproc conftest."""
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401

--- a/tests/components/zerproc/test_config_flow.py
+++ b/tests/components/zerproc/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the zerproc config flow."""
+
 from unittest.mock import patch
 
 import pyzerproc

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -1,4 +1,5 @@
 """Test the zerproc lights."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/zeversolar/test_config_flow.py
+++ b/tests/components/zeversolar/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the Zeversolar config flow."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/zha/conftest.py
+++ b/tests/components/zha/conftest.py
@@ -1,4 +1,5 @@
 """Test configuration for the ZHA component."""
+
 from collections.abc import Callable, Generator
 import itertools
 import time

--- a/tests/components/zha/test_alarm_control_panel.py
+++ b/tests/components/zha/test_alarm_control_panel.py
@@ -1,4 +1,5 @@
 """Test ZHA alarm control panel."""
+
 from unittest.mock import AsyncMock, call, patch, sentinel
 
 import pytest

--- a/tests/components/zha/test_api.py
+++ b/tests/components/zha/test_api.py
@@ -1,4 +1,5 @@
 """Test ZHA API."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/components/zha/test_backup.py
+++ b/tests/components/zha/test_backup.py
@@ -1,4 +1,5 @@
 """Unit tests for ZHA backup platform."""
+
 from unittest.mock import AsyncMock
 
 from zigpy.application import ControllerApplication

--- a/tests/components/zha/test_binary_sensor.py
+++ b/tests/components/zha/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test ZHA binary sensor."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_button.py
+++ b/tests/components/zha/test_button.py
@@ -1,4 +1,5 @@
 """Test ZHA button."""
+
 from typing import Final
 from unittest.mock import call, patch
 

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -1,4 +1,5 @@
 """Test ZHA climate."""
+
 from typing import Literal
 from unittest.mock import call, patch
 

--- a/tests/components/zha/test_cluster_handlers.py
+++ b/tests/components/zha/test_cluster_handlers.py
@@ -1,4 +1,5 @@
 """Test ZHA Core cluster handlers."""
+
 from collections.abc import Callable
 import logging
 import math

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -1,4 +1,5 @@
 """Test ZHA device switch."""
+
 from datetime import timedelta
 import logging
 import time

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -1,4 +1,5 @@
 """The test for ZHA device automation actions."""
+
 from unittest.mock import call, patch
 
 import pytest

--- a/tests/components/zha/test_device_tracker.py
+++ b/tests/components/zha/test_device_tracker.py
@@ -1,4 +1,5 @@
 """Test ZHA Device Tracker."""
+
 from datetime import timedelta
 import time
 from unittest.mock import patch

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -1,4 +1,5 @@
 """ZHA device automation trigger tests."""
+
 from datetime import timedelta
 import time
 from unittest.mock import patch

--- a/tests/components/zha/test_diagnostics.py
+++ b/tests/components/zha/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for the diagnostics data provided by the ESPHome integration."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -1,4 +1,5 @@
 """Test ZHA device discovery."""
+
 from collections.abc import Callable
 import re
 from typing import Any

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -1,4 +1,5 @@
 """Test ZHA fan."""
+
 from unittest.mock import AsyncMock, call, patch
 
 import pytest

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -1,4 +1,5 @@
 """Test ZHA light."""
+
 from datetime import timedelta
 from unittest.mock import AsyncMock, call, patch, sentinel
 

--- a/tests/components/zha/test_lock.py
+++ b/tests/components/zha/test_lock.py
@@ -1,4 +1,5 @@
 """Test ZHA lock."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_logbook.py
+++ b/tests/components/zha/test_logbook.py
@@ -1,4 +1,5 @@
 """ZHA logbook describe events tests."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -1,4 +1,5 @@
 """Test ZHA analog output."""
+
 from unittest.mock import call, patch
 
 import pytest

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -1,4 +1,5 @@
 """Test ZHA registries."""
+
 from __future__ import annotations
 
 import typing

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -1,4 +1,5 @@
 """Test ZHA repairs."""
+
 from collections.abc import Callable
 from http import HTTPStatus
 import logging

--- a/tests/components/zha/test_select.py
+++ b/tests/components/zha/test_select.py
@@ -1,4 +1,5 @@
 """Test ZHA select entities."""
+
 from unittest.mock import call, patch
 
 import pytest

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -1,4 +1,5 @@
 """Test ZHA sensor."""
+
 from datetime import timedelta
 import math
 from unittest.mock import MagicMock, patch

--- a/tests/components/zha/test_silabs_multiprotocol.py
+++ b/tests/components/zha/test_silabs_multiprotocol.py
@@ -1,4 +1,5 @@
 """Test ZHA Silicon Labs Multiprotocol support."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/tests/components/zha/test_siren.py
+++ b/tests/components/zha/test_siren.py
@@ -1,4 +1,5 @@
 """Test zha siren."""
+
 from datetime import timedelta
 from unittest.mock import ANY, call, patch
 

--- a/tests/components/zha/test_switch.py
+++ b/tests/components/zha/test_switch.py
@@ -1,4 +1,5 @@
 """Test ZHA switch."""
+
 from unittest.mock import AsyncMock, call, patch
 
 import pytest

--- a/tests/components/zha/test_update.py
+++ b/tests/components/zha/test_update.py
@@ -1,4 +1,5 @@
 """Test ZHA firmware updates."""
+
 from unittest.mock import AsyncMock, call, patch
 
 import pytest

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -1,4 +1,5 @@
 """Test ZHA WebSocket API."""
+
 from __future__ import annotations
 
 from binascii import unhexlify

--- a/tests/components/zodiac/test_config_flow.py
+++ b/tests/components/zodiac/test_config_flow.py
@@ -1,4 +1,5 @@
 """Tests for the Zodiac config flow."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zodiac/test_sensor.py
+++ b/tests/components/zodiac/test_sensor.py
@@ -1,4 +1,5 @@
 """The test for the zodiac sensor platform."""
+
 from datetime import datetime
 from unittest.mock import patch
 

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -1,4 +1,5 @@
 """Test zone component."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -1,4 +1,5 @@
 """Provide common test tools for Z-Wave JS."""
+
 from __future__ import annotations
 
 from copy import deepcopy

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS Websocket API."""
+
 from copy import deepcopy
 from http import HTTPStatus
 import json

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS binary sensor platform."""
+
 from zwave_js_server.event import Event
 from zwave_js_server.model.node import Node
 

--- a/tests/components/zwave_js/test_device_action.py
+++ b/tests/components/zwave_js/test_device_action.py
@@ -1,4 +1,5 @@
 """The tests for Z-Wave JS device actions."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -1,4 +1,5 @@
 """The tests for Z-Wave JS device conditions."""
+
 from __future__ import annotations
 
 from unittest.mock import patch

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for Z-Wave JS device triggers."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zwave_js/test_event.py
+++ b/tests/components/zwave_js/test_event.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS event platform."""
+
 from datetime import timedelta
 
 from freezegun import freeze_time

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -1,4 +1,5 @@
 """Test Z-Wave JS events."""
+
 from unittest.mock import AsyncMock
 
 import pytest

--- a/tests/components/zwave_js/test_humidifier.py
+++ b/tests/components/zwave_js/test_humidifier.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS humidifier platform."""
+
 from zwave_js_server.const import CommandClass
 from zwave_js_server.const.command_class.humidity_control import HumidityControlMode
 from zwave_js_server.event import Event

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS light platform."""
+
 from copy import deepcopy
 
 from zwave_js_server.event import Event

--- a/tests/components/zwave_js/test_logbook.py
+++ b/tests/components/zwave_js/test_logbook.py
@@ -1,4 +1,5 @@
 """The tests for Z-Wave JS logbook."""
+
 from zwave_js_server.const import CommandClass
 
 from homeassistant.components.zwave_js.const import (

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS number platform."""
+
 from unittest.mock import patch
 
 import pytest

--- a/tests/components/zwave_js/test_repairs.py
+++ b/tests/components/zwave_js/test_repairs.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS repairs module."""
+
 from copy import deepcopy
 from http import HTTPStatus
 from unittest.mock import patch

--- a/tests/components/zwave_js/test_select.py
+++ b/tests/components/zwave_js/test_select.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS number platform."""
+
 from unittest.mock import MagicMock
 
 from zwave_js_server.const import CURRENT_VALUE_PROPERTY, CommandClass

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS services."""
+
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/components/zwave_js/test_siren.py
+++ b/tests/components/zwave_js/test_siren.py
@@ -1,4 +1,5 @@
 """Test the Z-Wave JS siren platform."""
+
 from zwave_js_server.event import Event
 
 from homeassistant.components.siren import (

--- a/tests/components/zwave_js/test_trigger.py
+++ b/tests/components/zwave_js/test_trigger.py
@@ -1,4 +1,5 @@
 """The tests for Z-Wave JS automation triggers."""
+
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/components/zwave_me/test_config_flow.py
+++ b/tests/components/zwave_me/test_config_flow.py
@@ -1,4 +1,5 @@
 """Test the zwave_me config flow."""
+
 from ipaddress import ip_address
 from unittest.mock import patch
 

--- a/tests/components/zwave_me/test_remove_stale_devices.py
+++ b/tests/components/zwave_me/test_remove_stale_devices.py
@@ -1,4 +1,5 @@
 """Test the zwave_me removal of stale devices."""
+
 from unittest.mock import patch
 import uuid
 


### PR DESCRIPTION
## Proposed change
Formatting change required for ruff `0.3.1`. See #112690
Created with regex substitution
```diff
-"""\nfrom
+"""\n\nfrom
```

_Please feel free to merge directly after ruff checks pass to prevent accidental merge conflicts._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
