### PR TITLE
Revert time change in Shelly config flow tests

### DIFF
--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.setup import async_setup_component
 
 from . import init_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import WebSocketGenerator
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
@@ -1030,6 +1030,7 @@ async def test_zeroconf_already_configured_triggers_refresh_mac_in_name(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 2
 
@@ -1062,6 +1063,7 @@ async def test_zeroconf_already_configured_triggers_refresh(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 2
 
@@ -1100,6 +1102,7 @@ async def test_zeroconf_sleeping_device_not_triggers_refresh(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 0
     assert "device did not update" not in caplog.text

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -1,7 +1,6 @@
 """Test the Shelly config flow."""
 
 from dataclasses import replace
-from datetime import timedelta
 from ipaddress import ip_address
 from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
@@ -22,15 +21,13 @@ from homeassistant.components.shelly.const import (
     DOMAIN,
     BLEScannerMode,
 )
-from homeassistant.components.shelly.coordinator import ENTRY_RELOAD_COOLDOWN
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from homeassistant.util import dt as dt_util
 
 from . import init_integration
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
 
 DISCOVERY_INFO = zeroconf.ZeroconfServiceInfo(
@@ -1033,9 +1030,6 @@ async def test_zeroconf_already_configured_triggers_refresh_mac_in_name(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
-    )
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 2
 
@@ -1068,9 +1062,6 @@ async def test_zeroconf_already_configured_triggers_refresh(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
-    )
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 2
 
@@ -1109,9 +1100,6 @@ async def test_zeroconf_sleeping_device_not_triggers_refresh(
 
     monkeypatch.setattr(mock_rpc_device, "connected", False)
     mock_rpc_device.mock_disconnected()
-    async_fire_time_changed(
-        hass, dt_util.utcnow() + timedelta(seconds=ENTRY_RELOAD_COOLDOWN)
-    )
     await hass.async_block_till_done()
     assert len(mock_rpc_device.initialize.mock_calls) == 0
     assert "device did not update" not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Revert of changes to Shelly config flow tests from https://github.com/home-assistant/core/pull/112789
The changes create a race condition that may fail the tests.

`FAILED tests/components/shelly/test_config_flow.py::test_zeroconf_already_configured_triggers_refresh - AssertionError: assert 3 == 2`

The log shows that reload happens twice:
```
2024-03-15 21:23:46.856 DEBUG    MainThread homeassistant.components.shelly:coordinator.py:531 Reconnecting to Shelly RPC Device - Test name
2024-03-15 21:23:46.856 DEBUG    MainThread homeassistant.components.shelly:update_coordinator.py:397 Finished fetching Test name data in 0.000 seconds (success: True)
2024-03-15 21:23:46.857 DEBUG    MainThread homeassistant.components.shelly:coordinator.py:531 Reconnecting to Shelly RPC Device - Test name
2024-03-15 21:23:46.858 DEBUG    MainThread homeassistant.components.shelly:update_coordinator.py:397 Finished fetching Test name data in 0.000 seconds (success: True)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
