### PR TITLE
Fix local calendar handling of empty recurrence ids

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -190,6 +190,11 @@ def _validate_rrule(value: Any) -> str:
     return str(value)
 
 
+def _empty_as_none(value: str | None) -> str | None:
+    """Convert any empty string values to None."""
+    return value or None
+
+
 CREATE_EVENT_SERVICE = "create_event"
 CREATE_EVENT_SCHEMA = vol.All(
     cv.has_at_least_one_key(EVENT_START_DATE, EVENT_START_DATETIME, EVENT_IN),
@@ -735,7 +740,9 @@ async def handle_calendar_event_create(
         vol.Required("type"): "calendar/event/delete",
         vol.Required("entity_id"): cv.entity_id,
         vol.Required(EVENT_UID): cv.string,
-        vol.Optional(EVENT_RECURRENCE_ID): cv.string,
+        vol.Optional(EVENT_RECURRENCE_ID): vol.Any(
+            vol.All(cv.string, _empty_as_none), None
+        ),
         vol.Optional(EVENT_RECURRENCE_RANGE): cv.string,
     }
 )
@@ -779,7 +786,9 @@ async def handle_calendar_event_delete(
         vol.Required("type"): "calendar/event/update",
         vol.Required("entity_id"): cv.entity_id,
         vol.Required(EVENT_UID): cv.string,
-        vol.Optional(EVENT_RECURRENCE_ID): cv.string,
+        vol.Optional(EVENT_RECURRENCE_ID): vol.Any(
+            vol.All(cv.string, _empty_as_none), None
+        ),
         vol.Optional(EVENT_RECURRENCE_RANGE): cv.string,
         vol.Required(CONF_EVENT): WEBSOCKET_EVENT_SCHEMA,
     }
@@ -813,6 +822,7 @@ async def handle_calendar_event_update(
             recurrence_range=msg.get(EVENT_RECURRENCE_RANGE),
         )
     except (HomeAssistantError, ValueError) as ex:
+        _LOGGER.info(msg)
         _LOGGER.error("Error handling Calendar Event call: %s", ex)
         connection.send_error(msg["id"], "failed", str(ex))
     else:

--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -822,7 +822,6 @@ async def handle_calendar_event_update(
             recurrence_range=msg.get(EVENT_RECURRENCE_RANGE),
         )
     except (HomeAssistantError, ValueError) as ex:
-        _LOGGER.info(msg)
         _LOGGER.error("Error handling Calendar Event call: %s", ex)
         connection.send_error(msg["id"], "failed", str(ex))
     else:

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -141,6 +141,7 @@ class LocalCalendarEntity(CalendarEntity):
         recurrence_range: str | None = None,
     ) -> None:
         """Update an existing event on the calendar."""
+        _LOGGER.debug("async_update_event uid=%s, recurrence_id=%s", uid, recurrence_id)
         new_event = _parse_event(event)
         range_value: Range = Range.NONE
         if recurrence_range == Range.THIS_AND_FUTURE:
@@ -154,12 +155,14 @@ class LocalCalendarEntity(CalendarEntity):
             )
         except EventStoreError as err:
             raise HomeAssistantError(f"Error while updating event: {err}") from err
+        _LOGGER.debug("Updated event: %s", new_event)
         await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
 
 
 def _parse_event(event: dict[str, Any]) -> Event:
     """Parse an ical event from a home assistant event dictionary."""
+    _LOGGER.debug("Parsing event: %s", event)
     if rrule := event.get(EVENT_RRULE):
         event[EVENT_RRULE] = Recur.from_rrule(rrule)
 

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -141,7 +141,6 @@ class LocalCalendarEntity(CalendarEntity):
         recurrence_range: str | None = None,
     ) -> None:
         """Update an existing event on the calendar."""
-        _LOGGER.debug("async_update_event uid=%s, recurrence_id=%s", uid, recurrence_id)
         new_event = _parse_event(event)
         range_value: Range = Range.NONE
         if recurrence_range == Range.THIS_AND_FUTURE:
@@ -155,14 +154,12 @@ class LocalCalendarEntity(CalendarEntity):
             )
         except EventStoreError as err:
             raise HomeAssistantError(f"Error while updating event: {err}") from err
-        _LOGGER.debug("Updated event: %s", new_event)
         await self._async_store()
         await self.async_update_ha_state(force_refresh=True)
 
 
 def _parse_event(event: dict[str, Any]) -> Event:
     """Parse an ical event from a home assistant event dictionary."""
-    _LOGGER.debug("Parsing event: %s", event)
     if rrule := event.get(EVENT_RRULE):
         event[EVENT_RRULE] = Recur.from_rrule(rrule)
 

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -408,6 +408,46 @@ async def test_websocket_delete_recurring(
     ]
 
 
+async def test_websocket_delete_empty_recurrence_id(
+    ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
+) -> None:
+    """Test websocket delete command with an empty recurrence id no-op."""
+    client = await ws_client()
+    await client.cmd_result(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                "dtstart": "1997-07-14T17:00:00+00:00",
+                "dtend": "1997-07-15T04:00:00+00:00",
+            },
+        },
+    )
+
+    events = await get_events("1997-07-14T00:00:00", "1997-07-16T00:00:00")
+    assert list(map(event_fields, events)) == [
+        {
+            "summary": "Bastille Day Party",
+            "start": {"dateTime": "1997-07-14T11:00:00-06:00"},
+            "end": {"dateTime": "1997-07-14T22:00:00-06:00"},
+        }
+    ]
+    uid = events[0]["uid"]
+
+    # Delete the event with an empty recurrence id
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": uid,
+            "recurrence_id": "",
+        },
+    )
+    events = await get_events("1997-07-14T00:00:00", "1997-07-16T00:00:00")
+    assert list(map(event_fields, events)) == []
+
+
 async def test_websocket_update(
     ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
 ) -> None:
@@ -454,6 +494,58 @@ async def test_websocket_update(
             "summary": "Bastille Day Party [To be rescheduled]",
             "start": {"date": "1997-07-14"},
             "end": {"date": "1997-07-15"},
+        }
+    ]
+
+
+async def test_websocket_update_empty_recurrence(
+    ws_client: ClientFixture, setup_integration: None, get_events: GetEventsFn
+) -> None:
+    """Test an edit with an empty recurrence id (no-op)."""
+    client = await ws_client()
+    await client.cmd_result(
+        "create",
+        {
+            "entity_id": TEST_ENTITY,
+            "event": {
+                "summary": "Bastille Day Party",
+                "dtstart": "1997-07-14T17:00:00+00:00",
+                "dtend": "1997-07-15T04:00:00+00:00",
+            },
+        },
+    )
+
+    events = await get_events("1997-07-14T00:00:00", "1997-07-16T00:00:00")
+    assert list(map(event_fields, events)) == [
+        {
+            "summary": "Bastille Day Party",
+            "start": {"dateTime": "1997-07-14T11:00:00-06:00"},
+            "end": {"dateTime": "1997-07-14T22:00:00-06:00"},
+        }
+    ]
+    uid = events[0]["uid"]
+
+    # Update the event with an empty string for the recurrence id which should
+    # have no effect.
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": uid,
+            "recurrence_id": "",
+            "event": {
+                "summary": "Bastille Day Party [To be rescheduled]",
+                "dtstart": "1997-07-15T11:00:00-06:00",
+                "dtend": "1997-07-15T22:00:00-06:00",
+            },
+        },
+    )
+    events = await get_events("1997-07-14T00:00:00", "1997-07-16T00:00:00")
+    assert list(map(event_fields, events)) == [
+        {
+            "summary": "Bastille Day Party [To be rescheduled]",
+            "start": {"dateTime": "1997-07-15T11:00:00-06:00"},
+            "end": {"dateTime": "1997-07-15T22:00:00-06:00"},
         }
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix bug when editing or deleting existing calendar events which fails with:

`Error handling Calendar Event call: Unable to parse date/time value: [ValueError("Expected value to match DATE pattern: ''"), ValueError('Expected value to match DATE-TIME pattern: ')]`

The frontend currently passes in an empty string for the recurrence_id which is then attempted to be parsed as an event id instance. This fixes the schema parser to ignore empty strings and treat them as none.

Alternatives:
- An alternative could be to patch ical to handle this, but I like the idea of passing `None` explicitly into the entity APIs.
- Another alternative could be to fix the frontend to omit the [recurrence id](https://github.com/home-assistant/frontend/blob/cc0fde2c0805d49e155d97f987e3c680107cc77d/src/data/calendar.ts#L175) but I leaned towards this to just keep the code as defensive


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112561
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
