### PR TITLE
Remove built-in support for import_executor in manifest

### DIFF
--- a/homeassistant/components/airvisual/manifest.json
+++ b/homeassistant/components/airvisual/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["airvisual_pro"],
   "documentation": "https://www.home-assistant.io/integrations/airvisual",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyairvisual", "pysmb"],

--- a/homeassistant/components/ambient_station/manifest.json
+++ b/homeassistant/components/ambient_station/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@bachya"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ambient_station",
-  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["aioambient"],

--- a/homeassistant/components/analytics/manifest.json
+++ b/homeassistant/components/analytics/manifest.json
@@ -5,7 +5,6 @@
   "codeowners": ["@home-assistant/core", "@ludeeus"],
   "dependencies": ["api", "websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/analytics",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "cloud_push",
   "quality_scale": "internal"

--- a/homeassistant/components/analytics_insights/manifest.json
+++ b/homeassistant/components/analytics_insights/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@joostlek"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/analytics_insights",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["python_homeassistant_analytics"],

--- a/homeassistant/components/androidtv_remote/manifest.json
+++ b/homeassistant/components/androidtv_remote/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@tronikos", "@Drafteed"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/androidtv_remote",
-  "import_executor": true,
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["androidtvremote2"],

--- a/homeassistant/components/apple_tv/manifest.json
+++ b/homeassistant/components/apple_tv/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["zeroconf"],
   "documentation": "https://www.home-assistant.io/integrations/apple_tv",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["pyatv", "srptools"],
   "requirements": ["pyatv==0.14.3"],

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -26,7 +26,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "import_executor": true,
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
   "requirements": ["yalexs==1.11.4", "yalexs-ble==2.4.2"]

--- a/homeassistant/components/backup/manifest.json
+++ b/homeassistant/components/backup/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["http", "websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/backup",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "calculated",
   "quality_scale": "internal",

--- a/homeassistant/components/baf/manifest.json
+++ b/homeassistant/components/baf/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@bdraco", "@jfroy"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/baf",
-  "import_executor": true,
   "iot_class": "local_push",
   "requirements": ["aiobafi6==0.9.0"],
   "zeroconf": [

--- a/homeassistant/components/blink/manifest.json
+++ b/homeassistant/components/blink/manifest.json
@@ -18,7 +18,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/blink",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["blinkpy"],
   "requirements": ["blinkpy==0.22.6"]

--- a/homeassistant/components/bluetooth/manifest.json
+++ b/homeassistant/components/bluetooth/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/bluetooth",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": [
     "btsocket",

--- a/homeassistant/components/caldav/manifest.json
+++ b/homeassistant/components/caldav/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/caldav",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["caldav", "vobject"],
   "requirements": ["caldav==1.3.9"]

--- a/homeassistant/components/cloud/manifest.json
+++ b/homeassistant/components/cloud/manifest.json
@@ -5,7 +5,6 @@
   "codeowners": ["@home-assistant/cloud"],
   "dependencies": ["http", "webhook"],
   "documentation": "https://www.home-assistant.io/integrations/cloud",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "cloud_push",
   "loggers": ["hass_nabucasa"],

--- a/homeassistant/components/co2signal/manifest.json
+++ b/homeassistant/components/co2signal/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@jpbede", "@VIKTORVAV99"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/co2signal",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["aioelectricitymaps"],

--- a/homeassistant/components/coinbase/manifest.json
+++ b/homeassistant/components/coinbase/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@tombrien"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/coinbase",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["coinbase"],
   "requirements": ["coinbase==2.1.0"]

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@ol-iver", "@starkillerOG"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["denonavr"],
   "requirements": ["denonavr==0.11.6"],

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -3,7 +3,6 @@
   "name": "DHCP Discovery",
   "codeowners": ["@bdraco"],
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "local_push",
   "loggers": [

--- a/homeassistant/components/discord/manifest.json
+++ b/homeassistant/components/discord/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@tkdrob"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/discord",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_push",
   "loggers": ["discord"],

--- a/homeassistant/components/discovergy/manifest.json
+++ b/homeassistant/components/discovergy/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@jpbede"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/discovergy",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "requirements": ["pydiscovergy==3.0.0"]

--- a/homeassistant/components/emulated_kasa/manifest.json
+++ b/homeassistant/components/emulated_kasa/manifest.json
@@ -3,7 +3,6 @@
   "name": "Emulated Kasa",
   "codeowners": ["@kbickar"],
   "documentation": "https://www.home-assistant.io/integrations/emulated_kasa",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["sense_energy"],
   "quality_scale": "internal",

--- a/homeassistant/components/enphase_envoy/manifest.json
+++ b/homeassistant/components/enphase_envoy/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@bdraco", "@cgarwood", "@dgomes", "@joostlek", "@catsmanac"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/enphase_envoy",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["pyenphase"],
   "requirements": ["pyenphase==1.19.1"],

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -11,7 +11,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "import_executor": true,
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aioesphomeapi", "noiseprotocol", "bleak_esphome"],

--- a/homeassistant/components/flux_led/manifest.json
+++ b/homeassistant/components/flux_led/manifest.json
@@ -51,7 +51,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/flux_led",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["flux_led"],
   "requirements": ["flux-led==1.0.4"]

--- a/homeassistant/components/hardware/manifest.json
+++ b/homeassistant/components/hardware/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@home-assistant/core"],
   "config_flow": false,
   "documentation": "https://www.home-assistant.io/integrations/hardware",
-  "import_executor": true,
   "integration_type": "system",
   "quality_scale": "internal",
   "requirements": ["psutil-home-assistant==0.0.1"]

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -6,7 +6,6 @@
   "config_flow": true,
   "dependencies": ["ffmpeg", "http", "network"],
   "documentation": "https://www.home-assistant.io/integrations/homekit",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["pyhap"],
   "requirements": [

--- a/homeassistant/components/homekit_controller/manifest.json
+++ b/homeassistant/components/homekit_controller/manifest.json
@@ -12,7 +12,6 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters", "zeroconf"],
   "documentation": "https://www.home-assistant.io/integrations/homekit_controller",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["aiohomekit", "commentjson"],
   "requirements": ["aiohomekit==3.1.5"],

--- a/homeassistant/components/influxdb/manifest.json
+++ b/homeassistant/components/influxdb/manifest.json
@@ -3,7 +3,6 @@
   "name": "InfluxDB",
   "codeowners": ["@mdegat01"],
   "documentation": "https://www.home-assistant.io/integrations/influxdb",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["influxdb", "influxdb_client"],
   "requirements": ["influxdb==5.3.1", "influxdb-client==1.24.0"]

--- a/homeassistant/components/isy994/manifest.json
+++ b/homeassistant/components/isy994/manifest.json
@@ -21,7 +21,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/isy994",
-  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyisy"],

--- a/homeassistant/components/logbook/manifest.json
+++ b/homeassistant/components/logbook/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@home-assistant/core"],
   "dependencies": ["frontend", "http", "recorder"],
   "documentation": "https://www.home-assistant.io/integrations/logbook",
-  "import_executor": true,
   "integration_type": "system",
   "quality_scale": "internal"
 }

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/matter",
-  "import_executor": true,
   "iot_class": "local_push",
   "requirements": ["python-matter-server==5.7.0"]
 }

--- a/homeassistant/components/mobile_app/manifest.json
+++ b/homeassistant/components/mobile_app/manifest.json
@@ -6,7 +6,6 @@
   "config_flow": true,
   "dependencies": ["http", "webhook", "person", "tag", "websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/mobile_app",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["nacl"],
   "quality_scale": "internal",

--- a/homeassistant/components/mqtt/manifest.json
+++ b/homeassistant/components/mqtt/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["file_upload", "http"],
   "documentation": "https://www.home-assistant.io/integrations/mqtt",
-  "import_executor": true,
   "iot_class": "local_push",
   "quality_scale": "gold",
   "requirements": ["paho-mqtt==1.6.1"]

--- a/homeassistant/components/nexia/manifest.json
+++ b/homeassistant/components/nexia/manifest.json
@@ -10,7 +10,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/nexia",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["nexia"],
   "requirements": ["nexia==2.0.8"]

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["recorder"],
   "documentation": "https://www.home-assistant.io/integrations/opower",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
   "requirements": ["opower==0.3.1"]

--- a/homeassistant/components/plex/manifest.json
+++ b/homeassistant/components/plex/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/plex",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["plexapi", "plexwebsocket"],
   "requirements": [

--- a/homeassistant/components/powerwall/manifest.json
+++ b/homeassistant/components/powerwall/manifest.json
@@ -12,7 +12,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/powerwall",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["tesla_powerwall"],
   "requirements": ["tesla-powerwall==0.5.1"]

--- a/homeassistant/components/radio_browser/manifest.json
+++ b/homeassistant/components/radio_browser/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@frenck"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/radio_browser",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "requirements": ["radios==0.2.0"]

--- a/homeassistant/components/rest/manifest.json
+++ b/homeassistant/components/rest/manifest.json
@@ -3,7 +3,6 @@
   "name": "RESTful",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/rest",
-  "import_executor": true,
   "iot_class": "local_polling",
   "requirements": ["jsonpath==0.82.2", "xmltodict==0.13.0"]
 }

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -22,7 +22,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/roomba",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["paho_mqtt", "roombapy"],
   "requirements": ["roombapy==1.6.13"],

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -31,7 +31,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/samsungtv",
-  "import_executor": true,
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["samsungctl", "samsungtvws"],

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -13,7 +13,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["screenlogicpy"],
   "requirements": ["screenlogicpy==0.10.0"]

--- a/homeassistant/components/sense/manifest.json
+++ b/homeassistant/components/sense/manifest.json
@@ -18,7 +18,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/sense",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "loggers": ["sense_energy"],
   "requirements": ["sense-energy==0.12.2"]

--- a/homeassistant/components/shelly/manifest.json
+++ b/homeassistant/components/shelly/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["bluetooth", "http"],
   "documentation": "https://www.home-assistant.io/integrations/shelly",
-  "import_executor": true,
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["aioshelly"],

--- a/homeassistant/components/smtp/manifest.json
+++ b/homeassistant/components/smtp/manifest.json
@@ -3,6 +3,5 @@
   "name": "SMTP",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/smtp",
-  "import_executor": true,
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/snmp/manifest.json
+++ b/homeassistant/components/snmp/manifest.json
@@ -3,7 +3,6 @@
   "name": "SNMP",
   "codeowners": [],
   "documentation": "https://www.home-assistant.io/integrations/snmp",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["pyasn1", "pysmi", "pysnmp"],
   "requirements": ["pysnmp-lextudio==5.0.34"]

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -6,7 +6,6 @@
   "config_flow": true,
   "dependencies": ["ssdp"],
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["soco"],
   "requirements": ["soco==0.30.2", "sonos-websocket==0.1.3"],

--- a/homeassistant/components/spotify/manifest.json
+++ b/homeassistant/components/spotify/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/spotify",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["spotipy"],

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": [],
   "dependencies": ["network"],
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],

--- a/homeassistant/components/steamist/manifest.json
+++ b/homeassistant/components/steamist/manifest.json
@@ -14,7 +14,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/steamist",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["aiosteamist", "discovery30303"],
   "requirements": ["aiosteamist==0.3.2", "discovery30303==0.2.1"]

--- a/homeassistant/components/stream/manifest.json
+++ b/homeassistant/components/stream/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@hunterjm", "@uvjustin", "@allenporter"],
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/stream",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",

--- a/homeassistant/components/switchbot/manifest.json
+++ b/homeassistant/components/switchbot/manifest.json
@@ -37,7 +37,6 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/switchbot",
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["switchbot"],
   "requirements": ["PySwitchbot==0.45.0"]

--- a/homeassistant/components/synology_dsm/manifest.json
+++ b/homeassistant/components/synology_dsm/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/synology_dsm",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["synology_dsm"],
   "requirements": ["py-synologydsm-api==2.1.4"],

--- a/homeassistant/components/template/manifest.json
+++ b/homeassistant/components/template/manifest.json
@@ -5,7 +5,6 @@
   "codeowners": ["@PhracturedBlue", "@tetienne", "@home-assistant/core"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/template",
-  "import_executor": true,
   "integration_type": "helper",
   "iot_class": "local_push",
   "quality_scale": "internal"

--- a/homeassistant/components/thread/manifest.json
+++ b/homeassistant/components/thread/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["zeroconf"],
   "documentation": "https://www.home-assistant.io/integrations/thread",
-  "import_executor": true,
   "integration_type": "service",
   "iot_class": "local_polling",
   "requirements": ["python-otbr-api==2.6.0", "pyroute2==0.7.5"],

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -266,7 +266,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/tplink",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": ["kasa"],
   "quality_scale": "platinum",

--- a/homeassistant/components/unifi/manifest.json
+++ b/homeassistant/components/unifi/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@Kane610"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/unifi",
-  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["aiounifi"],

--- a/homeassistant/components/unifiprotect/manifest.json
+++ b/homeassistant/components/unifiprotect/manifest.json
@@ -37,7 +37,6 @@
     }
   ],
   "documentation": "https://www.home-assistant.io/integrations/unifiprotect",
-  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["pyunifiprotect", "unifi_discovery"],

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["network", "ssdp"],
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "import_executor": true,
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client"],

--- a/homeassistant/components/usb/manifest.json
+++ b/homeassistant/components/usb/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@bdraco"],
   "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/usb",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "local_push",
   "quality_scale": "internal",

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -7,7 +7,6 @@
   "homekit": {
     "models": ["Socket", "Wemo"]
   },
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["pywemo"],
   "requirements": ["pywemo==1.4.0"],

--- a/homeassistant/components/wyoming/manifest.json
+++ b/homeassistant/components/wyoming/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["assist_pipeline"],
   "documentation": "https://www.home-assistant.io/integrations/wyoming",
-  "import_executor": true,
   "iot_class": "local_push",
   "requirements": ["wyoming==1.5.3"],
   "zeroconf": ["_wyoming._tcp.local."]

--- a/homeassistant/components/xbox/manifest.json
+++ b/homeassistant/components/xbox/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["auth", "application_credentials"],
   "documentation": "https://www.home-assistant.io/integrations/xbox",
-  "import_executor": true,
   "iot_class": "cloud_polling",
   "requirements": ["xbox-webapi==2.0.11"]
 }

--- a/homeassistant/components/xiaomi_ble/manifest.json
+++ b/homeassistant/components/xiaomi_ble/manifest.json
@@ -23,7 +23,6 @@
   "config_flow": true,
   "dependencies": ["bluetooth_adapters"],
   "documentation": "https://www.home-assistant.io/integrations/xiaomi_ble",
-  "import_executor": true,
   "iot_class": "local_push",
   "requirements": ["xiaomi-ble==0.25.2"]
 }

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -14,7 +14,6 @@
   "homekit": {
     "models": ["YL*"]
   },
-  "import_executor": true,
   "iot_class": "local_push",
   "loggers": ["async_upnp_client", "yeelight"],
   "quality_scale": "platinum",

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -4,7 +4,6 @@
   "codeowners": ["@bdraco"],
   "dependencies": ["network", "api"],
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "import_executor": true,
   "integration_type": "system",
   "iot_class": "local_push",
   "loggers": ["zeroconf"],

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -6,7 +6,6 @@
   "config_flow": true,
   "dependencies": ["file_upload"],
   "documentation": "https://www.home-assistant.io/integrations/zha",
-  "import_executor": true,
   "iot_class": "local_polling",
   "loggers": [
     "aiosqlite",

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -5,7 +5,6 @@
   "config_flow": true,
   "dependencies": ["http", "repairs", "usb", "websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -1,4 +1,5 @@
 """Manifest validation."""
+
 from __future__ import annotations
 
 from enum import IntEnum
@@ -265,7 +266,6 @@ INTEGRATION_MANIFEST_SCHEMA = vol.Schema(
         vol.Optional("loggers"): [str],
         vol.Optional("disabled"): str,
         vol.Optional("iot_class"): vol.In(SUPPORTED_IOT_CLASSES),
-        vol.Optional("import_executor"): bool,
         vol.Optional("single_config_entry"): bool,
     }
 )
@@ -293,6 +293,7 @@ def manifest_schema(value: dict[str, Any]) -> vol.Schema:
 CUSTOM_INTEGRATION_MANIFEST_SCHEMA = INTEGRATION_MANIFEST_SCHEMA.extend(
     {
         vol.Optional("version"): vol.All(str, verify_version),
+        vol.Optional("import_executor"): bool,
     }
 )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We introduced import_executor to move imports to the executor. In the end, to avoid the complexity we are now importing all integrations in the executor. There is still an exception for custom components, but those will soon default to also be imported in executor (via https://github.com/home-assistant/core/pull/112177).

As we don't need this field in the built-in manifest anymore, it has been removed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
