### PR TITLE
Bump aioraven to 0.5.2

### DIFF
--- a/homeassistant/components/rainforest_raven/manifest.json
+++ b/homeassistant/components/rainforest_raven/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": ["usb"],
   "documentation": "https://www.home-assistant.io/integrations/rainforest_raven",
   "iot_class": "local_polling",
-  "requirements": ["aioraven==0.5.1"],
+  "requirements": ["aioraven==0.5.2"],
   "usb": [
     {
       "vid": "0403",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -347,7 +347,7 @@ aiopyarr==23.4.0
 aioqsw==0.3.5
 
 # homeassistant.components.rainforest_raven
-aioraven==0.5.1
+aioraven==0.5.2
 
 # homeassistant.components.recollect_waste
 aiorecollect==2023.09.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -320,7 +320,7 @@ aiopyarr==23.4.0
 aioqsw==0.3.5
 
 # homeassistant.components.rainforest_raven
-aioraven==0.5.1
+aioraven==0.5.2
 
 # homeassistant.components.recollect_waste
 aiorecollect==2023.09.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump aioraven to 0.5.2
Upstream diff: https://github.com/cottsay/aioraven/compare/0.5.1..0.5.2
Upstream changelog: https://github.com/cottsay/aioraven/blob/0.5.2/CHANGELOG.md#052-2024-03-17

> Defer feeding XML data until we likely trigger an event
>
> Recent changes to expat, the XML parser behind the Python XMLPullParser,
> utilize a backoff when feeding the parser in small chunks which don't
> (yet) constitute something interesting. Unfortunately, this could result
> in the parser sitting on a completed payload waiting for more data
> before it attempts parsing.
>
> The safest mitigation I can find is to just wait until we get a '>'
> before feeding the parser, which should hopefully mean that we'll never
> trigger the backoff.

For my personal use I have Home Assistant Core deployed directly to a server. Under those conditions I was never able to trigger this issue. However, an under-provisioned Home Assistant OS VM seems to occasionally break what is normally a single serial read operation into chunks of size 8. These conditions exposed the misbehavior when combined with the recent changes to the expat parser.

While this isn't directly a fix for #113473, it should address more of the data gaps reported there.

I'd like this fix to be considered for inclusion in the next 2024.3 patch release.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
