### PR TITLE
Bump aioautomower to 2024.3.3

### DIFF
--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/husqvarna_automower",
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
-  "requirements": ["aioautomower==2024.3.2"]
+  "requirements": ["aioautomower==2024.3.3"]
 }

--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -70,6 +70,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         suggested_unit_of_measurement=UnitOfTime.HOURS,
+        exists_fn=lambda data: data.statistics.total_charging_time is not None,
         value_fn=lambda data: data.statistics.total_charging_time,
     ),
     AutomowerSensorEntityDescription(
@@ -80,6 +81,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         suggested_unit_of_measurement=UnitOfTime.HOURS,
+        exists_fn=lambda data: data.statistics.total_cutting_time is not None,
         value_fn=lambda data: data.statistics.total_cutting_time,
     ),
     AutomowerSensorEntityDescription(
@@ -90,6 +92,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         suggested_unit_of_measurement=UnitOfTime.HOURS,
+        exists_fn=lambda data: data.statistics.total_running_time is not None,
         value_fn=lambda data: data.statistics.total_running_time,
     ),
     AutomowerSensorEntityDescription(
@@ -100,6 +103,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DURATION,
         native_unit_of_measurement=UnitOfTime.SECONDS,
         suggested_unit_of_measurement=UnitOfTime.HOURS,
+        exists_fn=lambda data: data.statistics.total_searching_time is not None,
         value_fn=lambda data: data.statistics.total_searching_time,
     ),
     AutomowerSensorEntityDescription(
@@ -107,6 +111,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         translation_key="number_of_charging_cycles",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
+        exists_fn=lambda data: data.statistics.number_of_charging_cycles is not None,
         value_fn=lambda data: data.statistics.number_of_charging_cycles,
     ),
     AutomowerSensorEntityDescription(
@@ -114,6 +119,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         translation_key="number_of_collisions",
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.TOTAL,
+        exists_fn=lambda data: data.statistics.number_of_collisions is not None,
         value_fn=lambda data: data.statistics.number_of_collisions,
     ),
     AutomowerSensorEntityDescription(
@@ -124,6 +130,7 @@ SENSOR_TYPES: tuple[AutomowerSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
         suggested_unit_of_measurement=UnitOfLength.KILOMETERS,
+        exists_fn=lambda data: data.statistics.total_drive_distance is not None,
         value_fn=lambda data: data.statistics.total_drive_distance,
     ),
     AutomowerSensorEntityDescription(

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -203,7 +203,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.3.2
+aioautomower==2024.3.3
 
 # homeassistant.components.azure_devops
 aioazuredevops==1.3.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -182,7 +182,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.3.2
+aioautomower==2024.3.3
 
 # homeassistant.components.azure_devops
 aioazuredevops==1.3.5

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -65,9 +65,9 @@ async def test_cutting_blade_usage_time_sensor(
 @pytest.mark.parametrize(
     ("sensor_to_test"),
     [
+        ("cutting_blade_usage_time"),
         ("number_of_charging_cycles"),
         ("number_of_collisions"),
-        ("cutting_blade_usage_time"),
         ("total_charging_time"),
         ("total_cutting_time"),
         ("total_running_time"),

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 from aioautomower.model import MowerModes
 from aioautomower.utils import mower_list_to_dictionary_dataclass
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.husqvarna_automower.const import DOMAIN
@@ -60,17 +61,36 @@ async def test_cutting_blade_usage_time_sensor(
     assert state is not None
     assert state.state == "0.034"
 
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    await hass.config_entries.async_remove(entry.entry_id)
-    await hass.async_block_till_done()
+
+@pytest.mark.parametrize(
+    ("sensor_to_test"),
+    [
+        ("number_of_charging_cycles"),
+        ("number_of_collisions"),
+        ("cutting_blade_usage_time"),
+        ("total_charging_time"),
+        ("total_cutting_time"),
+        ("total_running_time"),
+        ("total_searching_time"),
+        ("total_drive_distance"),
+    ],
+)
+async def test_statistics_not_available(
+    hass: HomeAssistant,
+    mock_automower_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    sensor_to_test: str,
+) -> None:
+    """Test if this sensor is only added, if data is available."""
+
     values = mower_list_to_dictionary_dataclass(
         load_json_value_fixture("mower.json", DOMAIN)
     )
 
-    delattr(values[TEST_MOWER_ID].statistics, "cutting_blade_usage_time")
+    delattr(values[TEST_MOWER_ID].statistics, sensor_to_test)
     mock_automower_client.get_status.return_value = values
     await setup_integration(hass, mock_config_entry)
-    state = hass.states.get("sensor.test_mower_1_cutting_blade_usage_time")
+    state = hass.states.get(f"sensor.test_mower_1_{sensor_to_test}")
     assert state is None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump aioautomower from 2024.3.2 to 2024.3.3
Release note: https://github.com/Thomas55555/aioautomower/releases/tag/2024.3.3
diff: https://github.com/Thomas55555/aioautomower/compare/2024.3.2...2024.3.3

This is a hotfix. Should be included in the next patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #113393
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
