### PR TITLE
Add binary sensor platform to romy integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1158,6 +1158,7 @@ omit =
     homeassistant/components/roborock/coordinator.py
     homeassistant/components/rocketchat/notify.py
     homeassistant/components/romy/__init__.py
+    homeassistant/components/romy/binary_sensor.py
     homeassistant/components/romy/coordinator.py
     homeassistant/components/romy/entity.py
     homeassistant/components/romy/vacuum.py

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -1,6 +1,5 @@
 """Checking binary status values from your ROMY."""
 
-
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -69,6 +68,7 @@ class RomyBinarySensor(RomyEntity, BinarySensorEntity):
         self.entity_description = entity_description
 
     @property
-    def is_on(self) -> bool | None:
+    def is_on(self) -> bool:
         """Return the value of the sensor."""
-        return self.romy.binary_sensors[self.entity_description.key]
+        is_on_value: bool = self.romy.binary_sensors[self.entity_description.key]
+        return is_on_value

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -18,24 +18,20 @@ BINARY_SENSORS: list[BinarySensorEntityDescription] = [
     BinarySensorEntityDescription(
         key="dustbin",
         translation_key="dustbin_present",
-        entity_registry_enabled_default=False,
     ),
     BinarySensorEntityDescription(
         key="dock",
         translation_key="docked",
-        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.PLUG,
     ),
     BinarySensorEntityDescription(
         key="water_tank",
         translation_key="water_tank_present",
-        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.MOISTURE,
     ),
     BinarySensorEntityDescription(
         key="water_tank_empty",
         translation_key="water_tank_empty",
-        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
 ]

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -1,0 +1,133 @@
+"""Sensor checking adc and status values from your ROMY."""
+
+from romy import RomyRobot
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, LOGGER
+from .coordinator import RomyVacuumCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up ROMY vacuum cleaner."""
+
+    coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    binary_sensor_entities = []
+
+    romy_binary_sensor_entitiy_dustbin_present = RomyBinarySensor(
+        coordinator, coordinator.romy, None, "Dustbin present", "dustbin"
+    )
+    if "dustbin" in coordinator.romy.binary_sensors:
+        LOGGER.info(
+            "Binary sensor Dustbin present found for ROMY %s",
+            coordinator.romy.unique_id,
+        )
+        binary_sensor_entities.append(romy_binary_sensor_entitiy_dustbin_present)
+
+    romy_binary_sensor_entitiy_docked = RomyBinarySensor(
+        coordinator,
+        coordinator.romy,
+        BinarySensorDeviceClass.PRESENCE,
+        "Robot docked",
+        "dock",
+    )
+    if "dock" in coordinator.romy.binary_sensors:
+        LOGGER.info("Binary Robot docked found for ROMY %s", coordinator.romy.unique_id)
+        binary_sensor_entities.append(romy_binary_sensor_entitiy_docked)
+
+    romy_binary_sensor_entitiy_watertank_present = RomyBinarySensor(
+        coordinator,
+        coordinator.romy,
+        BinarySensorDeviceClass.MOISTURE,
+        "Watertank present",
+        "water_tank",
+    )
+    if "water_tank" in coordinator.romy.binary_sensors:
+        LOGGER.info(
+            "Binary sensor Watertank present found for ROMY %s",
+            coordinator.romy.unique_id,
+        )
+        binary_sensor_entities.append(romy_binary_sensor_entitiy_watertank_present)
+
+    romy_binary_sensor_entitiy_watertank_empty = RomyBinarySensor(
+        coordinator,
+        coordinator.romy,
+        BinarySensorDeviceClass.PROBLEM,
+        "Watertank empty",
+        "water_tank_empty",
+    )
+    if "water_tank_empty" in coordinator.romy.binary_sensors:
+        LOGGER.info(
+            "Binary sensor Watertank empty found for ROMY %s",
+            coordinator.romy.unique_id,
+        )
+        binary_sensor_entities.append(romy_binary_sensor_entitiy_watertank_empty)
+
+    async_add_entities(binary_sensor_entities, True)
+
+
+class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEntity):
+    """RomyBinarySensor Class."""
+
+    def __init__(
+        self,
+        coordinator: RomyVacuumCoordinator,
+        romy: RomyRobot,
+        device_class: BinarySensorDeviceClass | None,
+        sensor_name: str,
+        device_descriptor: str,
+    ) -> None:
+        """Initialize ROMYs BinarySensor."""
+        super().__init__(coordinator)
+        self.romy = romy
+        self._attr_unique_id = self.romy.unique_id
+        self._device_info = DeviceInfo(
+            identifiers={(DOMAIN, romy.unique_id)},
+            manufacturer="ROMY",
+            name=romy.name,
+            model=romy.model,
+        )
+        self._attr_device_class = device_class
+        self._sensor_value = False
+        self._sensor_name = sensor_name
+        self._device_descriptor = device_descriptor
+
+    @property
+    def device_descriptor(self) -> str:
+        """Return the device_descriptor of this sensor."""
+        return self._device_descriptor
+
+    @property
+    def unique_id(self) -> str:
+        """Return the ID of this sensor."""
+        return f"{self._device_descriptor}_{self._attr_unique_id}"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        LOGGER.debug("################ async_update")
+        self._sensor_value = self.romy.binary_sensors[self._device_descriptor]
+        self.async_write_ha_state()
+
+    # async def async_update(self) -> None:
+    #    """Fetch value from the device."""
+    #    LOGGER.debug("################ async_update")
+    #    self._sensor_value = self.romy.binary_sensors[self._device_descriptor]
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the state of the sensor."""
+        return self._sensor_value

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -87,11 +87,6 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
         self.entity_description = entity_description
 
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        self._sensor_value = self.romy.binary_sensors[self.entity_description.key]
-        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import RomyVacuumCoordinator
@@ -54,9 +53,7 @@ async def async_setup_entry(
     )
 
 
-class RomyBinarySensor(
-    RomyEntity, CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEntity
-):
+class RomyBinarySensor(RomyEntity, BinarySensorEntity):
     """RomyBinarySensor Class."""
 
     entity_description: BinarySensorEntityDescription
@@ -67,8 +64,7 @@ class RomyBinarySensor(
         entity_description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize ROMYs StatusSensor."""
-        RomyEntity.__init__(self, coordinator.romy)
-        CoordinatorEntity.__init__(self, coordinator)
+        super().__init__(coordinator)
         self._attr_unique_id = f"{entity_description.key}_{self.romy.unique_id}"
         self.entity_description = entity_description
 

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -70,5 +70,4 @@ class RomyBinarySensor(RomyEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the value of the sensor."""
-        is_on_value: bool = self.romy.binary_sensors[self.entity_description.key]
-        return is_on_value
+        return bool(self.romy.binary_sensors[self.entity_description.key])

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -77,7 +77,7 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
         """Initialize ROMYs StatusSensor."""
         super().__init__(coordinator)
         self.romy = romy
-        self._attr_unique_id = self.romy.unique_id
+        self._attr_unique_id =f"{entity_description.key}_{romy.unique_id}"
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, romy.unique_id)},
             manufacturer="ROMY",

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -1,7 +1,5 @@
 """Checking binary status values from your ROMY."""
 
-from dataclasses import dataclass
-
 from romy import RomyRobot
 
 from homeassistant.components.binary_sensor import (
@@ -18,28 +16,22 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import RomyVacuumCoordinator
 
-
-@dataclass(frozen=True)
-class RomyBinarySensorEntityDescription(BinarySensorEntityDescription):
-    """Immutable class for describing Romy data."""
-
-
-BINARY_SENSORS: list[RomyBinarySensorEntityDescription] = [
-    RomyBinarySensorEntityDescription(
+BINARY_SENSORS: list[BinarySensorEntityDescription] = [
+    BinarySensorEntityDescription(
         key="dustbin",
         translation_key="dustbin_present",
     ),
-    RomyBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="dock",
         translation_key="docked",
         device_class=BinarySensorDeviceClass.PRESENCE,
     ),
-    RomyBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="water_tank",
         translation_key="water_tank_present",
         device_class=BinarySensorDeviceClass.MOISTURE,
     ),
-    RomyBinarySensorEntityDescription(
+    BinarySensorEntityDescription(
         key="water_tank_empty",
         translation_key="water_tank_empty",
         device_class=BinarySensorDeviceClass.PROBLEM,
@@ -66,13 +58,13 @@ async def async_setup_entry(
 class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEntity):
     """RomyBinarySensor Class."""
 
-    entity_description: RomyBinarySensorEntityDescription
+    entity_description: BinarySensorEntityDescription
 
     def __init__(
         self,
         coordinator: RomyVacuumCoordinator,
         romy: RomyRobot,
-        entity_description: RomyBinarySensorEntityDescription,
+        entity_description: BinarySensorEntityDescription,
     ) -> None:
         """Initialize ROMYs StatusSensor."""
         super().__init__(coordinator)

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -27,16 +27,16 @@ class RomyBinarySensorEntityDescription(BinarySensorEntityDescription):
 BINARY_SENSORS: list[RomyBinarySensorEntityDescription] = [
     RomyBinarySensorEntityDescription(
         key="dustbin",
-        translation_key="dustbin",
+        translation_key="dustbin_present",
     ),
     RomyBinarySensorEntityDescription(
         key="dock",
-        translation_key="dock",
+        translation_key="docked",
         device_class=BinarySensorDeviceClass.PRESENCE,
     ),
     RomyBinarySensorEntityDescription(
         key="water_tank",
-        translation_key="water_tank",
+        translation_key="water_tank_present",
         device_class=BinarySensorDeviceClass.MOISTURE,
     ),
     RomyBinarySensorEntityDescription(
@@ -77,7 +77,7 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
         """Initialize ROMYs StatusSensor."""
         super().__init__(coordinator)
         self.romy = romy
-        self._attr_unique_id =f"{entity_description.key}_{romy.unique_id}"
+        self._attr_unique_id = f"{entity_description.key}_{romy.unique_id}"
         self._device_info = DeviceInfo(
             identifiers={(DOMAIN, romy.unique_id)},
             manufacturer="ROMY",
@@ -85,8 +85,6 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
             model=romy.model,
         )
         self.entity_description = entity_description
-
-
 
     @property
     def is_on(self) -> bool | None:

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -87,10 +87,6 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
         )
         self.entity_description = entity_description
 
-    @property
-    def unique_id(self) -> str:
-        """Return the ID of this sensor."""
-        return f"{self.entity_description.key}_{self._attr_unique_id}"
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -75,7 +75,6 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
         entity_description: RomyBinarySensorEntityDescription,
     ) -> None:
         """Initialize ROMYs StatusSensor."""
-        self._sensor_value: bool | None = None
         super().__init__(coordinator)
         self.romy = romy
         self._attr_unique_id = self.romy.unique_id

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -23,7 +23,7 @@ BINARY_SENSORS: list[BinarySensorEntityDescription] = [
     BinarySensorEntityDescription(
         key="dock",
         translation_key="docked",
-        device_class=BinarySensorDeviceClass.PRESENCE,
+        device_class=BinarySensorDeviceClass.PLUG,
     ),
     BinarySensorEntityDescription(
         key="water_tank",

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -101,4 +101,4 @@ class RomyBinarySensor(CoordinatorEntity[RomyVacuumCoordinator], BinarySensorEnt
     @property
     def is_on(self) -> bool | None:
         """Return the value of the sensor."""
-        return self._sensor_value
+        return self.romy.binary_sensors[self.entity_description.key]

--- a/homeassistant/components/romy/binary_sensor.py
+++ b/homeassistant/components/romy/binary_sensor.py
@@ -18,20 +18,24 @@ BINARY_SENSORS: list[BinarySensorEntityDescription] = [
     BinarySensorEntityDescription(
         key="dustbin",
         translation_key="dustbin_present",
+        entity_registry_enabled_default=False,
     ),
     BinarySensorEntityDescription(
         key="dock",
         translation_key="docked",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.PLUG,
     ),
     BinarySensorEntityDescription(
         key="water_tank",
         translation_key="water_tank_present",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.MOISTURE,
     ),
     BinarySensorEntityDescription(
         key="water_tank_empty",
         translation_key="water_tank_empty",
+        entity_registry_enabled_default=False,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
 ]

--- a/homeassistant/components/romy/const.py
+++ b/homeassistant/components/romy/const.py
@@ -6,6 +6,6 @@ import logging
 from homeassistant.const import Platform
 
 DOMAIN = "romy"
-PLATFORMS = [Platform.VACUUM]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.VACUUM]
 UPDATE_INTERVAL = timedelta(seconds=5)
 LOGGER = logging.getLogger(__package__)

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -1,6 +1,5 @@
 """Base entity for ROMY."""
 
-
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -1,6 +1,5 @@
 """Base entity for ROMY."""
 
-from romy import RomyRobot
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -1,5 +1,7 @@
 """Base entity for ROMY."""
 
+from romy import RomyRobot
+
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/homeassistant/components/romy/icons.json
+++ b/homeassistant/components/romy/icons.json
@@ -1,0 +1,20 @@
+{
+  "entity": {
+    "binary_sensor": {
+      "water_tank_empty": {
+        "default": "mdi:cup-outline",
+        "state": {
+          "off": "mdi:cup-water",
+          "on": "mdi:cup-outline"
+        }
+      },
+      "dustbin_present": {
+        "default": "mdi:basket-check",
+        "state": {
+          "off": "mdi:basket-remove",
+          "on": "mdi:basket-check"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -48,13 +48,13 @@
       }
     },
     "binary_sensor": {
-      "dustbin": {
+      "dustbin_present": {
         "name": "Dustbin present"
       },
-      "dock": {
+      "docked": {
         "name": "Robot docked"
       },
-      "water_tank": {
+      "water_tank_present": {
         "name": "Watertank present"
       },
       "water_tank_empty": {

--- a/homeassistant/components/romy/strings.json
+++ b/homeassistant/components/romy/strings.json
@@ -46,6 +46,20 @@
           }
         }
       }
+    },
+    "binary_sensor": {
+      "dustbin": {
+        "name": "Dustbin present"
+      },
+      "dock": {
+        "name": "Robot docked"
+      },
+      "water_tank": {
+        "name": "Watertank present"
+      },
+      "water_tank_empty": {
+        "name": "Watertank empty"
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

is based on this branch, so this should be merged before:
romy_base_entity: https://github.com/home-assistant/core/pull/113750

adds support for binary sensors like dustbin_present, docked, water_tank_present, water_tank_empty if the romy robot type offers it

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31831

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
