### PR TITLE
Axis use entity description in switch platform

### DIFF
--- a/homeassistant/components/axis/switch.py
+++ b/homeassistant/components/axis/switch.py
@@ -1,16 +1,42 @@
 """Support for Axis switches."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from axis.models.event import Event, EventOperation, EventTopic
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import (
+    SwitchDeviceClass,
+    SwitchEntity,
+    SwitchEntityDescription,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AxisEventEntity
 from .hub import AxisHub
+
+
+@dataclass(frozen=True, kw_only=True)
+class AxisSwitchEntityDescription(SwitchEntityDescription):
+    """Axis switch entity description."""
+
+    event_topic: EventTopic
+    name_fn: Callable[[AxisHub, Event], str]
+    supported_fn: Callable[[AxisHub, Event], bool]
+
+
+ENTITY_DESCRIPTION = AxisSwitchEntityDescription(
+    key="Relay port control",
+    device_class=SwitchDeviceClass.OUTLET,
+    entity_category=EntityCategory.CONFIG,
+    event_topic=EventTopic.RELAY,
+    supported_fn=lambda hub, event: isinstance(int(event.id), int),
+    name_fn=lambda hub, event: hub.api.vapix.ports[event.id].name,
+)
 
 
 async def async_setup_entry(
@@ -24,7 +50,8 @@ async def async_setup_entry(
     @callback
     def async_create_entity(event: Event) -> None:
         """Create Axis switch entity."""
-        async_add_entities([AxisSwitch(event, hub)])
+        if ENTITY_DESCRIPTION.supported_fn(hub, event):
+            async_add_entities([AxisSwitch(hub, event)])
 
     hub.api.event.subscribe(
         async_create_entity,
@@ -36,11 +63,12 @@ async def async_setup_entry(
 class AxisSwitch(AxisEventEntity, SwitchEntity):
     """Representation of a Axis switch."""
 
-    def __init__(self, event: Event, hub: AxisHub) -> None:
+    entity_description = ENTITY_DESCRIPTION
+
+    def __init__(self, hub: AxisHub, event: Event) -> None:
         """Initialize the Axis switch."""
         super().__init__(event, hub)
-        if event.id and hub.api.vapix.ports[event.id].name:
-            self._attr_name = hub.api.vapix.ports[event.id].name
+        self._attr_name = self.entity_description.name_fn(hub, event) or self._attr_name
         self._attr_is_on = event.is_tripped
 
     @callback

--- a/homeassistant/components/axis/switch.py
+++ b/homeassistant/components/axis/switch.py
@@ -1,7 +1,8 @@
 """Support for Axis switches."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
 
 from axis.models.event import Event, EventOperation, EventTopic
@@ -21,21 +22,26 @@ from .hub import AxisHub
 
 
 @dataclass(frozen=True, kw_only=True)
-class AxisSwitchEntityDescription(SwitchEntityDescription):
+class AxisSwitchDescription(SwitchEntityDescription):
     """Axis switch entity description."""
 
     event_topic: EventTopic
+    """Event topic that provides state updates."""
     name_fn: Callable[[AxisHub, Event], str]
+    """Function providing the corresponding name to the event ID."""
     supported_fn: Callable[[AxisHub, Event], bool]
+    """Function validating if event is supported."""
 
 
-ENTITY_DESCRIPTION = AxisSwitchEntityDescription(
-    key="Relay port control",
-    device_class=SwitchDeviceClass.OUTLET,
-    entity_category=EntityCategory.CONFIG,
-    event_topic=EventTopic.RELAY,
-    supported_fn=lambda hub, event: isinstance(int(event.id), int),
-    name_fn=lambda hub, event: hub.api.vapix.ports[event.id].name,
+ENTITY_DESCRIPTIONS = (
+    AxisSwitchDescription(
+        key="Relay state control",
+        device_class=SwitchDeviceClass.OUTLET,
+        entity_category=EntityCategory.CONFIG,
+        event_topic=EventTopic.RELAY,
+        supported_fn=lambda hub, event: isinstance(int(event.id), int),
+        name_fn=lambda hub, event: hub.api.vapix.ports[event.id].name,
+    ),
 )
 
 
@@ -44,31 +50,39 @@ async def async_setup_entry(
     config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up a Axis switch."""
+    """Set up the Axis switch platform."""
     hub = AxisHub.get_hub(hass, config_entry)
 
     @callback
-    def async_create_entity(event: Event) -> None:
-        """Create Axis switch entity."""
-        if ENTITY_DESCRIPTION.supported_fn(hub, event):
-            async_add_entities([AxisSwitch(hub, event)])
+    def register_platform(descriptions: Iterable[AxisSwitchDescription]) -> None:
+        """Register entity platform to create entities on event initialized signal."""
 
-    hub.api.event.subscribe(
-        async_create_entity,
-        topic_filter=EventTopic.RELAY,
-        operation_filter=EventOperation.INITIALIZED,
-    )
+        @callback
+        def create_entity(description: AxisSwitchDescription, event: Event) -> None:
+            """Create Axis entity."""
+            if description.supported_fn(hub, event):
+                async_add_entities([AxisSwitch(hub, description, event)])
+
+        for description in descriptions:
+            hub.api.event.subscribe(
+                partial(create_entity, description),
+                topic_filter=description.event_topic,
+                operation_filter=EventOperation.INITIALIZED,
+            )
+
+    register_platform(ENTITY_DESCRIPTIONS)
 
 
 class AxisSwitch(AxisEventEntity, SwitchEntity):
     """Representation of a Axis switch."""
 
-    entity_description = ENTITY_DESCRIPTION
-
-    def __init__(self, hub: AxisHub, event: Event) -> None:
+    def __init__(
+        self, hub: AxisHub, description: AxisSwitchDescription, event: Event
+    ) -> None:
         """Initialize the Axis switch."""
         super().__init__(event, hub)
-        self._attr_name = self.entity_description.name_fn(hub, event) or self._attr_name
+        self.entity_description = description
+        self._attr_name = description.name_fn(hub, event) or self._attr_name
         self._attr_is_on = event.is_tripped
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve how to load switch entities in Axis integration by utilising entity description. Doing this separately per platform and then centralizing it.
Functionally same as https://github.com/home-assistant/core/pull/113602

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x]  The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
