### PR TITLE
Avoid pre-importing config_flows if the integration does not support migration

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -349,6 +349,9 @@ class ConfigEntry:
         # Supports remove device
         self.supports_remove_device: bool | None = None
 
+        # Supports migrate
+        self.supports_migrate: bool | None = None
+
         # Supports options
         self._supports_options: bool | None = None
 
@@ -491,6 +494,7 @@ class ConfigEntry:
             self.supports_remove_device = await support_remove_from_device(
                 hass, self.domain
             )
+
         try:
             component = await integration.async_get_component()
         except ImportError as err:
@@ -506,7 +510,12 @@ class ConfigEntry:
                 )
             return
 
-        if domain_is_integration:
+        if self.supports_migrate is None:
+            self.supports_migrate = hasattr(component, "async_migrate_entry")
+
+        if domain_is_integration and self.supports_migrate:
+            # Avoid loading the config_flow module unless we need to check
+            # the version to see if we need to migrate
             try:
                 await integration.async_get_platforms(("config_flow",))
             except ImportError as err:
@@ -787,11 +796,7 @@ class ConfigEntry:
         if same_major_version and self.minor_version == handler.MINOR_VERSION:
             return True
 
-        if not (integration := self._integration_for_domain):
-            integration = await loader.async_get_integration(hass, self.domain)
-        component = await integration.async_get_component()
-        supports_migrate = hasattr(component, "async_migrate_entry")
-        if not supports_migrate:
+        if not self.supports_migrate:
             if same_major_version:
                 return True
             _LOGGER.error(
@@ -800,6 +805,11 @@ class ConfigEntry:
                 self.domain,
             )
             return False
+
+        if not (integration := self._integration_for_domain):
+            integration = await loader.async_get_integration(hass, self.domain)
+
+        component = await integration.async_get_component()
 
         try:
             result = await component.async_migrate_entry(hass, self)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1691,7 +1691,7 @@ def async_suggest_report_issue(
 
 @callback
 def async_config_flow_needs_preload(component: ComponentProtocol) -> bool:
-    """Test if a component needs to be preloaded.
+    """Test if a config_flow for a component needs to be preloaded.
 
     Currently we need to preload a the config flow if the integration
     has a config flow and the component has an async_migrate_entry method

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -67,6 +67,7 @@ async def test_invalid_auth(
 
     mock_config_entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -105,7 +105,9 @@ async def test_migrate_config_entry(hass: HomeAssistant) -> None:
     assert entry.version == 1
     assert not entry.unique_id
 
-    await entry.async_migrate(hass)
+    with patch("homeassistant.components.sonarr.async_setup_entry", return_value=True):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
 
     assert entry.data == {
         CONF_API_KEY: "MOCK_API_KEY",

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -289,6 +289,7 @@ async def test_call_async_migrate_entry_failure_not_supported(
     )
     entry.add_to_hass(hass)
     assert not entry.supports_unload
+    entry.supports_migrate = True
 
     mock_setup_entry = AsyncMock(return_value=True)
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -117,6 +117,7 @@ async def test_call_setup_entry(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED
     assert entry.supports_unload
+    assert entry.supports_migrate
 
 
 async def test_call_setup_entry_without_reload_support(hass: HomeAssistant) -> None:
@@ -146,6 +147,7 @@ async def test_call_setup_entry_without_reload_support(hass: HomeAssistant) -> N
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED
     assert not entry.supports_unload
+    assert entry.supports_migrate
 
 
 @pytest.mark.parametrize(("major_version", "minor_version"), [(2, 1), (1, 2), (2, 2)])

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1204,31 +1204,21 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     assert "test_package_loaded_executor" not in hass.config.components
     assert "test_package_loaded_executor.config_flow" not in hass.config.components
 
-    config_flow_module_name = f"{integration.pkg_path}.config_flow"
-    module_mock = MagicMock(__file__="__init__.py")
-    config_flow_module_mock = MagicMock(__file__="config_flow.py")
+    module_mock = object()
 
     def import_module(name: str) -> Any:
         if name == integration.pkg_path:
             return module_mock
-        if name == config_flow_module_name:
-            return config_flow_module_mock
         raise ImportError
 
-    modules_without_config_flow = {
-        k: v for k, v in sys.modules.items() if k != config_flow_module_name
-    }
     with patch.dict(
         "sys.modules",
-        {**modules_without_config_flow, integration.pkg_path: module_mock},
+        {**sys.modules, integration.pkg_path: module_mock},
         clear=True,
     ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
 
-    # The config flow is missing so we should load
-    # in the executor
-    assert "loaded_executor=True" in caplog.text
-    assert "loaded_executor=False" not in caplog.text
+    assert "loaded_executor=False" in caplog.text
     assert module is module_mock
     caplog.clear()
 
@@ -1236,7 +1226,6 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
         "sys.modules",
         {
             integration.pkg_path: module_mock,
-            config_flow_module_name: config_flow_module_mock,
         },
     ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
@@ -1245,6 +1234,10 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     # so it should not have to call the load
     assert "loaded_executor" not in caplog.text
     assert module is module_mock
+
+    # The integration does not implement async_migrate_entry so it
+    # should not be preloaded
+    assert integration.get_platform_cached("config_flow") is None
 
 
 async def test_async_get_component_concurrent_loads(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Currently we pre-import the config flow module if it exists since setting up the config entry required comparing the versions found in the config_flow.py. We can avoid the pre-import if the integration does not support async_migrate_entry which means we avoid loading many config flows in memory at startup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
