### PR TITLE
Add profiler set_asyncio_debug service

### DIFF
--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -266,7 +266,7 @@ async def async_setup_entry(  # noqa: C901
         # Make sure the logger is set to at least INFO or
         # we won't see the messages
         base_logger = logging.getLogger()
-        if base_logger.getEffectiveLevel() <= logging.INFO:
+        if base_logger.getEffectiveLevel() > logging.INFO:
             base_logger.setLevel(logging.INFO)
         hass.loop.set_debug(enabled)
 

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -36,6 +36,7 @@ SERVICE_DUMP_LOG_OBJECTS = "dump_log_objects"
 SERVICE_LRU_STATS = "lru_stats"
 SERVICE_LOG_THREAD_FRAMES = "log_thread_frames"
 SERVICE_LOG_EVENT_LOOP_SCHEDULED = "log_event_loop_scheduled"
+SERVICE_SET_ASYNCIO_DEBUG = "set_asyncio_debug"
 
 _LRU_CACHE_WRAPPER_OBJECT = _lru_cache_wrapper.__name__
 _SQLALCHEMY_LRU_OBJECT = "LRUCache"
@@ -57,12 +58,14 @@ SERVICES = (
     SERVICE_LRU_STATS,
     SERVICE_LOG_THREAD_FRAMES,
     SERVICE_LOG_EVENT_LOOP_SCHEDULED,
+    SERVICE_SET_ASYNCIO_DEBUG,
 )
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 
 DEFAULT_MAX_OBJECTS = 5
 
+CONF_ENABLED = "enabled"
 CONF_SECONDS = "seconds"
 CONF_MAX_OBJECTS = "max_objects"
 
@@ -254,6 +257,10 @@ async def async_setup_entry(  # noqa: C901
             arepr.maxstring = original_maxstring
             arepr.maxother = original_maxother
 
+    async def _async_asyncio_debug(call: ServiceCall) -> None:
+        """Enable or disable asyncio debug."""
+        hass.loop.set_debug(call.data.get("enabled", False))
+
     async_register_admin_service(
         hass,
         DOMAIN,
@@ -346,6 +353,14 @@ async def async_setup_entry(  # noqa: C901
         DOMAIN,
         SERVICE_LOG_EVENT_LOOP_SCHEDULED,
         _async_dump_scheduled,
+    )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_SET_ASYNCIO_DEBUG,
+        _async_asyncio_debug,
+        schema=vol.Schema({vol.Optional(CONF_ENABLED, default=True): cv.boolean}),
     )
 
     return True

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -263,8 +263,11 @@ async def async_setup_entry(  # noqa: C901
         # Always log this at critical level so we know when
         # it's been changed when reviewing logs
         _LOGGER.critical("Setting asyncio debug to %s", enabled)
-        if _LOGGER.getEffectiveLevel() <= logging.INFO:
-            _LOGGER.setLevel(logging.INFO)
+        # Make sure the logger is set to at least INFO or
+        # we won't see the messages
+        base_logger = logging.getLogger()
+        if base_logger.getEffectiveLevel() <= logging.INFO:
+            base_logger.setLevel(logging.INFO)
         hass.loop.set_debug(enabled)
 
     async_register_admin_service(

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -266,7 +266,7 @@ async def async_setup_entry(  # noqa: C901
         # Make sure the logger is set to at least INFO or
         # we won't see the messages
         base_logger = logging.getLogger()
-        if base_logger.getEffectiveLevel() > logging.INFO:
+        if enabled and base_logger.getEffectiveLevel() > logging.INFO:
             base_logger.setLevel(logging.INFO)
         hass.loop.set_debug(enabled)
 

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -259,7 +259,11 @@ async def async_setup_entry(  # noqa: C901
 
     async def _async_asyncio_debug(call: ServiceCall) -> None:
         """Enable or disable asyncio debug."""
-        hass.loop.set_debug(call.data.get("enabled", False))
+        enabled = call.data[CONF_ENABLED]
+        # Always log this at critical level so we know when
+        # it's been changed when reviewing logs
+        _LOGGER.critical("Setting asyncio debug to %s", enabled)
+        hass.loop.set_debug(enabled)
 
     async_register_admin_service(
         hass,

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -263,6 +263,8 @@ async def async_setup_entry(  # noqa: C901
         # Always log this at critical level so we know when
         # it's been changed when reviewing logs
         _LOGGER.critical("Setting asyncio debug to %s", enabled)
+        if _LOGGER.getEffectiveLevel() <= logging.INFO:
+            _LOGGER.setLevel(logging.INFO)
         hass.loop.set_debug(enabled)
 
     async_register_admin_service(

--- a/homeassistant/components/profiler/icons.json
+++ b/homeassistant/components/profiler/icons.json
@@ -9,6 +9,7 @@
     "stop_log_object_sources": "mdi:stop",
     "lru_stats": "mdi:chart-areaspline",
     "log_thread_frames": "mdi:format-list-bulleted",
-    "log_event_loop_scheduled": "mdi:calendar-clock"
+    "log_event_loop_scheduled": "mdi:calendar-clock",
+    "set_asyncio_debug": "mdi:bug-check"
   }
 }

--- a/homeassistant/components/profiler/services.yaml
+++ b/homeassistant/components/profiler/services.yaml
@@ -53,3 +53,9 @@ stop_log_object_sources:
 lru_stats:
 log_thread_frames:
 log_event_loop_scheduled:
+set_asyncio_debug:
+  fields:
+    enabled:
+      default: true
+      selector:
+        boolean:

--- a/homeassistant/components/profiler/strings.json
+++ b/homeassistant/components/profiler/strings.json
@@ -86,7 +86,13 @@
     },
     "set_asyncio_debug": {
       "name": "Set asyncio debug",
-      "description": "Enable or disable asyncio debug."
+      "description": "Enable or disable asyncio debug.",
+      "fields": {
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether to enable or disable asyncio debug."
+        }
+      }
     }
   }
 }

--- a/homeassistant/components/profiler/strings.json
+++ b/homeassistant/components/profiler/strings.json
@@ -83,6 +83,10 @@
     "log_event_loop_scheduled": {
       "name": "Log event loop scheduled",
       "description": "Logs what is scheduled in the event loop."
+    },
+    "set_asyncio_debug": {
+      "name": "Set asyncio debug",
+      "description": "Enable or disable asyncio debug."
     }
   }
 }

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -390,6 +390,12 @@ async def test_set_asyncio_debug(
     original_level = logging.getLogger().getEffectiveLevel()
     logging.getLogger().setLevel(logging.WARNING)
 
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_ASYNCIO_DEBUG, {CONF_ENABLED: False}, blocking=True
+    )
+    # Ensure logging level is only increased if we enable
+    assert logging.getLogger().getEffectiveLevel() == logging.WARNING
+
     await hass.services.async_call(DOMAIN, SERVICE_SET_ASYNCIO_DEBUG, {}, blocking=True)
     assert hass.loop.get_debug() is True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently when a user has a problem with their event loop being blocked the simplest way to enable asyncio debug is to add `debugpy:` to `configuration.yaml`, however this approach slows the system which makes the report less useful and harder to track down the problem.

We need a lightweight way to enable debug mode without having to restart or slow down the system too much so users can report problems with the event loop being blocked, and we have a better chance of finding the source without side effects

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31889

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
