### PR TITLE
Remove deprecated `hass.components` from withings webhook tests

### DIFF
--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -16,7 +16,11 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.cloud import CloudNotAvailable
+from homeassistant.components.cloud import (
+    CloudNotAvailable,
+    async_active_subscription,
+    async_is_connected,
+)
 from homeassistant.components.webhook import async_generate_url
 from homeassistant.components.withings import CONFIG_SCHEMA, async_setup
 from homeassistant.components.withings.const import CONF_USE_WEBHOOK, DOMAIN
@@ -311,7 +315,7 @@ async def test_setup_with_cloudhook(
         "homeassistant.components.withings.webhook_generate_url"
     ):
         await setup_integration(hass, cloudhook_config_entry)
-        assert hass.components.cloud.async_active_subscription() is True
+        assert async_active_subscription(hass) is True
 
         assert (
             hass.config_entries.async_entries(DOMAIN)[0].data["cloudhook_url"]
@@ -356,7 +360,7 @@ async def test_removing_entry_with_cloud_unavailable(
         "homeassistant.components.withings.webhook_generate_url",
     ):
         await setup_integration(hass, cloudhook_config_entry)
-        assert hass.components.cloud.async_active_subscription() is True
+        assert async_active_subscription(hass) is True
 
         await hass.async_block_till_done()
         assert hass.config_entries.async_entries(DOMAIN)
@@ -397,8 +401,8 @@ async def test_setup_with_cloud(
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)
 
-        assert hass.components.cloud.async_active_subscription() is True
-        assert hass.components.cloud.async_is_connected() is True
+        assert async_active_subscription(hass) is True
+        assert async_is_connected(hass) is True
         fake_create_cloudhook.assert_called_once()
         fake_delete_cloudhook.assert_called_once()
 
@@ -476,8 +480,8 @@ async def test_cloud_disconnect(
     ):
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)
-        assert hass.components.cloud.async_active_subscription() is True
-        assert hass.components.cloud.async_is_connected() is True
+        assert async_active_subscription(hass) is True
+        assert async_is_connected(hass) is True
 
         await hass.async_block_till_done()
 

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -16,11 +16,8 @@ import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.cloud import (
-    CloudNotAvailable,
-    async_active_subscription,
-    async_is_connected,
-)
+from homeassistant.components import cloud
+from homeassistant.components.cloud import CloudNotAvailable
 from homeassistant.components.webhook import async_generate_url
 from homeassistant.components.withings import CONFIG_SCHEMA, async_setup
 from homeassistant.components.withings.const import CONF_USE_WEBHOOK, DOMAIN
@@ -302,9 +299,7 @@ async def test_setup_with_cloudhook(
         "homeassistant.components.cloud.async_is_logged_in", return_value=True
     ), patch(
         "homeassistant.components.cloud.async_is_connected", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_active_subscription", return_value=True
-    ), patch(
+    ), patch.object(cloud, "async_active_subscription", return_value=True), patch(
         "homeassistant.components.cloud.async_create_cloudhook",
         return_value="https://hooks.nabu.casa/ABCD",
     ) as fake_create_cloudhook, patch(
@@ -315,7 +310,8 @@ async def test_setup_with_cloudhook(
         "homeassistant.components.withings.webhook_generate_url"
     ):
         await setup_integration(hass, cloudhook_config_entry)
-        assert async_active_subscription(hass) is True
+
+        assert cloud.async_active_subscription(hass) is True
 
         assert (
             hass.config_entries.async_entries(DOMAIN)[0].data["cloudhook_url"]
@@ -346,9 +342,7 @@ async def test_removing_entry_with_cloud_unavailable(
         "homeassistant.components.cloud.async_is_logged_in", return_value=True
     ), patch(
         "homeassistant.components.cloud.async_is_connected", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_active_subscription", return_value=True
-    ), patch(
+    ), patch.object(cloud, "async_active_subscription", return_value=True), patch(
         "homeassistant.components.cloud.async_create_cloudhook",
         return_value="https://hooks.nabu.casa/ABCD",
     ), patch(
@@ -360,7 +354,8 @@ async def test_removing_entry_with_cloud_unavailable(
         "homeassistant.components.withings.webhook_generate_url",
     ):
         await setup_integration(hass, cloudhook_config_entry)
-        assert async_active_subscription(hass) is True
+
+        assert cloud.async_active_subscription(hass) is True
 
         await hass.async_block_till_done()
         assert hass.config_entries.async_entries(DOMAIN)
@@ -384,10 +379,8 @@ async def test_setup_with_cloud(
 
     with patch(
         "homeassistant.components.cloud.async_is_logged_in", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_is_connected", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_active_subscription", return_value=True
+    ), patch.object(cloud, "async_is_connected", return_value=True), patch.object(
+        cloud, "async_active_subscription", return_value=True
     ), patch(
         "homeassistant.components.cloud.async_create_cloudhook",
         return_value="https://hooks.nabu.casa/ABCD",
@@ -401,8 +394,8 @@ async def test_setup_with_cloud(
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)
 
-        assert async_active_subscription(hass) is True
-        assert async_is_connected(hass) is True
+        assert cloud.async_active_subscription(hass) is True
+        assert cloud.async_is_connected(hass) is True
         fake_create_cloudhook.assert_called_once()
         fake_delete_cloudhook.assert_called_once()
 
@@ -464,10 +457,8 @@ async def test_cloud_disconnect(
 
     with patch(
         "homeassistant.components.cloud.async_is_logged_in", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_is_connected", return_value=True
-    ), patch(
-        "homeassistant.components.cloud.async_active_subscription", return_value=True
+    ), patch.object(cloud, "async_is_connected", return_value=True), patch.object(
+        cloud, "async_active_subscription", return_value=True
     ), patch(
         "homeassistant.components.cloud.async_create_cloudhook",
         return_value="https://hooks.nabu.casa/ABCD",
@@ -480,8 +471,9 @@ async def test_cloud_disconnect(
     ):
         await setup_integration(hass, webhook_config_entry)
         await prepare_webhook_setup(hass, freezer)
-        assert async_active_subscription(hass) is True
-        assert async_is_connected(hass) is True
+
+        assert cloud.async_active_subscription(hass) is True
+        assert cloud.async_is_connected(hass) is True
 
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Proposed change
Remove the deprecated use of `hass.components` from withings webhook tests

~WIP: Wanted to see if CI has the same errors as locally~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
