### PR TITLE
Revert "Cleanup mqtt discovery code"

### DIFF
--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -463,7 +463,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # Setup discovery
         if conf.get(CONF_DISCOVERY, DEFAULT_DISCOVERY):
             await discovery.async_start(
-                hass, conf.get(CONF_DISCOVERY_PREFIX, DEFAULT_PREFIX)
+                hass, conf.get(CONF_DISCOVERY_PREFIX, DEFAULT_PREFIX), entry
             )
         # Setup reload service after all platforms have loaded
         await async_setup_reload_service()

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_NAME, CONF_PLATFORM
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
@@ -136,10 +137,11 @@ def async_log_discovery_origin_info(
 
 
 async def async_start(  # noqa: C901
-    hass: HomeAssistant, discovery_topic: str
+    hass: HomeAssistant, discovery_topic: str, config_entry: ConfigEntry
 ) -> None:
     """Start MQTT Discovery."""
     mqtt_data = get_mqtt_data(hass)
+    mqtt_integrations = {}
 
     @callback
     def async_discovery_message_received(msg: ReceiveMessage) -> None:  # noqa: C901
@@ -153,8 +155,9 @@ async def async_start(  # noqa: C901
             if topic_trimmed.endswith("config"):
                 _LOGGER.warning(
                     (
-                        "Received message on illegal discovery topic '%s'. The topic "
-                        "contains not allowed characters. For more information see "
+                        "Received message on illegal discovery topic '%s'. The topic"
+                        " contains "
+                        "not allowed characters. For more information see "
                         "https://www.home-assistant.io/integrations/mqtt/#discovery-topic"
                     ),
                     topic,

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -55,9 +55,10 @@ async def test_subscribing_config_topic(
 ) -> None:
     """Test setting up discovery."""
     mqtt_mock = await mqtt_mock_entry()
+    entry = hass.config_entries.async_entries(mqtt.DOMAIN)[0]
 
     discovery_topic = "homeassistant"
-    await async_start(hass, discovery_topic)
+    await async_start(hass, discovery_topic, entry)
 
     call_args1 = mqtt_mock.async_subscribe.mock_calls[0][1]
     assert call_args1[2] == 0
@@ -1502,13 +1503,14 @@ async def test_mqtt_integration_discovery_subscribe_unsubscribe(
     mqtt_mock = await mqtt_mock_entry()
     mock_platform(hass, "comp.config_flow", None)
 
+    entry = hass.config_entries.async_entries("mqtt")[0]
     mqtt_mock().connected = True
 
     with patch(
         "homeassistant.components.mqtt.discovery.async_get_mqtt",
         return_value={"comp": ["comp/discovery/#"]},
     ):
-        await async_start(hass, "homeassistant")
+        await async_start(hass, "homeassistant", entry)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
@@ -1551,13 +1553,14 @@ async def test_mqtt_discovery_unsubscribe_once(
     mqtt_mock = await mqtt_mock_entry()
     mock_platform(hass, "comp.config_flow", None)
 
+    entry = hass.config_entries.async_entries("mqtt")[0]
     mqtt_mock().connected = True
 
     with patch(
         "homeassistant.components.mqtt.discovery.async_get_mqtt",
         return_value={"comp": ["comp/discovery/#"]},
     ):
-        await async_start(hass, "homeassistant")
+        await async_start(hass, "homeassistant", entry)
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 


### PR DESCRIPTION
Reverts home-assistant/core#112749

If was too fast merging #112749, I'd like to revert it in favor of https://github.com/home-assistant/core/pull/112720 that will need the config entry parameter.