### PR TITLE
Fix delayed registry check to only using the short delay at running

### DIFF
--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .storage import Store
 
 SAVE_DELAY = 10
-SAVE_DELAY_LONG = 300
+SAVE_DELAY_LONG = 180
 
 
 class BaseRegistry(ABC):

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from .storage import Store
 
 SAVE_DELAY = 10
-SAVE_DELAY_STARTING = 300
+SAVE_DELAY_LONG = 300
 
 
 class BaseRegistry(ABC):
@@ -25,9 +25,7 @@ class BaseRegistry(ABC):
         """Schedule saving the registry."""
         # Schedule the save past startup to avoid writing
         # the file while the system is starting.
-        delay = (
-            SAVE_DELAY_STARTING if self.hass.state is CoreState.starting else SAVE_DELAY
-        )
+        delay = SAVE_DELAY if self.hass.state is CoreState.running else SAVE_DELAY_LONG
         self._store.async_delay_save(self._data_to_save, delay)
 
     @callback

--- a/tests/helpers/test_registry.py
+++ b/tests/helpers/test_registry.py
@@ -3,10 +3,11 @@
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import storage
-from homeassistant.helpers.registry import SAVE_DELAY, SAVE_DELAY_STARTING, BaseRegistry
+from homeassistant.helpers.registry import SAVE_DELAY, SAVE_DELAY_LONG, BaseRegistry
 
 from tests.common import async_fire_time_changed
 
@@ -26,12 +27,30 @@ class SampleRegistry(BaseRegistry):
         return None
 
 
+@pytest.mark.parametrize(
+    "long_delay_state",
+    (
+        CoreState.not_running,
+        CoreState.starting,
+        CoreState.stopped,
+        CoreState.final_write,
+    ),
+)
 async def test_async_schedule_save(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, hass_storage: dict[str, Any]
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    long_delay_state: CoreState,
+    hass_storage: dict[str, Any],
 ) -> None:
-    """Test saving the registry."""
+    """Test saving the registry.
+
+    If CoreState is not running, it should save with long delay.
+
+    Storage will always save at final write if there is a
+    write pending so we should not schedule a save in that case.
+    """
     registry = SampleRegistry(hass)
-    hass.set_state(CoreState.starting)
+    hass.set_state(long_delay_state)
 
     registry.async_schedule_save()
     freezer.tick(SAVE_DELAY)
@@ -39,7 +58,7 @@ async def test_async_schedule_save(
     await hass.async_block_till_done()
     assert registry.save_calls == 0
 
-    freezer.tick(SAVE_DELAY_STARTING)
+    freezer.tick(SAVE_DELAY_LONG)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert registry.save_calls == 1


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The check only checked starting which is the small window between when async_start is called and the started event is fired. Registry writes can be scheduled in the not_running or later phases which made the check ineffective at avoiding writes during busy startup or shutdown in these cases. As we will always write at the final write stage, we should not schedule a fast write at shutdown either.

I missed this because startup was taking less than 10s on my test machine.  I noticed when I was testing for the event loop being blocked that it still wrote too soon: 
```
Mar 14 22:34:43 homeassistant homeassistant[516]: 2024-03-14 17:34:43.277 DEBUG (MainThread) [homeassistant.bootstrap] Waiting for startup to wrap up
Mar 14 22:34:43 homeassistant homeassistant[516]: 2024-03-14 17:34:43.313 WARNING (SyncWorker_6) [homeassistant.helpers.storage] Writing data with data_func: core.device_registry
Mar 14 22:34:43 homeassistant homeassistant[516]: 2024-03-14 17:34:43.540 DEBUG (MainThread) [homeassistant.bootstrap] Waiting on tasks: {<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.11/asyncio/futures.py:387, <2 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.11/asyncio/tasks.py:519]>}
Mar 14 22:34:43 homeassistant homeassistant[516]: 2024-03-14 17:34:43.541 DEBUG (MainThread) [homeassistant.bootstrap] Running timeout Zones: {}
Mar 14 22:34:43 homeassistant homeassistant[516]: 2024-03-14 17:34:43.806 WARNING (SyncWorker_10) [homeassistant.helpers.storage] Writing data with data_func: core.entity_registry
Mar 14 22:34:44 homeassistant homeassistant[516]: 2024-03-14 17:34:44.542 DEBUG (MainThread) [homeassistant.bootstrap] Waiting on tasks: {<Future pending cb=[_chain_future.<locals>._call_check_cancel() at /usr/local/lib/python3.11/asyncio/futures.py:387, <2 more>, _wait.<locals>._on_completion() at /usr/local/lib/python3.11/asyncio/tasks.py:519]>}
Mar 14 22:34:44 homeassistant homeassistant[516]: 2024-03-14 17:34:44.542 DEBUG (MainThread) [homeassistant.bootstrap] Running timeout Zones: {}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
