### PR TITLE
Add theme color support to labels

### DIFF
--- a/homeassistant/components/config/label_registry.py
+++ b/homeassistant/components/config/label_registry.py
@@ -10,6 +10,35 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.label_registry import LabelEntry, async_get
 
+SUPPORTED_LABEL_THEME_COLORS = {
+    "primary",
+    "accent",
+    "disabled",
+    "red",
+    "pink",
+    "purple",
+    "deep-purple",
+    "indigo",
+    "blue",
+    "light-blue",
+    "cyan",
+    "teal",
+    "green",
+    "light-green",
+    "lime",
+    "yellow",
+    "amber",
+    "orange",
+    "deep-orange",
+    "brown",
+    "light-grey",
+    "grey",
+    "dark-grey",
+    "blue-grey",
+    "black",
+    "white",
+}
+
 
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
@@ -42,7 +71,9 @@ def websocket_list_labels(
     {
         vol.Required("type"): "config/label_registry/create",
         vol.Required("name"): str,
-        vol.Optional("color"): vol.Any(cv.color_hex, None),
+        vol.Optional("color"): vol.Any(
+            cv.color_hex, vol.In(SUPPORTED_LABEL_THEME_COLORS), None
+        ),
         vol.Optional("description"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(cv.icon, None),
     }
@@ -93,7 +124,9 @@ def websocket_delete_label(
     {
         vol.Required("type"): "config/label_registry/update",
         vol.Required("label_id"): str,
-        vol.Optional("color"): vol.Any(cv.color_hex, None),
+        vol.Optional("color"): vol.Any(
+            cv.color_hex, vol.In(SUPPORTED_LABEL_THEME_COLORS), None
+        ),
         vol.Optional("description"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(cv.icon, None),
         vol.Optional("name"): str,

--- a/tests/components/config/test_label_registry.py
+++ b/tests/components/config/test_label_registry.py
@@ -99,6 +99,27 @@ async def test_create_label(
         "name": "MOCKERY",
     }
 
+    await client.send_json_auto_id(
+        {
+            "name": "MAGIC",
+            "type": "config/label_registry/create",
+            "color": "indigo",
+            "description": "This is the third label",
+            "icon": "mdi:three",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert len(label_registry.labels) == 3
+    assert msg["result"] == {
+        "color": "indigo",
+        "description": "This is the third label",
+        "icon": "mdi:three",
+        "label_id": "magic",
+        "name": "MAGIC",
+    }
+
 
 async def test_create_label_with_name_already_in_use(
     client: MockHAClientWebSocket,
@@ -208,6 +229,28 @@ async def test_update_label(
         "icon": None,
         "label_id": "mock",
         "name": "UPDATED AGAIN",
+    }
+
+    await client.send_json_auto_id(
+        {
+            "label_id": label.label_id,
+            "name": "UPDATED YET AGAIN",
+            "icon": None,
+            "color": "primary",
+            "description": None,
+            "type": "config/label_registry/update",
+        }
+    )
+
+    msg = await client.receive_json()
+
+    assert len(label_registry.labels) == 1
+    assert msg["result"] == {
+        "color": "primary",
+        "description": None,
+        "icon": None,
+        "label_id": "mock",
+        "name": "UPDATED YET AGAIN",
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As decided in a meeting with frontend/UX, we are adding support for theme colors to labels. That means a user can select from a list of colors that will look great with their theme.

This is a known/fixed list of theme colors, that is also used for things like the Tile card.

This PR adds support for those theme variables/colors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
