### PR TITLE
OpenAI Conversation: Add function execution support

### DIFF
--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -2,7 +2,7 @@
   "domain": "conversation",
   "name": "Conversation",
   "codeowners": ["@home-assistant/core", "@synesthesiam"],
-  "dependencies": ["homeassistant", "http"],
+  "dependencies": ["http"],
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -2,7 +2,7 @@
   "domain": "conversation",
   "name": "Conversation",
   "codeowners": ["@home-assistant/core", "@synesthesiam"],
-  "dependencies": ["http"],
+  "dependencies": ["homeassistant", "http"],
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY, MATCH_ALL
 from homeassistant.core import (
+    Context,
     HomeAssistant,
     ServiceCall,
     ServiceResponse,
@@ -305,7 +306,7 @@ async def async_register_tool(
     """Register a function that the assistant may execute."""
     agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)
     if not isinstance(agent, OpenAIAgent):
-        raise RuntimeError("Agent ID must correspond to openai_conversation agent")
+        raise TypeError("Agent ID must correspond to openai_conversation agent")
     agent.register_tool(specification, async_callback)
 
 
@@ -316,5 +317,5 @@ async def async_unregister_tool(
     """Remove the function from the list of available tools for the assistant."""
     agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)
     if not isinstance(agent, OpenAIAgent):
-        raise RuntimeError("Agent ID must correspond to openai_conversation agent")
+        raise TypeError("Agent ID must correspond to openai_conversation agent")
     agent.unregister_tool(function_name)

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import json
 import logging
-from typing import Callable, Literal
+from typing import Literal
 
 import openai
 import voluptuous as vol

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -305,7 +305,7 @@ async def async_register_tool(
     hass: HomeAssistant, agent_id: str, specification: dict, async_callback: Callable
 ) -> None:
     """Register a function that the assistant may execute."""
-    agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)
+    agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)  # pylint: disable=protected-access
     if not isinstance(agent, OpenAIAgent):
         raise TypeError("Agent ID must correspond to openai_conversation agent")
     agent.register_tool(specification, async_callback)
@@ -316,7 +316,7 @@ async def async_unregister_tool(
     hass: HomeAssistant, agent_id: str, function_name: str
 ) -> None:
     """Remove the function from the list of available tools for the assistant."""
-    agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)
+    agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)  # pylint: disable=protected-access
     if not isinstance(agent, OpenAIAgent):
         raise TypeError("Agent ID must correspond to openai_conversation agent")
     agent.unregister_tool(function_name)

--- a/homeassistant/components/openai_conversation/__init__.py
+++ b/homeassistant/components/openai_conversation/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Literal
+from typing import Callable, Literal
 
 import openai
 import voluptuous as vol
@@ -149,14 +149,14 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
         self.hass = hass
         self.entry = entry
         self.history: dict[str, list[dict]] = {}
-        self.tools: list[tuple[dict, callable]] = []
+        self.tools: list[tuple[dict, Callable]] = []
 
     @property
     def supported_languages(self) -> list[str] | Literal["*"]:
         """Return a list of supported languages."""
         return MATCH_ALL
 
-    def register_tool(self, specification: dict, async_callback: callable) -> None:
+    def register_tool(self, specification: dict, async_callback: Callable) -> None:
         """Register a function that the assistant may execute."""
         if specification["function"]["name"] in [
             tool[0]["function"]["name"] for tool in self.tools
@@ -301,7 +301,7 @@ class OpenAIAgent(conversation.AbstractConversationAgent):
 
 @callback
 async def async_register_tool(
-    hass: HomeAssistant, agent_id: str, specification: dict, async_callback: callable
+    hass: HomeAssistant, agent_id: str, specification: dict, async_callback: Callable
 ) -> None:
     """Register a function that the assistant may execute."""
     agent = await conversation._get_agent_manager(hass).async_get_agent(agent_id)

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -22,11 +22,13 @@ An overview of the areas and the devices in this smart home:
 Answer the user's questions about the world truthfully.
 
 If the user wants to control a device, reject the request and suggest using the Home Assistant app.
+
+The response may be used in Text-to-Speech synthesizers, so prefer shorter responses that are optimized to be spoken.
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"
 CONF_MAX_TOKENS = "max_tokens"
-DEFAULT_MAX_TOKENS = 150
+DEFAULT_MAX_TOKENS = 256
 CONF_TOP_P = "top_p"
 DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"

--- a/tests/components/openai_conversation/snapshots/test_init.ambr
+++ b/tests/components/openai_conversation/snapshots/test_init.ambr
@@ -19,6 +19,8 @@
         Answer the user's questions about the world truthfully.
         
         If the user wants to control a device, reject the request and suggest using the Home Assistant app.
+        
+        The response may be used in Text-to-Speech synthesizers, so prefer shorter responses that are optimized to be spoken.
       ''',
       'role': 'system',
     }),
@@ -26,9 +28,6 @@
       'content': 'hello',
       'role': 'user',
     }),
-    dict({
-      'content': 'Hello, how can I help you?',
-      'role': 'assistant',
-    }),
+    ChatCompletionMessage(content='Hello, how can I help you?', role='assistant', function_call=None, tool_calls=None),
   ])
 # ---

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -319,7 +319,7 @@ async def test_function_exception(
     )
 
     with pytest.raises(
-        RuntimeError, match="Agent ID must correspond to openai_conversation agent"
+        TypeError, match="Agent ID must correspond to openai_conversation agent"
     ):
         await openai_conversation.async_register_tool(
             hass,
@@ -329,7 +329,7 @@ async def test_function_exception(
         )
 
     with pytest.raises(
-        RuntimeError, match="Agent ID must correspond to openai_conversation agent"
+        TypeError, match="Agent ID must correspond to openai_conversation agent"
     ):
         await openai_conversation.async_unregister_tool(
             hass,

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -318,6 +318,8 @@ async def test_function_exception(
         async_callback=mock_tool,
     )
 
+    assert await async_setup_component(hass, "homeassistant", {})
+
     with pytest.raises(
         TypeError, match="Agent ID must correspond to openai_conversation agent"
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is an attempt to break the functionality of https://github.com/home-assistant/core/pull/105770 down into separate parts for easy review. It allows the OpenAI Conversation platform to use the new [parallel function calling feature](https://platform.openai.com/docs/guides/function-calling/parallel-function-calling). This PR creates the framework to allow the function execution, but does not yet add any of those functions. They could be provided with a future PR or registered by a custom component.

One limitation is that the conversation platform only supports one response, while the model may output several messages in the process when calling additional functions. We only keep the last message, which is probably fine because the intermediate messages are usually excuses that it couldn't do the task in one iteration, so let's just consider it an inner voice.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
