### PR TITLE
Replace EventType with Event [missing]

### DIFF
--- a/homeassistant/components/bthome/logbook.py
+++ b/homeassistant/components/bthome/logbook.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from homeassistant.components.logbook import LOGBOOK_ENTRY_MESSAGE, LOGBOOK_ENTRY_NAME
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.device_registry import async_get
-from homeassistant.helpers.typing import EventType
 
 from .const import BTHOME_BLE_EVENT, DOMAIN, BTHomeBleEvent
 
@@ -16,14 +15,14 @@ from .const import BTHOME_BLE_EVENT, DOMAIN, BTHomeBleEvent
 def async_describe_events(
     hass: HomeAssistant,
     async_describe_event: Callable[
-        [str, str, Callable[[EventType[BTHomeBleEvent]], dict[str, str]]], None
+        [str, str, Callable[[Event[BTHomeBleEvent]], dict[str, str]]], None
     ],
 ) -> None:
     """Describe logbook events."""
     dr = async_get(hass)
 
     @callback
-    def async_describe_bthome_event(event: EventType[BTHomeBleEvent]) -> dict[str, str]:
+    def async_describe_bthome_event(event: Event[BTHomeBleEvent]) -> dict[str, str]:
         """Describe bthome logbook event."""
         data = event.data
         device = dr.async_get(data["device_id"])

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -43,7 +43,6 @@ from homeassistant.helpers.event import (
     EventStateChangedData,
     async_track_state_added_domain,
 )
-from homeassistant.helpers.typing import EventType
 from homeassistant.util.json import JsonObjectType, json_loads_object
 
 from .agent import AbstractConversationAgent, ConversationInput, ConversationResult
@@ -696,14 +695,14 @@ class DefaultAgent(AbstractConversationAgent):
 
     @core.callback
     def _async_handle_area_registry_changed(
-        self, event: EventType[ar.EventAreaRegistryUpdatedData]
+        self, event: core.Event[ar.EventAreaRegistryUpdatedData]
     ) -> None:
         """Clear area area cache when the area registry has changed."""
         self._slot_lists = None
 
     @core.callback
     def _async_handle_entity_registry_changed(
-        self, event: EventType[er.EventEntityRegistryUpdatedData]
+        self, event: core.Event[er.EventEntityRegistryUpdatedData]
     ) -> None:
         """Clear names list cache when an entity registry entry has changed."""
         if event.data["action"] != "update" or not any(

--- a/homeassistant/components/image/__init__.py
+++ b/homeassistant/components/image/__init__.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.event import (
     async_track_time_interval,
 )
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.typing import UNDEFINED, ConfigType, EventType, UndefinedType
+from homeassistant.helpers.typing import UNDEFINED, ConfigType, UndefinedType
 
 from .const import DOMAIN, IMAGE_TIMEOUT  # noqa: F401
 
@@ -342,7 +342,7 @@ async def async_get_still_stream(
 
     event = asyncio.Event()
 
-    async def image_state_update(_event: EventType[EventStateChangedData]) -> None:
+    async def image_state_update(_event: Event[EventStateChangedData]) -> None:
         """Write image to stream."""
         event.set()
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -60,7 +60,6 @@ from homeassistant.helpers.typing import (
     UNDEFINED,
     ConfigType,
     DiscoveryInfoType,
-    EventType,
     UndefinedType,
 )
 from homeassistant.util.json import json_loads
@@ -769,7 +768,7 @@ async def async_remove_discovery_payload(
 async def async_clear_discovery_topic_if_entity_removed(
     hass: HomeAssistant,
     discovery_data: DiscoveryInfoType,
-    event: EventType[er.EventEntityRegistryUpdatedData],
+    event: Event[er.EventEntityRegistryUpdatedData],
 ) -> None:
     """Clear the discovery topic if the entity is removed."""
     if event.data["action"] == "remove":

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -15,10 +15,10 @@ from homeassistant.const import (
     CONF_ZONE,
     UnitOfLength,
 )
-from homeassistant.core import HomeAssistant, State, callback
+from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
-from homeassistant.helpers.typing import ConfigType, EventType
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.location import distance
 from homeassistant.util.unit_conversion import DistanceConverter
@@ -107,7 +107,7 @@ class ProximityDataUpdateCoordinator(DataUpdateCoordinator[ProximityData]):
         await self.async_refresh()
 
     async def async_check_tracked_entity_change(
-        self, event: EventType[er.EventEntityRegistryUpdatedData]
+        self, event: Event[er.EventEntityRegistryUpdatedData]
     ) -> None:
         """Fetch and process tracked entity change event."""
         data = event.data

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -9,10 +9,9 @@ import voluptuous as vol
 from homeassistant.components.homeassistant import exposed_entities
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ENTITY_ID
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
-from homeassistant.helpers.typing import EventType
 
 from .const import CONF_INVERT, CONF_TARGET_DOMAIN
 from .light import LightSwitch
@@ -58,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return False
 
     async def async_registry_updated(
-        event: EventType[er.EventEntityRegistryUpdatedData],
+        event: Event[er.EventEntityRegistryUpdatedData],
     ) -> None:
         """Handle entity registry update."""
         data = event.data

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -68,7 +68,7 @@ from .event import (
     async_track_device_registry_updated_event,
     async_track_entity_registry_updated_event,
 )
-from .typing import UNDEFINED, EventType, StateType, UndefinedType
+from .typing import UNDEFINED, StateType, UndefinedType
 
 if TYPE_CHECKING:
     from functools import cached_property
@@ -1455,7 +1455,7 @@ class Entity(
 
     @callback
     def _async_registry_updated(
-        self, event: EventType[er.EventEntityRegistryUpdatedData]
+        self, event: Event[er.EventEntityRegistryUpdatedData]
     ) -> None:
         """Handle entity registry update."""
         action = event.data["action"]
@@ -1467,7 +1467,7 @@ class Entity(
             )
 
     async def _async_process_registry_update_or_remove(
-        self, event: EventType[er.EventEntityRegistryUpdatedData]
+        self, event: Event[er.EventEntityRegistryUpdatedData]
     ) -> None:
         """Handle entity registry update or remove."""
         data = event.data

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -7,7 +7,7 @@ import dataclasses
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, TypedDict, cast
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
 
 from .normalized_name_base_registry import (
@@ -17,7 +17,7 @@ from .normalized_name_base_registry import (
 )
 from .registry import BaseRegistry
 from .storage import Store
-from .typing import UNDEFINED, EventType, UndefinedType
+from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "floor_registry"
 EVENT_FLOOR_REGISTRY_UPDATED = "floor_registry_updated"
@@ -32,7 +32,7 @@ class EventFloorRegistryUpdatedData(TypedDict):
     floor_id: str
 
 
-EventFloorRegistryUpdated = EventType[EventFloorRegistryUpdatedData]
+EventFloorRegistryUpdated = Event[EventFloorRegistryUpdatedData]
 
 
 @dataclass(slots=True, kw_only=True, frozen=True)

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -11,7 +11,7 @@ from types import ModuleType
 from typing import Any
 
 from homeassistant.const import EVENT_COMPONENT_LOADED
-from homeassistant.core import HassJob, HomeAssistant, callback
+from homeassistant.core import Event, HassJob, HomeAssistant, callback
 from homeassistant.loader import (
     Integration,
     async_get_integrations,
@@ -21,8 +21,6 @@ from homeassistant.loader import (
 )
 from homeassistant.setup import ATTR_COMPONENT, EventComponentLoaded
 from homeassistant.util.logging import catch_log_exception
-
-from .typing import EventType
 
 _LOGGER = logging.getLogger(__name__)
 DATA_INTEGRATION_PLATFORMS = "integration_platforms"
@@ -41,7 +39,7 @@ class IntegrationPlatform:
 def _async_integration_platform_component_loaded(
     hass: HomeAssistant,
     integration_platforms: list[IntegrationPlatform],
-    event: EventType[EventComponentLoaded],
+    event: Event[EventComponentLoaded],
 ) -> None:
     """Process integration platforms for a component."""
     if "." in (component_name := event.data[ATTR_COMPONENT]):

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -7,7 +7,7 @@ import dataclasses
 from dataclasses import dataclass
 from typing import Literal, TypedDict, cast
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
 
 from .normalized_name_base_registry import (
@@ -17,7 +17,7 @@ from .normalized_name_base_registry import (
 )
 from .registry import BaseRegistry
 from .storage import Store
-from .typing import UNDEFINED, EventType, UndefinedType
+from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "label_registry"
 EVENT_LABEL_REGISTRY_UPDATED = "label_registry_updated"
@@ -32,7 +32,7 @@ class EventLabelRegistryUpdatedData(TypedDict):
     label_id: str
 
 
-EventLabelRegistryUpdated = EventType[EventLabelRegistryUpdatedData]
+EventLabelRegistryUpdated = Event[EventLabelRegistryUpdatedData]
 
 
 @dataclass(slots=True, frozen=True, kw_only=True)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -28,7 +28,7 @@ from .core import (
 from .exceptions import DependencyError, HomeAssistantError
 from .helpers import translation
 from .helpers.issue_registry import IssueSeverity, async_create_issue
-from .helpers.typing import ConfigType, EventType
+from .helpers.typing import ConfigType
 from .util import ensure_unique_string
 from .util.async_ import create_eager_task
 
@@ -592,7 +592,7 @@ def _async_when_setup(
         await when_setup()
 
     @callback
-    def _async_is_component_filter(event: EventType[EventComponentLoaded]) -> bool:
+    def _async_is_component_filter(event: Event[EventComponentLoaded]) -> bool:
         """Check if the event is for the component."""
         return event.data[ATTR_COMPONENT] == component
 

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -23,13 +23,12 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import (
     EventStateChangedData,
     async_track_state_change_event,
 )
-from homeassistant.helpers.typing import EventType
 
 from .conftest import MockESPHomeDevice
 
@@ -225,7 +224,7 @@ async def test_entities_removed_after_reload(
     on_future = hass.loop.create_future()
 
     @callback
-    def _async_wait_for_on(event: EventType[EventStateChangedData]) -> None:
+    def _async_wait_for_on(event: Event[EventStateChangedData]) -> None:
         if event.data["new_state"].state == STATE_ON:
             on_future.set_result(None)
 


### PR DESCRIPTION
## Proposed change
Followup to #111955
`EventType` is just an alias for `Event` now.

_Replace the last instances missed during the first pass._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
`