### PR TITLE
Bump numato-gpio to v0.13.0

### DIFF
--- a/homeassistant/components/numato/binary_sensor.py
+++ b/homeassistant/components/numato/binary_sensor.py
@@ -54,7 +54,6 @@ def setup_platform(
         for port, port_name in ports.items():
             try:
                 api.setup_input(device_id, port)
-                api.edge_detect(device_id, port, partial(read_gpio, device_id))
 
             except NumatoGpioError as err:
                 _LOGGER.error(
@@ -68,7 +67,17 @@ def setup_platform(
                     err,
                 )
                 continue
+            try:
+                api.edge_detect(device_id, port, partial(read_gpio, device_id))
 
+            except NumatoGpioError as err:
+                _LOGGER.info(
+                    "Notification setup failed on device %s, "
+                    "updates on binary sensor %s only in polling mode: %s",
+                    device_id,
+                    port_name,
+                    err,
+                )
             binary_sensors.append(
                 NumatoGpioBinarySensor(
                     port_name,

--- a/homeassistant/components/numato/manifest.json
+++ b/homeassistant/components/numato/manifest.json
@@ -6,5 +6,5 @@
   "integration_type": "hub",
   "iot_class": "local_push",
   "loggers": ["numato_gpio"],
-  "requirements": ["numato-gpio==0.12.0"]
+  "requirements": ["numato-gpio==0.13.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1406,7 +1406,7 @@ nsw-fuel-api-client==1.1.0
 nuheat==1.0.1
 
 # homeassistant.components.numato
-numato-gpio==0.12.0
+numato-gpio==0.13.0
 
 # homeassistant.components.compensation
 # homeassistant.components.iqvia

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1124,7 +1124,7 @@ nsw-fuel-api-client==1.1.0
 nuheat==1.0.1
 
 # homeassistant.components.numato
-numato-gpio==0.12.0
+numato-gpio==0.13.0
 
 # homeassistant.components.compensation
 # homeassistant.components.iqvia

--- a/tests/components/numato/numato_mock.py
+++ b/tests/components/numato/numato_mock.py
@@ -62,7 +62,8 @@ class NumatoModuleMock:
 
         Ignore the device list argument, mock discovers /dev/ttyACM0.
         """
-        self.devices[0] = NumatoModuleMock.NumatoDeviceMock("/dev/ttyACM0")
+        if not self.devices:
+            self.devices[0] = NumatoModuleMock.NumatoDeviceMock("/dev/ttyACM0")
 
     def cleanup(self):
         """Mockup for the numato device cleanup."""

--- a/tests/components/numato/test_binary_sensor.py
+++ b/tests/components/numato/test_binary_sensor.py
@@ -1,11 +1,17 @@
 """Tests for the numato binary_sensor platform."""
 
+import logging
+from unittest.mock import patch
+
+import pytest
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
 from .common import NUMATO_CFG, mockup_raise
+from .numato_mock import NumatoGpioError, NumatoModuleMock
 
 MOCKUP_ENTITY_IDS = {
     "binary_sensor.numato_binary_sensor_mock_port2",
@@ -73,3 +79,32 @@ async def test_binary_sensor_setup_without_discovery_info(
     await hass.async_block_till_done()  # wait for numato platform to be loaded
     for entity_id in MOCKUP_ENTITY_IDS:
         assert entity_id in hass.states.async_entity_ids()
+
+
+async def test_binary_sensor_setup_no_notify(
+    hass: HomeAssistant,
+    numato_fixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Setup of a device without notification capability shall print an info message."""
+    caplog.set_level(logging.INFO)
+
+    def raise_notification_error(self, port, callback, direction):
+        raise NumatoGpioError(
+            f"{repr(self)} Mockup device doesn't support notifications."
+        )
+
+    with patch.object(
+        NumatoModuleMock.NumatoDeviceMock,
+        "add_event_detect",
+        raise_notification_error,
+    ):
+        numato_fixture.discover()
+        assert await async_setup_component(hass, "numato", NUMATO_CFG)
+        await hass.async_block_till_done()  # wait until services are registered
+
+    assert all(
+        f"updates on binary sensor numato_binary_sensor_mock_port{port} only in polling mode"
+        in caplog.text
+        for port in NUMATO_CFG["numato"]["devices"][0]["binary_sensors"]["ports"]
+    )

--- a/tests/components/numato/test_binary_sensor.py
+++ b/tests/components/numato/test_binary_sensor.py
@@ -31,23 +31,25 @@ async def test_failing_setups_no_entities(
         assert entity_id not in hass.states.async_entity_ids()
 
 
-async def test_setup_callbacks(
-    hass: HomeAssistant, numato_fixture, monkeypatch
-) -> None:
+async def test_setup_callbacks(hass: HomeAssistant, numato_fixture) -> None:
     """During setup a callback shall be registered."""
 
-    numato_fixture.discover()
+    with patch.object(
+        NumatoModuleMock.NumatoDeviceMock, "add_event_detect"
+    ) as mock_add_event_detect:
+        numato_fixture.discover()
+        assert await async_setup_component(hass, "numato", NUMATO_CFG)
+        await hass.async_block_till_done()  # wait until services are registered
 
-    def mock_add_event_detect(self, port, callback, direction):
-        assert self == numato_fixture.devices[0]
-        assert port == 1
-        assert callback is callable
-        assert direction == numato_fixture.BOTH
-
-    monkeypatch.setattr(
-        numato_fixture.devices[0], "add_event_detect", mock_add_event_detect
+    mock_add_event_detect.assert_called()
+    assert {call.args[0] for call in mock_add_event_detect.mock_calls} == {
+        int(port)
+        for port in NUMATO_CFG["numato"]["devices"][0]["binary_sensors"]["ports"]
+    }
+    assert all(callable(call.args[1]) for call in mock_add_event_detect.mock_calls)
+    assert all(
+        call.args[2] == numato_fixture.BOTH for call in mock_add_event_detect.mock_calls
     )
-    assert await async_setup_component(hass, "numato", NUMATO_CFG)
 
 
 async def test_hass_binary_sensor_notification(


### PR DESCRIPTION
This is going to improve compatibility of most if not all device variants.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
None.
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

The numato-gpio dependency is updated to v0.13.0 ([changelog](https://github.com/clssn/numato-gpio/commit/8a8090e8a313103d9565ce3b9877b72b1ff99bef)).

Errors raised from numato-gpio 0.13.0 in case of 8 bit devices which don't support notifications are handled with an info level log message. This way this integration has no breaking change.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes #112101, #99508 and #112784

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
