### PR TITLE
Preserve DataUpdateCoordinator._job backwards compatibility for subclasses

### DIFF
--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -255,7 +255,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
         ).cancel
 
     @callback
-    def __wrap_handle_refresh_interval(self) -> None:
+    def __wrap_handle_refresh_interval(self, _now: datetime | None = None) -> None:
         """Handle a refresh interval occurrence."""
         if self.config_entry:
             self.config_entry.async_create_background_task(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#### Reintroduce the optional `_now` param to the `DataUpdateCoordinator._job` target

As part of #111570 the `__wrap_handle_refresh_interval` callback was introduced, which delegates to the existing `_handle_refresh_interval`. This was done because `_handle_refresh_interval` is overridden in some integrations as per the summary on that PR.

However, the `_schedule_refresh` is also overridden in custom integrations and some/many of these will still be using `event.async_track_point_in_utc_time` as was the case in HA core prior to #98937 ([prior code](https://github.com/home-assistant/core/blob/c47983621c4c28dcd9418ae3f83653ed2edc774d/homeassistant/helpers/update_coordinator.py#L227-L231
)).

 The problem is that the new `__wrap_handle_refresh_interval` has a different signature from `__wrap_handle_refresh_interval`, making it backwards incompatible for integrations that are using `event.async_track_point_in_utc_time` (example: https://github.com/luuuis/hass_omie/pull/53).

<details>

<summary>Expand for code snippets</summary>

https://github.com/home-assistant/core/blob/70f3da93d47d417fc7b4694937258c924ad3cc11/homeassistant/helpers/update_coordinator.py#L258

https://github.com/home-assistant/core/blob/70f3da93d47d417fc7b4694937258c924ad3cc11/homeassistant/helpers/update_coordinator.py#L274
</details>

This manifests in custom integrations with the following error and a failure to refresh any data.

```
2024-03-11 00:00:00.418 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback _TrackPointUTCTime._run_action()
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/src/homeassistant/homeassistant/helpers/event.py", line 1468, in _run_action
    self.hass.async_run_hass_job(self.job, self.utc_point_in_time)
  File "/usr/src/homeassistant/homeassistant/core.py", line 727, in async_run_hass_job
    hassjob.target(*args)
TypeError: DataUpdateCoordinator.__wrap_handle_refresh_interval() takes 1 positional argument but 2 were given
```

I suggest to add the (optional, ignored) `_now: datetime` param to keep the HassJob backwards compatible for custom integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
