### PR TITLE
create issues for modbus config errors

### DIFF
--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -77,6 +77,22 @@
     "deprecated_retries": {
       "title": "`{config_key}` configuration key is being removed",
       "description": "Please remove the `{config_key}` key from the {integration} entry in your configuration.yaml file and restart Home Assistant to fix this issue.\n\nThe maximum number of retries is now fixed to 3."
+    },
+    "missing_modbus_name": {
+      "title": "Modbus entry with host `{sub_2}` missing name",
+      "description": "Please add `{sub_1}` key to the {integration} entry with host `{sub_2}` in your configuration.yaml file and restart Home Assistant to fix this issue\n\n. `{sub_1}: {sub_3}` have been added."
+    },
+    "duplicate_modbus_entry": {
+      "title": "Modbus {sub_2} host/port {sub_1} is duplicate, second entry not loaded.",
+      "description": "Please update {sub_2} and/or {sub_1} for the entry in your configuration.yaml file and restart Home Assistant to fix this issue."
+    },
+    "duplicate_entity_entry": {
+      "title": "Modbus {sub_1} address {sub_2} is duplicate, second entry not loaded.",
+      "description": "An address can only be associated with on entity, Please correct the entry in your configuration.yaml file and restart Home Assistant to fix this issue."
+    },
+    "duplicate_entity_name": {
+      "title": "Modbus {sub_1} is duplicate, second entry not loaded.",
+      "description": "A entity name must be unique, Please correct the entry in your configuration.yaml file and restart Home Assistant to fix this issue."
     }
   }
 }

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -356,7 +356,7 @@ def validate_entity(
     scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     if 0 < scan_interval < 5:
         err = (
-            f"{hub_name} {name} scan_intervalscan_interval is lower than 5 seconds, "
+            f"{hub_name} {name} scan_interval is lower than 5 seconds, "
             "which may cause Home Assistant stability issues"
         )
         _LOGGER.warning(err)

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -130,8 +130,9 @@ def modbus_create_issue(
             "sub_2": subs[1],
             "sub_3": subs[2],
             "integration": DOMAIN,
-            "url": "https://www.home-assistant.io/integrations/modbus",
         },
+        issue_domain=DOMAIN,
+        learn_more_url="https://www.home-assistant.io/integrations/modbus",
     )
     _LOGGER.warning(err)
 

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 
 from .const import (
     CONF_DATA_TYPE,
@@ -44,6 +45,7 @@ from .const import (
     CONF_WRITE_TYPE,
     DEFAULT_HUB,
     DEFAULT_SCAN_INTERVAL,
+    MODBUS_DOMAIN as DOMAIN,
     PLATFORMS,
     SERIAL,
     DataType,
@@ -110,6 +112,28 @@ DEFAULT_STRUCT_FORMAT = {
         "?", 0, PARM_IS_LEGAL(DEMANDED, DEMANDED, ILLEGAL, ILLEGAL, ILLEGAL)
     ),
 }
+
+
+def modbus_create_issue(
+    hass: HomeAssistant, key: str, subs: list[str], err: str
+) -> None:
+    """Create issue modbus style."""
+    async_create_issue(
+        hass,
+        DOMAIN,
+        key,
+        is_fixable=False,
+        severity=IssueSeverity.WARNING,
+        translation_key=key,
+        translation_placeholders={
+            "sub_1": subs[0],
+            "sub_2": subs[1],
+            "sub_3": subs[2],
+            "integration": DOMAIN,
+            "url": "https://www.home-assistant.io/integrations/modbus",
+        },
+    )
+    _LOGGER.warning(err)
 
 
 def struct_validator(config: dict[str, Any]) -> dict[str, Any]:
@@ -289,12 +313,28 @@ def validate_modbus(
             DEFAULT_HUB if not hub_name_inx else f"{DEFAULT_HUB}_{hub_name_inx}"
         )
         hub_name_inx += 1
-        err = f"Modbus host/port {host} is missing name, added {hub[CONF_NAME]}!"
-        _LOGGER.warning(err)
+        modbus_create_issue(
+            hass,
+            "missing_modbus_name",
+            [
+                "name",
+                host,
+                hub[CONF_NAME],
+            ],
+            f"Modbus host/port {host} is missing name, added {hub[CONF_NAME]}!",
+        )
     name = hub[CONF_NAME]
     if host in hosts or name in hub_names:
-        err = f"Modbus {name} host/port {host} is duplicate, not loaded!"
-        _LOGGER.warning(err)
+        modbus_create_issue(
+            hass,
+            "duplicate_modbus_entry",
+            [
+                host,
+                hub[CONF_NAME],
+                "",
+            ],
+            f"Modbus {name} host/port {host} is duplicate, not loaded!",
+        )
         return False
     hosts.add(host)
     hub_names.add(name)
@@ -315,15 +355,11 @@ def validate_entity(
     addr = f"{hub_name}{entity[CONF_ADDRESS]}"
     scan_interval = entity.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
     if 0 < scan_interval < 5:
-        _LOGGER.warning(
-            (
-                "%s %s scan_interval(%d) is lower than 5 seconds, "
-                "which may cause Home Assistant stability issues"
-            ),
-            hub_name,
-            name,
-            scan_interval,
+        err = (
+            f"{hub_name} {name} scan_intervalscan_interval is lower than 5 seconds, "
+            "which may cause Home Assistant stability issues"
         )
+        _LOGGER.warning(err)
     entity[CONF_SCAN_INTERVAL] = scan_interval
     minimum_scan_interval = min(scan_interval, minimum_scan_interval)
     for conf_type in (
@@ -337,7 +373,6 @@ def validate_entity(
     inx = entity.get(CONF_SLAVE) or entity.get(CONF_DEVICE_ADDRESS, 0)
     addr += f"_{inx}"
     loc_addr: set[str] = {addr}
-
     if CONF_TARGET_TEMP in entity:
         loc_addr.add(f"{hub_name}{entity[CONF_TARGET_TEMP]}_{inx}")
     if CONF_HVAC_MODE_REGISTER in entity:
@@ -348,15 +383,28 @@ def validate_entity(
     dup_addrs = ent_addr.intersection(loc_addr)
     if len(dup_addrs) > 0:
         for addr in dup_addrs:
-            err = (
-                f"Modbus {hub_name}/{name} address {addr} is duplicate, second"
-                " entry not loaded!"
+            modbus_create_issue(
+                hass,
+                "duplicate_entity_entry",
+                [
+                    f"{hub_name}/{name}",
+                    addr,
+                    "",
+                ],
+                f"Modbus {hub_name}/{name} address {addr} is duplicate, second entry not loaded!",
             )
-            _LOGGER.warning(err)
         return False
     if name in ent_names:
-        err = f"Modbus {hub_name}/{name} is duplicate, second entry not loaded!"
-        _LOGGER.warning(err)
+        modbus_create_issue(
+            hass,
+            "duplicate_entity_name",
+            [
+                f"{hub_name}/{name}",
+                "",
+                "",
+            ],
+            f"Modbus {hub_name}/{name} is duplicate, second entry not loaded!",
+        )
         return False
     ent_names.add(name)
     ent_addr.update(loc_addr)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
a number of configuration errors are detected and automatically corrected but only reported in the log, and thus often goes unseen.

All these errors are now reported as issues, to make the end-user more aware of a problem


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
validate_modbus, validate_entitiy and check_config in validators.py, catches a lot of configuration errors, most of which was automatically corrected but only reported in the log.

An internal function "modbus_create_issue" have been added to reduce the maintenance, since a lot of the parameters are identical.

modbus_create_issue are now called in validate_modbus, validate_entitiy and check_config in validators.py, to both have logging and issues.


- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
