### PR TITLE
Fix ghost events for Hue remotes 

### DIFF
--- a/homeassistant/components/hue/event.py
+++ b/homeassistant/components/hue/event.py
@@ -95,7 +95,9 @@ class HueButtonEventEntity(HueBaseEntity, EventEntity):
     def _handle_event(self, event_type: EventType, resource: Button) -> None:
         """Handle status event for this resource (or it's parent)."""
         if event_type == EventType.RESOURCE_UPDATED and resource.id == self.resource.id:
-            self._trigger_event(resource.button.last_event.value)
+            if resource.button is None or resource.button.button_report is None:
+                return
+            self._trigger_event(resource.button.button_report.event.value)
             self.async_write_ha_state()
             return
         super()._handle_event(event_type, resource)
@@ -119,11 +121,16 @@ class HueRotaryEventEntity(HueBaseEntity, EventEntity):
     def _handle_event(self, event_type: EventType, resource: RelativeRotary) -> None:
         """Handle status event for this resource (or it's parent)."""
         if event_type == EventType.RESOURCE_UPDATED and resource.id == self.resource.id:
-            event_key = resource.relative_rotary.last_event.rotation.direction.value
+            if (
+                resource.relative_rotary is None
+                or resource.relative_rotary.rotary_report is None
+            ):
+                return
+            event_key = resource.relative_rotary.rotary_report.rotation.direction.value
             event_data = {
-                "duration": resource.relative_rotary.last_event.rotation.duration,
-                "steps": resource.relative_rotary.last_event.rotation.steps,
-                "action": resource.relative_rotary.last_event.action.value,
+                "duration": resource.relative_rotary.rotary_report.rotation.duration,
+                "steps": resource.relative_rotary.rotary_report.rotation.steps,
+                "action": resource.relative_rotary.rotary_report.action.value,
             }
             self._trigger_event(event_key, event_data)
             self.async_write_ha_state()

--- a/tests/components/hue/const.py
+++ b/tests/components/hue/const.py
@@ -126,13 +126,14 @@ FAKE_ROTARY = {
     "id_v1": "/sensors/1",
     "owner": {"rid": "fake_device_id_1", "rtype": "device"},
     "relative_rotary": {
-        "last_event": {
+        "rotary_report": {
             "action": "start",
             "rotation": {
                 "direction": "clock_wise",
                 "steps": 0,
                 "duration": 0,
             },
+            "updated": "2023-09-27T10:06:41.822Z",
         }
     },
     "type": "relative_rotary",

--- a/tests/components/hue/test_event.py
+++ b/tests/components/hue/test_event.py
@@ -31,7 +31,12 @@ async def test_event(
     ]
     # trigger firing 'initial_press' event from the device
     btn_event = {
-        "button": {"last_event": "initial_press"},
+        "button": {
+            "button_report": {
+                "event": "initial_press",
+                "updated": "2023-09-27T10:06:41.822Z",
+            }
+        },
         "id": "f92aa267-1387-4f02-9950-210fb7ca1f5a",
         "metadata": {"control_id": 1},
         "type": "button",
@@ -42,7 +47,12 @@ async def test_event(
     assert state.attributes[ATTR_EVENT_TYPE] == "initial_press"
     # trigger firing 'long_release' event from the device
     btn_event = {
-        "button": {"last_event": "long_release"},
+        "button": {
+            "button_report": {
+                "event": "long_release",
+                "updated": "2023-09-27T10:06:41.822Z",
+            }
+        },
         "id": "f92aa267-1387-4f02-9950-210fb7ca1f5a",
         "metadata": {"control_id": 1},
         "type": "button",
@@ -79,13 +89,14 @@ async def test_sensor_add_update(hass: HomeAssistant, mock_bridge_v2) -> None:
     btn_event = {
         "id": "fake_relative_rotary",
         "relative_rotary": {
-            "last_event": {
+            "rotary_report": {
                 "action": "repeat",
                 "rotation": {
                     "direction": "counter_clock_wise",
                     "steps": 60,
                     "duration": 400,
                 },
+                "updated": "2023-09-27T10:06:41.822Z",
             }
         },
         "type": "relative_rotary",


### PR DESCRIPTION
## Proposed change
Fix for ghost events triggered when the Hue bridge updates by using the report values instead of the (deprecated) last event values.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #99125
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
