### PR TITLE
Reduce script overhead by avoiding creation of many tasks

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -157,12 +157,6 @@ SCRIPT_DEBUG_CONTINUE_ALL = "script_debug_continue_all"
 script_stack_cv: ContextVar[list[int] | None] = ContextVar("script_stack", default=None)
 
 
-def _clear_timeout_future(timeout_future: asyncio.Future[None]) -> None:
-    """Clear the exception retrieved from the timeout future."""
-    with suppress(asyncio.CancelledError):
-        timeout_future.result()
-
-
 def _set_result_unless_done(future: asyncio.Future[None]) -> None:
     """Set result of future unless it is done."""
     if not future.done():
@@ -620,7 +614,6 @@ class _ScriptRun:
             )
         finally:
             if timeout_future.done():
-                _clear_timeout_future(timeout_future)
                 trace_set_result(delay=delay_seconds, done=True)
             else:
                 timeout_handle.cancel()
@@ -676,7 +669,6 @@ class _ScriptRun:
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_handle and timeout_future.done():
-                _clear_timeout_future(timeout_future)
                 self._variables["wait"]["remaining"] = 0.0
                 if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
                     self._log(_TIMEOUT_MSG)
@@ -1062,7 +1054,6 @@ class _ScriptRun:
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_handle and timeout_future.done():
-                _clear_timeout_future(timeout_future)
                 self._variables["wait"]["remaining"] = 0.0
                 if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
                     self._log(_TIMEOUT_MSG)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -650,7 +650,7 @@ class _ScriptRun:
         @callback
         def async_script_wait(entity_id, from_s, to_s):
             """Handle script after template condition is true."""
-            self._async_set_remaining_time(timeout_handle)
+            self._async_set_remaining_time_var(timeout_handle)
             self._variables["wait"]["completed"] = True
             _set_result_unless_done(done)
 
@@ -662,10 +662,10 @@ class _ScriptRun:
             futures, timeout_handle, timeout_future, unsub
         )
 
-    def _async_set_remaining_time(
+    def _async_set_remaining_time_var(
         self, timeout_handle: asyncio.TimerHandle | None
     ) -> None:
-        """Set the remaining time for a wait step."""
+        """Set the remaining time variable for a wait step."""
         wait_var = self._variables["wait"]
         if timeout_handle:
             wait_var["remaining"] = timeout_handle.when() - self._hass.loop.time()
@@ -1009,7 +1009,7 @@ class _ScriptRun:
         )
 
         async def async_done(variables, context=None):
-            self._async_set_remaining_time(timeout_handle)
+            self._async_set_remaining_time_var(timeout_handle)
             self._variables["wait"]["trigger"] = variables["trigger"]
             _set_result_unless_done(done)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -976,9 +976,8 @@ class _ScriptRun:
         timeout_handle: asyncio.TimerHandle | None = None
         timeout_future: asyncio.Future[None] | None = None
         if timeout:
-            loop = self._hass.loop
-            timeout_future = loop.create_future()
-            timeout_handle = loop.call_later(
+            timeout_future = self._hass.loop.create_future()
+            timeout_handle = self._hass.loop.call_later(
                 timeout, _set_result_unless_done, timeout_future
             )
             futures.append(timeout_future)
@@ -998,8 +997,7 @@ class _ScriptRun:
         self._variables["wait"] = {"remaining": timeout, "trigger": None}
         trace_set_result(wait=self._variables["wait"])
 
-        loop = self._hass.loop
-        done = loop.create_future()
+        done = self._hass.loop.create_future()
         futures: list[asyncio.Future[None]] = [self._stop, done]
         timeout_handle, timeout_future = self._async_add_future_timeout(
             futures, timeout
@@ -1009,7 +1007,7 @@ class _ScriptRun:
             # pylint: disable=protected-access
             wait_var = self._variables["wait"]
             if timeout_handle:
-                wait_var["remaining"] = timeout_handle._when - loop.time()
+                wait_var["remaining"] = timeout_handle._when - self._hass.loop.time()
             else:
                 wait_var["remaining"] = timeout
             wait_var["trigger"] = variables["trigger"]

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -620,7 +620,7 @@ class _ScriptRun:
             else:
                 timeout_handle.cancel()
 
-    def _get_timeout_seconds_From_action(self) -> float | None:
+    def _get_timeout_seconds_from_action(self) -> float | None:
         """Get the timeout from the action."""
         if CONF_TIMEOUT in self._action:
             return self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
@@ -628,7 +628,7 @@ class _ScriptRun:
 
     async def _async_wait_template_step(self):
         """Handle a wait template."""
-        timeout = self._get_timeout_seconds_From_action()
+        timeout = self._get_timeout_seconds_from_action()
         self._step_log("wait template", timeout)
 
         self._variables["wait"] = {"remaining": timeout, "completed": False}
@@ -991,7 +991,7 @@ class _ScriptRun:
 
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""
-        timeout = self._get_timeout_seconds_From_action()
+        timeout = self._get_timeout_seconds_from_action()
 
         self._step_log("wait for trigger", timeout)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -633,10 +633,9 @@ class _ScriptRun:
 
     async def _async_wait_template_step(self):
         """Handle a wait template."""
+        timeout: float | None
         if CONF_TIMEOUT in self._action:
-            timeout: float | None = self._get_pos_time_period_template(
-                CONF_TIMEOUT
-            ).total_seconds()
+            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
         else:
             timeout = None
 
@@ -1017,10 +1016,9 @@ class _ScriptRun:
 
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""
+        timeout: float | None
         if CONF_TIMEOUT in self._action:
-            timeout: float | None = self._get_pos_time_period_template(
-                CONF_TIMEOUT
-            ).total_seconds()
+            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
         else:
             timeout = None
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -601,22 +601,22 @@ class _ScriptRun:
 
     async def _async_delay_step(self):
         """Handle delay."""
-        delay = self._get_pos_time_period_template(CONF_DELAY)
+        delay_delta = self._get_pos_time_period_template(CONF_DELAY)
 
-        self._step_log(f"delay {delay}")
+        self._step_log(f"delay {delay_delta}")
 
-        delay_seconds = delay.total_seconds()
+        delay = delay_delta.total_seconds()
         self._changed()
-        trace_set_result(delay=delay_seconds, done=False)
+        trace_set_result(delay=delay, done=False)
         futures, timeout_handle, timeout_future = self._async_futures_with_timeout(
-            delay_seconds
+            delay
         )
 
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
         finally:
             if timeout_future.done():
-                trace_set_result(delay=delay_seconds, done=True)
+                trace_set_result(delay=delay, done=True)
             else:
                 timeout_handle.cancel()
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -620,14 +620,15 @@ class _ScriptRun:
             else:
                 timeout_handle.cancel()
 
+    def _get_timeout_seconds_From_action(self) -> float | None:
+        """Get the timeout from the action."""
+        if CONF_TIMEOUT in self._action:
+            return self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
+        return None
+
     async def _async_wait_template_step(self):
         """Handle a wait template."""
-        timeout: float | None
-        if CONF_TIMEOUT in self._action:
-            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
-        else:
-            timeout = None
-
+        timeout = self._get_timeout_seconds_From_action()
         self._step_log("wait template", timeout)
 
         self._variables["wait"] = {"remaining": timeout, "completed": False}
@@ -990,11 +991,7 @@ class _ScriptRun:
 
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""
-        timeout: float | None
-        if CONF_TIMEOUT in self._action:
-            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
-        else:
-            timeout = None
+        timeout = self._get_timeout_seconds_From_action()
 
         self._step_log("wait for trigger", timeout)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -77,7 +77,6 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.util import slugify
-from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.dt import utcnow
 
 from . import condition, config_validation as cv, service, template
@@ -1665,7 +1664,7 @@ class Script:
         # asyncio.shield as asyncio.shield yields to the event loop, which would cause
         # us to wait for script runs added after the call to async_stop.
         aws = [
-            create_eager_task(run.async_stop()) for run in self._runs if run != spare
+            asyncio.create_task(run.async_stop()) for run in self._runs if run != spare
         ]
         if not aws:
             return

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -674,11 +674,7 @@ class _ScriptRun:
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_handle and timeout_future.done():
-                self._variables["wait"]["remaining"] = 0.0
-                if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
-                    self._log(_TIMEOUT_MSG)
-                    trace_set_result(wait=self._variables["wait"], timeout=True)
-                    raise _AbortScript from TimeoutError()
+                self._handle_timeout()
         finally:
             if timeout_handle and not timeout_future.done():
                 timeout_handle.cancel()
@@ -1039,16 +1035,20 @@ class _ScriptRun:
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_handle and timeout_future.done():
-                self._variables["wait"]["remaining"] = 0.0
-                if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
-                    self._log(_TIMEOUT_MSG)
-                    trace_set_result(wait=self._variables["wait"], timeout=True)
-                    raise _AbortScript from TimeoutError()
+                self._handle_timeout()
         finally:
             if timeout_handle and not timeout_future.done():
                 timeout_handle.cancel()
 
             remove_triggers()
+
+    def _handle_timeout(self) -> None:
+        """Handle timeout."""
+        self._variables["wait"]["remaining"] = 0.0
+        if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
+            self._log(_TIMEOUT_MSG)
+            trace_set_result(wait=self._variables["wait"], timeout=True)
+            raise _AbortScript from TimeoutError()
 
     async def _async_variables_step(self):
         """Set a variable value."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1041,20 +1041,16 @@ class _ScriptRun:
         try:
             await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_future and timeout_future.done():
-                self._handle_timeout()
+                self._variables["wait"]["remaining"] = 0.0
+                if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
+                    self._log(_TIMEOUT_MSG)
+                    trace_set_result(wait=self._variables["wait"], timeout=True)
+                    raise _AbortScript from TimeoutError()
         finally:
             if timeout_future and not timeout_future.done() and timeout_handle:
                 timeout_handle.cancel()
 
             unsub()
-
-    def _handle_timeout(self) -> None:
-        """Handle timeout."""
-        self._variables["wait"]["remaining"] = 0.0
-        if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
-            self._log(_TIMEOUT_MSG)
-            trace_set_result(wait=self._variables["wait"], timeout=True)
-            raise _AbortScript from TimeoutError()
 
     async def _async_variables_step(self):
         """Set a variable value."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1004,8 +1004,8 @@ class _ScriptRun:
         timeout_handle: asyncio.TimerHandle | None = None
         futures: list[asyncio.Future[None]] = [self._stop, done]
         if timeout:
-            timeout_future = self._hass.loop.create_future()
-            timeout_handle = self._hass.loop.call_later(
+            timeout_future = loop.create_future()
+            timeout_handle = loop.call_later(
                 timeout, _set_result_unless_done, timeout_future
             )
             futures.append(timeout_future)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1141,10 +1141,9 @@ class _QueuedScriptRun(_ScriptRun):
         """Run script."""
         # Wait for previous run, if any, to finish by attempting to acquire the script's
         # shared lock. At the same time monitor if we've been told to stop.
-        lock = self._script._queue_lck  # pylint: disable=protected-access
         try:
             async with async_interrupt.interrupt(self._stop, ScriptStoppedError, None):
-                await lock.acquire()
+                await self._script._queue_lck.acquire()  # pylint: disable=protected-access
         except ScriptStoppedError as ex:
             # If we've been told to stop, then just finish up.
             self._finish()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -718,8 +718,6 @@ class _ScriptRun:
 
         if self._stop.done():
             return None
-        if long_task.cancelled():
-            raise asyncio.CancelledError
         if long_task.done():
             # Propagate any exceptions that occurred.
             return long_task.result()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -650,7 +650,6 @@ class _ScriptRun:
         @callback
         def async_script_wait(entity_id, from_s, to_s):
             """Handle script after template condition is true."""
-            # pylint: disable=protected-access
             wait_var = self._variables["wait"]
             if timeout_handle:
                 wait_var["remaining"] = timeout_handle.when() - self._hass.loop.time()
@@ -1004,7 +1003,6 @@ class _ScriptRun:
         )
 
         async def async_done(variables, context=None):
-            # pylint: disable=protected-access
             wait_var = self._variables["wait"]
             if timeout_handle:
                 wait_var["remaining"] = timeout_handle.when() - self._hass.loop.time()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -713,10 +713,12 @@ class _ScriptRun:
             # is cancelled otherwise the CancelledError exception will not be raised to
             # here due to the call to asyncio.wait(). Rather we'll check for that below.
             if self._stop.done():
-                # Stop requested, cancel long task and return None.
+                # Stop requested, cancel long task and return None below
                 await async_cancel_long_task()
 
-        if long_task.cancelled() or self._stop.done():
+        if self._stop.done():
+            return None
+        if long_task.cancelled():
             raise asyncio.CancelledError
         if long_task.done():
             # Propagate any exceptions that occurred.

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1146,12 +1146,12 @@ class _QueuedScriptRun(_ScriptRun):
             async with async_interrupt.interrupt(self._stop, ScriptStoppedError, None):
                 await lock.acquire()
         except ScriptStoppedError as ex:
+            # If we've been told to stop, then just finish up.
             self._finish()
             raise asyncio.CancelledError from ex
 
         self.lock_acquired = True
-        # If we've been told to stop, then just finish up. Otherwise, we've acquired the
-        # lock so we can go ahead and start the run.
+        # We've acquired the lock so we can go ahead and start the run.
         await super().async_run()
 
     def _finish(self) -> None:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -718,7 +718,7 @@ class _ScriptRun:
                 await async_cancel_long_task()
 
         if long_task.cancelled() or self._stop.done():
-            raise asyncio.CancelledError()
+            raise asyncio.CancelledError
         if long_task.done():
             # Propagate any exceptions that occurred.
             return long_task.result()

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -652,8 +652,8 @@ class _ScriptRun:
             """Handle script after template condition is true."""
             # pylint: disable=protected-access
             wait_var = self._variables["wait"]
-            if timeout_handle and timeout_handle._when:
-                wait_var["remaining"] = timeout_handle._when - self._hass.loop.time()
+            if timeout_handle:
+                wait_var["remaining"] = timeout_handle.when() - self._hass.loop.time()
             else:
                 wait_var["remaining"] = timeout
             wait_var["completed"] = True
@@ -1007,7 +1007,7 @@ class _ScriptRun:
             # pylint: disable=protected-access
             wait_var = self._variables["wait"]
             if timeout_handle:
-                wait_var["remaining"] = timeout_handle._when - self._hass.loop.time()
+                wait_var["remaining"] = timeout_handle.when() - self._hass.loop.time()
             else:
                 wait_var["remaining"] = timeout
             wait_var["trigger"] = variables["trigger"]

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -689,9 +689,9 @@ class _ScriptRun:
         """Run a long task while monitoring for stop request."""
         try:
             async with async_interrupt.interrupt(self._stop, ScriptStoppedError, None):
-                # interrupt will raise ScriptStoppedError
-                # if stop is set it will also cancel the
-                # long_task
+                # if stop is set, interrupt will cancel inside the context
+                # manager which will cancel long_task, and raise
+                # ScriptStoppedError outside the context manager
                 return await long_task
         except ScriptStoppedError as ex:
             raise asyncio.CancelledError from ex

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -642,10 +642,10 @@ class _ScriptRun:
             self._variables["wait"]["completed"] = True
             return
 
-        done = self._hass.loop.create_future()
         futures, timeout_handle, timeout_future = self._async_futures_with_timeout(
             timeout
         )
+        done = self._hass.loop.create_future()
         futures.append(done)
 
         @callback


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I've always had a little bit of a hard time telling people to disable polling and make an automation to pull because I know how much overhead was introduced by doing that. This is a step towards reducing that.

Reduce script overhead by avoiding creation of many tasks. Instead of creating `asyncio.Event`s and wrapping them in tasks, we now use `asyncio.Future`s as they can be waited for with `asyncio.wait` without having to be wrapped in a task.

Timeouts are handled by adding in another `asyncio.Future` to the list being waited for and are fired with a `call_later`

If the automation/script doesn't suspend there is a good chance it will never have to be scheduled on the event loop.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
