### PR TITLE
Cache late imported async_get_exception_message for HomeAssistantError

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -18,7 +18,7 @@ def import_async_get_exception_message() -> (
 ):
     """Return a method that can fetch a translated exception message.
 
-    Defaults to English, requires translations to already be cached./
+    Defaults to English, requires translations to already be cached.
     """
 
     # pylint: disable-next=import-outside-toplevel

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -10,40 +10,23 @@ if TYPE_CHECKING:
     from .core import Context
 
 
-class _FunctionCache:
-    """Exception lookup function cache."""
-
-    async_get_exception_message: Callable[
-        [str, str, dict[str, str] | None], str
-    ] | None = None
+_function_cache: dict[str, Callable[[str, str, dict[str, str] | None], str]] = {}
 
 
-_function_cache = _FunctionCache()
+def import_async_get_exception_message() -> (
+    Callable[[str, str, dict[str, str] | None], str]
+):
+    """Return a method that can fetch a translated exception message.
 
-
-def async_get_exception_message(
-    translation_domain: str,
-    translation_key: str,
-    translation_placeholders: dict[str, str] | None = None,
-) -> str:
-    """Return a translated exception message.
-
-    Defaults to English, requires translations to already be cached.
+    Defaults to English, requires translations to already be cached./
     """
 
-    if _function_cache.async_get_exception_message is None:
-        # pylint: disable-next=import-outside-toplevel
-        from .helpers.translation import (
-            async_get_exception_message as async_get_exception_message_import,
-        )
-
-        _function_cache.async_get_exception_message = async_get_exception_message_import
-        # mark as hass event loop save callback function
-        setattr(_function_cache.async_get_exception_message, "_hass_callback", True)
-
-    return _function_cache.async_get_exception_message(
-        translation_domain, translation_key, translation_placeholders
+    # pylint: disable-next=import-outside-toplevel
+    from .helpers.translation import (
+        async_get_exception_message as async_get_exception_message_import,
     )
+
+    return async_get_exception_message_import
 
 
 class HomeAssistantError(Exception):
@@ -88,7 +71,12 @@ class HomeAssistantError(Exception):
             assert self.translation_key is not None
             assert self.translation_domain is not None
 
-        self._message = async_get_exception_message(
+        if "async_get_exception_message" not in _function_cache:
+            _function_cache[
+                "async_get_exception_message"
+            ] = import_async_get_exception_message()
+
+        self._message = _function_cache["async_get_exception_message"](
             self.translation_domain, self.translation_key, self.translation_placeholders
         )
         return self._message


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cache late imported async_get_exception_message for HomeAssistantError.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
