### PR TITLE
Only load services.yaml for integrations that have it

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -633,16 +633,18 @@ async def async_get_all_descriptions(
         ints_or_excs = await async_get_integrations(hass, domains_with_missing_services)
         integrations: list[Integration] = []
         for domain, int_or_exc in ints_or_excs.items():
-            if type(int_or_exc) is Integration:  # noqa: E721
+            if type(int_or_exc) is Integration and int_or_exc.has_services:  # noqa: E721
                 integrations.append(int_or_exc)
                 continue
             if TYPE_CHECKING:
                 assert isinstance(int_or_exc, Exception)
             _LOGGER.error("Failed to load integration: %s", domain, exc_info=int_or_exc)
-        contents = await hass.async_add_executor_job(
-            _load_services_files, hass, integrations
-        )
-        loaded = dict(zip(domains_with_missing_services, contents))
+
+        if integrations:
+            contents = await hass.async_add_executor_job(
+                _load_services_files, hass, integrations
+            )
+            loaded = dict(zip(domains_with_missing_services, contents))
 
     # Load translations for all service domains
     translations = await translation.async_get_translations(

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -296,9 +296,9 @@ async def async_get_custom_components(
     hass: HomeAssistant,
 ) -> dict[str, Integration]:
     """Return cached list of custom integrations."""
-    comps_or_future: (
-        dict[str, Integration] | asyncio.Future[dict[str, Integration]] | None
-    ) = hass.data.get(DATA_CUSTOM_COMPONENTS)
+    comps_or_future: dict[str, Integration] | asyncio.Future[
+        dict[str, Integration]
+    ] | None = hass.data.get(DATA_CUSTOM_COMPONENTS)
 
     if comps_or_future is None:
         future = hass.data[DATA_CUSTOM_COMPONENTS] = hass.loop.create_future()
@@ -842,11 +842,6 @@ class Integration:
     def has_services(self) -> bool:
         """Return if the integration has services."""
         return "services.yaml" in self._top_level_files
-
-    @cached_property
-    def has_translations(self) -> bool:
-        """Return if the integration has translations."""
-        return "translations" in self._top_level_files
 
     @property
     def mqtt(self) -> list[str] | None:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -296,9 +296,9 @@ async def async_get_custom_components(
     hass: HomeAssistant,
 ) -> dict[str, Integration]:
     """Return cached list of custom integrations."""
-    comps_or_future: dict[str, Integration] | asyncio.Future[
-        dict[str, Integration]
-    ] | None = hass.data.get(DATA_CUSTOM_COMPONENTS)
+    comps_or_future: (
+        dict[str, Integration] | asyncio.Future[dict[str, Integration]] | None
+    ) = hass.data.get(DATA_CUSTOM_COMPONENTS)
 
     if comps_or_future is None:
         future = hass.data[DATA_CUSTOM_COMPONENTS] = hass.loop.create_future()
@@ -837,6 +837,11 @@ class Integration:
     def has_translations(self) -> bool:
         """Return if the integration has translations."""
         return "translations" in self._top_level_files
+
+    @cached_property
+    def has_services(self) -> bool:
+        """Return if the integration has services."""
+        return "services.yaml" in self._top_level_files
 
     @property
     def mqtt(self) -> list[str] | None:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -296,9 +296,9 @@ async def async_get_custom_components(
     hass: HomeAssistant,
 ) -> dict[str, Integration]:
     """Return cached list of custom integrations."""
-    comps_or_future: dict[str, Integration] | asyncio.Future[
-        dict[str, Integration]
-    ] | None = hass.data.get(DATA_CUSTOM_COMPONENTS)
+    comps_or_future: (
+        dict[str, Integration] | asyncio.Future[dict[str, Integration]] | None
+    ) = hass.data.get(DATA_CUSTOM_COMPONENTS)
 
     if comps_or_future is None:
         future = hass.data[DATA_CUSTOM_COMPONENTS] = hass.loop.create_future()
@@ -842,6 +842,11 @@ class Integration:
     def has_services(self) -> bool:
         """Return if the integration has services."""
         return "services.yaml" in self._top_level_files
+
+    @cached_property
+    def has_translations(self) -> bool:
+        """Return if the integration has translations."""
+        return "translations" in self._top_level_files
 
     @property
     def mqtt(self) -> list[str] | None:

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -296,9 +296,9 @@ async def async_get_custom_components(
     hass: HomeAssistant,
 ) -> dict[str, Integration]:
     """Return cached list of custom integrations."""
-    comps_or_future: (
-        dict[str, Integration] | asyncio.Future[dict[str, Integration]] | None
-    ) = hass.data.get(DATA_CUSTOM_COMPONENTS)
+    comps_or_future: dict[str, Integration] | asyncio.Future[
+        dict[str, Integration]
+    ] | None = hass.data.get(DATA_CUSTOM_COMPONENTS)
 
     if comps_or_future is None:
         future = hass.data[DATA_CUSTOM_COMPONENTS] = hass.loop.create_future()

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -35,6 +35,7 @@ from homeassistant.helpers import (
     template,
 )
 import homeassistant.helpers.config_validation as cv
+from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -564,13 +565,28 @@ async def test_async_get_all_descriptions(hass: HomeAssistant) -> None:
     """Test async_get_all_descriptions."""
     group = hass.components.group
     group_config = {group.DOMAIN: {}}
-    await async_setup_component(hass, group.DOMAIN, group_config)
-    descriptions = await service.async_get_all_descriptions(hass)
+    assert await async_setup_component(hass, group.DOMAIN, group_config)
+    assert await async_setup_component(hass, "system_health", {})
+
+    with patch(
+        "homeassistant.helpers.service._load_services_files",
+        side_effect=service._load_services_files,
+    ) as proxy_load_services_files:
+        descriptions = await service.async_get_all_descriptions(hass)
+
+    # Test we only load services.yaml for integrations with services.yaml
+    # And system_health has no services
+    assert proxy_load_services_files.mock_calls[0][1][1] == [
+        await async_get_integration(hass, "group")
+    ]
 
     assert len(descriptions) == 1
 
     assert "description" in descriptions["group"]["reload"]
     assert "fields" in descriptions["group"]["reload"]
+
+    # Does not have services
+    assert "system_health" not in descriptions
 
     logger = hass.components.logger
     logger_config = {logger.DOMAIN: {}}

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1685,3 +1685,11 @@ async def test_integration_warnings(
     """Test integration warnings."""
     await loader.async_get_integration(hass, "test_package_loaded_loop")
     assert "configured to to import its code in the event loop" in caplog.text
+
+
+async def test_has_services(hass: HomeAssistant, enable_custom_integrations) -> None:
+    """Test has_services."""
+    integration = await loader.async_get_integration(hass, "test")
+    assert integration.has_services is False
+    integration = await loader.async_get_integration(hass, "test_with_services")
+    assert integration.has_services is True

--- a/tests/testing_config/custom_components/test_with_services/__init__.py
+++ b/tests/testing_config/custom_components/test_with_services/__init__.py
@@ -1,0 +1,1 @@
+"""Provide a mock integration."""

--- a/tests/testing_config/custom_components/test_with_services/manifest.json
+++ b/tests/testing_config/custom_components/test_with_services/manifest.json
@@ -1,0 +1,4 @@
+{
+  "domain": "test_with_services",
+  "version": "1.0"
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following example of #112683, we know the top-level files in an integration folder so we know if we don't even have to try fetching the services.yaml for an integration.

TODO

- [x] Tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
