### PR TITLE
Convert dsmr to getattr instead of using the dict interface

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -10,13 +10,12 @@ from dataclasses import dataclass
 from datetime import timedelta
 from functools import partial
 
-from dsmr_parser import obis_references
 from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
 from dsmr_parser.clients.rfxtrx_protocol import (
     create_rfxtrx_dsmr_reader,
     create_rfxtrx_tcp_dsmr_reader,
 )
-from dsmr_parser.objects import DSMRObject
+from dsmr_parser.objects import Telegram
 import serial
 
 from homeassistant.components.sensor import (
@@ -81,7 +80,7 @@ class DSMRSensorEntityDescription(SensorEntityDescription):
 SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="timestamp",
-        obis_reference=obis_references.P1_MESSAGE_TIMESTAMP,
+        obis_reference="P1_MESSAGE_TIMESTAMP",
         device_class=SensorDeviceClass.TIMESTAMP,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -89,21 +88,21 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="current_electricity_usage",
         translation_key="current_electricity_usage",
-        obis_reference=obis_references.CURRENT_ELECTRICITY_USAGE,
+        obis_reference="CURRENT_ELECTRICITY_USAGE",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     DSMRSensorEntityDescription(
         key="current_electricity_delivery",
         translation_key="current_electricity_delivery",
-        obis_reference=obis_references.CURRENT_ELECTRICITY_DELIVERY,
+        obis_reference="CURRENT_ELECTRICITY_DELIVERY",
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     DSMRSensorEntityDescription(
         key="electricity_active_tariff",
         translation_key="electricity_active_tariff",
-        obis_reference=obis_references.ELECTRICITY_ACTIVE_TARIFF,
+        obis_reference="ELECTRICITY_ACTIVE_TARIFF",
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENUM,
         options=["low", "normal"],
@@ -111,7 +110,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_1",
         translation_key="electricity_used_tariff_1",
-        obis_reference=obis_references.ELECTRICITY_USED_TARIFF_1,
+        obis_reference="ELECTRICITY_USED_TARIFF_1",
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -119,7 +118,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_used_tariff_2",
         translation_key="electricity_used_tariff_2",
-        obis_reference=obis_references.ELECTRICITY_USED_TARIFF_2,
+        obis_reference="ELECTRICITY_USED_TARIFF_2",
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -127,7 +126,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_1",
         translation_key="electricity_delivered_tariff_1",
-        obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_1,
+        obis_reference="ELECTRICITY_DELIVERED_TARIFF_1",
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -135,7 +134,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_delivered_tariff_2",
         translation_key="electricity_delivered_tariff_2",
-        obis_reference=obis_references.ELECTRICITY_DELIVERED_TARIFF_2,
+        obis_reference="ELECTRICITY_DELIVERED_TARIFF_2",
         dsmr_versions={"2.2", "4", "5", "5B", "5L"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -143,7 +142,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_positive",
         translation_key="instantaneous_active_power_l1_positive",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L1_POSITIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -151,7 +150,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_positive",
         translation_key="instantaneous_active_power_l2_positive",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L2_POSITIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -159,7 +158,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_positive",
         translation_key="instantaneous_active_power_l3_positive",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L3_POSITIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -167,7 +166,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l1_negative",
         translation_key="instantaneous_active_power_l1_negative",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L1_NEGATIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -175,7 +174,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l2_negative",
         translation_key="instantaneous_active_power_l2_negative",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L2_NEGATIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -183,7 +182,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_active_power_l3_negative",
         translation_key="instantaneous_active_power_l3_negative",
-        obis_reference=obis_references.INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE,
+        obis_reference="INSTANTANEOUS_ACTIVE_POWER_L3_NEGATIVE",
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -191,7 +190,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="short_power_failure_count",
         translation_key="short_power_failure_count",
-        obis_reference=obis_references.SHORT_POWER_FAILURE_COUNT,
+        obis_reference="SHORT_POWER_FAILURE_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -199,7 +198,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="long_power_failure_count",
         translation_key="long_power_failure_count",
-        obis_reference=obis_references.LONG_POWER_FAILURE_COUNT,
+        obis_reference="LONG_POWER_FAILURE_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -207,7 +206,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_sag_l1_count",
         translation_key="voltage_sag_l1_count",
-        obis_reference=obis_references.VOLTAGE_SAG_L1_COUNT,
+        obis_reference="VOLTAGE_SAG_L1_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -215,7 +214,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_sag_l2_count",
         translation_key="voltage_sag_l2_count",
-        obis_reference=obis_references.VOLTAGE_SAG_L2_COUNT,
+        obis_reference="VOLTAGE_SAG_L2_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -223,7 +222,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_sag_l3_count",
         translation_key="voltage_sag_l3_count",
-        obis_reference=obis_references.VOLTAGE_SAG_L3_COUNT,
+        obis_reference="VOLTAGE_SAG_L3_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -231,7 +230,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_swell_l1_count",
         translation_key="voltage_swell_l1_count",
-        obis_reference=obis_references.VOLTAGE_SWELL_L1_COUNT,
+        obis_reference="VOLTAGE_SWELL_L1_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -239,7 +238,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_swell_l2_count",
         translation_key="voltage_swell_l2_count",
-        obis_reference=obis_references.VOLTAGE_SWELL_L2_COUNT,
+        obis_reference="VOLTAGE_SWELL_L2_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -247,7 +246,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="voltage_swell_l3_count",
         translation_key="voltage_swell_l3_count",
-        obis_reference=obis_references.VOLTAGE_SWELL_L3_COUNT,
+        obis_reference="VOLTAGE_SWELL_L3_COUNT",
         dsmr_versions={"2.2", "4", "5", "5L"},
         entity_registry_enabled_default=False,
         entity_category=EntityCategory.DIAGNOSTIC,
@@ -255,7 +254,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l1",
         translation_key="instantaneous_voltage_l1",
-        obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L1,
+        obis_reference="INSTANTANEOUS_VOLTAGE_L1",
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -264,7 +263,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l2",
         translation_key="instantaneous_voltage_l2",
-        obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L2,
+        obis_reference="INSTANTANEOUS_VOLTAGE_L2",
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -273,7 +272,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_voltage_l3",
         translation_key="instantaneous_voltage_l3",
-        obis_reference=obis_references.INSTANTANEOUS_VOLTAGE_L3,
+        obis_reference="INSTANTANEOUS_VOLTAGE_L3",
         device_class=SensorDeviceClass.VOLTAGE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -282,7 +281,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_current_l1",
         translation_key="instantaneous_current_l1",
-        obis_reference=obis_references.INSTANTANEOUS_CURRENT_L1,
+        obis_reference="INSTANTANEOUS_CURRENT_L1",
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -291,7 +290,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_current_l2",
         translation_key="instantaneous_current_l2",
-        obis_reference=obis_references.INSTANTANEOUS_CURRENT_L2,
+        obis_reference="INSTANTANEOUS_CURRENT_L2",
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -300,7 +299,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="instantaneous_current_l3",
         translation_key="instantaneous_current_l3",
-        obis_reference=obis_references.INSTANTANEOUS_CURRENT_L3,
+        obis_reference="INSTANTANEOUS_CURRENT_L3",
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.MEASUREMENT,
@@ -309,7 +308,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="belgium_max_power_per_phase",
         translation_key="max_power_per_phase",
-        obis_reference=obis_references.BELGIUM_MAX_POWER_PER_PHASE,
+        obis_reference="BELGIUM_MAX_POWER_PER_PHASE",
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
         entity_registry_enabled_default=False,
@@ -319,7 +318,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="belgium_max_current_per_phase",
         translation_key="max_current_per_phase",
-        obis_reference=obis_references.BELGIUM_MAX_CURRENT_PER_PHASE,
+        obis_reference="BELGIUM_MAX_CURRENT_PER_PHASE",
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.CURRENT,
         entity_registry_enabled_default=False,
@@ -329,7 +328,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_imported_total",
         translation_key="electricity_imported_total",
-        obis_reference=obis_references.ELECTRICITY_IMPORTED_TOTAL,
+        obis_reference="ELECTRICITY_IMPORTED_TOTAL",
         dsmr_versions={"5L", "5S", "Q3D"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -337,7 +336,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="electricity_exported_total",
         translation_key="electricity_exported_total",
-        obis_reference=obis_references.ELECTRICITY_EXPORTED_TOTAL,
+        obis_reference="ELECTRICITY_EXPORTED_TOTAL",
         dsmr_versions={"5L", "5S", "Q3D"},
         device_class=SensorDeviceClass.ENERGY,
         state_class=SensorStateClass.TOTAL_INCREASING,
@@ -345,7 +344,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="belgium_current_average_demand",
         translation_key="current_average_demand",
-        obis_reference=obis_references.BELGIUM_CURRENT_AVERAGE_DEMAND,
+        obis_reference="BELGIUM_CURRENT_AVERAGE_DEMAND",
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -353,7 +352,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="belgium_maximum_demand_current_month",
         translation_key="maximum_demand_current_month",
-        obis_reference=obis_references.BELGIUM_MAXIMUM_DEMAND_MONTH,
+        obis_reference="BELGIUM_MAXIMUM_DEMAND_MONTH",
         dsmr_versions={"5B"},
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -361,7 +360,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="hourly_gas_meter_reading",
         translation_key="gas_meter_reading",
-        obis_reference=obis_references.HOURLY_GAS_METER_READING,
+        obis_reference="HOURLY_GAS_METER_READING",
         dsmr_versions={"4", "5", "5L"},
         is_gas=True,
         device_class=SensorDeviceClass.GAS,
@@ -370,7 +369,7 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
     DSMRSensorEntityDescription(
         key="gas_meter_reading",
         translation_key="gas_meter_reading",
-        obis_reference=obis_references.GAS_METER_READING,
+        obis_reference="GAS_METER_READING",
         dsmr_versions={"2.2"},
         is_gas=True,
         device_class=SensorDeviceClass.GAS,
@@ -380,39 +379,23 @@ SENSORS: tuple[DSMRSensorEntityDescription, ...] = (
 
 
 def create_mbus_entity(
-    mbus: int, mtype: int, telegram: dict[str, DSMRObject]
+    mbus: int, mtype: int, telegram: Telegram
 ) -> DSMRSensorEntityDescription | None:
     """Create a new MBUS Entity."""
-    if (
-        mtype == 3
-        and (
-            obis_reference := getattr(
-                obis_references, f"BELGIUM_MBUS{mbus}_METER_READING2"
-            )
-        )
-        in telegram
-    ):
+    if mtype == 3 and hasattr(telegram, f"BELGIUM_MBUS{mbus}_METER_READING2"):
         return DSMRSensorEntityDescription(
             key=f"mbus{mbus}_gas_reading",
             translation_key="gas_meter_reading",
-            obis_reference=obis_reference,
+            obis_reference=f"BELGIUM_MBUS{mbus}_METER_READING2",
             is_gas=True,
             device_class=SensorDeviceClass.GAS,
             state_class=SensorStateClass.TOTAL_INCREASING,
         )
-    if (
-        mtype == 7
-        and (
-            obis_reference := getattr(
-                obis_references, f"BELGIUM_MBUS{mbus}_METER_READING1"
-            )
-        )
-        in telegram
-    ):
+    if mtype == 7 and hasattr(telegram, f"BELGIUM_MBUS{mbus}_METER_READING1"):
         return DSMRSensorEntityDescription(
             key=f"mbus{mbus}_water_reading",
             translation_key="water_meter_reading",
-            obis_reference=obis_reference,
+            obis_reference=f"BELGIUM_MBUS{mbus}_METER_READING1",
             is_water=True,
             device_class=SensorDeviceClass.WATER,
             state_class=SensorStateClass.TOTAL_INCREASING,
@@ -421,11 +404,11 @@ def create_mbus_entity(
 
 
 def device_class_and_uom(
-    telegram: dict[str, DSMRObject],
+    telegram: Telegram,
     entity_description: DSMRSensorEntityDescription,
 ) -> tuple[SensorDeviceClass | None, str | None]:
     """Get native unit of measurement from telegram,."""
-    dsmr_object = telegram[entity_description.obis_reference]
+    dsmr_object = getattr(telegram, entity_description.obis_reference)
     uom: str | None = getattr(dsmr_object, "unit") or None
     with suppress(ValueError):
         if entity_description.device_class == SensorDeviceClass.GAS and (
@@ -478,24 +461,23 @@ def rename_old_gas_to_mbus(
 
 
 def create_mbus_entities(
-    hass: HomeAssistant, telegram: dict[str, DSMRObject], entry: ConfigEntry
+    hass: HomeAssistant, telegram: Telegram, entry: ConfigEntry
 ) -> list[DSMREntity]:
     """Create MBUS Entities."""
     entities = []
     for idx in range(1, 5):
         if (
-            device_type := getattr(obis_references, f"BELGIUM_MBUS{idx}_DEVICE_TYPE")
-        ) not in telegram:
+            device_type := getattr(telegram, f"BELGIUM_MBUS{idx}_DEVICE_TYPE", None)
+        ) is None:
             continue
-        if (type_ := int(telegram[device_type].value)) not in (3, 7):
+        if (type_ := int(device_type.value)) not in (3, 7):
             continue
         if (
             identifier := getattr(
-                obis_references,
-                f"BELGIUM_MBUS{idx}_EQUIPMENT_IDENTIFIER",
+                telegram, f"BELGIUM_MBUS{idx}_EQUIPMENT_IDENTIFIER", None
             )
-        ) in telegram:
-            serial_ = telegram[identifier].value
+        ) is not None:
+            serial_ = identifier.value
             rename_old_gas_to_mbus(hass, entry, serial_)
         else:
             serial_ = ""
@@ -523,7 +505,7 @@ async def async_setup_entry(
     add_entities_handler: Callable[..., None] | None
 
     @callback
-    def init_async_add_entities(telegram: dict[str, DSMRObject]) -> None:
+    def init_async_add_entities(telegram: Telegram) -> None:
         """Add the sensor entities after the first telegram was received."""
         nonlocal add_entities_handler
         assert add_entities_handler is not None
@@ -547,7 +529,7 @@ async def async_setup_entry(
                     or dsmr_version in description.dsmr_versions
                 )
                 and (not description.is_gas or CONF_SERIAL_ID_GAS in entry.data)
-                and description.obis_reference in telegram
+                and hasattr(telegram, description.obis_reference)
             ]
         )
         async_add_entities(entities)
@@ -560,7 +542,7 @@ async def async_setup_entry(
     )
 
     @Throttle(min_time_between_updates)
-    def update_entities_telegram(telegram: dict[str, DSMRObject] | None) -> None:
+    def update_entities_telegram(telegram: Telegram | None) -> None:
         """Update entities with latest telegram and trigger state update."""
         nonlocal initialized
         # Make all device entities aware of new telegram
@@ -709,7 +691,7 @@ class DSMREntity(SensorEntity):
         self,
         entity_description: DSMRSensorEntityDescription,
         entry: ConfigEntry,
-        telegram: dict[str, DSMRObject],
+        telegram: Telegram,
         device_class: SensorDeviceClass,
         native_unit_of_measurement: str | None,
         serial_id: str = "",
@@ -720,7 +702,7 @@ class DSMREntity(SensorEntity):
         self._attr_device_class = device_class
         self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._entry = entry
-        self.telegram: dict[str, DSMRObject] | None = telegram
+        self.telegram: Telegram | None = telegram
 
         device_serial = entry.data[CONF_SERIAL_ID]
         device_name = DEVICE_NAME_ELECTRICITY
@@ -750,25 +732,25 @@ class DSMREntity(SensorEntity):
             self._attr_unique_id = f"{device_serial}_{entity_description.key}"
 
     @callback
-    def update_data(self, telegram: dict[str, DSMRObject] | None) -> None:
+    def update_data(self, telegram: Telegram | None) -> None:
         """Update data."""
         self.telegram = telegram
         if self.hass and (
-            telegram is None or self.entity_description.obis_reference in telegram
+            telegram is None
+            or hasattr(telegram, self.entity_description.obis_reference)
         ):
             self.async_write_ha_state()
 
     def get_dsmr_object_attr(self, attribute: str) -> str | None:
         """Read attribute from last received telegram for this DSMR object."""
         # Make sure telegram contains an object for this entities obis
-        if (
-            self.telegram is None
-            or self.entity_description.obis_reference not in self.telegram
+        if self.telegram is None or not hasattr(
+            self.telegram, self.entity_description.obis_reference
         ):
             return None
 
         # Get the attribute value if the object has it
-        dsmr_object = self.telegram[self.entity_description.obis_reference]
+        dsmr_object = getattr(self.telegram, self.entity_description.obis_reference)
         attr: str | None = getattr(dsmr_object, attribute)
         return attr
 
@@ -784,10 +766,7 @@ class DSMREntity(SensorEntity):
         if (value := self.get_dsmr_object_attr("value")) is None:
             return None
 
-        if (
-            self.entity_description.obis_reference
-            == obis_references.ELECTRICITY_ACTIVE_TARIFF
-        ):
+        if self.entity_description.obis_reference == "ELECTRICITY_ACTIVE_TARIFF":
             return self.translate_tariff(value, self._entry.data[CONF_DSMR_VERSION])
 
         with suppress(TypeError):

--- a/tests/components/dsmr/test_mbus_migration.py
+++ b/tests/components/dsmr/test_mbus_migration.py
@@ -22,7 +22,7 @@ async def test_migrate_gas_to_mbus(
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS1_METER_READING2,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -62,22 +62,31 @@ async def test_migrate_gas_to_mbus(
     assert entity.unique_id == old_unique_id
     await hass.async_block_till_done()
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS1_METER_READING2",
+    )
 
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
@@ -118,7 +127,7 @@ async def test_migrate_gas_to_mbus_exists(
         BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS1_METER_READING2,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -175,22 +184,31 @@ async def test_migrate_gas_to_mbus_exists(
     )
     await hass.async_block_till_done()
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS1_METER_READING2",
+    )
 
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -46,7 +46,7 @@ async def test_default_setup(
         ELECTRICITY_ACTIVE_TARIFF,
         GAS_METER_READING,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -58,22 +58,31 @@ async def test_default_setup(
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal("0.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-        GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": UnitOfVolume.CUBIC_METERS},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -112,22 +121,31 @@ async def test_default_setup(
     )
     assert power_consumption.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "W"
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-        GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(745.701), "unit": UnitOfVolume.CUBIC_METERS},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     # simulate a telegram pushed from the smartmeter and parsed by dsmr_parser
     telegram_callback(telegram)
@@ -180,7 +198,7 @@ async def test_setup_only_energy(
         CURRENT_ELECTRICITY_USAGE,
         ELECTRICITY_ACTIVE_TARIFF,
     )
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -191,15 +209,20 @@ async def test_setup_only_energy(
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-    }
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -234,7 +257,7 @@ async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         ELECTRICITY_ACTIVE_TARIFF,
         HOURLY_GAS_METER_READING,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -246,18 +269,23 @@ async def test_v4_meter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-    }
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -320,7 +348,7 @@ async def test_v5_meter(
         ELECTRICITY_ACTIVE_TARIFF,
         HOURLY_GAS_METER_READING,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -332,18 +360,23 @@ async def test_v5_meter(
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": value, "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-    }
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -393,7 +426,7 @@ async def test_luxembourg_meter(hass: HomeAssistant, dsmr_connection_fixture) ->
         ELECTRICITY_IMPORTED_TOTAL,
         HOURLY_GAS_METER_READING,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -405,23 +438,34 @@ async def test_luxembourg_meter(hass: HomeAssistant, dsmr_connection_fixture) ->
         "time_between_update": 0,
     }
 
-    telegram = {
-        HOURLY_GAS_METER_READING: MBusObject(
-            HOURLY_GAS_METER_READING,
+    telegram = Telegram()
+    telegram.add(
+        HOURLY_GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+        "HOURLY_GAS_METER_READING",
+    )
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -494,7 +538,7 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         BELGIUM_MBUS4_METER_READING1,
         ELECTRICITY_ACTIVE_TARIFF,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -506,78 +550,127 @@ async def test_belgian_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         "time_between_update": 0,
     }
 
-    telegram = {
-        BELGIUM_CURRENT_AVERAGE_DEMAND: CosemObject(
-            BELGIUM_CURRENT_AVERAGE_DEMAND,
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_CURRENT_AVERAGE_DEMAND,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(1.75), "unit": "kW"}],
         ),
-        BELGIUM_MAXIMUM_DEMAND_MONTH: MBusObject(
-            BELGIUM_MAXIMUM_DEMAND_MONTH,
+        "BELGIUM_CURRENT_AVERAGE_DEMAND",
+    )
+    telegram.add(
+        BELGIUM_MAXIMUM_DEMAND_MONTH,
+        MBusObject(
+            (0, 0),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(4.11), "unit": "kW"},
             ],
         ),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MAXIMUM_DEMAND_MONTH",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING2: MBusObject(
-            BELGIUM_MBUS1_METER_READING2,
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING2,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(745.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS1_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 2), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS2_METER_READING1: MBusObject(
-            BELGIUM_MBUS2_METER_READING1,
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_METER_READING1,
+        MBusObject(
+            (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642214)},
                 {"value": Decimal(678.695), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS2_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 3), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
-            BELGIUM_MBUS3_METER_READING2,
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING2,
+        MBusObject(
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS3_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 4), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
-        BELGIUM_MBUS4_METER_READING1: MBusObject(
-            BELGIUM_MBUS4_METER_READING1,
+        "BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING1,
+        MBusObject(
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-    }
+        "BELGIUM_MBUS4_METER_READING1",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -693,7 +786,7 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
         BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
         BELGIUM_MBUS4_METER_READING2,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -705,64 +798,103 @@ async def test_belgian_meter_alt(hass: HomeAssistant, dsmr_connection_fixture) -
         "time_between_update": 0,
     }
 
-    telegram = {
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+    telegram = Telegram()
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS1_METER_READING1: MBusObject(
-            BELGIUM_MBUS1_METER_READING1,
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_METER_READING1,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642215)},
                 {"value": Decimal(123.456), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS1_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 2), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS2_METER_READING2: MBusObject(
-            BELGIUM_MBUS2_METER_READING2,
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_METER_READING2,
+        MBusObject(
+            (0, 2),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642216)},
                 {"value": Decimal(678.901), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS2_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 3), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING1: MBusObject(
-            BELGIUM_MBUS3_METER_READING1,
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING1,
+        MBusObject(
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS3_METER_READING1",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 4), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 4),
             [{"value": "37464C4F32313139303333373334", "unit": ""}],
         ),
-        BELGIUM_MBUS4_METER_READING2: MBusObject(
-            BELGIUM_MBUS4_METER_READING2,
+        "BELGIUM_MBUS4_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING2,
+        MBusObject(
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS4_METER_READING2",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -854,7 +986,7 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
         BELGIUM_MBUS4_METER_READING1,
         ELECTRICITY_ACTIVE_TARIFF,
     )
-    from dsmr_parser.objects import CosemObject, MBusObject
+    from dsmr_parser.objects import CosemObject, MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -866,49 +998,78 @@ async def test_belgian_meter_mbus(hass: HomeAssistant, dsmr_connection_fixture) 
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0003", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS1_DEVICE_TYPE, [{"value": "006", "unit": ""}]
-        ),
-        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0003", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_DEVICE_TYPE,
+        CosemObject((0, 1), [{"value": "006", "unit": ""}]),
+        "BELGIUM_MBUS1_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 1),
             [{"value": "37464C4F32313139303333373331", "unit": ""}],
         ),
-        BELGIUM_MBUS2_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS2_DEVICE_TYPE, [{"value": "003", "unit": ""}]
-        ),
-        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS1_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_DEVICE_TYPE,
+        CosemObject((0, 2), [{"value": "003", "unit": ""}]),
+        "BELGIUM_MBUS2_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 2),
             [{"value": "37464C4F32313139303333373332", "unit": ""}],
         ),
-        BELGIUM_MBUS3_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS3_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER: CosemObject(
-            BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        "BELGIUM_MBUS2_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_DEVICE_TYPE,
+        CosemObject((0, 3), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS3_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER,
+        CosemObject(
+            (0, 3),
             [{"value": "37464C4F32313139303333373333", "unit": ""}],
         ),
-        BELGIUM_MBUS3_METER_READING2: MBusObject(
-            BELGIUM_MBUS3_METER_READING2,
+        "BELGIUM_MBUS3_EQUIPMENT_IDENTIFIER",
+    )
+    telegram.add(
+        BELGIUM_MBUS3_METER_READING2,
+        MBusObject(
+            (0, 3),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642217)},
                 {"value": Decimal(12.12), "unit": "m3"},
             ],
         ),
-        BELGIUM_MBUS4_DEVICE_TYPE: CosemObject(
-            BELGIUM_MBUS4_DEVICE_TYPE, [{"value": "007", "unit": ""}]
-        ),
-        BELGIUM_MBUS4_METER_READING1: MBusObject(
-            BELGIUM_MBUS4_METER_READING1,
+        "BELGIUM_MBUS3_METER_READING2",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_DEVICE_TYPE,
+        CosemObject((0, 4), [{"value": "007", "unit": ""}]),
+        "BELGIUM_MBUS4_DEVICE_TYPE",
+    )
+    telegram.add(
+        BELGIUM_MBUS4_METER_READING1,
+        MBusObject(
+            (0, 4),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642218)},
                 {"value": Decimal(13.13), "unit": "m3"},
             ],
         ),
-    }
+        "BELGIUM_MBUS4_METER_READING1",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -964,7 +1125,7 @@ async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
     from dsmr_parser.obis_references import ELECTRICITY_ACTIVE_TARIFF
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -976,11 +1137,12 @@ async def test_belgian_meter_low(hass: HomeAssistant, dsmr_connection_fixture) -
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0002", "unit": ""}]
-        )
-    }
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0002", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -1016,7 +1178,7 @@ async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         ELECTRICITY_EXPORTED_TOTAL,
         ELECTRICITY_IMPORTED_TOTAL,
     )
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -1028,16 +1190,23 @@ async def test_swedish_meter(hass: HomeAssistant, dsmr_connection_fixture) -> No
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(123.456), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(654.321), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options
@@ -1088,7 +1257,7 @@ async def test_easymeter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         ELECTRICITY_EXPORTED_TOTAL,
         ELECTRICITY_IMPORTED_TOTAL,
     )
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -1100,16 +1269,23 @@ async def test_easymeter(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         "time_between_update": 0,
     }
 
-    telegram = {
-        ELECTRICITY_IMPORTED_TOTAL: CosemObject(
-            ELECTRICITY_IMPORTED_TOTAL,
+    telegram = Telegram()
+    telegram.add(
+        ELECTRICITY_IMPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(54184.6316), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-        ELECTRICITY_EXPORTED_TOTAL: CosemObject(
-            ELECTRICITY_EXPORTED_TOTAL,
+        "ELECTRICITY_IMPORTED_TOTAL",
+    )
+    telegram.add(
+        ELECTRICITY_EXPORTED_TOTAL,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal(19981.1069), "unit": UnitOfEnergy.KILO_WATT_HOUR}],
         ),
-    }
+        "ELECTRICITY_EXPORTED_TOTAL",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr",
@@ -1252,7 +1428,7 @@ async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         CURRENT_ELECTRICITY_USAGE,
         ELECTRICITY_ACTIVE_TARIFF,
     )
-    from dsmr_parser.objects import CosemObject
+    from dsmr_parser.objects import CosemObject, Telegram
 
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
@@ -1266,15 +1442,20 @@ async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
         "time_between_update": 0,
     }
 
-    telegram = {
-        CURRENT_ELECTRICITY_USAGE: CosemObject(
-            CURRENT_ELECTRICITY_USAGE,
+    telegram = Telegram()
+    telegram.add(
+        CURRENT_ELECTRICITY_USAGE,
+        CosemObject(
+            (0, 0),
             [{"value": Decimal("35.0"), "unit": UnitOfPower.WATT}],
         ),
-        ELECTRICITY_ACTIVE_TARIFF: CosemObject(
-            ELECTRICITY_ACTIVE_TARIFF, [{"value": "0001", "unit": ""}]
-        ),
-    }
+        "CURRENT_ELECTRICITY_USAGE",
+    )
+    telegram.add(
+        ELECTRICITY_ACTIVE_TARIFF,
+        CosemObject((0, 0), [{"value": "0001", "unit": ""}]),
+        "ELECTRICITY_ACTIVE_TARIFF",
+    )
 
     # mock waiting coroutine while connection lasts
     closed = asyncio.Event()
@@ -1335,7 +1516,7 @@ async def test_gas_meter_providing_energy_reading(
     (connection_factory, transport, protocol) = dsmr_connection_fixture
 
     from dsmr_parser.obis_references import GAS_METER_READING
-    from dsmr_parser.objects import MBusObject
+    from dsmr_parser.objects import MBusObject, Telegram
 
     entry_data = {
         "port": "/dev/ttyUSB0",
@@ -1347,15 +1528,18 @@ async def test_gas_meter_providing_energy_reading(
         "time_between_update": 0,
     }
 
-    telegram = {
-        GAS_METER_READING: MBusObject(
-            GAS_METER_READING,
+    telegram = Telegram()
+    telegram.add(
+        GAS_METER_READING,
+        MBusObject(
+            (0, 1),
             [
                 {"value": datetime.datetime.fromtimestamp(1551642213)},
                 {"value": Decimal(123.456), "unit": UnitOfEnergy.GIGA_JOULE},
             ],
         ),
-    }
+        "GAS_METER_READING",
+    )
 
     mock_entry = MockConfigEntry(
         domain="dsmr", unique_id="/dev/ttyUSB0", data=entry_data, options=entry_options


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
dsmr_parser deprecated the dict interface.
See https://github.com/ndokter/dsmr_parser/blob/master/dsmr_parser/objects.py#L21

Convert the code and tests to use the Telegram object. This will clear the path for further improvements and is needed for changes in dsmr_parser 1.4.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
