### PR TITLE
Bump weatherflow_cloud backing lib v0.2.13

### DIFF
--- a/homeassistant/components/weatherflow_cloud/coordinator.py
+++ b/homeassistant/components/weatherflow_cloud/coordinator.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 
 from aiohttp import ClientResponseError
 from weatherflow4py.api import WeatherFlowRestAPI
-from weatherflow4py.models.unified import WeatherFlowData
+from weatherflow4py.models.rest.unified import WeatherFlowData
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed

--- a/homeassistant/components/weatherflow_cloud/manifest.json
+++ b/homeassistant/components/weatherflow_cloud/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/weatherflow_cloud",
   "iot_class": "cloud_polling",
-  "requirements": ["weatherflow4py==0.1.17"]
+  "requirements": ["weatherflow4py==0.2.13"]
 }

--- a/homeassistant/components/weatherflow_cloud/weather.py
+++ b/homeassistant/components/weatherflow_cloud/weather.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from weatherflow4py.models.unified import WeatherFlowData
+from weatherflow4py.models.rest.unified import WeatherFlowData
 
 from homeassistant.components.weather import (
     Forecast,

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2833,7 +2833,7 @@ watchdog==2.3.1
 waterfurnace==1.1.0
 
 # homeassistant.components.weatherflow_cloud
-weatherflow4py==0.1.17
+weatherflow4py==0.2.13
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2174,7 +2174,7 @@ wallbox==0.6.0
 watchdog==2.3.1
 
 # homeassistant.components.weatherflow_cloud
-weatherflow4py==0.1.17
+weatherflow4py==0.2.13
 
 # homeassistant.components.webmin
 webmin-xmlrpc==0.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As we've seen a few times before there are "keys" that are listed in the API Docs that dont always seem to appear. One example is `precip_accum_local_day_final` which is causing an issue for @gingerbreadassassin

This PR bumps the backing lib minor version to 0.2 with the main difference being models were refactored into `rest` models and `ws` (websocket) models 


The main change in the backing lib we need is this: 
![image](https://github.com/home-assistant/core/assets/6491743/28606795-dcaa-4840-ade6-3fa37720e086)

https://github.com/jeeftor/weatherflow4py/compare/v0.1.17...v0.2.13


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->


- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/112030#issuecomment-1992515032
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
