### PR TITLE
Ensure calls to async_request_refresh on coordinators run in background tasks

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -23,6 +23,7 @@ class Debouncer(Generic[_R_co]):
         cooldown: float,
         immediate: bool,
         function: Callable[[], _R_co] | None = None,
+        background: bool = False,
     ) -> None:
         """Initialize debounce.
 
@@ -45,6 +46,7 @@ class Debouncer(Generic[_R_co]):
                 function, f"debouncer cooldown={cooldown}, immediate={immediate}"
             )
         )
+        self._background = background
         self._shutdown_requested = False
 
     @property
@@ -109,7 +111,9 @@ class Debouncer(Generic[_R_co]):
 
             assert self._job is not None
             try:
-                if task := self.hass.async_run_hass_job(self._job):
+                if task := self.hass.async_run_hass_job(
+                    self._job, background=self._background
+                ):
                     await task
             finally:
                 self._schedule_timer()
@@ -130,7 +134,9 @@ class Debouncer(Generic[_R_co]):
                 return
 
             try:
-                if task := self.hass.async_run_hass_job(self._job):
+                if task := self.hass.async_run_hass_job(
+                    self._job, background=self._background
+                ):
                     await task
             except Exception:  # pylint: disable=broad-except
                 self.logger.exception("Unexpected exception from %s", self.function)

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -133,6 +133,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
                 cooldown=REQUEST_REFRESH_DEFAULT_COOLDOWN,
                 immediate=REQUEST_REFRESH_DEFAULT_IMMEDIATE,
                 function=self.async_refresh,
+                background=True,
             )
         else:
             request_refresh_debouncer.function = self.async_refresh


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently if `async_request_refresh` was called during startup it would delay startup because it was scheduled as a tracked task.

```
2024-03-09 10:11:50.132 DEBUG (MainThread) [homeassistant.bootstrap] Waiting on tasks: {

<Task pending name='debouncer cooldown=10, immediate=True' coro=<DataUpdateCoordinator.async_refresh() running at /usr/src/homeassistant/homeassistant/helpers/update_coordinator.py:310> wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.12/asyncio/futures.py:387, <2 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]> cb=[set.remove(), <1 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]>, 

<Task pending name='debouncer <Job debouncer cooldown=10, immediate=True HassJobType.Coroutinefunction <bound method DataUpdateCoordinator.async_refresh of <custom_components.solaredgeoptimizers.sensor.MyCoordinator object at 0x7f964dbb48c0>>> finish cooldown=10, immediate=True' coro=<Debouncer._handle_timer_finish() running at /usr/src/homeassistant/homeassistant/helpers/debounce.py:134> wait_for=<Task pending name='debouncer cooldown=10, immediate=True' coro=<DataUpdateCoordinator.async_refresh() running at /usr/src/homeassistant/homeassistant/helpers/update_coordinator.py:310> wait_for=<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.12/asyncio/futures.py:387, <2 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]> cb=[set.remove(), <1 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]> cb=[set.remove(), _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]>, <Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.12/asyncio/futures.py:387, <1 more>, Task.task_wakeup()]>, <Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.12/asyncio/futures.py:387, <2 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.12/asyncio/tasks.py:534]>

}

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
