### PR TITLE
Add graceful handling for LASTSTEST sensor in APCUPSD

### DIFF
--- a/homeassistant/components/apcupsd/const.py
+++ b/homeassistant/components/apcupsd/const.py
@@ -4,3 +4,6 @@ from typing import Final
 
 DOMAIN: Final = "apcupsd"
 CONNECTION_TIMEOUT: int = 10
+
+# Field name of last self test retrieved from apcupsd.
+LASTSTEST: Final = "laststest"

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -157,7 +157,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    "laststest": SensorEntityDescription(
+    LASTSTEST: SensorEntityDescription(
         key="laststest",
         translation_key="last_self_test",
     ),
@@ -418,19 +418,17 @@ async def async_setup_entry(
     available_resources: set[str] = {k.lower() for k, _ in coordinator.data.items()}
 
     entities = []
-    for resource in available_resources:
-        if resource not in SENSORS:
-            _LOGGER.warning("Invalid resource from APCUPSd: %s", resource.upper())
-            continue
-
-        entities.append(APCUPSdSensor(coordinator, SENSORS[resource]))
 
     # "laststest" is a special sensor that only appears when the APC UPS daemon has done a
     # periodical (or manual) self test since last daemon restart. It might not be available
     # when we set up the integration, and we do not know if it would ever be available. Here we
     # add it anyway and mark it as unknown initially.
-    if LASTSTEST not in coordinator.data:
-        entities.append(APCUPSdSensor(coordinator, SENSORS[LASTSTEST]))
+    for resource in available_resources | {LASTSTEST}:
+        if resource not in SENSORS:
+            _LOGGER.warning("Invalid resource from APCUPSd: %s", resource.upper())
+            continue
+
+        entities.append(APCUPSdSensor(coordinator, SENSORS[resource]))
 
     async_add_entities(entities)
 

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -158,7 +158,7 @@ SENSORS: dict[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
     ),
     LASTSTEST: SensorEntityDescription(
-        key="laststest",
+        key=LASTSTEST,
         translation_key="last_self_test",
     ),
     "lastxfer": SensorEntityDescription(

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    STATE_UNKNOWN,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -25,7 +26,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import DOMAIN, LASTSTEST
 from .coordinator import APCUPSdCoordinator
 
 PARALLEL_UPDATES = 0
@@ -427,9 +428,9 @@ async def async_setup_entry(
     # "laststest" is a special sensor that only appears when the APC UPS daemon has done a
     # periodical (or manual) self test since last daemon restart. It might not be available
     # when we set up the integration, and we do not know if it would ever be available. Here we
-    # add it anyway and mark it as unavailable initially.
-    if "laststest" not in coordinator.data:
-        entities.append(APCUPSdSensor(coordinator, SENSORS["laststest"]))
+    # add it anyway and mark it as unknown initially.
+    if LASTSTEST not in coordinator.data:
+        entities.append(APCUPSdSensor(coordinator, SENSORS[LASTSTEST]))
 
     async_add_entities(entities)
 
@@ -471,11 +472,6 @@ class APCUPSdSensor(CoordinatorEntity[APCUPSdCoordinator], SensorEntity):
         # Initial update of attributes.
         self._update_attrs()
 
-    @property
-    def available(self) -> bool:
-        """Return True if entity is available."""
-        return self.coordinator.last_update_success and self._attr_available
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -487,14 +483,12 @@ class APCUPSdSensor(CoordinatorEntity[APCUPSdCoordinator], SensorEntity):
         key = self.entity_description.key.upper()
         # For most sensors the key will always be available for each refresh. However, some sensors
         # (e.g., "laststest") will only appear after certain event occurs (e.g., a self test is
-        # performed) and may disappear again after certain event. So we properly mark the
-        # availability of the sensor when we update the attributes.
+        # performed) and may disappear again after certain event. So we mark the state as "unknown"
+        # when it becomes unknown after such events.
         if key not in self.coordinator.data:
-            self._attr_available = False
+            self._attr_native_value = STATE_UNKNOWN
             return
 
         self._attr_native_value, inferred_unit = infer_unit(self.coordinator.data[key])
         if not self.native_unit_of_measurement:
             self._attr_native_unit_of_measurement = inferred_unit
-
-        self._attr_available = True


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds graceful handling for sensors that could become available/unavailable after certain events:

(1) for `LASTSTEST` sensor that could become available after a certain event (a periodical or manual self test), we add them during integration set up no matter what (such that if it's not available during integration set up, the state would just be "unknown").
(2) for all sensors that could become unknown (currently only `LASTSTEST`, but the handling is for all sensors) after certain event, we now properly mark them as "unknown" instead of crashing (and set the values again once they become available).

A test case that simulates such events is also added to prevent future regressions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #111831
- This PR is related to issue: #111831
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
