### PR TITLE
Update ring integration imports so patching happens where library is created

### DIFF
--- a/homeassistant/components/ring/__init__.py
+++ b/homeassistant/components/ring/__init__.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import partial
 import logging
 
-import ring_doorbell
+from ring_doorbell import Auth, Ring
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import APPLICATION_NAME, CONF_TOKEN, __version__
@@ -39,10 +39,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         )
 
-    auth = ring_doorbell.Auth(
+    auth = Auth(
         f"{APPLICATION_NAME}/{__version__}", entry.data[CONF_TOKEN], token_updater
     )
-    ring = ring_doorbell.Ring(auth)
+    ring = Ring(auth)
 
     devices_coordinator = RingDataCoordinator(hass, ring)
     notifications_coordinator = RingNotificationsCoordinator(hass, ring)

--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
-import ring_doorbell
+from ring_doorbell import Auth, AuthenticationError, Requires2FAError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
@@ -31,7 +31,7 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 async def validate_input(hass: HomeAssistant, data):
     """Validate the user input allows us to connect."""
 
-    auth = ring_doorbell.Auth(f"{APPLICATION_NAME}/{ha_version}")
+    auth = Auth(f"{APPLICATION_NAME}/{ha_version}")
 
     try:
         token = await hass.async_add_executor_job(
@@ -40,9 +40,9 @@ async def validate_input(hass: HomeAssistant, data):
             data[CONF_PASSWORD],
             data.get(CONF_2FA),
         )
-    except ring_doorbell.Requires2FAError as err:
+    except Requires2FAError as err:
         raise Require2FA from err
-    except ring_doorbell.AuthenticationError as err:
+    except AuthenticationError as err:
         raise InvalidAuth from err
 
     return token

--- a/homeassistant/components/ring/coordinator.py
+++ b/homeassistant/components/ring/coordinator.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 import logging
 from typing import Any, Optional
 
-import ring_doorbell
-from ring_doorbell.generic import RingGeneric
+from ring_doorbell import AuthenticationError, Ring, RingError, RingGeneric, RingTimeout
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
@@ -23,15 +22,15 @@ async def _call_api(
 ):
     try:
         return await hass.async_add_executor_job(target, *args)
-    except ring_doorbell.AuthenticationError as err:
+    except AuthenticationError as err:
         # Raising ConfigEntryAuthFailed will cancel future updates
         # and start a config flow with SOURCE_REAUTH (async_step_reauth)
         raise ConfigEntryAuthFailed from err
-    except ring_doorbell.RingTimeout as err:
+    except RingTimeout as err:
         raise UpdateFailed(
             f"Timeout communicating with API{msg_suffix}: {err}"
         ) from err
-    except ring_doorbell.RingError as err:
+    except RingError as err:
         raise UpdateFailed(f"Error communicating with API{msg_suffix}: {err}") from err
 
 
@@ -49,7 +48,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
     def __init__(
         self,
         hass: HomeAssistant,
-        ring_api: ring_doorbell.Ring,
+        ring_api: Ring,
     ) -> None:
         """Initialize my coordinator."""
         super().__init__(
@@ -58,7 +57,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
             logger=_LOGGER,
             update_interval=SCAN_INTERVAL,
         )
-        self.ring_api: ring_doorbell.Ring = ring_api
+        self.ring_api: Ring = ring_api
         self.first_call: bool = True
 
     async def _async_update_data(self):
@@ -105,7 +104,7 @@ class RingDataCoordinator(DataUpdateCoordinator[dict[int, RingDeviceData]]):
 class RingNotificationsCoordinator(DataUpdateCoordinator[None]):
     """Global notifications coordinator."""
 
-    def __init__(self, hass: HomeAssistant, ring_api: ring_doorbell.Ring) -> None:
+    def __init__(self, hass: HomeAssistant, ring_api: Ring) -> None:
         """Initialize my coordinator."""
         super().__init__(
             hass,
@@ -113,7 +112,7 @@ class RingNotificationsCoordinator(DataUpdateCoordinator[None]):
             name="active dings",
             update_interval=NOTIFICATIONS_SCAN_INTERVAL,
         )
-        self.ring_api: ring_doorbell.Ring = ring_api
+        self.ring_api: Ring = ring_api
 
     async def _async_update_data(self):
         """Fetch data from API endpoint."""

--- a/homeassistant/components/ring/diagnostics.py
+++ b/homeassistant/components/ring/diagnostics.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-import ring_doorbell
+from ring_doorbell import Ring
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
@@ -33,7 +33,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    ring: ring_doorbell.Ring = hass.data[DOMAIN][entry.entry_id]["api"]
+    ring: Ring = hass.data[DOMAIN][entry.entry_id]["api"]
     devices_raw = [
         ring.devices_data[device_type][device_id]
         for device_type in ring.devices_data

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -2,7 +2,7 @@
 from collections.abc import Callable
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
-import ring_doorbell
+from ring_doorbell import AuthenticationError, RingError, RingGeneric, RingTimeout
 
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
@@ -32,16 +32,16 @@ def exception_wrap(
     def _wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
         try:
             return func(self, *args, **kwargs)
-        except ring_doorbell.AuthenticationError as err:
+        except AuthenticationError as err:
             self.hass.loop.call_soon_threadsafe(
                 self.coordinator.config_entry.async_start_reauth, self.hass
             )
             raise HomeAssistantError(err) from err
-        except ring_doorbell.RingTimeout as err:
+        except RingTimeout as err:
             raise HomeAssistantError(
                 f"Timeout communicating with API {func}: {err}"
             ) from err
-        except ring_doorbell.RingError as err:
+        except RingError as err:
             raise HomeAssistantError(
                 f"Error communicating with API{func}: {err}"
             ) from err
@@ -58,7 +58,7 @@ class RingEntity(CoordinatorEntity[_RingCoordinatorT]):
 
     def __init__(
         self,
-        device: ring_doorbell.RingGeneric,
+        device: RingGeneric,
         coordinator: _RingCoordinatorT,
     ) -> None:
         """Initialize a sensor for Ring device."""
@@ -79,7 +79,7 @@ class RingEntity(CoordinatorEntity[_RingCoordinatorT]):
             return device_data
         return None
 
-    def _get_coordinator_device(self) -> ring_doorbell.RingGeneric | None:
+    def _get_coordinator_device(self) -> RingGeneric | None:
         if (device_data := self._get_coordinator_device_data()) and (
             device := device_data.device
         ):

--- a/homeassistant/components/ring/light.py
+++ b/homeassistant/components/ring/light.py
@@ -4,8 +4,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from ring_doorbell import RingStickUpCam
-from ring_doorbell.generic import RingGeneric
+from ring_doorbell import RingGeneric, RingStickUpCam
 
 from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/ring/sensor.py
+++ b/homeassistant/components/ring/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from ring_doorbell.generic import RingGeneric
+from ring_doorbell import RingGeneric
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,

--- a/homeassistant/components/ring/siren.py
+++ b/homeassistant/components/ring/siren.py
@@ -3,8 +3,8 @@
 import logging
 from typing import Any
 
+from ring_doorbell import RingGeneric
 from ring_doorbell.const import CHIME_TEST_SOUND_KINDS, KIND_DING
-from ring_doorbell.generic import RingGeneric
 
 from homeassistant.components.siren import ATTR_TONE, SirenEntity, SirenEntityFeature
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/ring/switch.py
+++ b/homeassistant/components/ring/switch.py
@@ -4,8 +4,7 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from ring_doorbell import RingStickUpCam
-from ring_doorbell.generic import RingGeneric
+from ring_doorbell import RingGeneric, RingStickUpCam
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry

--- a/tests/components/ring/conftest.py
+++ b/tests/components/ring/conftest.py
@@ -27,18 +27,13 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_ring_auth():
     """Mock ring_doorbell.Auth."""
-    with patch("ring_doorbell.Auth", autospec=True) as mock_ring_auth:
+    with patch(
+        "homeassistant.components.ring.config_flow.Auth", autospec=True
+    ) as mock_ring_auth:
         mock_ring_auth.return_value.fetch_token.return_value = {
             "access_token": "mock-token"
         }
         yield mock_ring_auth.return_value
-
-
-@pytest.fixture
-def mock_ring():
-    """Mock ring_doorbell.Ring."""
-    with patch("ring_doorbell.Ring", autospec=True) as mock_ring:
-        yield mock_ring.return_value
 
 
 @pytest.fixture
@@ -60,7 +55,6 @@ async def mock_added_config_entry(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_ring_auth: Mock,
-    mock_ring: Mock,
 ) -> MockConfigEntry:
     """Mock ConfigEntry that's been added to HA."""
     mock_config_entry.add_to_hass(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the ring integration imports the whole `ring_doorbell` library each time and the test framework patches `ring_doorbell.RingObject`.  This changes the imports to `import from` so the patching will patch the ha module where the library object is imported/created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Resulting from PR comment here https://github.com/home-assistant/core/pull/113140#discussion_r1521175396

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
