### PR TITLE
Fix here_travel_time creating many refresh requests at startup

### DIFF
--- a/homeassistant/components/here_travel_time/__init__.py
+++ b/homeassistant/components/here_travel_time/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, CONF_MODE, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.start import async_at_started
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -49,22 +50,19 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         departure=departure,
     )
 
+    cls: type[HERETransitDataUpdateCoordinator] | type[HERERoutingDataUpdateCoordinator]
     if config_entry.data[CONF_MODE] in {TRAVEL_MODE_PUBLIC, "publicTransportTimeTable"}:
-        hass.data.setdefault(DOMAIN, {})[
-            config_entry.entry_id
-        ] = HERETransitDataUpdateCoordinator(
-            hass,
-            api_key,
-            here_travel_time_config,
-        )
+        cls = HERETransitDataUpdateCoordinator
     else:
-        hass.data.setdefault(DOMAIN, {})[
-            config_entry.entry_id
-        ] = HERERoutingDataUpdateCoordinator(
-            hass,
-            api_key,
-            here_travel_time_config,
-        )
+        cls = HERERoutingDataUpdateCoordinator
+
+    data_coordinator = cls(hass, api_key, here_travel_time_config)
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = data_coordinator
+
+    async def _async_update_at_start(_: HomeAssistant) -> None:
+        await data_coordinator.async_refresh()
+
+    config_entry.async_on_unload(async_at_started(hass, _async_update_at_start))
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -25,7 +25,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -140,11 +139,6 @@ class HERETravelTimeSensor(
         """Wait for start so origin and destination entities can be resolved."""
         await self._async_restore_state()
         await super().async_added_to_hass()
-
-        async def _update_at_start(_: HomeAssistant) -> None:
-            await self.async_update()
-
-        self.async_on_remove(async_at_started(self.hass, _update_at_start))
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -60,7 +60,7 @@ from homeassistant.const import (
     CONF_API_KEY,
     CONF_MODE,
     CONF_NAME,
-    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
     UnitOfLength,
     UnitOfTime,
 )
@@ -122,6 +122,7 @@ async def test_sensor(
     departure_time,
 ) -> None:
     """Test that sensor works."""
+    hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="0123456789",
@@ -143,7 +144,7 @@ async def test_sensor(
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     duration = hass.states.get("sensor.test_duration")
@@ -201,7 +202,7 @@ async def test_circular_ref(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert "No coordinates found for test.first" in caplog.text
@@ -210,6 +211,7 @@ async def test_circular_ref(
 @pytest.mark.usefixtures("valid_response")
 async def test_public_transport(hass: HomeAssistant) -> None:
     """Test that public transport mode is handled."""
+    hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="0123456789",
@@ -232,7 +234,7 @@ async def test_public_transport(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert (
@@ -263,7 +265,7 @@ async def test_no_attribution_response(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert (
@@ -273,6 +275,7 @@ async def test_no_attribution_response(hass: HomeAssistant) -> None:
 
 async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> None:
     """Test that origin/destination supplied by entities works."""
+    hass.set_state(CoreState.not_running)
     zone_config = {
         "zone": [
             {
@@ -309,7 +312,7 @@ async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> Non
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.test_distance").state == "13.682"
@@ -348,7 +351,7 @@ async def test_destination_entity_not_found(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert "Could not find entity device_tracker.test" in caplog.text
@@ -376,7 +379,7 @@ async def test_origin_entity_not_found(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert "Could not find entity device_tracker.test" in caplog.text
@@ -408,7 +411,7 @@ async def test_invalid_destination_entity_state(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert (
@@ -442,7 +445,7 @@ async def test_invalid_origin_entity_state(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     assert (
@@ -477,7 +480,7 @@ async def test_route_not_found(
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
         assert "Route calculation failed: Couldn't find a route." in caplog.text
@@ -635,6 +638,7 @@ async def test_transit_errors(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, exception, expected_message
 ) -> None:
     """Test that transit errors are correctly handled."""
+    hass.set_state(CoreState.not_running)
     with patch(
         "here_transit.HERETransitApi.route",
         side_effect=exception(),
@@ -656,7 +660,7 @@ async def test_transit_errors(
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
         assert expected_message in caplog.text
@@ -668,6 +672,7 @@ async def test_routing_rate_limit(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that rate limiting is applied when encountering HTTP 429."""
+    hass.set_state(CoreState.not_running)
     with patch(
         "here_routing.HERERoutingApi.route",
         return_value=RESPONSE,
@@ -681,7 +686,7 @@ async def test_routing_rate_limit(
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
         assert hass.states.get("sensor.test_distance").state == "13.682"
@@ -716,6 +721,7 @@ async def test_transit_rate_limit(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that rate limiting is applied when encountering HTTP 429."""
+    hass.set_state(CoreState.not_running)
     with patch(
         "here_transit.HERETransitApi.route",
         return_value=TRANSIT_RESPONSE,
@@ -737,7 +743,7 @@ async def test_transit_rate_limit(
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
         assert hass.states.get("sensor.test_distance").state == "1.883"
@@ -771,6 +777,7 @@ async def test_multiple_sections(
     hass: HomeAssistant,
 ) -> None:
     """Test that multiple sections are handled correctly."""
+    hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="0123456789",
@@ -788,7 +795,7 @@ async def test_multiple_sections(
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
     await hass.async_block_till_done()
 
     duration = hass.states.get("sensor.test_duration")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Each entity would try to refresh the coordinator which created many tasks. Move the refresh to a single `async_at_started`

- The tests fired the `EVENT_HOMEASSISTANT_START` event but the code used `async_at_started` which only worked because the tests did not set `CoreState` to `not_running`

needed for https://github.com/home-assistant/core/pull/111683 https://github.com/home-assistant/core/pull/112802

## Type of change 
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
