### PR TITLE
Move modbus check_config to setup, to have access to hass

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -132,7 +132,6 @@ from .const import (  # noqa: F401
 )
 from .modbus import ModbusHub, async_modbus_setup
 from .validators import (
-    check_config,
     check_hvac_target_temp_registers,
     duplicate_fan_mode_validator,
     hvac_fixedsize_reglist_validator,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -418,7 +418,6 @@ CONFIG_SCHEMA = vol.Schema(
             [
                 vol.Any(SERIAL_SCHEMA, ETHERNET_SCHEMA),
             ],
-            check_config,
         ),
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -69,6 +69,7 @@ from .const import (
     TCP,
     UDP,
 )
+from .validators import check_config
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -127,6 +128,8 @@ async def async_modbus_setup(
 
     await async_setup_reload_service(hass, DOMAIN, [DOMAIN])
 
+    if config[DOMAIN]:
+        config[DOMAIN] = check_config(hass, config[DOMAIN])
     if DOMAIN in hass.data and config[DOMAIN] == []:
         hubs = hass.data[DOMAIN]
         for name in hubs:

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_TYPE,
 )
+from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_DATA_TYPE,
@@ -270,7 +271,99 @@ def register_int_list_validator(value: Any) -> Any:
     )
 
 
-def check_config(config: dict) -> dict:
+def validate_modbus(
+    hass: HomeAssistant,
+    hosts: set[str],
+    hub_names: set[str],
+    hub: dict,
+    hub_name_inx: int,
+) -> bool:
+    """Validate modbus entries."""
+    host: str = (
+        hub[CONF_PORT]
+        if hub[CONF_TYPE] == SERIAL
+        else f"{hub[CONF_HOST]}_{hub[CONF_PORT]}"
+    )
+    if CONF_NAME not in hub:
+        hub[CONF_NAME] = (
+            DEFAULT_HUB if not hub_name_inx else f"{DEFAULT_HUB}_{hub_name_inx}"
+        )
+        hub_name_inx += 1
+        err = f"Modbus host/port {host} is missing name, added {hub[CONF_NAME]}!"
+        _LOGGER.warning(err)
+    name = hub[CONF_NAME]
+    if host in hosts or name in hub_names:
+        err = f"Modbus {name} host/port {host} is duplicate, not loaded!"
+        _LOGGER.warning(err)
+        return False
+    hosts.add(host)
+    hub_names.add(name)
+    return True
+
+
+def validate_entity(
+    hass: HomeAssistant,
+    hub_name: str,
+    component: str,
+    entity: dict,
+    minimum_scan_interval: int,
+    ent_names: set[str],
+    ent_addr: set[str],
+) -> bool:
+    """Validate entity."""
+    name = f"{component}.{entity[CONF_NAME]}"
+    addr = f"{hub_name}{entity[CONF_ADDRESS]}"
+    scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    if 0 < scan_interval < 5:
+        _LOGGER.warning(
+            (
+                "%s %s scan_interval(%d) is lower than 5 seconds, "
+                "which may cause Home Assistant stability issues"
+            ),
+            hub_name,
+            name,
+            scan_interval,
+        )
+    entity[CONF_SCAN_INTERVAL] = scan_interval
+    minimum_scan_interval = min(scan_interval, minimum_scan_interval)
+    for conf_type in (
+        CONF_INPUT_TYPE,
+        CONF_WRITE_TYPE,
+        CONF_COMMAND_ON,
+        CONF_COMMAND_OFF,
+    ):
+        if conf_type in entity:
+            addr += f"_{entity[conf_type]}"
+    inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
+    addr += f"_{inx}"
+    loc_addr: set[str] = {addr}
+
+    if CONF_TARGET_TEMP in entity:
+        loc_addr.add(f"{hub_name}{entity[CONF_TARGET_TEMP]}_{inx}")
+    if CONF_HVAC_MODE_REGISTER in entity:
+        loc_addr.add(f"{hub_name}{entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS]}_{inx}")
+    if CONF_FAN_MODE_REGISTER in entity:
+        loc_addr.add(f"{hub_name}{entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS]}_{inx}")
+
+    dup_addrs = ent_addr.intersection(loc_addr)
+    if len(dup_addrs) > 0:
+        for addr in dup_addrs:
+            err = (
+                f"Modbus {hub_name}/{name} address {addr} is duplicate, second"
+                " entry not loaded!"
+            )
+            _LOGGER.warning(err)
+        return False
+    if name in ent_names:
+        err = f"Modbus {hub_name}/{name} is duplicate, second entry not loaded!"
+        _LOGGER.warning(err)
+        return False
+    ent_names.add(name)
+    ent_addr.update(loc_addr)
+    return True
+
+
+def check_config(hass: HomeAssistant, config: dict) -> dict:
     """Do final config check."""
     hosts: set[str] = set()
     hub_names: set[str] = set()
@@ -279,97 +372,10 @@ def check_config(config: dict) -> dict:
     ent_names: set[str] = set()
     ent_addr: set[str] = set()
 
-    def validate_modbus(hub: dict, hub_name_inx: int) -> bool:
-        """Validate modbus entries."""
-        host: str = (
-            hub[CONF_PORT]
-            if hub[CONF_TYPE] == SERIAL
-            else f"{hub[CONF_HOST]}_{hub[CONF_PORT]}"
-        )
-        if CONF_NAME not in hub:
-            hub[CONF_NAME] = (
-                DEFAULT_HUB if not hub_name_inx else f"{DEFAULT_HUB}_{hub_name_inx}"
-            )
-            hub_name_inx += 1
-            err = f"Modbus host/port {host} is missing name, added {hub[CONF_NAME]}!"
-            _LOGGER.warning(err)
-        name = hub[CONF_NAME]
-        if host in hosts or name in hub_names:
-            err = f"Modbus {name} host/port {host} is duplicate, not loaded!"
-            _LOGGER.warning(err)
-            return False
-        hosts.add(host)
-        hub_names.add(name)
-        return True
-
-    def validate_entity(
-        hub_name: str,
-        component: str,
-        entity: dict,
-        minimum_scan_interval: int,
-        ent_names: set,
-        ent_addr: set,
-    ) -> bool:
-        """Validate entity."""
-        name = f"{component}.{entity[CONF_NAME]}"
-        addr = f"{hub_name}{entity[CONF_ADDRESS]}"
-        scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
-        if 0 < scan_interval < 5:
-            _LOGGER.warning(
-                (
-                    "%s %s scan_interval(%d) is lower than 5 seconds, "
-                    "which may cause Home Assistant stability issues"
-                ),
-                hub_name,
-                name,
-                scan_interval,
-            )
-        entity[CONF_SCAN_INTERVAL] = scan_interval
-        minimum_scan_interval = min(scan_interval, minimum_scan_interval)
-        for conf_type in (
-            CONF_INPUT_TYPE,
-            CONF_WRITE_TYPE,
-            CONF_COMMAND_ON,
-            CONF_COMMAND_OFF,
-        ):
-            if conf_type in entity:
-                addr += f"_{entity[conf_type]}"
-        inx = entity.get(CONF_SLAVE) or entity.get(CONF_DEVICE_ADDRESS, 0)
-        addr += f"_{inx}"
-        loc_addr: set[str] = {addr}
-
-        if CONF_TARGET_TEMP in entity:
-            loc_addr.add(f"{hub_name}{entity[CONF_TARGET_TEMP]}_{inx}")
-        if CONF_HVAC_MODE_REGISTER in entity:
-            loc_addr.add(
-                f"{hub_name}{entity[CONF_HVAC_MODE_REGISTER][CONF_ADDRESS]}_{inx}"
-            )
-        if CONF_FAN_MODE_REGISTER in entity:
-            loc_addr.add(
-                f"{hub_name}{entity[CONF_FAN_MODE_REGISTER][CONF_ADDRESS]}_{inx}"
-            )
-
-        dup_addrs = ent_addr.intersection(loc_addr)
-        if len(dup_addrs) > 0:
-            for addr in dup_addrs:
-                err = (
-                    f"Modbus {hub_name}/{name} address {addr} is duplicate, second"
-                    " entry not loaded!"
-                )
-                _LOGGER.warning(err)
-            return False
-        if name in ent_names:
-            err = f"Modbus {hub_name}/{name} is duplicate, second entry not loaded!"
-            _LOGGER.warning(err)
-            return False
-        ent_names.add(name)
-        ent_addr.update(loc_addr)
-        return True
-
     hub_inx = 0
     while hub_inx < len(config):
         hub = config[hub_inx]
-        if not validate_modbus(hub, hub_name_inx):
+        if not validate_modbus(hass, hosts, hub_names, hub, hub_name_inx):
             del config[hub_inx]
             continue
         minimum_scan_interval = 9999
@@ -382,6 +388,7 @@ def check_config(config: dict) -> dict:
             entities = hub[conf_key]
             while entity_inx < len(entities):
                 if not validate_entity(
+                    hass,
                     hub[CONF_NAME],
                     component,
                     entities[entity_inx],

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -334,7 +334,7 @@ def validate_entity(
     ):
         if conf_type in entity:
             addr += f"_{entity[conf_type]}"
-    inx = entity.get(CONF_SLAVE, None) or entity.get(CONF_DEVICE_ADDRESS, 0)
+    inx = entity.get(CONF_SLAVE) or entity.get(CONF_DEVICE_ADDRESS, 0)
     addr += f"_{inx}"
     loc_addr: set[str] = {addr}
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -423,9 +423,9 @@ async def test_exception_struct_validator(do_config) -> None:
         ],
     ],
 )
-async def test_check_config(do_config) -> None:
+async def test_check_config(hass: HomeAssistant, do_config) -> None:
     """Test duplicate modbus validator."""
-    check_config(do_config)
+    check_config(hass, do_config)
     assert len(do_config) == 1
 
 
@@ -476,9 +476,9 @@ async def test_check_config(do_config) -> None:
         ],
     ],
 )
-async def test_check_config_sensor(do_config) -> None:
+async def test_check_config_sensor(hass: HomeAssistant, do_config) -> None:
     """Test duplicate entity validator."""
-    check_config(do_config)
+    check_config(hass, do_config)
     assert len(do_config[0][CONF_SENSORS]) == 1
 
 
@@ -691,9 +691,9 @@ async def test_check_config_sensor(do_config) -> None:
         ],
     ],
 )
-async def test_check_config_climate(do_config) -> None:
+async def test_check_config_climate(hass: HomeAssistant, do_config) -> None:
     """Test duplicate entity validator."""
-    check_config(do_config)
+    check_config(hass, do_config)
     assert len(do_config[0][CONF_CLIMATES]) == 1
 
 
@@ -913,9 +913,9 @@ async def test_duplicate_fan_mode_validator(do_config) -> None:
         ),
     ],
 )
-async def test_duplicate_addresses(do_config, sensor_cnt) -> None:
+async def test_duplicate_addresses(hass: HomeAssistant, do_config, sensor_cnt) -> None:
     """Test duplicate entity validator."""
-    check_config(do_config)
+    check_config(hass, do_config)
     use_inx = len(do_config) - 1
     assert len(do_config[use_inx][CONF_SENSORS]) == sensor_cnt
 
@@ -948,9 +948,9 @@ async def test_duplicate_addresses(do_config, sensor_cnt) -> None:
         ],
     ],
 )
-async def test_no_duplicate_names(do_config) -> None:
+async def test_no_duplicate_names(hass: HomeAssistant, do_config) -> None:
     """Test duplicate entity validator."""
-    check_config(do_config)
+    check_config(hass, do_config)
     assert len(do_config[0][CONF_SENSORS]) == 1
     assert len(do_config[0][CONF_BINARY_SENSORS]) == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR, moves the global check_config from voluptuous to async_modbus_setup(), allowing us to access hass.

This PR only moves the code around, there are NO functionality changes, in the hope it makes a review a lot easier.

Once merged, all configuration errors (log.error) in check_config will be changed to create_issue, to make problems more visible to the user.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
