### PR TITLE
Don't set 'assist in progess' flag on wake_word-end

### DIFF
--- a/homeassistant/components/wyoming/satellite.py
+++ b/homeassistant/components/wyoming/satellite.py
@@ -400,8 +400,6 @@ class WyomingSatellite:
             self.hass.add_job(self._client.write_event(Detect().event()))
         elif event.type == assist_pipeline.PipelineEventType.WAKE_WORD_END:
             # Wake word detection
-            self.device.set_is_active(True)
-
             # Inform client of wake word detection
             if event.data and (wake_word_output := event.data.get("wake_word_output")):
                 detection = Detection(

--- a/tests/components/wyoming/test_satellite.py
+++ b/tests/components/wyoming/test_satellite.py
@@ -298,9 +298,6 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
         assert mock_client.detection is not None
         assert mock_client.detection.name == "test_wake_word"
 
-        # "Assist in progress" sensor should be active now
-        assert device.is_active
-
         # Speech-to-text started
         pipeline_event_callback(
             assist_pipeline.PipelineEvent(
@@ -313,6 +310,9 @@ async def test_satellite_pipeline(hass: HomeAssistant) -> None:
 
         assert mock_client.transcribe is not None
         assert mock_client.transcribe.language == "en"
+
+        # "Assist in progress" sensor should be active now
+        assert device.is_active
 
         # Push in some audio
         mock_client.inject_event(


### PR DESCRIPTION
## Proposed change

The issue: when trying wyoming-satellite with `--vad` I noticed that the "assist in progress" sensor was constantly being turned on and instantly off again, a couple of times every minute, without really interacting with the satellite. I had thousands of these instant toggles in my history.

The satellite starts sending audio to HA when vad is triggered, and stops sending audio later if there is again silence. After some debugging I found that when audio is closed by the client the pipeline is stopped.
- This first triggers `wake_word-end` which turns the progress sensor on
- And immediately triggers `run-end` which turns the sensor off again.

It seems that `wake_word-end` just signifies the end of wake word detection, not necessarily a _successful_ detection, so it's not accurate to use it to turn the progress sensor on. But also, it just seems redundant to me, since the sensor is turned on anyway by `stt-start` (which is always accurate). Are there cases when a pipeline is considered "in progress" without triggering `stt-start`? Or is it a timing issue, we want to turn on the sensor sooner?

So I thought to create a small PR simply removing the line that turns on the sensor on `wake_word-end`, so that it is only turned on by `stt-start`. Even if I'm missing something it's still a good way to initiate the discussion to fix the issue.

(If we do want to keep the  `wake_word-end` behaviour, the alternative solution would be to flag pipelines for which the client stopped sending audio, and ignore `wake_word-end` only for them.)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
