### PR TITLE
Migrate homekit to use async_at_started

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -45,13 +45,11 @@ from homeassistant.const import (
     CONF_IP_ADDRESS,
     CONF_NAME,
     CONF_PORT,
-    EVENT_HOMEASSISTANT_STARTED,
     EVENT_HOMEASSISTANT_STOP,
     SERVICE_RELOAD,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
-    CoreState,
     HomeAssistant,
     ServiceCall,
     State,
@@ -75,6 +73,7 @@ from homeassistant.helpers.service import (
     async_extract_referenced_entity_ids,
     async_register_admin_service,
 )
+from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import IntegrationNotFound, async_get_integration
 
@@ -358,10 +357,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     hass.data[DOMAIN][entry.entry_id] = entry_data
 
-    if hass.state is CoreState.running:
+    async def _async_start_homekit(hass: HomeAssistant) -> None:
         await homekit.async_start()
-    else:
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, homekit.async_start)
+
+    entry.async_on_unload(async_at_started(hass, _async_start_homekit))
 
     return True
 
@@ -553,7 +552,6 @@ class HomeKit:
         """Set up bridge and accessory driver."""
         assert self.iid_storage is not None
         persist_file = get_persist_fullpath_for_entry_id(self.hass, self._entry_id)
-
         self.driver = HomeDriver(
             self.hass,
             self._entry_id,
@@ -569,7 +567,6 @@ class HomeKit:
             loader=get_loader(),
             iid_storage=self.iid_storage,
         )
-
         # If we do not load the mac address will be wrong
         # as pyhap uses a random one until state is restored
         if os.path.exists(persist_file):

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the HomeKit config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import voluptuous as vol
@@ -428,62 +428,68 @@ async def test_options_flow_devices(
     demo_config_entry = MockConfigEntry(domain="domain")
     demo_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "demo", {"demo": {}})
-    assert await async_setup_component(hass, "homekit", {"homekit": {}})
+    with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:
+        mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
+        assert await async_setup_component(hass, "homekit", {"homekit": {}})
+        assert await async_setup_component(hass, "homeassistant", {})
+        assert await async_setup_component(hass, "demo", {"demo": {}})
+        assert await async_setup_component(hass, "homekit", {"homekit": {}})
 
-    hass.states.async_set("climate.old", "off")
-    await hass.async_block_till_done()
+        hass.states.async_set("climate.old", "off")
+        await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_init(
-        config_entry.entry_id, context={"show_advanced_options": True}
-    )
-
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "domains": ["fan", "vacuum", "climate"],
-            "include_exclude_mode": "exclude",
-        },
-    )
-
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "exclude"
-
-    entry = entity_registry.async_get("light.ceiling_lights")
-    assert entry is not None
-    device_id = entry.device_id
-
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "entities": ["climate.old"],
-        },
-    )
-
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={"devices": [device_id]},
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id, context={"show_advanced_options": True}
         )
 
-    assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert config_entry.options == {
-        "devices": [device_id],
-        "mode": "bridge",
-        "filter": {
-            "exclude_domains": [],
-            "exclude_entities": ["climate.old"],
-            "include_domains": ["fan", "vacuum", "climate"],
-            "include_entities": [],
-        },
-    }
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "init"
 
-    await hass.async_block_till_done()
-    await hass.config_entries.async_unload(config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "domains": ["fan", "vacuum", "climate"],
+                "include_exclude_mode": "exclude",
+            },
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "exclude"
+
+        entry = entity_registry.async_get("light.ceiling_lights")
+        assert entry is not None
+        device_id = entry.device_id
+
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "entities": ["climate.old"],
+            },
+        )
+
+        with patch(
+            "homeassistant.components.homekit.async_setup_entry", return_value=True
+        ):
+            result3 = await hass.config_entries.options.async_configure(
+                result2["flow_id"],
+                user_input={"devices": [device_id]},
+            )
+
+        assert result3["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert config_entry.options == {
+            "devices": [device_id],
+            "mode": "bridge",
+            "filter": {
+                "exclude_domains": [],
+                "exclude_entities": ["climate.old"],
+                "include_domains": ["fan", "vacuum", "climate"],
+                "include_entities": [],
+            },
+        }
+
+        await hass.async_block_till_done()
+        await hass.config_entries.async_unload(config_entry.entry_id)
 
 
 @patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
@@ -514,49 +520,53 @@ async def test_options_flow_devices_preserved_when_advanced_off(
     demo_config_entry = MockConfigEntry(domain="domain")
     demo_config_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, "homekit", {"homekit": {}})
+    with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:
+        mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
+        assert await async_setup_component(hass, "homekit", {"homekit": {}})
 
-    hass.states.async_set("climate.old", "off")
-    await hass.async_block_till_done()
+        hass.states.async_set("climate.old", "off")
+        await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_init(
-        config_entry.entry_id, context={"show_advanced_options": False}
-    )
+        result = await hass.config_entries.options.async_init(
+            config_entry.entry_id, context={"show_advanced_options": False}
+        )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "init"
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "init"
 
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "domains": ["fan", "vacuum", "climate"],
-            "include_exclude_mode": "exclude",
-        },
-    )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "domains": ["fan", "vacuum", "climate"],
+                "include_exclude_mode": "exclude",
+            },
+        )
 
-    assert result["type"] == data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "exclude"
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "exclude"
 
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "entities": ["climate.old"],
-        },
-    )
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={
+                "entities": ["climate.old"],
+            },
+        )
 
-    assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
-    assert config_entry.options == {
-        "devices": ["1fabcabcabcabcabcabcabcabcabc"],
-        "mode": "bridge",
-        "filter": {
-            "exclude_domains": [],
-            "exclude_entities": ["climate.old"],
-            "include_domains": ["fan", "vacuum", "climate"],
-            "include_entities": [],
-        },
-    }
-    await hass.async_block_till_done()
-    await hass.config_entries.async_unload(config_entry.entry_id)
+        assert result2["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert config_entry.options == {
+            "devices": ["1fabcabcabcabcabcabcabcabcabc"],
+            "mode": "bridge",
+            "filter": {
+                "exclude_domains": [],
+                "exclude_entities": ["climate.old"],
+                "include_domains": ["fan", "vacuum", "climate"],
+                "include_entities": [],
+            },
+        }
+        await hass.async_block_till_done()
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 async def test_options_flow_include_mode_with_non_existant_entity(

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -347,7 +347,7 @@ async def test_homekit_with_single_advertise_ips(
     )
     entry.add_to_hass(hass)
     with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
-        mock_driver.async_start = AsyncMock()
+        hk_driver.async_start = AsyncMock()
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -386,7 +386,7 @@ async def test_homekit_with_many_advertise_ips(
     )
     entry.add_to_hass(hass)
     with patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver) as mock_driver:
-        mock_driver.async_start = AsyncMock()
+        hk_driver.async_start = AsyncMock()
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
@@ -2043,6 +2043,7 @@ async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
         "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
     ):
         mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
         assert await async_setup_component(
             hass, "homekit", {"homekit": {CONF_NAME: "reloadable", CONF_PORT: 12345}}
         )
@@ -2065,16 +2066,15 @@ async def test_reload(hass: HomeAssistant, mock_async_zeroconf: None) -> None:
     yaml_path = get_fixture_path("configuration.yaml", "homekit")
     with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path), patch(
         f"{PATH_HOMEKIT}.HomeKit"
-    ) as mock_homekit2, patch.object(homekit.bridge, "add_accessory"), patch(
-        f"{PATH_HOMEKIT}.async_show_setup_message"
-    ), patch(
+    ) as mock_homekit2, patch(f"{PATH_HOMEKIT}.async_show_setup_message"), patch(
         f"{PATH_HOMEKIT}.get_accessory",
-    ), patch(
+    ), patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True), patch(
         "pyhap.accessory_driver.AccessoryDriver.async_start",
     ), patch(
         "homeassistant.components.network.async_get_source_ip", return_value="1.2.3.4"
     ):
         mock_homekit2.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
         await hass.services.async_call(
             "homekit",
             SERVICE_RELOAD,

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -1,6 +1,6 @@
 """Test HomeKit initialization."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -31,7 +31,9 @@ async def test_humanify_homekit_changed_event(
 ) -> None:
     """Test humanifying HomeKit changed event."""
     hass.config.components.add("recorder")
-    with patch("homeassistant.components.homekit.HomeKit"):
+    with patch("homeassistant.components.homekit.HomeKit") as mock_homekit:
+        mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
         assert await async_setup_component(hass, "homekit", {"homekit": {}})
     assert await async_setup_component(hass, "logbook", {})
     await hass.async_block_till_done()


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate homekit to use async_at_started

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
