### PR TITLE
Send keep-alive frames in image proxy stream

### DIFF
--- a/tests/components/image/test_init.py
+++ b/tests/components/image/test_init.py
@@ -354,4 +354,3 @@ async def test_image_stream(
             await hass.async_block_till_done()
 
     await close_future
-    assert resp.closed

--- a/tests/components/image/test_init.py
+++ b/tests/components/image/test_init.py
@@ -1,11 +1,12 @@
 """The tests for the image component."""
 
-import datetime
+from datetime import datetime
 from http import HTTPStatus
 import ssl
 from unittest.mock import MagicMock, patch
 
 from aiohttp import hdrs
+from freezegun.api import FrozenDateTimeFactory
 import httpx
 import pytest
 import respx
@@ -24,7 +25,12 @@ from .conftest import (
     MockURLImageEntity,
 )
 
-from tests.common import MockModule, mock_integration, mock_platform
+from tests.common import (
+    MockModule,
+    async_fire_time_changed,
+    mock_integration,
+    mock_platform,
+)
 from tests.typing import ClientSessionGenerator
 
 
@@ -292,7 +298,9 @@ async def test_fetch_image_url_wrong_content_type(
 
 
 async def test_image_stream(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test image stream."""
 
@@ -323,15 +331,24 @@ async def test_image_stream(
             assert not resp.closed
             assert resp.status == HTTPStatus.OK
 
-            mock_image.image_last_updated = datetime.datetime.now()
+            mock_image.image_last_updated = datetime.now()
             mock_image.async_write_ha_state()
             # Two blocks to ensure the frame is written
             await hass.async_block_till_done()
             await hass.async_block_till_done()
 
+        with patch.object(mock_image, "async_image", return_value=b"") as mock:
+            # Simulate a "keep alive" frame
+            freezer.tick(55)
+            async_fire_time_changed(hass)
+            # Two blocks to ensure the frame is written
+            await hass.async_block_till_done()
+            await hass.async_block_till_done()
+            mock.assert_called_once()
+
         with patch.object(mock_image, "async_image", return_value=None):
-            mock_image.image_last_updated = datetime.datetime.now()
-            mock_image.async_write_ha_state()
+            freezer.tick(55)
+            async_fire_time_changed(hass)
             # Two blocks to ensure the frame is written
             await hass.async_block_till_done()
             await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The image proxy stream sends out a new frame when the entity is updated. Some Chromecast devices require a frame be sent at least once a minute. This PR ensures such a frame is sent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
