### PR TITLE
Avoid multiple context switches to setup a sonos speaker

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
     dispatcher_send,
 )
-from homeassistant.helpers.event import async_track_time_interval, track_time_interval
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .alarms import SonosAlarms
@@ -179,13 +179,31 @@ class SonosSpeaker:
         self.snapshot_group: list[SonosSpeaker] = []
         self._group_members_missing: set[str] = set()
 
-    async def async_setup(self, entry: ConfigEntry) -> None:
+    async def async_setup(
+        self, entry: ConfigEntry, has_battery: bool, dispatches: list[tuple[Any, ...]]
+    ) -> None:
         """Complete setup in async context."""
+        # Battery events can be infrequent, polling is still necessary
+        if has_battery:
+            self._battery_poll_timer = async_track_time_interval(
+                self.hass, self.async_poll_battery, BATTERY_SCAN_INTERVAL
+            )
+
+        self._event_dispatchers = {
+            "AlarmClock": self.async_dispatch_alarms,
+            "AVTransport": self.async_dispatch_media_update,
+            "ContentDirectory": self.async_dispatch_favorites,
+            "DeviceProperties": self.async_dispatch_device_properties,
+            "RenderingControl": self.async_update_volume,
+            "ZoneGroupTopology": self.async_update_groups,
+        }
+
         self.websocket = SonosWebsocket(
             self.soco.ip_address,
             player_id=self.soco.uid,
             session=async_get_clientsession(self.hass),
         )
+
         dispatch_pairs: tuple[tuple[str, Callable[..., Any]], ...] = (
             (SONOS_CHECK_ACTIVITY, self.async_check_activity),
             (SONOS_SPEAKER_ADDED, self.async_update_group_for_uid),
@@ -203,6 +221,11 @@ class SonosSpeaker:
                 )
             )
 
+        for dispatch in dispatches:
+            async_dispatcher_send(self.hass, *dispatch)
+
+        await self.async_subscribe()
+
     def setup(self, entry: ConfigEntry) -> None:
         """Run initial setup of the speaker."""
         self.media.play_mode = self.soco.play_mode
@@ -211,53 +234,34 @@ class SonosSpeaker:
         if self.is_coordinator:
             self.media.poll_media()
 
-        future = asyncio.run_coroutine_threadsafe(
-            self.async_setup(entry), self.hass.loop
-        )
-        future.result(timeout=10)
-
-        dispatcher_send(self.hass, SONOS_CREATE_LEVELS, self)
+        dispatches: list[tuple[Any, ...]] = [(SONOS_CREATE_LEVELS, self)]
 
         if audio_format := self.soco.soundbar_audio_input_format:
-            dispatcher_send(
-                self.hass, SONOS_CREATE_AUDIO_FORMAT_SENSOR, self, audio_format
-            )
+            dispatches.append((SONOS_CREATE_AUDIO_FORMAT_SENSOR, self, audio_format))
 
+        has_battery = False
         try:
             self.battery_info = self.fetch_battery_info()
         except SonosUpdateError:
             _LOGGER.debug("No battery available for %s", self.zone_name)
         else:
-            # Battery events can be infrequent, polling is still necessary
-            self._battery_poll_timer = track_time_interval(
-                self.hass, self.async_poll_battery, BATTERY_SCAN_INTERVAL
-            )
+            has_battery = True
             dispatcher_send(self.hass, SONOS_CREATE_BATTERY, self)
 
         if (mic_enabled := self.soco.mic_enabled) is not None:
             self.mic_enabled = mic_enabled
-            dispatcher_send(self.hass, SONOS_CREATE_MIC_SENSOR, self)
+            dispatches.append((SONOS_CREATE_MIC_SENSOR, self))
 
         if new_alarms := [
             alarm.alarm_id for alarm in self.alarms if alarm.zone.uid == self.soco.uid
         ]:
-            dispatcher_send(self.hass, SONOS_CREATE_ALARM, self, new_alarms)
+            dispatches.append((SONOS_CREATE_ALARM, self, new_alarms))
 
-        dispatcher_send(self.hass, SONOS_CREATE_SWITCHES, self)
+        dispatches.append((SONOS_CREATE_SWITCHES, self))
+        dispatches.append((SONOS_CREATE_MEDIA_PLAYER, self))
+        dispatches.append((SONOS_SPEAKER_ADDED, self.soco.uid))
 
-        self._event_dispatchers = {
-            "AlarmClock": self.async_dispatch_alarms,
-            "AVTransport": self.async_dispatch_media_update,
-            "ContentDirectory": self.async_dispatch_favorites,
-            "DeviceProperties": self.async_dispatch_device_properties,
-            "RenderingControl": self.async_update_volume,
-            "ZoneGroupTopology": self.async_update_groups,
-        }
-
-        dispatcher_send(self.hass, SONOS_CREATE_MEDIA_PLAYER, self)
-        dispatcher_send(self.hass, SONOS_SPEAKER_ADDED, self.soco.uid)
-
-        self.hass.create_task(self.async_subscribe())
+        self.hass.create_task(self.async_setup(entry, has_battery, dispatches))
 
     #
     # Entity management


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of doing multiple calls that use call_soon_threadsafe, we pass all the calls back to the event loop in a single call to async_setup so we can free up the executor as soon as possible

The goal is to remove as many `run_coroutine_threadsafe` calls as possible since they tie up the executor thread for the duration of the call while its waiting on the event loop to do work.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
