### PR TITLE
Allow customizing display name for energy device

### DIFF
--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -136,6 +136,8 @@ class DeviceConsumption(TypedDict):
     # This is an ever increasing value
     stat_consumption: str
 
+    name: str
+
 
 class EnergyPreferences(TypedDict):
     """Dictionary holding the energy data."""
@@ -287,6 +289,7 @@ ENERGY_SOURCE_SCHEMA = vol.All(
 DEVICE_CONSUMPTION_SCHEMA = vol.Schema(
     {
         vol.Required("stat_consumption"): str,
+        vol.Optional("name"): str,
     }
 )
 

--- a/homeassistant/components/energy/data.py
+++ b/homeassistant/components/energy/data.py
@@ -136,7 +136,8 @@ class DeviceConsumption(TypedDict):
     # This is an ever increasing value
     stat_consumption: str
 
-    name: str
+    # An optional custom name for display in energy graphs
+    name: str | None
 
 
 class EnergyPreferences(TypedDict):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Allow for storing a custom display name with individual device consumptions for energy dashboard. This allows users for a cleaner and less cluttered dashboard, as entity ids for energy devices often have terms like "Energy", "Consumption", "Daily", "Weekly", "Total", etc which are not relevant for the energy dashboard, but may still be wanted as part of the entity name when looking at it out of the context of energy dashboard. 

Also space is at a premium for smaller/mobile devices, and the visual display can be improved with shorter names to minimize space consumption of the legend. 

![image](https://github.com/home-assistant/frontend/assets/32912880/7ba8a555-689d-4ca8-97cc-a3130b2f75bb)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
https://community.home-assistant.io/t/energy-custom-names-for-individual-devices/372943
https://community.home-assistant.io/t/wth-can-t-i-change-name-on-energy-dashboard-monitor-individual-devices/472496
https://community.home-assistant.io/t/to-have-the-ability-to-rename-in-energy-dashboard/503823
https://community.home-assistant.io/t/rename-energys-individual-devices/378360
https://community.home-assistant.io/t/wth-cant-i-still-not-change-source-names-for-energy-dashboard/470467
https://github.com/home-assistant/frontend/discussions/20024
https://github.com/home-assistant/frontend/discussions/19983
https://github.com/home-assistant/frontend/discussions/18215
https://community.home-assistant.io/t/detail-devices-energy-card-entity-friendly-name-labels/700475


- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
