### PR TITLE
Avoid creating tasks in homeassistant_alerts when the debouncer will not fire

### DIFF
--- a/homeassistant/components/homeassistant_alerts/__init__.py
+++ b/homeassistant/components/homeassistant_alerts/__init__.py
@@ -98,11 +98,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             function=coordinator.async_refresh,
         )
 
-        async def _component_loaded(_: Event) -> None:
-            await refresh_debouncer.async_call()
+        @callback
+        def _component_loaded(_: Event) -> None:
+            refresh_debouncer.async_schedule_call()
 
         await coordinator.async_refresh()
-        hass.bus.async_listen(EVENT_COMPONENT_LOADED, _component_loaded)
+        hass.bus.async_listen(
+            EVENT_COMPONENT_LOADED, _component_loaded, run_immediately=True
+        )
 
     async_at_start(hass, initial_refresh)
 

--- a/tests/components/homeassistant_alerts/test_init.py
+++ b/tests/components/homeassistant_alerts/test_init.py
@@ -323,33 +323,33 @@ async def test_alerts_refreshed_on_component_load(
     ):
         assert await async_setup_component(hass, DOMAIN, {})
 
-    client = await hass_ws_client(hass)
+        client = await hass_ws_client(hass)
 
-    await client.send_json({"id": 1, "type": "repairs/list_issues"})
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert msg["result"] == {
-        "issues": [
-            {
-                "breaks_in_ha_version": None,
-                "created": ANY,
-                "dismissed_version": None,
-                "domain": "homeassistant_alerts",
-                "ignored": False,
-                "is_fixable": False,
-                "issue_id": f"{alert}.markdown_{integration}",
-                "issue_domain": integration,
-                "learn_more_url": None,
-                "severity": "warning",
-                "translation_key": "alert",
-                "translation_placeholders": {
-                    "title": f"Title for {alert}",
-                    "description": f"Content for {alert}",
-                },
-            }
-            for alert, integration in initial_alerts
-        ]
-    }
+        await client.send_json({"id": 1, "type": "repairs/list_issues"})
+        msg = await client.receive_json()
+        assert msg["success"]
+        assert msg["result"] == {
+            "issues": [
+                {
+                    "breaks_in_ha_version": None,
+                    "created": ANY,
+                    "dismissed_version": None,
+                    "domain": "homeassistant_alerts",
+                    "ignored": False,
+                    "is_fixable": False,
+                    "issue_id": f"{alert}.markdown_{integration}",
+                    "issue_domain": integration,
+                    "learn_more_url": None,
+                    "severity": "warning",
+                    "translation_key": "alert",
+                    "translation_placeholders": {
+                        "title": f"Title for {alert}",
+                        "description": f"Content for {alert}",
+                    },
+                }
+                for alert, integration in initial_alerts
+            ]
+        }
 
     with patch(
         "homeassistant.components.homeassistant_alerts.__version__",
@@ -368,33 +368,33 @@ async def test_alerts_refreshed_on_component_load(
         freezer.tick(COMPONENT_LOADED_COOLDOWN + 1)
         await hass.async_block_till_done()
 
-    client = await hass_ws_client(hass)
+        client = await hass_ws_client(hass)
 
-    await client.send_json({"id": 2, "type": "repairs/list_issues"})
-    msg = await client.receive_json()
-    assert msg["success"]
-    assert msg["result"] == {
-        "issues": [
-            {
-                "breaks_in_ha_version": None,
-                "created": ANY,
-                "dismissed_version": None,
-                "domain": "homeassistant_alerts",
-                "ignored": False,
-                "is_fixable": False,
-                "issue_id": f"{alert}.markdown_{integration}",
-                "issue_domain": integration,
-                "learn_more_url": None,
-                "severity": "warning",
-                "translation_key": "alert",
-                "translation_placeholders": {
-                    "title": f"Title for {alert}",
-                    "description": f"Content for {alert}",
-                },
-            }
-            for alert, integration in late_alerts
-        ]
-    }
+        await client.send_json({"id": 2, "type": "repairs/list_issues"})
+        msg = await client.receive_json()
+        assert msg["success"]
+        assert msg["result"] == {
+            "issues": [
+                {
+                    "breaks_in_ha_version": None,
+                    "created": ANY,
+                    "dismissed_version": None,
+                    "domain": "homeassistant_alerts",
+                    "ignored": False,
+                    "is_fixable": False,
+                    "issue_id": f"{alert}.markdown_{integration}",
+                    "issue_domain": integration,
+                    "learn_more_url": None,
+                    "severity": "warning",
+                    "translation_key": "alert",
+                    "translation_placeholders": {
+                        "title": f"Title for {alert}",
+                        "description": f"Content for {alert}",
+                    },
+                }
+                for alert, integration in late_alerts
+            ]
+        }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch the debouncer call to use async_schedule_call since it will above creating a task when it will not fire


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
