### PR TITLE
Revert "Remove unused test helper mock_area_registry"

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 from collections.abc import AsyncGenerator, Generator, Mapping, Sequence
 from contextlib import asynccontextmanager, contextmanager
 from datetime import UTC, datetime, timedelta
@@ -617,6 +618,27 @@ def mock_registry(
         registry.entities[key] = entry
 
     hass.data[er.DATA_REGISTRY] = registry
+    return registry
+
+
+def mock_area_registry(
+    hass: HomeAssistant, mock_entries: dict[str, ar.AreaEntry] | None = None
+) -> ar.AreaRegistry:
+    """Mock the Area Registry.
+
+    This should only be used if you need to mock/re-stage a clean mocked
+    area registry in your current hass object. It can be useful to,
+    for example, pre-load the registry with items.
+
+    This mock will thus replace the existing registry in the running hass.
+
+    If you just need to access the existing registry, use the `area_registry`
+    fixture instead.
+    """
+    registry = ar.AreaRegistry(hass)
+    registry.areas = mock_entries or OrderedDict()
+
+    hass.data[ar.DATA_REGISTRY] = registry
     return registry
 
 


### PR DESCRIPTION
Reverts home-assistant/core#112172

Fix CI test,
