### PR TITLE
Use async code and live status refresh for tolo integration

### DIFF
--- a/homeassistant/components/tolo/button.py
+++ b/homeassistant/components/tolo/button.py
@@ -53,4 +53,4 @@ class ToloLampNextColorButton(ToloSaunaCoordinatorEntity, ButtonEntity):
         await self.hass.async_add_executor_job(
             self.coordinator.client.lamp_change_color
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/button.py
+++ b/homeassistant/components/tolo/button.py
@@ -48,6 +48,9 @@ class ToloLampNextColorButton(ToloSaunaCoordinatorEntity, ButtonEntity):
             and self.coordinator.data.settings.lamp_mode == LampMode.MANUAL
         )
 
-    def press(self) -> None:
+    async def async_press(self) -> None:
         """Execute action when lamp change color button was pressed."""
-        self.coordinator.client.lamp_change_color()
+        await self.hass.async_add_executor_job(
+            self.coordinator.client.lamp_change_color
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/climate.py
+++ b/homeassistant/components/tolo/climate.py
@@ -130,21 +130,21 @@ class SaunaClimate(ToloSaunaCoordinatorEntity, ClimateEntity):
         if hvac_mode == HVACMode.DRY:
             await self._async_set_power_and_fan(False, True)
 
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode."""
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_fan_on(fan_mode == FAN_ON)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_set_humidity(self, humidity: int) -> None:
         """Set desired target humidity."""
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_target_humidity(humidity)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set desired target temperature."""
@@ -154,7 +154,7 @@ class SaunaClimate(ToloSaunaCoordinatorEntity, ClimateEntity):
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_target_temperature(round(temperature))
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     def _set_power_and_fan(self, power_on: bool, fan_on: bool) -> None:
         """Shortcut for setting power and fan of TOLO device on one method."""
@@ -166,4 +166,4 @@ class SaunaClimate(ToloSaunaCoordinatorEntity, ClimateEntity):
         await self.hass.async_add_executor_job(
             lambda: self._set_power_and_fan(power_on, fan_on)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/fan.py
+++ b/homeassistant/components/tolo/fan.py
@@ -51,11 +51,11 @@ class ToloFan(ToloSaunaCoordinatorEntity, FanEntity):
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_fan_on(True)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off sauna fan."""
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_fan_on(False)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/fan.py
+++ b/homeassistant/components/tolo/fan.py
@@ -41,15 +41,21 @@ class ToloFan(ToloSaunaCoordinatorEntity, FanEntity):
         """Return if sauna fan is running."""
         return self.coordinator.data.status.fan_on
 
-    def turn_on(
+    async def async_turn_on(
         self,
         percentage: int | None = None,
         preset_mode: str | None = None,
         **kwargs: Any,
     ) -> None:
         """Turn on sauna fan."""
-        self.coordinator.client.set_fan_on(True)
+        await self.hass.async_add_executor_job(
+            lambda: self.coordinator.client.set_fan_on(True)
+        )
+        await self.coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off sauna fan."""
-        self.coordinator.client.set_fan_on(False)
+        await self.hass.async_add_executor_job(
+            lambda: self.coordinator.client.set_fan_on(False)
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/light.py
+++ b/homeassistant/components/tolo/light.py
@@ -48,11 +48,11 @@ class ToloLight(ToloSaunaCoordinatorEntity, LightEntity):
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_lamp_on(True)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off TOLO Sauna lamp."""
         await self.hass.async_add_executor_job(
             lambda: self.coordinator.client.set_lamp_on(False)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/light.py
+++ b/homeassistant/components/tolo/light.py
@@ -43,10 +43,16 @@ class ToloLight(ToloSaunaCoordinatorEntity, LightEntity):
         """Return current lamp status."""
         return self.coordinator.data.status.lamp_on
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on TOLO Sauna lamp."""
-        self.coordinator.client.set_lamp_on(True)
+        await self.hass.async_add_executor_job(
+            lambda: self.coordinator.client.set_lamp_on(True)
+        )
+        await self.coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off TOLO Sauna lamp."""
-        self.coordinator.client.set_lamp_on(False)
+        await self.hass.async_add_executor_job(
+            lambda: self.coordinator.client.set_lamp_on(False)
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/number.py
+++ b/homeassistant/components/tolo/number.py
@@ -110,4 +110,4 @@ class ToloNumberEntity(ToloSaunaCoordinatorEntity, NumberEntity):
             lambda: self.entity_description.setter(self.coordinator.client, int_value)
         )
 
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/number.py
+++ b/homeassistant/components/tolo/number.py
@@ -97,10 +97,17 @@ class ToloNumberEntity(ToloSaunaCoordinatorEntity, NumberEntity):
         """Return the value of this TOLO Number entity."""
         return self.entity_description.getter(self.coordinator.data.settings) or 0
 
-    def set_native_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the value of this TOLO Number entity."""
         int_value = int(value)
         if int_value == 0:
-            self.entity_description.setter(self.coordinator.client, None)
+            await self.hass.async_add_executor_job(
+                lambda: self.entity_description.setter(self.coordinator.client, None)
+            )
             return
-        self.entity_description.setter(self.coordinator.client, int_value)
+
+        await self.hass.async_add_executor_job(
+            lambda: self.entity_description.setter(self.coordinator.client, int_value)
+        )
+
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/select.py
+++ b/homeassistant/components/tolo/select.py
@@ -93,4 +93,4 @@ class ToloSelectEntity(ToloSaunaCoordinatorEntity, SelectEntity):
         await self.hass.async_add_executor_job(
             lambda: self.entity_description.setter(self.coordinator.client, option)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/tolo/select.py
+++ b/homeassistant/components/tolo/select.py
@@ -88,6 +88,9 @@ class ToloSelectEntity(ToloSaunaCoordinatorEntity, SelectEntity):
         """Return current select option."""
         return self.entity_description.getter(self.coordinator.data.settings)
 
-    def select_option(self, option: str) -> None:
+    async def async_select_option(self, option: str) -> None:
         """Select a select option."""
-        self.entity_description.setter(self.coordinator.client, option)
+        await self.hass.async_add_executor_job(
+            lambda: self.entity_description.setter(self.coordinator.client, option)
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/switch.py
+++ b/homeassistant/components/tolo/switch.py
@@ -74,10 +74,16 @@ class ToloSwitchEntity(ToloSaunaCoordinatorEntity, SwitchEntity):
         """Return if the switch is currently on."""
         return self.entity_description.getter(self.coordinator.data.status)
 
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self.entity_description.setter(self.coordinator.client, True)
+        await self.hass.async_add_executor_job(
+            lambda: self.entity_description.setter(self.coordinator.client, True)
+        )
+        await self.coordinator.async_request_refresh()
 
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self.entity_description.setter(self.coordinator.client, False)
+        await self.hass.async_add_executor_job(
+            lambda: self.entity_description.setter(self.coordinator.client, False)
+        )
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/tolo/switch.py
+++ b/homeassistant/components/tolo/switch.py
@@ -79,11 +79,11 @@ class ToloSwitchEntity(ToloSaunaCoordinatorEntity, SwitchEntity):
         await self.hass.async_add_executor_job(
             lambda: self.entity_description.setter(self.coordinator.client, True)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.hass.async_add_executor_job(
             lambda: self.entity_description.setter(self.coordinator.client, False)
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As async code is preferrable for HA, this is a change towards more async code in the `tolo` integration, which also allows to request some in-time data refresh instead of waiting for the next regular polling interval. The latter fixes some strange flickering of settings, e.g. when the user turns a button on and UI refreshes before new data is fetched from the device, the button switches back to off and then back to on again once the data is updated. That's very confusing for users and improved in this change.

Unfortunately, the backend library does not support async calls (yet), so we still have to use job executor.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
