### PR TITLE
Add Home Connect settings

### DIFF
--- a/homeassistant/components/home_connect/binary_sensor.py
+++ b/homeassistant/components/home_connect/binary_sensor.py
@@ -17,6 +17,12 @@ from .const import (
     BSH_REMOTE_CONTROL_ACTIVATION_STATE,
     BSH_REMOTE_START_ALLOWANCE_STATE,
     DOMAIN,
+    FREEZER_DOOR_STATE,
+    FREEZER_DOOR_STATE_CLOSED,
+    FREEZER_DOOR_STATE_OPEN,
+    REFRIGERATOR_DOOR_STATE,
+    REFRIGERATOR_DOOR_STATE_CLOSED,
+    REFRIGERATOR_DOOR_STATE_OPEN,
 )
 from .entity import HomeConnectEntity
 
@@ -54,6 +60,14 @@ class HomeConnectBinarySensor(HomeConnectEntity, BinarySensorEntity):
             self._update_key = BSH_DOOR_STATE
             self._false_value_list = (BSH_DOOR_STATE_CLOSED, BSH_DOOR_STATE_LOCKED)
             self._true_value_list = [BSH_DOOR_STATE_OPEN]
+        elif self._type == "freezer_door":
+            self._update_key = FREEZER_DOOR_STATE
+            self._false_value_list = [FREEZER_DOOR_STATE_CLOSED]
+            self._true_value_list = [FREEZER_DOOR_STATE_OPEN]
+        elif self._type == "refrigerator_door":
+            self._update_key = REFRIGERATOR_DOOR_STATE
+            self._false_value_list = [REFRIGERATOR_DOOR_STATE_CLOSED]
+            self._true_value_list = [REFRIGERATOR_DOOR_STATE_OPEN]
         elif self._type == "remote_control":
             self._update_key = BSH_REMOTE_CONTROL_ACTIVATION_STATE
             self._false_value_list = [False]

--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -34,6 +34,14 @@ BSH_DOOR_STATE_CLOSED = "BSH.Common.EnumType.DoorState.Closed"
 BSH_DOOR_STATE_LOCKED = "BSH.Common.EnumType.DoorState.Locked"
 BSH_DOOR_STATE_OPEN = "BSH.Common.EnumType.DoorState.Open"
 
+REFRIGERATOR_DOOR_STATE = "Refrigeration.Common.Status.Door.Refrigerator"
+REFRIGERATOR_DOOR_STATE_CLOSED = "Refrigeration.Common.EnumType.Door.States.Closed"
+REFRIGERATOR_DOOR_STATE_OPEN = "Refrigeration.Common.EnumType.Door.States.Open"
+
+FREEZER_DOOR_STATE = "Refrigeration.Common.Status.Door.Freezer"
+FREEZER_DOOR_STATE_CLOSED = "Refrigeration.Common.EnumType.Door.States.Closed"
+FREEZER_DOOR_STATE_OPEN = "Refrigeration.Common.EnumType.Door.States.Open"
+
 BSH_PAUSE = "BSH.Common.Command.PauseProgram"
 BSH_RESUME = "BSH.Common.Command.ResumeProgram"
 
@@ -56,3 +64,21 @@ ATTR_SENSOR_TYPE = "sensor_type"
 ATTR_SIGN = "sign"
 ATTR_UNIT = "unit"
 ATTR_VALUE = "value"
+
+# https://api-docs.home-connect.com/settings
+SETTINGS_NAMES = {
+    "Refrigeration.FridgeFreezer.Setting.SuperModeFreezer": "Super Mode Freezer",
+    "Refrigeration.Common.Setting.FreshMode": "Fresh Mode",
+    "Refrigeration.FridgeFreezer.Setting.SuperModeRefrigerator": "Super Mode Refrigerator",
+    "Refrigeration.Common.Setting.VacationMode": "Vacation Mode",
+    "Refrigeration.Common.Setting.EcoMode": "Eco Mode",
+    "Refrigeration.Common.Setting.Dispenser.Enabled": "Dispenser Enabled",
+    "Refrigeration.Common.Setting.SabbathMode": "Sabbath Mode",
+    "BSH.Common.Setting.ChildLock": "Child Lock",
+    "Refrigeration.Common.Setting.Light.Internal.Power": "Internal Cooling Light Power",
+    "Refrigeration.Common.Setting.Light.External.Power": "External Cooling Light Power",
+    "ConsumerProducts.CoffeeMaker.Setting.CupWarmer": "Cup Warmer",
+    "Refrigeration.Common.Setting.Door.AssistantFridge Refrigeration.Common.Setting.Door.AssistantFreezer": "Door Assistant",
+    "Cooking.Common.Setting.Lighting": "Functional Light",
+    "BSH.Common.Setting.AmbientLightEnabled": "Ambient Light",
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR enables more settings for Home Connect devices. This should fix https://github.com/home-assistant/core/issues/91216

This is done by reading the available settings from the Home Connect API and displaying all available boolean settings as boolean switches (and maps their name properly).

The changes also removes the "Power" switch for devices which it does not work. The removal could be considered a breaking change, and I could re-add it as a read-only switch for the unsupported devices (could not figure out how to do that though).

<img src="https://github.com/home-assistant/core/assets/2672503/fa742919-12b9-4548-b23d-020b47573851" width=300 />


### More changes

This same approach could also be used to discover sensors, which would enable all sensors to work for all device types.

Additionally, other settings like temperature control have no yet been implemented. **One question for this**: Should a fridge temperature use the climate entity type? (with fans disabled of course)

Plus, the lights should be converted to light entities since we can also control their brightness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/91216

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
