### PR TITLE
Only read cpu once during systemmonitor setup

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass
 from datetime import datetime
 from functools import lru_cache
@@ -69,13 +70,6 @@ def get_cpu_icon() -> Literal["mdi:cpu-64-bit", "mdi:cpu-32-bit"]:
     if sys.maxsize > 2**32:
         return "mdi:cpu-64-bit"
     return "mdi:cpu-32-bit"
-
-
-def get_processor_temperature(
-    entity: SystemMonitorSensor,
-) -> float | None:
-    """Return processor temperature."""
-    return read_cpu_temperature(entity.hass, entity.coordinator.data.temperatures)
 
 
 def get_process(entity: SystemMonitorSensor) -> str:
@@ -374,7 +368,9 @@ SENSOR_TYPES: dict[str, SysMonitorSensorEntityDescription] = {
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=get_processor_temperature,
+        value_fn=lambda entity: read_cpu_temperature(
+            entity.coordinator.data.temperatures
+        ),
         none_is_unavailable=True,
         add_to_update=lambda entity: ("temperatures", ""),
     ),
@@ -506,22 +502,21 @@ async def async_setup_entry(  # noqa: C901
     legacy_resources: set[str] = set(entry.options.get("resources", []))
     loaded_resources: set[str] = set()
     coordinator: SystemMonitorCoordinator = hass.data[DOMAIN_COORDINATOR]
+    sensor_data = coordinator.data
 
     def get_arguments() -> dict[str, Any]:
         """Return startup information."""
-        disk_arguments = get_all_disk_mounts(hass)
-        network_arguments = get_all_network_interfaces(hass)
-        try:
-            cpu_temperature = read_cpu_temperature(hass)
-        except AttributeError:
-            cpu_temperature = 0.0
         return {
-            "disk_arguments": disk_arguments,
-            "network_arguments": network_arguments,
-            "cpu_temperature": cpu_temperature,
+            "disk_arguments": get_all_disk_mounts(hass),
+            "network_arguments": get_all_network_interfaces(hass),
         }
 
+    cpu_temperature = 0.0
+    with contextlib.suppress(AttributeError):
+        cpu_temperature = read_cpu_temperature(sensor_data.temperatures) or 0.0
+
     startup_arguments = await hass.async_add_executor_job(get_arguments)
+    startup_arguments["cpu_temperature"] = cpu_temperature
 
     _LOGGER.debug("Setup from options %s", entry.options)
 

--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -511,9 +511,9 @@ async def async_setup_entry(  # noqa: C901
             "network_arguments": get_all_network_interfaces(hass),
         }
 
-    cpu_temperature = 0.0
+    cpu_temperature: float | None = None
     with contextlib.suppress(AttributeError):
-        cpu_temperature = read_cpu_temperature(sensor_data.temperatures) or 0.0
+        cpu_temperature = read_cpu_temperature(sensor_data.temperatures)
 
     startup_arguments = await hass.async_add_executor_job(get_arguments)
     startup_arguments["cpu_temperature"] = cpu_temperature

--- a/homeassistant/components/systemmonitor/util.py
+++ b/homeassistant/components/systemmonitor/util.py
@@ -77,13 +77,8 @@ def get_all_running_processes(hass: HomeAssistant) -> set[str]:
     return processes
 
 
-def read_cpu_temperature(
-    hass: HomeAssistant, temps: dict[str, list[shwtemp]] | None = None
-) -> float | None:
+def read_cpu_temperature(temps: dict[str, list[shwtemp]]) -> float | None:
     """Attempt to read CPU / processor temperature."""
-    if temps is None:
-        psutil_wrapper: ha_psutil = hass.data[DOMAIN]
-        temps = psutil_wrapper.psutil.sensors_temperatures()
     entry: shwtemp
 
     _LOGGER.debug("CPU Temperatures: %s", temps)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only read cpu once during systemmonitor setup
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
