### PR TITLE
Make async_at_start wait for the start event to be fired

### DIFF
--- a/homeassistant/components/google_assistant/helpers.py
+++ b/homeassistant/components/google_assistant/helpers.py
@@ -113,7 +113,7 @@ class AbstractConfig(ABC):
             """Sync entities to Google."""
             await self.async_sync_entities_all()
 
-        self._on_deinitialize.append(start.async_at_start(self.hass, sync_google))
+        self._on_deinitialize.append(start.async_at_started(self.hass, sync_google))
 
     @callback
     def async_deinitialize(self) -> None:

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -51,6 +51,10 @@ def _async_at_core_state(
     return cancel
 
 
+def _is_running(hass: HomeAssistant) -> bool:
+    return hass.state is CoreState.running
+
+
 @callback
 def async_at_start(
     hass: HomeAssistant,
@@ -58,13 +62,10 @@ def async_at_start(
 ) -> CALLBACK_TYPE:
     """Execute a job at_start_cb when Home Assistant is starting.
 
-    The job is executed immediately if Home Assistant is already starting or started.
-    Will wait for EVENT_HOMEASSISTANT_START if it isn't.
+    The job is executed immediately if Home Assistant has fired
+    the start event (reached CoreState.running), Otherwise, it
+    will wait for EVENT_HOMEASSISTANT_START
     """
-
-    def _is_running(hass: HomeAssistant) -> bool:
-        return hass.is_running
-
     return _async_at_core_state(
         hass, at_start_cb, EVENT_HOMEASSISTANT_START, _is_running
     )
@@ -77,13 +78,10 @@ def async_at_started(
 ) -> CALLBACK_TYPE:
     """Execute a job at_start_cb when Home Assistant has started.
 
-    The job is executed immediately if Home Assistant is already started.
-    Will wait for EVENT_HOMEASSISTANT_STARTED if it isn't.
+    The job is executed immediately if Home Assistant has fired
+    the start event (reached CoreState.running), Otherwise, it
+    will wait for EVENT_HOMEASSISTANT_STARTED
     """
-
-    def _is_started(hass: HomeAssistant) -> bool:
-        return hass.state is CoreState.running
-
     return _async_at_core_state(
-        hass, at_start_cb, EVENT_HOMEASSISTANT_STARTED, _is_started
+        hass, at_start_cb, EVENT_HOMEASSISTANT_STARTED, _is_running
     )

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -62,9 +62,11 @@ def async_at_start(
 ) -> CALLBACK_TYPE:
     """Execute a job at_start_cb when Home Assistant is starting.
 
-    The job is executed immediately if Home Assistant has fired
-    the start event (reached CoreState.running), Otherwise, it
-    will wait for EVENT_HOMEASSISTANT_START
+    The job is executed immediately if Home Assistant has reached
+    CoreState.running
+
+    Otherwise, it will wait for EVENT_HOMEASSISTANT_START event
+    to be fired.
     """
     return _async_at_core_state(
         hass, at_start_cb, EVENT_HOMEASSISTANT_START, _is_running
@@ -78,9 +80,11 @@ def async_at_started(
 ) -> CALLBACK_TYPE:
     """Execute a job at_start_cb when Home Assistant has started.
 
-    The job is executed immediately if Home Assistant has fired
-    the start event (reached CoreState.running), Otherwise, it
-    will wait for EVENT_HOMEASSISTANT_STARTED
+    The job is executed immediately if Home Assistant has reached
+    CoreState.running
+
+    Otherwise, it will wait for the EVENT_HOMEASSISTANT_STARTED
+    event to be fired.
     """
     return _async_at_core_state(
         hass, at_start_cb, EVENT_HOMEASSISTANT_STARTED, _is_running

--- a/tests/components/cloud/test_google_config.py
+++ b/tests/components/cloud/test_google_config.py
@@ -344,6 +344,7 @@ async def test_sync_google_on_home_assistant_start(
     hass.set_state(CoreState.starting)
     with patch.object(config, "async_sync_entities_all") as mock_sync:
         await config.async_initialize()
+        await hass.async_block_till_done()
         assert len(mock_sync.mock_calls) == 0
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)

--- a/tests/helpers/test_start.py
+++ b/tests/helpers/test_start.py
@@ -22,8 +22,13 @@ async def test_at_start_when_running_awaitable(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(calls) == 1
 
-    hass.set_state(CoreState.starting)
-    assert hass.is_running
+    hass.set_state(CoreState.not_running)
+
+    start.async_at_start(hass, cb_at_start)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.set_state(CoreState.running)
 
     start.async_at_start(hass, cb_at_start)
     await hass.async_block_till_done()
@@ -47,8 +52,12 @@ async def test_at_start_when_running_callback(
     start.async_at_start(hass, cb_at_start)()
     assert len(calls) == 1
 
-    hass.set_state(CoreState.starting)
-    assert hass.is_running
+    hass.set_state(CoreState.not_running)
+
+    start.async_at_start(hass, cb_at_start)()
+    assert len(calls) == 1
+
+    hass.set_state(CoreState.running)
 
     start.async_at_start(hass, cb_at_start)()
     assert len(calls) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Summary: 
- `async_at_start` always ran the job right away if hass was up and running - this was not expected
- `async_at_started` ran the job if the `start` event had been fired or when the `started` event fires.

The check in `async_at_start` used [`hass.is_running`](https://github.com/home-assistant/core/blob/e91a38eede5131aebe1ed6d03ce9debe1994ab6a/homeassistant/core.py#L413) instead of checking if the `CoreState` was `CoreState.running`. This meant that as soon as [HA began starting](https://github.com/home-assistant/core/blob/e91a38eede5131aebe1ed6d03ce9debe1994ab6a/homeassistant/core.py#L475) any calls to `async_at_start` would be triggered right away even though the `EVENT_HOMEASSISTANT_START` had not been fired.

This was noticed in #112802 when I was trying to figure out why `eager_start` made the cloud tests fail

I believe the intent here was to sync google assistant at the `EVENT_HOMEASSISTANT_STARTED` event and not right away (maybe its at `EVENT_HOMEASSISTANT_START`). That is what should happen now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
