### PR TITLE
Add a helper to import modules from the event loop

### DIFF
--- a/homeassistant/helpers/importlib.py
+++ b/homeassistant/helpers/importlib.py
@@ -1,0 +1,57 @@
+"""Class to reload platforms."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import suppress
+import importlib
+import logging
+import sys
+from types import ModuleType
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_IMPORT_CACHE = "import_cache"
+DATA_IMPORT_FUTURES = "import_futures"
+
+
+def _get_module(cache: dict[str, ModuleType], name: str) -> ModuleType:
+    """Get a module."""
+    cache[name] = importlib.import_module(name)
+    return cache[name]
+
+
+async def async_import_module(hass: HomeAssistant, name: str) -> ModuleType:
+    """Import a module or return it from the cache."""
+    cache: dict[str, ModuleType] = hass.data.setdefault(DATA_IMPORT_CACHE, {})
+    if module := cache.get(name):
+        return module
+
+    import_futures: dict[str, asyncio.Future[ModuleType]]
+    import_futures = hass.data.setdefault(DATA_IMPORT_FUTURES, {})
+
+    if future := import_futures.get(name):
+        return await future
+
+    if name in sys.modules:
+        return _get_module(cache, name)
+
+    import_future = hass.loop.create_future()
+    import_futures[name] = import_future
+    try:
+        module = await hass.async_add_import_executor_job(_get_module, cache, name)
+        import_future.set_result(module)
+    except BaseException as ex:
+        import_future.set_exception(ex)
+        with suppress(BaseException):
+            # Set the exception retrieved flag on the future since
+            # it will never be retrieved unless there
+            # are concurrent calls
+            import_future.result()
+        raise
+    finally:
+        del import_futures[name]
+
+    return module

--- a/homeassistant/helpers/importlib.py
+++ b/homeassistant/helpers/importlib.py
@@ -1,4 +1,4 @@
-"""Class to reload platforms."""
+"""Helper to import modules from asyncio."""
 
 from __future__ import annotations
 

--- a/tests/helpers/test_importlib.py
+++ b/tests/helpers/test_importlib.py
@@ -1,0 +1,41 @@
+"""Tests for the importlib helper."""
+
+from unittest.mock import patch
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import importlib
+
+from tests.common import MockModule
+
+
+async def test_async_import_module(hass: HomeAssistant) -> None:
+    """Test importing a module."""
+    mock_module = MockModule()
+    with patch(
+        "homeassistant.helpers.importlib.importlib.import_module",
+        return_value=mock_module,
+    ):
+        module = await importlib.async_import_module(hass, "test.module")
+
+    assert module is mock_module
+
+
+async def test_async_import_module_concurrency(hass: HomeAssistant) -> None:
+    """Test importing a module."""
+    mock_module = MockModule()
+
+    with patch(
+        "homeassistant.helpers.importlib.importlib.import_module",
+        return_value=mock_module,
+    ):
+        task1 = hass.async_create_task(
+            importlib.async_import_module(hass, "test.module")
+        )
+        task2 = hass.async_create_task(
+            importlib.async_import_module(hass, "test.module")
+        )
+        module1 = await task1
+        module2 = await task2
+
+    assert module1 is mock_module
+    assert module2 is mock_module

--- a/tests/helpers/test_importlib.py
+++ b/tests/helpers/test_importlib.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import importlib
 
@@ -20,8 +22,25 @@ async def test_async_import_module(hass: HomeAssistant) -> None:
     assert module is mock_module
 
 
+async def test_async_import_module_failures(hass: HomeAssistant) -> None:
+    """Test importing a module fails."""
+    with patch(
+        "homeassistant.helpers.importlib.importlib.import_module",
+        side_effect=ImportError,
+    ), pytest.raises(ImportError):
+        await importlib.async_import_module(hass, "test.module")
+
+    mock_module = MockModule()
+    # The failure should be cached
+    with pytest.raises(ImportError), patch(
+        "homeassistant.helpers.importlib.importlib.import_module",
+        return_value=mock_module,
+    ):
+        await importlib.async_import_module(hass, "test.module")
+
+
 async def test_async_import_module_concurrency(hass: HomeAssistant) -> None:
-    """Test importing a module."""
+    """Test importing a module with concurrency."""
     mock_module = MockModule()
 
     with patch(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replaces the one used for triggers with a more generic helper
that can be reused and uses a future to avoid importing concurrently

There are a few other places we will want to use this.  Need to do it in `scene` as well but there is no coro entry point so that one is a bit harder to refactor.

```
homeassistant/auth/mfa_modules/__init__.py:        module = importlib.import_module(module_path)
homeassistant/auth/providers/__init__.py:        module = importlib.import_module(f"homeassistant.auth.providers.{provider}")
homeassistant/components/avion/light.py:    avion = importlib.import_module("avion")
homeassistant/components/avion/light.py:        avion = importlib.import_module("avion")
homeassistant/components/cups/sensor.py:        cups = importlib.import_module("cups")
homeassistant/components/smartthings/__init__.py:                platform_module = importlib.import_module(
homeassistant/components/telegram_bot/__init__.py:        platform = importlib.import_module(f".{p_config[CONF_PLATFORM]}", __name__)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
