### PR TITLE
Apply suggestion failures fail supervisor repair

### DIFF
--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -263,10 +263,7 @@ async def async_update_core(
 @bind_hass
 @_api_bool
 async def async_apply_suggestion(hass: HomeAssistant, suggestion_uuid: str) -> dict:
-    """Apply a suggestion from supervisor's resolution center.
-
-    The caller of the function should handle HassioAPIError.
-    """
+    """Apply a suggestion from supervisor's resolution center."""
     hassio: HassIO = hass.data[DOMAIN]
     command = f"/resolution/suggestion/{suggestion_uuid}"
     return await hassio.send_command(command, timeout=None)

--- a/homeassistant/components/hassio/repairs.py
+++ b/homeassistant/components/hassio/repairs.py
@@ -19,7 +19,7 @@ from .const import (
     PLACEHOLDER_KEY_REFERENCE,
     SupervisorIssueContext,
 )
-from .handler import HassioAPIError, async_apply_suggestion
+from .handler import async_apply_suggestion
 from .issues import Issue, Suggestion
 
 SUGGESTION_CONFIRMATION_REQUIRED = {"system_execute_reboot"}
@@ -110,12 +110,9 @@ class SupervisorIssueRepairFlow(RepairsFlow):
         if not confirmed and suggestion.key in SUGGESTION_CONFIRMATION_REQUIRED:
             return self._async_form_for_suggestion(suggestion)
 
-        try:
-            await async_apply_suggestion(self.hass, suggestion.uuid)
-        except HassioAPIError:
-            return self.async_abort(reason="apply_suggestion_fail")
-
-        return self.async_create_entry(data={})
+        if await async_apply_suggestion(self.hass, suggestion.uuid):
+            return self.async_create_entry(data={})
+        return self.async_abort(reason="apply_suggestion_fail")
 
     @staticmethod
     def _async_step(

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -41,6 +41,7 @@ def mock_resolution_info(
     unsupported: list[str] | None = None,
     unhealthy: list[str] | None = None,
     issues: list[dict[str, str]] | None = None,
+    suggestion_result: str = "ok",
 ):
     """Mock resolution/info endpoint with unsupported/unhealthy reasons and/or issues."""
     aioclient_mock.get(
@@ -77,7 +78,7 @@ def mock_resolution_info(
             for suggestion in suggestions:
                 aioclient_mock.post(
                     f"http://127.0.0.1/resolution/suggestion/{suggestion['uuid']}",
-                    json={"result": "ok"},
+                    json={"result": suggestion_result},
                 )
 
 

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -396,6 +396,78 @@ async def test_supervisor_issue_repair_flow_skip_confirmation(
     )
 
 
+async def test_mount_failed_repair_flow_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_client: ClientSessionGenerator,
+    issue_registry: ir.IssueRegistry,
+    all_setup_requests,
+) -> None:
+    """Test repair flow fails when repair fails to apply."""
+    mock_resolution_info(
+        aioclient_mock,
+        issues=[
+            {
+                "uuid": "1234",
+                "type": "mount_failed",
+                "context": "mount",
+                "reference": "backup_share",
+                "suggestions": [
+                    {
+                        "uuid": "1235",
+                        "type": "execute_reload",
+                        "context": "mount",
+                        "reference": "backup_share",
+                    },
+                    {
+                        "uuid": "1236",
+                        "type": "execute_remove",
+                        "context": "mount",
+                        "reference": "backup_share",
+                    },
+                ],
+            },
+        ],
+        suggestion_result=False,
+    )
+
+    assert await async_setup_component(hass, "hassio", {})
+
+    repair_issue = issue_registry.async_get_issue(domain="hassio", issue_id="1234")
+    assert repair_issue
+
+    client = await hass_client()
+
+    resp = await client.post(
+        "/api/repairs/issues/fix",
+        json={"handler": "hassio", "issue_id": repair_issue.issue_id},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+    flow_id = data["flow_id"]
+
+    resp = await client.post(
+        f"/api/repairs/issues/fix/{flow_id}",
+        json={"next_step_id": "mount_execute_reload"},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    data = await resp.json()
+
+    flow_id = data["flow_id"]
+    assert data == {
+        "type": "abort",
+        "flow_id": flow_id,
+        "handler": "hassio",
+        "reason": "apply_suggestion_fail",
+        "result": None,
+        "description_placeholders": None,
+    }
+
+    assert issue_registry.async_get_issue(domain="hassio", issue_id="1234")
+
+
 async def test_mount_failed_repair_flow(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Applying a suggestion in supervisor via repair is still always succeeding even if it failed behind the scenes after #111162 . Appears that is because the apply suggestion API in handler only returns `True` or `False`, it never raises. Adjusted code to treat `False` response as failure and correctly abort the repair when the suggestion fails to apply.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
