### PR TITLE
Fix race condition when ZHA group members change

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -311,6 +311,10 @@ class ZhaGroupEntity(BaseZhaEntity):
 
         self._handled_group_membership = True
         await self.async_remove(force_remove=True)
+        if len(self._group.members) >= 2:
+            async_dispatcher_send(
+                self.hass, SIGNAL_GROUP_ENTITY_REMOVED, self._group_id
+            )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -336,13 +340,6 @@ class ZhaGroupEntity(BaseZhaEntity):
         self._async_unsub_state_changed = async_track_state_change_event(
             self.hass, self._entity_ids, self.async_state_changed_listener
         )
-
-        def send_removed_signal():
-            async_dispatcher_send(
-                self.hass, SIGNAL_GROUP_ENTITY_REMOVED, self._group_id
-            )
-
-        self.async_on_remove(send_removed_signal)
 
     @callback
     def async_state_changed_listener(self, event: Event[EventStateChangedData]) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a race condition when handling ZHA Zigbee group membership changes. The issue was exposed in PR: #112845

Background: 

the original code would fire before the entity was completely removed from HA and that caused the following chain of events to happen out of order: 

```
2024-03-10 15:42:49.336 INFO     MainThread homeassistant.components.zha.core.group:group.py:251 [Test Group](0x0002): group_member_added - endpoint: <Endpoint id=1 in=[on_off:0x0006, level:0x0008, light_color:0x0300, groups:0x0004, identify:0x0003] out=[] status=<Status.NEW: 0>>
2024-03-10 15:42:49.337 DEBUG    MainThread homeassistant.components.zha.core.discovery:discovery.py:644 The entity domains are: ['light'] for group: Test Group:0x0002
2024-03-10 15:42:49.338 ERROR    MainThread homeassistant.components.light:entity_platform.py:732 Platform zha does not generate unique IDs. ID light_zha_group_0x0002 already exists - ignoring light.coordinator_manufacturer_coordinator_model_test_group
2024-03-10 15:42:49.338 DEBUG    MainThread homeassistant.core:core.py:1339 Bus:Handling <Event state_changed[L]: entity_id=light.coordinator_manufacturer_coordinator_model_test_group, old_state=<state light.coordinator_manufacturer_coordinator_model_test_group=off; min_color_temp_kelvin=2000, max_color_temp_kelvin=6535, min_mireds=153, max_mireds=500, supported_color_modes=[<ColorMode.COLOR_TEMP: 'color_temp'>, <ColorMode.XY: 'xy'>], color_mode=None, brightness=None, color_temp_kelvin=None, color_temp=None, hs_color=None, rgb_color=None, xy_color=None, off_with_transition=False, off_brightness=None, friendly_name=Coordinator Manufacturer Coordinator Model Test Group, supported_features=40 @ 2024-03-10T12:42:49.336389-07:00>, new_state=None>
```

Line 1 is the member being added
Line 2 is the probe firing before the entity was actually removed
Line 3 is the error caused by the out of order handling
Line 4 is HA wiping the state from the entity when it is removed from HA

![image](https://github.com/home-assistant/core/assets/1335687/afa09c48-5bf6-4800-84fe-9b97e88b1bf5)

The on_remove callbacks happen before the entity is actually removed from the system. With this change we now dispatch the signal to reprobe the group when the entity is completely removed. 

CC: @bdraco 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
