### PR TITLE
Fix some handle leaks in rainforest_raven

### DIFF
--- a/homeassistant/components/rainforest_raven/coordinator.py
+++ b/homeassistant/components/rainforest_raven/coordinator.py
@@ -133,16 +133,27 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
             )
         return None
 
+    async def async_shutdown(self) -> None:
+        """Shutdown the coordinator."""
+        await self._cleanup_device()
+        await super().async_shutdown()
+
     async def _async_update_data(self) -> dict[str, Any]:
         try:
             device = await self._get_device()
             async with asyncio.timeout(5):
                 return await _get_all_data(device, self.entry.data[CONF_MAC])
         except RAVEnConnectionError as err:
-            if self._raven_device:
-                await self._raven_device.close()
-                self._raven_device = None
+            await self._cleanup_device()
             raise UpdateFailed(f"RAVEnConnectionError: {err}") from err
+        except TimeoutError:
+            await self._cleanup_device()
+            raise
+
+    async def _cleanup_device(self) -> None:
+        device, self._raven_device = self._raven_device, None
+        if device is not None:
+            await device.close()
 
     async def _get_device(self) -> RAVEnSerialDevice:
         if self._raven_device is not None:
@@ -150,15 +161,14 @@ class RAVEnDataCoordinator(DataUpdateCoordinator):
 
         device = RAVEnSerialDevice(self.entry.data[CONF_DEVICE])
 
-        async with asyncio.timeout(5):
-            await device.open()
-
-            try:
+        try:
+            async with asyncio.timeout(5):
+                await device.open()
                 await device.synchronize()
                 self._device_info = await device.get_device_info()
-            except Exception:
-                await device.close()
-                raise
+        except:
+            await device.close()
+            raise
 
         self._raven_device = device
         return device

--- a/tests/components/rainforest_raven/test_coordinator.py
+++ b/tests/components/rainforest_raven/test_coordinator.py
@@ -1,5 +1,8 @@
 """Tests for the Rainforest RAVEn data coordinator."""
 
+import asyncio
+import functools
+
 from aioraven.device import RAVEnConnectionError
 import pytest
 
@@ -80,6 +83,19 @@ async def test_coordinator_device_error_update(hass: HomeAssistant, mock_device)
     assert coordinator.last_update_success is True
 
     mock_device.get_network_info.side_effect = RAVEnConnectionError
+    await coordinator.async_refresh()
+    assert coordinator.last_update_success is False
+
+
+async def test_coordinator_device_timeout_update(hass: HomeAssistant, mock_device):
+    """Test handling of a device timeout during an update."""
+    entry = create_mock_entry()
+    coordinator = RAVEnDataCoordinator(hass, entry)
+
+    await coordinator.async_config_entry_first_refresh()
+    assert coordinator.last_update_success is True
+
+    mock_device.get_network_info.side_effect = functools.partial(asyncio.sleep, 10)
     await coordinator.async_refresh()
     assert coordinator.last_update_success is False
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
There were file handle leaks when:
* The component was shutdown or reloaded
* There was a timeout during the initial device opening

Additionally, the device was not closed/reopened when there was a timeout reading regular data.

A test was added to exercise the timeout code. Note that this test actually does wait for the timeout to trigger normally, and therefore takes 5 seconds to complete. If this is not acceptable, I can update the test to explicitly raise a `TimeoutError` immediately.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #111886
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
