### PR TITLE
Add reauth to schema config flow

### DIFF
--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -190,7 +190,7 @@ class SchemaCommonFlowHandler:
                 self.parent_handler.context["entry_id"]
             )
             assert entry
-            cast(
+            return cast(
                 SchemaConfigFlowHandler, self.parent_handler
             ).async_update_reload_and_abort(entry, options=user_input)
 

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -190,12 +190,9 @@ class SchemaCommonFlowHandler:
                 self.parent_handler.context["entry_id"]
             )
             assert entry
-            hass.config_entries.async_update_entry(
-                entry=entry,
-                options=user_input,
-            )
-            hass.config_entries.async_schedule_reload(entry.entry_id)
-            return self.parent_handler.async_abort(reason="reauth_successful")
+            cast(
+                SchemaConfigFlowHandler, self.parent_handler
+            ).async_update_reload_and_abort(entry, options=user_input)
 
         if user_input is not None or form_step.schema is None:
             return await self._show_next_step_or_create_entry(form_step)

--- a/homeassistant/helpers/schema_config_entry_flow.py
+++ b/homeassistant/helpers/schema_config_entry_flow.py
@@ -192,7 +192,9 @@ class SchemaCommonFlowHandler:
             assert entry
             return cast(
                 SchemaConfigFlowHandler, self.parent_handler
-            ).async_update_reload_and_abort(entry, options=user_input)
+            ).async_update_reload_and_abort(
+                entry, options={**entry.options, **user_input}
+            )
 
         if user_input is not None or form_step.schema is None:
             return await self._show_next_step_or_create_entry(form_step)

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -768,7 +768,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
     mock_platform(hass, "test.config_flow", None)
     config_entry = MockConfigEntry(
         domain=TEST_DOMAIN,
-        options={"username": "test", "password": "test1"},
+        options={"username": "test", "password": "test1", "test": 1},
     )
     config_entry.add_to_hass(hass)
 
@@ -783,7 +783,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
-    assert config_entry.options == {"username": "test", "password": "test2"}
+    assert config_entry.options == {"username": "test", "password": "test2", "test": 1}
     assert config_entry.state == config_entries.ConfigEntryState.LOADED
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the capability for reauth flows for integrations with Schema config flows.

My idea is that the return value of the `validate_user_input` function contains the updated options for the config entry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
