### PR TITLE
Add the ability to create Debouncer tasks as background tasks

### DIFF
--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -168,7 +168,9 @@ class Debouncer(Generic[_R_co]):
         self._execute_at_end_of_timer = False
         name = f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}"
         if not self._background:
-            self.hass.async_create_task(self._handle_timer_finish(), name)
+            self.hass.async_create_task(
+                self._handle_timer_finish(), name, eager_start=True
+            )
             return
         self.hass.async_create_background_task(
             self._handle_timer_finish(), name, eager_start=True

--- a/homeassistant/helpers/debounce.py
+++ b/homeassistant/helpers/debounce.py
@@ -163,15 +163,16 @@ class Debouncer(Generic[_R_co]):
     def _on_debounce(self) -> None:
         """Create job task, but only if pending."""
         self._timer_task = None
-        if self._execute_at_end_of_timer:
-            self._execute_at_end_of_timer = False
-            name = f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}"
-            if self._background:
-                self.hass.async_create_background_task(
-                    self._handle_timer_finish(), name, eager_start=True
-                )
-            else:
-                self.hass.async_create_task(self._handle_timer_finish(), name)
+        if not self._execute_at_end_of_timer:
+            return
+        self._execute_at_end_of_timer = False
+        name = f"debouncer {self._job} finish cooldown={self.cooldown}, immediate={self.immediate}"
+        if not self._background:
+            self.hass.async_create_task(self._handle_timer_finish(), name)
+            return
+        self.hass.async_create_background_task(
+            self._handle_timer_finish(), name, eager_start=True
+        )
 
     @callback
     def _schedule_timer(self) -> None:

--- a/tests/helpers/test_debounce.py
+++ b/tests/helpers/test_debounce.py
@@ -497,3 +497,35 @@ async def test_shutdown(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -
 
     assert len(calls) == 1
     assert debouncer._timer_task is None
+
+
+async def test_background(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test background tasks are created when background is True."""
+    calls = []
+
+    async def _func() -> None:
+        await asyncio.sleep(0.1)
+        calls.append(None)
+
+    debouncer = debounce.Debouncer(
+        hass, _LOGGER, cooldown=0.05, immediate=True, function=_func, background=True
+    )
+
+    await debouncer.async_call()
+    assert len(calls) == 1
+
+    debouncer.async_schedule_call()
+    assert len(calls) == 1
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=False)
+    assert len(calls) == 1
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert len(calls) == 2
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=1))
+    await hass.async_block_till_done(wait_background_tasks=False)
+    assert len(calls) == 2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a more general solution as a followup to #112652 (which will be used for https://github.com/home-assistant/core/pull/113129 and a few other places that currently block startup)

Note that this does not affect how they are run other than they do not block startup or shutdown, only which bucket (`HomeAssistant._background_tasks`) they are saved in

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
