### PR TITLE
Revert "Avoid pre-importing config_flows if the integration does not …

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -349,9 +349,6 @@ class ConfigEntry:
         # Supports remove device
         self.supports_remove_device: bool | None = None
 
-        # Supports migrate
-        self.supports_migrate: bool | None = None
-
         # Supports options
         self._supports_options: bool | None = None
 
@@ -494,7 +491,6 @@ class ConfigEntry:
             self.supports_remove_device = await support_remove_from_device(
                 hass, self.domain
             )
-
         try:
             component = await integration.async_get_component()
         except ImportError as err:
@@ -510,12 +506,7 @@ class ConfigEntry:
                 )
             return
 
-        if self.supports_migrate is None:
-            self.supports_migrate = hasattr(component, "async_migrate_entry")
-
-        if domain_is_integration and self.supports_migrate:
-            # Avoid loading the config_flow module unless we need to check
-            # the version to see if we need to migrate
+        if domain_is_integration:
             try:
                 await integration.async_get_platforms(("config_flow",))
             except ImportError as err:
@@ -796,7 +787,11 @@ class ConfigEntry:
         if same_major_version and self.minor_version == handler.MINOR_VERSION:
             return True
 
-        if not self.supports_migrate:
+        if not (integration := self._integration_for_domain):
+            integration = await loader.async_get_integration(hass, self.domain)
+        component = await integration.async_get_component()
+        supports_migrate = hasattr(component, "async_migrate_entry")
+        if not supports_migrate:
             if same_major_version:
                 return True
             _LOGGER.error(
@@ -805,11 +800,6 @@ class ConfigEntry:
                 self.domain,
             )
             return False
-
-        if not (integration := self._integration_for_domain):
-            integration = await loader.async_get_integration(hass, self.domain)
-
-        component = await integration.async_get_component()
 
         try:
             result = await component.async_migrate_entry(hass, self)

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -961,7 +961,10 @@ class Integration:
 
         # Some integrations fail on import because they call functions incorrectly.
         # So we do it before validating config to catch these errors.
-        load_executor = self.import_executor and self.pkg_path not in sys.modules
+        load_executor = self.import_executor and (
+            self.pkg_path not in sys.modules
+            or (self.config_flow and f"{self.pkg_path}.config_flow" not in sys.modules)
+        )
         if not load_executor:
             comp = self._get_component()
             if debug:
@@ -1048,12 +1051,6 @@ class Integration:
 
         if preload_platforms:
             for platform_name in self.platforms_exists(self._platforms_to_preload):
-                if (
-                    platform_name == "config_flow"
-                    and not async_config_flow_needs_preload(cache[domain])
-                ):
-                    continue
-
                 with suppress(ImportError):
                     self.get_platform(platform_name)
 
@@ -1687,15 +1684,3 @@ def async_suggest_report_issue(
         )
 
     return f"create a bug report at {issue_tracker}"
-
-
-@callback
-def async_config_flow_needs_preload(component: ComponentProtocol) -> bool:
-    """Test if a config_flow for a component needs to be preloaded.
-
-    Currently we need to preload a the config flow if the integration
-    has a config flow and the component has an async_migrate_entry method
-    because it means that config_entries will always have to load
-    it to check if it needs to be migrated.
-    """
-    return hasattr(component, "async_migrate_entry")

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -67,7 +67,6 @@ async def test_invalid_auth(
 
     mock_config_entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/sonarr/test_init.py
+++ b/tests/components/sonarr/test_init.py
@@ -105,9 +105,7 @@ async def test_migrate_config_entry(hass: HomeAssistant) -> None:
     assert entry.version == 1
     assert not entry.unique_id
 
-    with patch("homeassistant.components.sonarr.async_setup_entry", return_value=True):
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    await entry.async_migrate(hass)
 
     assert entry.data == {
         CONF_API_KEY: "MOCK_API_KEY",

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -219,31 +219,25 @@ async def test_form_reauth_auth(
     )
     mock_config.add_to_hass(hass)
 
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_REAUTH,
+            "entry_id": mock_config.entry_id,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert not result["errors"]
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert flows[0]["context"]["title_placeholders"] == {
+        "ip_address": "1.1.1.1",
+        "name": "Mock Title",
+    }
+
     with patch(
         "homeassistant.components.unifiprotect.config_flow.ProtectApiClient.get_bootstrap",
         side_effect=NotAuthorized,
-    ), patch(
-        "homeassistant.components.unifiprotect.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.unifiprotect.async_setup_entry",
-        return_value=True,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={
-                "source": config_entries.SOURCE_REAUTH,
-                "entry_id": mock_config.entry_id,
-            },
-        )
-        assert result["type"] == FlowResultType.FORM
-        assert not result["errors"]
-        flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
-        assert flows[0]["context"]["title_placeholders"] == {
-            "ip_address": "1.1.1.1",
-            "name": "Mock Title",
-        }
-
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -263,10 +257,7 @@ async def test_form_reauth_auth(
     ), patch(
         "homeassistant.components.unifiprotect.async_setup",
         return_value=True,
-    ) as mock_setup, patch(
-        "homeassistant.components.unifiprotect.async_setup_entry",
-        return_value=True,
-    ):
+    ) as mock_setup:
         result3 = await hass.config_entries.flow.async_configure(
             result2["flow_id"],
             {
@@ -777,20 +768,6 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
     )
     mock_config.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.components.unifiprotect.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry, patch(
-        "homeassistant.components.unifiprotect.async_setup",
-        return_value=True,
-    ) as mock_setup:
-        await hass.config_entries.async_setup(mock_config.entry_id)
-        await hass.async_block_till_done()
-
-    assert mock_config.state == config_entries.ConfigEntryState.LOADED
-    assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_setup.mock_calls) == 1
-
     other_ip_dict = UNIFI_DISCOVERY_DICT.copy()
     other_ip_dict["source_ip"] = "127.0.0.2"
     other_ip_dict["direct_connect_domain"] = "nomatchsameip.ui.direct"
@@ -846,7 +823,7 @@ async def test_discovered_by_unifi_discovery_direct_connect_on_different_interfa
         "verify_ssl": True,
     }
     assert len(mock_setup_entry.mock_calls) == 1
-    assert len(mock_setup.mock_calls) == 0
+    assert len(mock_setup.mock_calls) == 1
 
 
 async def test_discovered_by_unifi_discovery_direct_connect_on_different_interface_resolver_no_result(

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -117,7 +117,6 @@ async def test_call_setup_entry(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED
     assert entry.supports_unload
-    assert entry.supports_migrate
 
 
 async def test_call_setup_entry_without_reload_support(hass: HomeAssistant) -> None:
@@ -147,7 +146,6 @@ async def test_call_setup_entry_without_reload_support(hass: HomeAssistant) -> N
     assert len(mock_setup_entry.mock_calls) == 1
     assert entry.state is config_entries.ConfigEntryState.LOADED
     assert not entry.supports_unload
-    assert entry.supports_migrate
 
 
 @pytest.mark.parametrize(("major_version", "minor_version"), [(2, 1), (1, 2), (2, 2)])
@@ -291,7 +289,6 @@ async def test_call_async_migrate_entry_failure_not_supported(
     )
     entry.add_to_hass(hass)
     assert not entry.supports_unload
-    entry.supports_migrate = True
 
     mock_setup_entry = AsyncMock(return_value=True)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1204,21 +1204,31 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     assert "test_package_loaded_executor" not in hass.config.components
     assert "test_package_loaded_executor.config_flow" not in hass.config.components
 
-    module_mock = object()
+    config_flow_module_name = f"{integration.pkg_path}.config_flow"
+    module_mock = MagicMock(__file__="__init__.py")
+    config_flow_module_mock = MagicMock(__file__="config_flow.py")
 
     def import_module(name: str) -> Any:
         if name == integration.pkg_path:
             return module_mock
+        if name == config_flow_module_name:
+            return config_flow_module_mock
         raise ImportError
 
+    modules_without_config_flow = {
+        k: v for k, v in sys.modules.items() if k != config_flow_module_name
+    }
     with patch.dict(
         "sys.modules",
-        {**sys.modules, integration.pkg_path: module_mock},
+        {**modules_without_config_flow, integration.pkg_path: module_mock},
         clear=True,
     ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
 
-    assert "loaded_executor=False" in caplog.text
+    # The config flow is missing so we should load
+    # in the executor
+    assert "loaded_executor=True" in caplog.text
+    assert "loaded_executor=False" not in caplog.text
     assert module is module_mock
     caplog.clear()
 
@@ -1226,6 +1236,7 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
         "sys.modules",
         {
             integration.pkg_path: module_mock,
+            config_flow_module_name: config_flow_module_mock,
         },
     ), patch("homeassistant.loader.importlib.import_module", import_module):
         module = await integration.async_get_component()
@@ -1234,10 +1245,6 @@ async def test_async_get_component_loads_loop_if_already_in_sys_modules(
     # so it should not have to call the load
     assert "loaded_executor" not in caplog.text
     assert module is module_mock
-
-    # The integration does not implement async_migrate_entry so it
-    # should not be preloaded
-    assert integration.get_platform_cached("config_flow") is None
 
 
 async def test_async_get_component_concurrent_loads(


### PR DESCRIPTION
…support …"

This reverts commit 9940f51b95b7ba3423cd6079bd83ecf325bca7c2.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
PR https://github.com/home-assistant/core/pull/113369 introduced to not pre-load all config flows to reduce overhead.

This has a problem with that we then don't know if a config flow has an attached options flow or a reconfigure step.
In frontend this is illustrated as that the button to click are not there anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
