### PR TITLE
Add support for BleBox MulitSensor illuminance sensor

### DIFF
--- a/homeassistant/components/blebox/sensor.py
+++ b/homeassistant/components/blebox/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    LIGHT_LUX,
     PERCENTAGE,
     UnitOfEnergy,
     UnitOfSpeed,
@@ -59,6 +60,11 @@ SENSOR_TYPES = (
         key="wind_speed",
         device_class=SensorDeviceClass.WIND_SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
+    ),
+    SensorEntityDescription(
+        key="illuminance",
+        device_class=SensorDeviceClass.ILLUMINANCE,
+        native_unit_of_measurement=LIGHT_LUX,
     ),
 )
 


### PR DESCRIPTION
Updated SENSOR_TYPES tuple in homeassistant.components.blebox.sensor module to include a new entry for the illuminance sensor.