### PR TITLE
Simplify clearing _attr cached_property in entities

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -357,13 +357,17 @@ class CachedProperties(type):
             def _setter(o: Any, val: Any) -> None:
                 """Set an _attr_ property to the backing __attr attribute.
 
-                Also set the corresponding cached_property by updating
-                __dict__ directly.
+                Also invalidates the corresponding cached_property by calling
+                delattr on it.
                 """
                 if getattr(o, private_attr_name, _SENTINEL) == val:
                     return
                 setattr(o, private_attr_name, val)
-                o.__dict__[name] = val
+                if name in o.__dict__:
+                    try:  # noqa: SIM105  suppress is much slower
+                        delattr(o, name)
+                    except AttributeError:
+                        pass
 
             return _setter
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -363,10 +363,11 @@ class CachedProperties(type):
                 if getattr(o, private_attr_name, _SENTINEL) == val:
                     return
                 setattr(o, private_attr_name, val)
-                try:  # noqa: SIM105  suppress is much slower
-                    delattr(o, name)
-                except AttributeError:
-                    pass
+                if name in o.__dict__:
+                    try:  # noqa: SIM105  suppress is much slower
+                        delattr(o, name)
+                    except AttributeError:
+                        pass
 
             return _setter
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -357,17 +357,13 @@ class CachedProperties(type):
             def _setter(o: Any, val: Any) -> None:
                 """Set an _attr_ property to the backing __attr attribute.
 
-                Also invalidates the corresponding cached_property by calling
-                delattr on it.
+                Also set the corresponding cached_property by updating
+                __dict__ directly.
                 """
                 if getattr(o, private_attr_name, _SENTINEL) == val:
                     return
                 setattr(o, private_attr_name, val)
-                if name in o.__dict__:
-                    try:  # noqa: SIM105  suppress is much slower
-                        delattr(o, name)
-                    except AttributeError:
-                        pass
+                o.__dict__[name] = val
 
             return _setter
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -331,10 +331,7 @@ class CachedProperties(type):
                 Raises AttributeError if the __attr_ attribute does not exist
                 """
                 # Invalidate the cache of the cached property
-                try:  # noqa: SIM105  suppress is much slower
-                    delattr(o, name)
-                except AttributeError:
-                    pass
+                o.__dict__.pop(name, None)
                 # Delete the __attr_ attribute
                 delattr(o, private_attr_name)
 
@@ -363,11 +360,8 @@ class CachedProperties(type):
                 if getattr(o, private_attr_name, _SENTINEL) == val:
                     return
                 setattr(o, private_attr_name, val)
-                if name in o.__dict__:
-                    try:  # noqa: SIM105  suppress is much slower
-                        delattr(o, name)
-                    except AttributeError:
-                        pass
+                # Invalidate the cache of the cached property
+                o.__dict__.pop(name, None)
 
             return _setter
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Clear the cache by poping the value out of `__dict__` to avoid calling delattr since the ["zero cost exception"](https://github.com/python/cpython/issues/84403) only applies if it does not raise.

This reduces the run time significantly

before
<img width="314" alt="Screenshot 2024-03-11 at 9 17 34 PM" src="https://github.com/home-assistant/core/assets/663432/f8953c8e-eacc-47f4-ba38-6d907d7cb0f6">

after
<img width="383" alt="Screenshot 2024-03-12 at 3 51 19 PM" src="https://github.com/home-assistant/core/assets/663432/15ae3dd2-8b69-4841-9e1d-bdce0e6db231">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
