### PR TITLE
Check for EA release channel for UniFi Protect

### DIFF
--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 import logging
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from pyunifiprotect.data import Bootstrap, FirmwareReleaseChannel
+from pyunifiprotect.data import Bootstrap
+from pyunifiprotect.data.types import FirmwareReleaseChannel
 from pyunifiprotect.exceptions import ClientError, NotAuthorized
 
 # Import the test_util.anonymize module from the pyunifiprotect package
@@ -119,12 +120,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ir.async_create_issue(
             hass,
             DOMAIN,
-            "ea_warning_channel",
+            "ea_channel_warning",
             is_fixable=True,
             is_persistent=True,
             learn_more_url="https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access",
             severity=IssueSeverity.WARNING,
-            translation_key="ea_warning_channel",
+            translation_key="ea_channel_warning",
             translation_placeholders={"version": str(nvr_info.version)},
             data={"entry_id": entry.entry_id},
         )
@@ -150,7 +151,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     "version": str(nvr_info.version),
                 },
             )
-            ir.async_delete_issue(hass, DOMAIN, "ea_warning")
+            ir.async_delete_issue(hass, DOMAIN, "ea_channel_warning")
             _LOGGER.exception("Error setting up UniFi Protect integration: %s", err)
         raise
 

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 import logging
 
 from aiohttp.client_exceptions import ServerDisconnectedError
-from pyunifiprotect.data import Bootstrap
+from pyunifiprotect.data import Bootstrap, FirmwareReleaseChannel
 from pyunifiprotect.exceptions import ClientError, NotAuthorized
 
 # Import the test_util.anonymize module from the pyunifiprotect package
@@ -112,19 +112,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, data_service.async_stop)
     )
 
-    if (
-        not entry.options.get(CONF_ALLOW_EA, False)
-        and await nvr_info.get_is_prerelease()
+    if not entry.options.get(CONF_ALLOW_EA, False) and (
+        await nvr_info.get_is_prerelease()
+        or nvr_info.release_channel != FirmwareReleaseChannel.RELEASE
     ):
         ir.async_create_issue(
             hass,
             DOMAIN,
-            "ea_warning",
+            "ea_warning_channel",
             is_fixable=True,
             is_persistent=True,
             learn_more_url="https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access",
             severity=IssueSeverity.WARNING,
-            translation_key="ea_warning",
+            translation_key="ea_warning_channel",
             translation_placeholders={"version": str(nvr_info.version)},
             data={"entry_id": entry.entry_id},
         )

--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -24,7 +24,7 @@ CONF_DISABLE_RTSP = "disable_rtsp"
 CONF_ALL_UPDATES = "all_updates"
 CONF_OVERRIDE_CHOST = "override_connection_host"
 CONF_MAX_MEDIA = "max_media"
-CONF_ALLOW_EA = "allow_ea"
+CONF_ALLOW_EA = "allow_ea_channel"
 
 CONFIG_OPTIONS = [
     CONF_ALL_UPDATES,

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -69,10 +69,7 @@ class EAConfirm(ProtectRepair):
             )
 
         nvr = await self._api.get_nvr()
-        if (
-            await nvr.get_is_prerelease()
-            or nvr.release_channel != FirmwareReleaseChannel.RELEASE
-        ):
+        if nvr.release_channel != FirmwareReleaseChannel.RELEASE:
             return await self.async_step_confirm()
         await self.hass.config_entries.async_reload(self._entry.entry_id)
         return self.async_create_entry(data={})

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -6,6 +6,7 @@ import logging
 from typing import cast
 
 from pyunifiprotect import ProtectApiClient
+from pyunifiprotect.data import FirmwareReleaseChannel
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
@@ -68,7 +69,10 @@ class EAConfirm(ProtectRepair):
             )
 
         nvr = await self._api.get_nvr()
-        if await nvr.get_is_prerelease():
+        if (
+            await nvr.get_is_prerelease()
+            or nvr.release_channel != FirmwareReleaseChannel.RELEASE
+        ):
             return await self.async_step_confirm()
         await self.hass.config_entries.async_reload(self._entry.entry_id)
         return self.async_create_entry(data={})

--- a/homeassistant/components/unifiprotect/repairs.py
+++ b/homeassistant/components/unifiprotect/repairs.py
@@ -6,7 +6,7 @@ import logging
 from typing import cast
 
 from pyunifiprotect import ProtectApiClient
-from pyunifiprotect.data import FirmwareReleaseChannel
+from pyunifiprotect.data.types import FirmwareReleaseChannel
 import voluptuous as vol
 
 from homeassistant import data_entry_flow
@@ -128,7 +128,7 @@ async def async_create_fix_flow(
     data: dict[str, str | int | float | None] | None,
 ) -> RepairsFlow:
     """Create flow."""
-    if data is not None and issue_id == "ea_warning":
+    if data is not None and issue_id == "ea_channel_warning":
         entry_id = cast(str, data["entry_id"])
         if (entry := hass.config_entries.async_get_entry(entry_id)) is not None:
             api = async_create_api_client(hass, entry)

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -67,7 +67,7 @@
         "step": {
           "start": {
             "title": "UniFi Protect Early Access enabled",
-            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidentally upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have switched back to the official release channel or you agree to run an unsupported version of UniFi Protect which may break your Home Assistant integration at anytime."
+            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or opt-ed into a release channel that is not the Official Release Channel. [Home Assistant does not support Early Access versions](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access), so you should immediately switch to the Official Release Channel. Accidentally upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form, you have switched back to the Official Release Channel or agree to run an unsupported version of UniFi Protect, which may break your Home Assistant integration at any time."
           },
           "confirm": {
             "title": "[%key:component::unifiprotect::issues::ea_channel_warning::fix_flow::step::start::title%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -61,7 +61,7 @@
     }
   },
   "issues": {
-    "ea_warning": {
+    "ea_channel_warning": {
       "title": "UniFi Protect Early Access enabled",
       "fix_flow": {
         "step": {
@@ -70,7 +70,7 @@
             "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidently upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have either restored a backup back to a stable release of UniFi Protect and have switched back to the offical release channel or you agree to run an unsupported version of UniFi Protect and your Home Assistant integration may break at anytime."
           },
           "confirm": {
-            "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
+            "title": "[%key:component::unifiprotect::issues::ea_channel_warning::fix_flow::step::start::title%]",
             "description": "Are you sure you want to run unsupported versions of UniFi Protect? This may cause your Home Assistant integration to break."
           }
         }

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -67,7 +67,7 @@
         "step": {
           "start": {
             "title": "UniFi Protect Early Access enabled",
-            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidently upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have either restored a backup back to a stable release of UniFi Protect and have switched back to the offical release channel or you agree to run an unsupported version of UniFi Protect and your Home Assistant integration may break at anytime."
+            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidently upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have switched back to the offical release channel or you agree to run an unsupported version of UniFi Protect which may breal your Home Assistant integration at anytime."
           },
           "confirm": {
             "title": "[%key:component::unifiprotect::issues::ea_channel_warning::fix_flow::step::start::title%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -67,7 +67,7 @@
         "step": {
           "start": {
             "title": "UniFi Protect Early Access enabled",
-            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidently upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have switched back to the offical release channel or you agree to run an unsupported version of UniFi Protect which may breal your Home Assistant integration at anytime."
+            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidentally upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have switched back to the official release channel or you agree to run an unsupported version of UniFi Protect which may break your Home Assistant integration at anytime."
           },
           "confirm": {
             "title": "[%key:component::unifiprotect::issues::ea_channel_warning::fix_flow::step::start::title%]",

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -62,12 +62,12 @@
   },
   "issues": {
     "ea_warning": {
-      "title": "UniFi Protect v{version} is an Early Access version",
+      "title": "UniFi Protect Early Access enabled",
       "fix_flow": {
         "step": {
           "start": {
-            "title": "v{version} is an Early Access version",
-            "description": "You are using v{version} of UniFi Protect which is an Early Access version. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and it is recommended to go back to a stable release as soon as possible.\n\nBy submitting this form you have either [downgraded UniFi Protect](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) or you agree to run an unsupported version of UniFi Protect."
+            "title": "UniFi Protect Early Access enabled",
+            "description": "You are either running an Early Access version of UniFi Protect (v{version}) or you have opt-ed into a release channel that is not the Official stable release channel. [Early Access versions are not supported by Home Assistant](https://www.home-assistant.io/integrations/unifiprotect#about-unifi-early-access) and you should switch back to the Official stable release channel as soon as possible. Accidently upgrading to an Early Access version can break your UniFi Protect integration.\n\nBy submitting this form you have either restored a backup back to a stable release of UniFi Protect and have switched back to the offical release channel or you agree to run an unsupported version of UniFi Protect and your Home Assistant integration may break at anytime."
           },
           "confirm": {
             "title": "[%key:component::unifiprotect::issues::ea_warning::fix_flow::step::start::title%]",
@@ -78,7 +78,7 @@
     },
     "ea_setup_failed": {
       "title": "Setup error using Early Access version",
-      "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please [downgrade to a stable version](https://www.home-assistant.io/integrations/unifiprotect#downgrading-unifi-protect) of UniFi Protect to continue using the integration.\n\nError: {error}"
+      "description": "You are using v{version} of UniFi Protect which is an Early Access version. An unrecoverable error occurred while trying to load the integration. Please restore a backup of a stable release of UniFi Protect to continue using the integration.\n\nError: {error}"
     },
     "cloud_user": {
       "title": "Ubiquiti Cloud Users are not Supported",

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -328,7 +328,7 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
             "disable_rtsp": True,
             "override_connection_host": True,
             "max_media": 1000,
-            "allow_ea": False,
+            "allow_ea_channel": False,
         }
         await hass.config_entries.async_unload(mock_config.entry_id)
 

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -126,8 +126,9 @@ async def test_ea_warning_fix(
 
     new_nvr = copy(ufp.api.bootstrap.nvr)
     new_nvr.version = Version("2.2.6")
+    new_nvr.release_channel = "release"
     mock_msg = Mock()
-    mock_msg.changed_data = {"version": "2.2.6"}
+    mock_msg.changed_data = {"version": "2.2.6", "releaseChannel": "release"}
     mock_msg.new_obj = new_nvr
 
     ufp.api.bootstrap.nvr = new_nvr

--- a/tests/components/unifiprotect/test_repairs.py
+++ b/tests/components/unifiprotect/test_repairs.py
@@ -46,12 +46,14 @@ async def test_ea_warning_ignore(
     assert len(msg["result"]["issues"]) > 0
     issue = None
     for i in msg["result"]["issues"]:
-        if i["issue_id"] == "ea_warning":
+        if i["issue_id"] == "ea_channel_warning":
             issue = i
     assert issue is not None
 
     url = RepairsFlowIndexView.url
-    resp = await client.post(url, json={"handler": DOMAIN, "issue_id": "ea_warning"})
+    resp = await client.post(
+        url, json={"handler": DOMAIN, "issue_id": "ea_channel_warning"}
+    )
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
@@ -104,12 +106,14 @@ async def test_ea_warning_fix(
     assert len(msg["result"]["issues"]) > 0
     issue = None
     for i in msg["result"]["issues"]:
-        if i["issue_id"] == "ea_warning":
+        if i["issue_id"] == "ea_channel_warning":
             issue = i
     assert issue is not None
 
     url = RepairsFlowIndexView.url
-    resp = await client.post(url, json={"handler": DOMAIN, "issue_id": "ea_warning"})
+    resp = await client.post(
+        url, json={"handler": DOMAIN, "issue_id": "ea_channel_warning"}
+    )
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ubiquiti does not provide any official API or third-party support. They do not give open-source developers preview access to new versions to make their software compatible. They also do not have any kind of rules behind their versioning. A bugfix version can (and has) made breaking changes in the past. 

As a result, any new version can break compatibility in unexpected ways. So, the UniFi Protect integration does not officially support any releases that are not on the official release channel to help mitigate this. Based on the fact that version 3.0.x has had 4 issues + numerous comments complaining about EA breaking their HA, the message is not being made clear enough to users that EA versions **will** eventually break their HA and they should not use them if they do not want HA to break.

This PR add an additional check for the release channel being used by the console, updates the messaging to be more specific that any release channel other than Official can break your HA integration as well as resets the EA warning prompt for all users to force them to accept it again. It also removes all references to manually downgrading since Ubiquiti does not want us to tell users to use `apt` to downgrade and instead tells them to restore a backup, which is the "official" way of downgrading, even though Ubiquiti makes that really hard as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
