### PR TITLE
Bump ical to 7.0.3 to fix local-todo persisted with invalid DTSTART values

### DIFF
--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3", "ical==7.0.1"]
+  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3", "ical==7.0.2"]
 }

--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/calendar.google",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3", "ical==7.0.2"]
+  "requirements": ["gcal-sync==6.0.3", "oauth2client==4.1.3", "ical==7.0.3"]
 }

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
   "iot_class": "local_polling",
   "loggers": ["ical"],
-  "requirements": ["ical==7.0.1"]
+  "requirements": ["ical==7.0.2"]
 }

--- a/homeassistant/components/local_calendar/manifest.json
+++ b/homeassistant/components/local_calendar/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/local_calendar",
   "iot_class": "local_polling",
   "loggers": ["ical"],
-  "requirements": ["ical==7.0.2"]
+  "requirements": ["ical==7.0.3"]
 }

--- a/homeassistant/components/local_todo/manifest.json
+++ b/homeassistant/components/local_todo/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_todo",
   "iot_class": "local_polling",
-  "requirements": ["ical==7.0.1"]
+  "requirements": ["ical==7.0.2"]
 }

--- a/homeassistant/components/local_todo/manifest.json
+++ b/homeassistant/components/local_todo/manifest.json
@@ -5,5 +5,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/local_todo",
   "iot_class": "local_polling",
-  "requirements": ["ical==7.0.2"]
+  "requirements": ["ical==7.0.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1112,7 +1112,7 @@ ibmiotf==0.3.4
 # homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
-ical==7.0.1
+ical==7.0.2
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1112,7 +1112,7 @@ ibmiotf==0.3.4
 # homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
-ical==7.0.2
+ical==7.0.3
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -902,7 +902,7 @@ ibeacon-ble==1.2.0
 # homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
-ical==7.0.1
+ical==7.0.2
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -902,7 +902,7 @@ ibeacon-ble==1.2.0
 # homeassistant.components.google
 # homeassistant.components.local_calendar
 # homeassistant.components.local_todo
-ical==7.0.2
+ical==7.0.3
 
 # homeassistant.components.ping
 icmplib==3.0

--- a/tests/components/local_todo/snapshots/test_todo.ambr
+++ b/tests/components/local_todo/snapshots/test_todo.ambr
@@ -22,6 +22,16 @@
   list([
   ])
 # ---
+# name: test_parse_existing_ics[invalid_dtstart_tzname]
+  list([
+    dict({
+      'due': '2023-10-24T11:30:00',
+      'status': 'needs_action',
+      'summary': 'Task',
+      'uid': '077cb7f2-6c89-11ee-b2a9-0242ac110002',
+    }),
+  ])
+# ---
 # name: test_parse_existing_ics[migrate_legacy_due]
   list([
     dict({

--- a/tests/components/local_todo/test_todo.py
+++ b/tests/components/local_todo/test_todo.py
@@ -671,6 +671,28 @@ async def test_move_item_previous_unknown(
             ),
             "1",
         ),
+        (
+            textwrap.dedent(
+                """\
+                    BEGIN:VCALENDAR
+                    PRODID:-//homeassistant.io//local_todo 2.0//EN
+                    VERSION:2.0
+                    BEGIN:VTODO
+                    DTSTAMP:20231024T014011
+                    UID:077cb7f2-6c89-11ee-b2a9-0242ac110002
+                    CREATED:20231017T010348
+                    LAST-MODIFIED:20231024T014011
+                    SEQUENCE:1
+                    STATUS:NEEDS-ACTION
+                    SUMMARY:Task
+                    DUE:20231024T113000
+                    DTSTART;TZID=CST:20231024T113000
+                    END:VTODO
+                    END:VCALENDAR
+                """
+            ),
+            "1",
+        ),
     ],
     ids=(
         "empty",
@@ -679,6 +701,7 @@ async def test_move_item_previous_unknown(
         "needs_action",
         "migrate_legacy_due",
         "due",
+        "invalid_dtstart_tzname",
     ),
 )
 async def test_parse_existing_ics(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump ical to 7.0.3:
Release Notes: https://github.com/allenporter/ical/releases/tag/7.0.3
Full changelog: https://github.com/allenporter/ical/compare/7.0.2...7.0.3

Previously this test fails with:
```
  Failed to validate: TZID=CST;20231024T113000, errors: (['Expected value to match DATE-TIME pattern: TZID=CST;20231024T113000', "Expected value to match DATE pattern: 'TZID=CST;20231024T113000'"]) (type=value_error)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #113445 #113421
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
