### PR TITLE
Refactor handling of device updates in ESPHome

### DIFF
--- a/homeassistant/components/esphome/entity.py
+++ b/homeassistant/components/esphome/entity.py
@@ -22,7 +22,6 @@ from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -205,25 +204,19 @@ class EsphomeEntity(Entity, Generic[_InfoT, _StateT]):
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         entry_data = self._entry_data
-        hass = self.hass
-        key = self._key
-        static_info = self._static_info
-
         self.async_on_remove(
-            async_dispatcher_connect(
-                hass,
-                entry_data.signal_device_updated,
+            entry_data.async_subscribe_device_updated(
                 self._on_device_update,
             )
         )
         self.async_on_remove(
             entry_data.async_subscribe_state_update(
-                self._state_type, key, self._on_state_update
+                self._state_type, self._key, self._on_state_update
             )
         )
         self.async_on_remove(
             entry_data.async_register_key_static_info_updated_callback(
-                static_info, self._on_static_info_update
+                self._static_info, self._on_static_info_update
             )
         )
         self._update_state_from_entry_data()

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -108,18 +108,17 @@ class RuntimeEntryData:
     device_info: DeviceInfo | None = None
     bluetooth_device: ESPHomeBluetoothDevice | None = None
     api_version: APIVersion = field(default_factory=APIVersion)
-    cleanup_callbacks: list[Callable[[], None]] = field(default_factory=list)
-    disconnect_callbacks: set[Callable[[], None]] = field(default_factory=set)
-    state_subscriptions: dict[
-        tuple[type[EntityState], int], Callable[[], None]
-    ] = field(default_factory=dict)
+    cleanup_callbacks: list[CALLBACK_TYPE] = field(default_factory=list)
+    disconnect_callbacks: set[CALLBACK_TYPE] = field(default_factory=set)
+    state_subscriptions: dict[tuple[type[EntityState], int], CALLBACK_TYPE] = field(
+        default_factory=dict
+    )
+    device_update_subscriptions: set[CALLBACK_TYPE] = field(default_factory=set)
     loaded_platforms: set[Platform] = field(default_factory=set)
     platform_load_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _storage_contents: StoreData | None = None
     _pending_storage: Callable[[], StoreData] | None = None
-    assist_pipeline_update_callbacks: list[Callable[[], None]] = field(
-        default_factory=list
-    )
+    assist_pipeline_update_callbacks: list[CALLBACK_TYPE] = field(default_factory=list)
     assist_pipeline_state: bool = False
     entity_info_callbacks: dict[
         type[EntityInfo], list[Callable[[list[EntityInfo]], None]]
@@ -142,11 +141,6 @@ class RuntimeEntryData:
         return (device_info and device_info.friendly_name) or self.name.title().replace(
             "_", " "
         )
-
-    @property
-    def signal_device_updated(self) -> str:
-        """Return the signal to listen to for core device state update."""
-        return f"esphome_{self.entry_id}_on_device_update"
 
     @property
     def signal_static_info_updated(self) -> str:
@@ -216,15 +210,15 @@ class RuntimeEntryData:
 
     @callback
     def async_subscribe_assist_pipeline_update(
-        self, update_callback: Callable[[], None]
-    ) -> Callable[[], None]:
+        self, update_callback: CALLBACK_TYPE
+    ) -> CALLBACK_TYPE:
         """Subscribe to assist pipeline updates."""
         self.assist_pipeline_update_callbacks.append(update_callback)
         return partial(self._async_unsubscribe_assist_pipeline_update, update_callback)
 
     @callback
     def _async_unsubscribe_assist_pipeline_update(
-        self, update_callback: Callable[[], None]
+        self, update_callback: CALLBACK_TYPE
     ) -> None:
         """Unsubscribe to assist pipeline updates."""
         self.assist_pipeline_update_callbacks.remove(update_callback)
@@ -308,12 +302,23 @@ class RuntimeEntryData:
         async_dispatcher_send(hass, self.signal_static_info_updated, infos)
 
     @callback
+    def async_subscribe_device_updated(self, callback_: CALLBACK_TYPE) -> CALLBACK_TYPE:
+        """Subscribe to state updates."""
+        self.device_update_subscriptions.add(callback_)
+        return partial(self._async_unsubscribe_device_update, callback_)
+
+    @callback
+    def _async_unsubscribe_device_update(self, callback_: CALLBACK_TYPE) -> None:
+        """Unsubscribe to device updates."""
+        self.device_update_subscriptions.remove(callback_)
+
+    @callback
     def async_subscribe_state_update(
         self,
         state_type: type[EntityState],
         state_key: int,
-        entity_callback: Callable[[], None],
-    ) -> Callable[[], None]:
+        entity_callback: CALLBACK_TYPE,
+    ) -> CALLBACK_TYPE:
         """Subscribe to state updates."""
         subscription_key = (state_type, state_key)
         self.state_subscriptions[subscription_key] = entity_callback
@@ -359,9 +364,10 @@ class RuntimeEntryData:
                 _LOGGER.exception("Error while calling subscription: %s", ex)
 
     @callback
-    def async_update_device_state(self, hass: HomeAssistant) -> None:
+    def async_update_device_state(self) -> None:
         """Distribute an update of a core device state like availability."""
-        async_dispatcher_send(hass, self.signal_device_updated)
+        for callback_ in self.device_update_subscriptions:
+            callback_()
 
     async def async_load_from_store(self) -> tuple[list[EntityInfo], list[UserService]]:
         """Load the retained data from store and return de-serialized data."""

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -366,7 +366,7 @@ class RuntimeEntryData:
     @callback
     def async_update_device_state(self) -> None:
         """Distribute an update of a core device state like availability."""
-        for callback_ in self.device_update_subscriptions:
+        for callback_ in self.device_update_subscriptions.copy():
             callback_()
 
     async def async_load_from_store(self) -> tuple[list[EntityInfo], list[UserService]]:

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -455,7 +455,7 @@ class ESPHomeManager:
 
         self.device_id = _async_setup_device_registry(hass, entry, entry_data)
 
-        entry_data.async_update_device_state(hass)
+        entry_data.async_update_device_state()
         await entry_data.async_update_static_infos(
             hass, entry, entity_infos, device_info.mac_address
         )
@@ -510,7 +510,7 @@ class ESPHomeManager:
             # since it generates a lot of state changed events and database
             # writes when we already know we're shutting down and the state
             # will be cleared anyway.
-            entry_data.async_update_device_state(hass)
+            entry_data.async_update_device_state()
 
     async def on_connect_error(self, err: Exception) -> None:
         """Start reauth flow if appropriate connect error type."""

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -61,9 +61,7 @@ async def async_setup_entry(
         return
 
     unsubs = [
-        async_dispatcher_connect(
-            hass, entry_data.signal_device_updated, _async_setup_update_entity
-        ),
+        entry_data.async_subscribe_device_updated(_async_setup_update_entity),
         dashboard.async_add_listener(_async_setup_update_entity),
     ]
 
@@ -159,11 +157,7 @@ class ESPHomeUpdateEntity(CoordinatorEntity[ESPHomeDashboard], UpdateEntity):
             )
         )
         self.async_on_remove(
-            async_dispatcher_connect(
-                hass,
-                entry_data.signal_device_updated,
-                self._handle_device_update,
-            )
+            entry_data.async_subscribe_device_updated(self._handle_device_update)
         )
 
     async def async_install(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert the dispatcher to a subscription callback to match the rest of the interfaces

- The dispatchers are untyped which tends to lead to mistakes (at least I've screwed them up a fair amount of times since the args aren't type checked)
- Dispatchers have to have its job type worked out at startup and since this one always fires if the device is up for every entity it has to be worked out many times. We don't need that level of flexibility here

Refactor the update tests to use the existing test fixtures to reduce its size and complexity


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
