### PR TITLE
Remove deprecated `hass.components` from image_processing platform

### DIFF
--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -178,7 +178,7 @@ class ImageProcessingEntity(Entity):
         """
         if self.camera_entity is None:
             _LOGGER.error(
-                "Camera entity (%s) not available to process image", self.camera_entity
+                "No camera entity id was set by the image processing entity",
             )
             return
 

--- a/homeassistant/components/image_processing/__init__.py
+++ b/homeassistant/components/image_processing/__init__.py
@@ -10,7 +10,7 @@ from typing import Any, Final, TypedDict, final
 
 import voluptuous as vol
 
-from homeassistant.components.camera import Image
+from homeassistant.components.camera import async_get_image
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
@@ -176,13 +176,16 @@ class ImageProcessingEntity(Entity):
 
         This method is a coroutine.
         """
-        camera = self.hass.components.camera
+        if self.camera_entity is None:
+            _LOGGER.error(
+                "Camera entity (%s) not available to process image", self.camera_entity
+            )
+            return
 
         try:
-            image: Image = await camera.async_get_image(
-                self.camera_entity, timeout=self.timeout
+            image = await async_get_image(
+                self.hass, self.camera_entity, timeout=self.timeout
             )
-
         except HomeAssistantError as err:
             _LOGGER.error("Error on receive image from entity: %s", err)
             return

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -103,7 +103,7 @@ async def test_get_image_from_camera(
 
 
 @patch(
-    "homeassistant.components.camera.async_get_image",
+    "homeassistant.components.image_processing.async_get_image",
     side_effect=HomeAssistantError(),
 )
 async def test_get_image_without_exists_camera(

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the image_processing component."""
-
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -180,3 +179,22 @@ async def test_face_event_call_no_confidence(
     assert event_data[0]["confidence"] == 98.34
     assert event_data[0]["gender"] == "male"
     assert event_data[0]["entity_id"] == "image_processing.demo_face"
+
+
+async def test_update_missing_camera(
+    hass: HomeAssistant,
+    aiohttp_unused_port_factory,
+    enable_custom_integrations: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test when entity does not set camera."""
+    await setup_image_processing(hass, aiohttp_unused_port_factory)
+
+    with patch(
+        "custom_components.test.image_processing.TestImageProcessing.camera_entity",
+        new_callable=PropertyMock(return_value=None),
+    ):
+        common.async_scan(hass, entity_id="image_processing.test")
+        await hass.async_block_till_done()
+
+    assert "No camera entity id was provided" in caplog.text

--- a/tests/components/image_processing/test_init.py
+++ b/tests/components/image_processing/test_init.py
@@ -197,4 +197,4 @@ async def test_update_missing_camera(
         common.async_scan(hass, entity_id="image_processing.test")
         await hass.async_block_till_done()
 
-    assert "No camera entity id was provided" in caplog.text
+    assert "No camera entity id was set by the image processing entity" in caplog.text


### PR DESCRIPTION
## Proposed change
SSIA, needed to add a if statement to make mypy happy. Needed also to change the patch in the test, as we import the function now.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
