### PR TITLE
Support configuring Axis to use HTTPS

### DIFF
--- a/homeassistant/components/axis/hub/api.py
+++ b/homeassistant/components/axis/hub/api.py
@@ -7,7 +7,13 @@ from typing import Any
 import axis
 from axis.configuration import Configuration
 
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_PROTOCOL,
+    CONF_USERNAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.httpx_client import get_async_client
 
@@ -29,6 +35,7 @@ async def get_axis_api(
             port=config[CONF_PORT],
             username=config[CONF_USERNAME],
             password=config[CONF_PASSWORD],
+            web_proto=config.get(CONF_PROTOCOL, "http"),
         )
     )
 

--- a/tests/components/axis/test_config_flow.py
+++ b/tests/components/axis/test_config_flow.py
@@ -28,6 +28,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PORT,
+    CONF_PROTOCOL,
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
@@ -65,6 +66,7 @@ async def test_flow_manual_configuration(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
+            CONF_PROTOCOL: "http",
             CONF_HOST: "1.2.3.4",
             CONF_USERNAME: "user",
             CONF_PASSWORD: "pass",
@@ -75,6 +77,7 @@ async def test_flow_manual_configuration(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
+        CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
         CONF_PASSWORD: "pass",
@@ -101,6 +104,7 @@ async def test_manual_configuration_update_configuration(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
+            CONF_PROTOCOL: "http",
             CONF_HOST: "2.3.4.5",
             CONF_USERNAME: "user",
             CONF_PASSWORD: "pass",
@@ -130,6 +134,7 @@ async def test_flow_fails_faulty_credentials(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
+                CONF_PROTOCOL: "http",
                 CONF_HOST: "1.2.3.4",
                 CONF_USERNAME: "user",
                 CONF_PASSWORD: "pass",
@@ -156,6 +161,7 @@ async def test_flow_fails_cannot_connect(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
+                CONF_PROTOCOL: "http",
                 CONF_HOST: "1.2.3.4",
                 CONF_USERNAME: "user",
                 CONF_PASSWORD: "pass",
@@ -191,6 +197,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
+            CONF_PROTOCOL: "http",
             CONF_HOST: "1.2.3.4",
             CONF_USERNAME: "user",
             CONF_PASSWORD: "pass",
@@ -201,6 +208,7 @@ async def test_flow_create_entry_multiple_existing_entries_of_same_model(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
+        CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
         CONF_PASSWORD: "pass",
@@ -233,17 +241,20 @@ async def test_reauth_flow_update_configuration(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
+            CONF_PROTOCOL: "https",
             CONF_HOST: "2.3.4.5",
             CONF_USERNAME: "user2",
             CONF_PASSWORD: "pass2",
-            CONF_PORT: 80,
+            CONF_PORT: 443,
         },
     )
     await hass.async_block_till_done()
 
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    assert mock_config_entry.data[CONF_PROTOCOL] == "https"
     assert mock_config_entry.data[CONF_HOST] == "2.3.4.5"
+    assert mock_config_entry.data[CONF_PORT] == 443
     assert mock_config_entry.data[CONF_USERNAME] == "user2"
     assert mock_config_entry.data[CONF_PASSWORD] == "pass2"
 
@@ -334,6 +345,7 @@ async def test_discovery_flow(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
+            CONF_PROTOCOL: "http",
             CONF_HOST: "1.2.3.4",
             CONF_USERNAME: "user",
             CONF_PASSWORD: "pass",
@@ -344,6 +356,7 @@ async def test_discovery_flow(
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == f"M1065-LW - {MAC}"
     assert result["data"] == {
+        CONF_PROTOCOL: "http",
         CONF_HOST: "1.2.3.4",
         CONF_USERNAME: "user",
         CONF_PASSWORD: "pass",
@@ -430,7 +443,7 @@ async def test_discovered_device_already_configured(
                     "presentationURL": "http://2.3.4.5:8080/",
                 },
             ),
-            8080,
+            80,
         ),
         (
             SOURCE_ZEROCONF,
@@ -443,7 +456,7 @@ async def test_discovered_device_already_configured(
                 properties={"macaddress": MAC},
                 type="mock_type",
             ),
-            8080,
+            80,
         ),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add the option to configure protocol, default new flows to https
<img width="343" alt="Screenshot 2024-03-13 at 22 17 23" src="https://github.com/home-assistant/core/assets/24575746/aabe625a-9751-4b06-abb4-f3eea72dc761">
Removed functionality to update port based on discovery information as discovery always report the http path

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
