### PR TITLE
Add empty line after module docstring (2) [other]

### DIFF
--- a/homeassistant/helpers/signal.py
+++ b/homeassistant/helpers/signal.py
@@ -1,4 +1,5 @@
 """Signal handling related helpers."""
+
 import asyncio
 import logging
 import signal

--- a/homeassistant/scripts/auth.py
+++ b/homeassistant/scripts/auth.py
@@ -1,4 +1,5 @@
 """Script to manage users for the Home Assistant auth provider."""
+
 import argparse
 import asyncio
 import logging

--- a/homeassistant/scripts/ensure_config.py
+++ b/homeassistant/scripts/ensure_config.py
@@ -1,4 +1,5 @@
 """Script to ensure a configuration file exists."""
+
 import argparse
 import asyncio
 import os

--- a/homeassistant/scripts/macos/__init__.py
+++ b/homeassistant/scripts/macos/__init__.py
@@ -1,4 +1,5 @@
 """Script to install/uninstall HA into OS X."""
+
 import os
 import time
 

--- a/homeassistant/util/ssl.py
+++ b/homeassistant/util/ssl.py
@@ -1,4 +1,5 @@
 """Helper to create SSL contexts."""
+
 import contextlib
 from enum import StrEnum
 from functools import cache

--- a/homeassistant/util/thread.py
+++ b/homeassistant/util/thread.py
@@ -1,4 +1,5 @@
 """Threading util helpers."""
+
 import ctypes
 import inspect
 import logging

--- a/script/hassfest/metadata.py
+++ b/script/hassfest/metadata.py
@@ -1,4 +1,5 @@
 """Package metadata validation."""
+
 import tomllib
 
 from homeassistant.const import REQUIRED_PYTHON_VER, __version__

--- a/script/inspect_schemas.py
+++ b/script/inspect_schemas.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Inspect all component SCHEMAS."""
+
 import importlib
 import os
 import pkgutil

--- a/script/languages.py
+++ b/script/languages.py
@@ -1,4 +1,5 @@
 """Helper script to update language list from the frontend source."""
+
 import json
 from pathlib import Path
 import sys

--- a/script/lint_and_test.py
+++ b/script/lint_and_test.py
@@ -3,6 +3,7 @@
 
 This is NOT a full CI/linting replacement, only a quick check during development.
 """
+
 import asyncio
 from collections import namedtuple
 from contextlib import suppress

--- a/script/scaffold/__main__.py
+++ b/script/scaffold/__main__.py
@@ -1,4 +1,5 @@
 """Validate manifests."""
+
 import argparse
 from pathlib import Path
 import subprocess

--- a/script/scaffold/gather_info.py
+++ b/script/scaffold/gather_info.py
@@ -1,4 +1,5 @@
 """Gather info for scaffolding."""
+
 import json
 
 from homeassistant.util import slugify

--- a/script/scaffold/templates/config_flow_discovery/integration/config_flow.py
+++ b/script/scaffold/templates/config_flow_discovery/integration/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for NEW_NAME."""
+
 import my_pypi_dependency
 
 from homeassistant.core import HomeAssistant

--- a/script/scaffold/templates/config_flow_helper/tests/test_init.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_init.py
@@ -1,4 +1,5 @@
 """Test the NEW_NAME integration."""
+
 import pytest
 
 from homeassistant.components.NEW_DOMAIN.const import DOMAIN

--- a/script/scaffold/templates/config_flow_oauth2/integration/config_flow.py
+++ b/script/scaffold/templates/config_flow_oauth2/integration/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for NEW_NAME."""
+
 import logging
 
 from homeassistant.helpers import config_entry_oauth2_flow

--- a/script/scaffold/templates/device_action/tests/test_device_action.py
+++ b/script/scaffold/templates/device_action/tests/test_device_action.py
@@ -1,4 +1,5 @@
 """The tests for NEW_NAME device actions."""
+
 import pytest
 from pytest_unordered import unordered
 

--- a/script/scaffold/templates/device_trigger/tests/test_device_trigger.py
+++ b/script/scaffold/templates/device_trigger/tests/test_device_trigger.py
@@ -1,4 +1,5 @@
 """The tests for NEW_NAME device triggers."""
+
 import pytest
 from pytest_unordered import unordered
 

--- a/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
+++ b/script/scaffold/templates/reproduce_state/tests/test_reproduce_state.py
@@ -1,4 +1,5 @@
 """Test reproduce state for NEW_NAME."""
+
 import pytest
 
 from homeassistant.core import HomeAssistant, State

--- a/script/translations/__main__.py
+++ b/script/translations/__main__.py
@@ -1,4 +1,5 @@
 """Validate manifests."""
+
 import argparse
 import importlib
 from pathlib import Path

--- a/script/translations/clean.py
+++ b/script/translations/clean.py
@@ -1,4 +1,5 @@
 """Find translation keys that are in Lokalise but no longer defined in source."""
+
 import argparse
 
 from .const import CORE_PROJECT_ID, FRONTEND_DIR, FRONTEND_PROJECT_ID, INTEGRATIONS_DIR

--- a/script/translations/const.py
+++ b/script/translations/const.py
@@ -1,4 +1,5 @@
 """Translation constants."""
+
 import pathlib
 
 CORE_PROJECT_ID = "130246255a974bd3b5e8a1.51616605"

--- a/script/translations/develop.py
+++ b/script/translations/develop.py
@@ -1,4 +1,5 @@
 """Compile the current translation strings files for testing."""
+
 import argparse
 import json
 from pathlib import Path

--- a/script/translations/error.py
+++ b/script/translations/error.py
@@ -1,4 +1,5 @@
 """Errors for translations."""
+
 import json
 
 

--- a/script/translations/frontend.py
+++ b/script/translations/frontend.py
@@ -1,4 +1,5 @@
 """Write updated translations to the frontend."""
+
 import argparse
 import json
 

--- a/script/translations/migrate.py
+++ b/script/translations/migrate.py
@@ -1,4 +1,5 @@
 """Migrate things."""
+
 import json
 import pathlib
 from pprint import pprint

--- a/script/translations/upload.py
+++ b/script/translations/upload.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Merge all translation sources into a single JSON file."""
+
 import json
 import os
 import pathlib

--- a/script/translations/util.py
+++ b/script/translations/util.py
@@ -1,4 +1,5 @@
 """Translation utils."""
+
 import argparse
 import json
 import os

--- a/script/version_bump.py
+++ b/script/version_bump.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Helper script to bump the current version."""
+
 import argparse
 import re
 import subprocess

--- a/tests/auth/mfa_modules/test_notify.py
+++ b/tests/auth/mfa_modules/test_notify.py
@@ -1,4 +1,5 @@
 """Test the HMAC-based One Time Password (MFA) auth module."""
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/auth/mfa_modules/test_totp.py
+++ b/tests/auth/mfa_modules/test_totp.py
@@ -1,4 +1,5 @@
 """Test the Time-based One Time Password (MFA) auth module."""
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/auth/permissions/test_entities.py
+++ b/tests/auth/permissions/test_entities.py
@@ -1,4 +1,5 @@
 """Tests for entity permissions."""
+
 import pytest
 import voluptuous as vol
 

--- a/tests/auth/providers/test_homeassistant.py
+++ b/tests/auth/providers/test_homeassistant.py
@@ -1,4 +1,5 @@
 """Test the Home Assistant local auth provider."""
+
 import asyncio
 from unittest.mock import Mock, patch
 

--- a/tests/auth/providers/test_legacy_api_password.py
+++ b/tests/auth/providers/test_legacy_api_password.py
@@ -1,4 +1,5 @@
 """Tests for the legacy_api_password auth provider."""
+
 import pytest
 
 from homeassistant import auth, data_entry_flow

--- a/tests/auth/test_auth_store.py
+++ b/tests/auth/test_auth_store.py
@@ -1,4 +1,5 @@
 """Tests for the auth store."""
+
 import asyncio
 from datetime import timedelta
 from typing import Any

--- a/tests/hassfest/test_dependencies.py
+++ b/tests/hassfest/test_dependencies.py
@@ -1,4 +1,5 @@
 """Tests for hassfest dependency finder."""
+
 import ast
 
 import pytest
@@ -59,6 +60,7 @@ def test_renamed_absolute(mock_collector) -> None:
     mock_collector.visit(
         ast.parse(
             """
+
 import homeassistant.components.renamed_absolute as hue
 """
         )

--- a/tests/hassfest/test_version.py
+++ b/tests/hassfest/test_version.py
@@ -1,4 +1,5 @@
 """Tests for hassfest version."""
+
 import pytest
 import voluptuous as vol
 

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -1,4 +1,5 @@
 """Test check_config helper."""
+
 import logging
 from unittest.mock import Mock, patch
 

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -1,4 +1,5 @@
 """Tests for debounce."""
+
 import asyncio
 from datetime import timedelta
 import logging

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1,4 +1,5 @@
 """Test the entity helper."""
+
 import asyncio
 from collections.abc import Iterable
 import dataclasses

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1,4 +1,5 @@
 """Tests for the EntityPlatform helper."""
+
 import asyncio
 from collections.abc import Iterable
 from datetime import timedelta

--- a/tests/helpers/test_floor_registry.py
+++ b/tests/helpers/test_floor_registry.py
@@ -1,4 +1,5 @@
 """Tests for the floor registry."""
+
 import re
 from typing import Any
 

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -1,4 +1,5 @@
 """Test Home Assistant remote methods and classes."""
+
 import datetime
 from functools import partial
 import json

--- a/tests/helpers/test_label_registry.py
+++ b/tests/helpers/test_label_registry.py
@@ -1,4 +1,5 @@
 """Tests for the Label Registry."""
+
 import re
 from typing import Any
 

--- a/tests/helpers/test_normalized_name_base_registry.py
+++ b/tests/helpers/test_normalized_name_base_registry.py
@@ -1,4 +1,5 @@
 """Tests for the normalized name base registry helper."""
+
 import pytest
 
 from homeassistant.helpers.normalized_name_base_registry import (

--- a/tests/helpers/test_ratelimit.py
+++ b/tests/helpers/test_ratelimit.py
@@ -1,4 +1,5 @@
 """Tests for ratelimit."""
+
 import asyncio
 from datetime import timedelta
 

--- a/tests/helpers/test_reload.py
+++ b/tests/helpers/test_reload.py
@@ -1,4 +1,5 @@
 """Tests for the reload helper."""
+
 import logging
 from unittest.mock import AsyncMock, Mock, patch
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1,4 +1,5 @@
 """The tests for the Script component."""
+
 import asyncio
 from contextlib import contextmanager
 from datetime import timedelta

--- a/tests/helpers/test_script_variables.py
+++ b/tests/helpers/test_script_variables.py
@@ -1,4 +1,5 @@
 """Test script variables."""
+
 import pytest
 
 from homeassistant.core import HomeAssistant

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1,4 +1,5 @@
 """Test service helpers."""
+
 import asyncio
 from collections.abc import Iterable
 from copy import deepcopy

--- a/tests/helpers/test_significant_change.py
+++ b/tests/helpers/test_significant_change.py
@@ -1,4 +1,5 @@
 """Test significant change helper."""
+
 import pytest
 
 from homeassistant.components.sensor import SensorDeviceClass

--- a/tests/helpers/test_start.py
+++ b/tests/helpers/test_start.py
@@ -1,4 +1,5 @@
 """Test starting HA helpers."""
+
 import pytest
 
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STARTED

--- a/tests/helpers/test_state.py
+++ b/tests/helpers/test_state.py
@@ -1,4 +1,5 @@
 """Test state helpers."""
+
 import asyncio
 from unittest.mock import patch
 

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -1,4 +1,5 @@
 """Tests for the storage helper."""
+
 import asyncio
 from datetime import timedelta
 import json

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -1,4 +1,5 @@
 """Tests for the system info helper."""
+
 import json
 import os
 from unittest.mock import patch

--- a/tests/helpers/test_temperature.py
+++ b/tests/helpers/test_temperature.py
@@ -1,4 +1,5 @@
 """Tests Home Assistant temperature helpers."""
+
 import pytest
 
 from homeassistant.const import (

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -1,4 +1,5 @@
 """Test the translation helper."""
+
 import asyncio
 from os import path
 import pathlib

--- a/tests/scripts/test_auth.py
+++ b/tests/scripts/test_auth.py
@@ -1,4 +1,5 @@
 """Test the auth script to manage local users."""
+
 import logging
 from typing import Any
 from unittest.mock import Mock, patch

--- a/tests/scripts/test_check_config.py
+++ b/tests/scripts/test_check_config.py
@@ -1,4 +1,5 @@
 """Test check_config script."""
+
 import logging
 from unittest.mock import patch
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,4 +1,5 @@
 """Test the bootstrapping."""
+
 import asyncio
 from collections.abc import Generator, Iterable
 import glob

--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -1,4 +1,5 @@
 """Test to check for circular imports in core components."""
+
 import asyncio
 import sys
 

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -1,4 +1,5 @@
 """Test the flow classes."""
+
 import asyncio
 import dataclasses
 import logging

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,4 +1,5 @@
 """Test to verify that we can load components."""
+
 import asyncio
 import os
 import sys

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,4 +1,5 @@
 """Test requirements module."""
+
 import asyncio
 import logging
 import os

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,4 +1,5 @@
 """Test the runner."""
+
 import asyncio
 from collections.abc import Iterator
 import threading

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -1,4 +1,5 @@
 """Aiohttp test utils."""
+
 import asyncio
 from contextlib import contextmanager
 from http import HTTPStatus

--- a/tests/test_util/test_aiohttp.py
+++ b/tests/test_util/test_aiohttp.py
@@ -1,4 +1,5 @@
 """Tests for our aiohttp mocker."""
+
 import pytest
 
 from .aiohttp import AiohttpClientMocker

--- a/tests/testing_config/custom_components/test/button.py
+++ b/tests/testing_config/custom_components/test/button.py
@@ -2,6 +2,7 @@
 
 Call init before using it in your tests to ensure clean test data.
 """
+
 import logging
 
 from homeassistant.components.button import ButtonEntity

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -1,4 +1,5 @@
 """Tests for async util methods from Python source."""
+
 import asyncio
 import sys
 import time

--- a/tests/util/test_color.py
+++ b/tests/util/test_color.py
@@ -1,4 +1,5 @@
 """Test Home Assistant color util methods."""
+
 import math
 
 import pytest

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -1,4 +1,5 @@
 """Test Home Assistant file utility functions."""
+
 import os
 from pathlib import Path
 from unittest.mock import patch

--- a/tests/util/test_logging.py
+++ b/tests/util/test_logging.py
@@ -1,4 +1,5 @@
 """Test Home Assistant logging util methods."""
+
 import asyncio
 from functools import partial
 import logging

--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -1,4 +1,5 @@
 """Test Home Assistant package util methods."""
+
 import asyncio
 from importlib.metadata import metadata
 import logging

--- a/tests/util/test_read_only_dict.py
+++ b/tests/util/test_read_only_dict.py
@@ -1,4 +1,5 @@
 """Test read only dictionary."""
+
 import json
 
 import pytest

--- a/tests/util/test_timeout.py
+++ b/tests/util/test_timeout.py
@@ -1,4 +1,5 @@
 """Test Home Assistant timeout handler."""
+
 import asyncio
 from contextlib import suppress
 import time

--- a/tests/util/yaml/test_input.py
+++ b/tests/util/yaml/test_input.py
@@ -1,4 +1,5 @@
 """Test inputs."""
+
 import pytest
 
 from homeassistant.util.yaml import (


### PR DESCRIPTION
## Proposed change
Formatting change required for ruff `0.3.1`. See #112690
Created with regex substitution
```diff
-"""\nimport
+"""\n\nimport
```
_This time with `import`._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
