### PR TITLE
Add previous track intent

### DIFF
--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
-    SERVICE_MEDIA_STOP,
     SERVICE_VOLUME_SET,
 )
 from homeassistant.core import Context, HomeAssistant, State
@@ -20,12 +19,10 @@ from homeassistant.helpers import intent
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
 from .const import MediaPlayerEntityFeature, MediaPlayerState
 
-INTENT_CLEAR_PLAYLIST = "HassMediaClearPlaylist"
 INTENT_MEDIA_PAUSE = "HassMediaPause"
 INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
 INTENT_MEDIA_PREVIOUS = "HassMediaPrevious"
-INTENT_MEDIA_STOP = "HassMediaStop"
 INTENT_SET_VOLUME = "HassSetVolume"
 
 
@@ -79,10 +76,6 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
         intent.ServiceIntentHandler(
             INTENT_MEDIA_PREVIOUS, DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK
         ),
-    )
-    intent.async_register(
-        hass,
-        intent.ServiceIntentHandler(INTENT_MEDIA_STOP, DOMAIN, SERVICE_MEDIA_STOP),
     )
     intent.async_register(
         hass,

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -74,7 +74,14 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
     intent.async_register(
         hass,
         intent.ServiceIntentHandler(
-            INTENT_MEDIA_PREVIOUS, DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK
+            INTENT_MEDIA_PREVIOUS,
+            DOMAIN,
+            SERVICE_MEDIA_PREVIOUS_TRACK,
+            required_domains={DOMAIN},
+            required_features=MediaPlayerEntityFeature.PREVIOUS_TRACK,
+            required_states={MediaPlayerState.PLAYING},
+            description="Replays the previous item for a media player",
+            platforms={DOMAIN},
         ),
     )
     intent.async_register(

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_VOLUME_SET,
 )
 from homeassistant.core import Context, HomeAssistant, State
@@ -21,6 +22,7 @@ from .const import MediaPlayerEntityFeature, MediaPlayerState
 INTENT_MEDIA_PAUSE = "HassMediaPause"
 INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
+INTENT_MEDIA_PREVIOUS = "HassMediaPrevious"
 INTENT_SET_VOLUME = "HassSetVolume"
 
 
@@ -67,6 +69,12 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             required_states={MediaPlayerState.PLAYING},
             description="Skips a media player to the next item",
             platforms={DOMAIN},
+        ),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(
+            INTENT_MEDIA_PREVIOUS, DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK
         ),
     )
     intent.async_register(

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_MEDIA_STOP,
     SERVICE_VOLUME_SET,
 )
 from homeassistant.core import Context, HomeAssistant, State
@@ -19,10 +20,12 @@ from homeassistant.helpers import intent
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
 from .const import MediaPlayerEntityFeature, MediaPlayerState
 
+INTENT_CLEAR_PLAYLIST = "HassMediaClearPlaylist"
 INTENT_MEDIA_PAUSE = "HassMediaPause"
 INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
 INTENT_MEDIA_PREVIOUS = "HassMediaPrevious"
+INTENT_MEDIA_STOP = "HassMediaStop"
 INTENT_SET_VOLUME = "HassSetVolume"
 
 
@@ -76,6 +79,10 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
         intent.ServiceIntentHandler(
             INTENT_MEDIA_PREVIOUS, DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK
         ),
+    )
+    intent.async_register(
+        hass,
+        intent.ServiceIntentHandler(INTENT_MEDIA_STOP, DOMAIN, SERVICE_MEDIA_STOP),
     )
     intent.async_register(
         hass,

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -7,6 +7,7 @@ from homeassistant.components.media_player import (
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
     SERVICE_VOLUME_SET,
     intent as media_player_intent,
 )
@@ -171,6 +172,30 @@ async def test_next_media_player_intent(hass: HomeAssistant) -> None:
             {"name": {"value": "test media player"}},
         )
         await hass.async_block_till_done()
+
+
+async def test_previous_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaPrevious intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PREVIOUS_TRACK)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_PREVIOUS,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_MEDIA_PREVIOUS_TRACK
+    assert call.data == {"entity_id": entity_id}
 
 
 async def test_volume_media_player_intent(hass: HomeAssistant) -> None:

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -4,12 +4,10 @@ import pytest
 
 from homeassistant.components.media_player import (
     DOMAIN,
-    SERVICE_CLEAR_PLAYLIST,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
-    SERVICE_MEDIA_STOP,
     SERVICE_VOLUME_SET,
     intent as media_player_intent,
 )
@@ -29,30 +27,6 @@ from homeassistant.helpers import (
 )
 
 from tests.common import async_mock_service
-
-
-async def test_clear_playlist_media_player_intent(hass: HomeAssistant) -> None:
-    """Test HassMediaClearPlaylist intent for media players."""
-    await media_player_intent.async_setup_intents(hass)
-
-    entity_id = f"{DOMAIN}.test_media_player"
-    hass.states.async_set(entity_id, STATE_IDLE)
-    calls = async_mock_service(hass, DOMAIN, SERVICE_CLEAR_PLAYLIST)
-
-    response = await intent.async_handle(
-        hass,
-        "test",
-        media_player_intent.INTENT_CLEAR_PLAYLIST,
-        {"name": {"value": "test media player"}},
-    )
-    await hass.async_block_till_done()
-
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == DOMAIN
-    assert call.service == SERVICE_CLEAR_PLAYLIST
-    assert call.data == {"entity_id": entity_id}
 
 
 async def test_pause_media_player_intent(hass: HomeAssistant) -> None:
@@ -221,30 +195,6 @@ async def test_previous_media_player_intent(hass: HomeAssistant) -> None:
     call = calls[0]
     assert call.domain == DOMAIN
     assert call.service == SERVICE_MEDIA_PREVIOUS_TRACK
-    assert call.data == {"entity_id": entity_id}
-
-
-async def test_stop_media_player_intent(hass: HomeAssistant) -> None:
-    """Test HassMediaStop intent for media players."""
-    await media_player_intent.async_setup_intents(hass)
-
-    entity_id = f"{DOMAIN}.test_media_player"
-    hass.states.async_set(entity_id, STATE_IDLE)
-    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_STOP)
-
-    response = await intent.async_handle(
-        hass,
-        "test",
-        media_player_intent.INTENT_MEDIA_STOP,
-        {"name": {"value": "test media player"}},
-    )
-    await hass.async_block_till_done()
-
-    assert response.response_type == intent.IntentResponseType.ACTION_DONE
-    assert len(calls) == 1
-    call = calls[0]
-    assert call.domain == DOMAIN
-    assert call.service == SERVICE_MEDIA_STOP
     assert call.data == {"entity_id": entity_id}
 
 

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -4,10 +4,12 @@ import pytest
 
 from homeassistant.components.media_player import (
     DOMAIN,
+    SERVICE_CLEAR_PLAYLIST,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_MEDIA_PREVIOUS_TRACK,
+    SERVICE_MEDIA_STOP,
     SERVICE_VOLUME_SET,
     intent as media_player_intent,
 )
@@ -27,6 +29,30 @@ from homeassistant.helpers import (
 )
 
 from tests.common import async_mock_service
+
+
+async def test_clear_playlist_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaClearPlaylist intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_CLEAR_PLAYLIST)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_CLEAR_PLAYLIST,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_CLEAR_PLAYLIST
+    assert call.data == {"entity_id": entity_id}
 
 
 async def test_pause_media_player_intent(hass: HomeAssistant) -> None:
@@ -195,6 +221,30 @@ async def test_previous_media_player_intent(hass: HomeAssistant) -> None:
     call = calls[0]
     assert call.domain == DOMAIN
     assert call.service == SERVICE_MEDIA_PREVIOUS_TRACK
+    assert call.data == {"entity_id": entity_id}
+
+
+async def test_stop_media_player_intent(hass: HomeAssistant) -> None:
+    """Test HassMediaStop intent for media players."""
+    await media_player_intent.async_setup_intents(hass)
+
+    entity_id = f"{DOMAIN}.test_media_player"
+    hass.states.async_set(entity_id, STATE_IDLE)
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_STOP)
+
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_STOP,
+        {"name": {"value": "test media player"}},
+    )
+    await hass.async_block_till_done()
+
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.domain == DOMAIN
+    assert call.service == SERVICE_MEDIA_STOP
     assert call.data == {"entity_id": entity_id}
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds previous track intent. At least I hope it does as I just mimic-ed Mike H's previous PR. This is in support of the equivalent PR in the intents repo https://github.com/home-assistant/intents/pull/2080 I don't have a full dev environment so I don't think I can do the local tests? Maybe this work can be picked up by someone if this not acceptable? 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
