### PR TITLE
Move legacy device_tracker setup to a tracked task

### DIFF
--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -69,16 +69,7 @@ def is_on(hass: HomeAssistant, entity_id: str) -> bool:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the device tracker."""
-
-    # We need to add the component here break the deadlock
-    # when setting up integrations from config entries as
-    # they would otherwise wait for the device tracker to be
-    # setup and thus the config entries would not be able to
-    # setup their platforms.
-    hass.config.components.add(DOMAIN)
-
     await async_setup_legacy_integration(hass, config)
-
     return True
 
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -55,6 +55,7 @@ from homeassistant.setup import (
     async_start_setup,
 )
 from homeassistant.util import dt as dt_util
+from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.yaml import dump
 
 from .const import (
@@ -215,10 +216,12 @@ async def async_setup_integration(hass: HomeAssistant, config: ConfigType) -> No
         DOMAIN, SERVICE_SEE, async_see_service, SERVICE_SEE_PAYLOAD_SCHEMA
     )
 
-    # The platforms load in a tracked task to ensure
-    # device tracker setup can continue and config
-    # entry integrations are not waiting for
-    # legacy device tracker platforms to be set up.
+    #
+    # The platforms load in a non-awaited tracked task
+    # to ensure device tracker setup can continue and config
+    # entry integrations are not waiting for legacy device
+    # tracker platforms to be set up.
+    #
     hass.async_create_task(
         _async_setup_legacy_integration(hass, config, tracker), eager_start=True
     )
@@ -231,7 +234,7 @@ async def _async_setup_legacy_integration(
     legacy_platforms = await async_extract_config(hass, config)
 
     setup_tasks = [
-        asyncio.create_task(legacy_platform.async_setup_legacy(hass, tracker))
+        create_eager_task(legacy_platform.async_setup_legacy(hass, tracker))
         for legacy_platform in legacy_platforms
     ]
 

--- a/tests/components/bluetooth_le_tracker/test_device_tracker.py
+++ b/tests/components/bluetooth_le_tracker/test_device_tracker.py
@@ -103,6 +103,7 @@ async def test_do_not_see_device_if_time_not_updated(
             CONF_CONSIDER_HOME: timedelta(minutes=10),
         }
         result = await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
         assert result
 
         # Tick until device seen enough times for to be registered for tracking
@@ -246,6 +247,7 @@ async def test_preserve_new_tracked_device_name(
             CONF_TRACK_NEW: True,
         }
         assert await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
 
         # Seen once here; return without name when seen subsequent times
         device = BluetoothServiceInfoBleak(
@@ -315,6 +317,7 @@ async def test_tracking_battery_times_out(
             CONF_TRACK_NEW: True,
         }
         result = await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
         assert result
 
         # Tick until device seen enough times for to be registered for tracking
@@ -449,6 +452,7 @@ async def test_tracking_battery_successful(
             CONF_TRACK_NEW: True,
         }
         result = await async_setup_component(hass, DOMAIN, {DOMAIN: config})
+        await hass.async_block_till_done()
         assert result
 
         # Tick until device seen enough times for to be registered for tracking

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -310,6 +310,7 @@ async def test_entity_attributes(
 
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
 
     attrs = hass.states.get(entity_id).attributes
 

--- a/tests/components/meraki/test_device_tracker.py
+++ b/tests/components/meraki/test_device_tracker.py
@@ -21,8 +21,9 @@ from homeassistant.setup import async_setup_component
 def meraki_client(event_loop, hass, hass_client):
     """Meraki mock client."""
     loop = event_loop
-    assert loop.run_until_complete(
-        async_setup_component(
+
+    async def setup_and_wait():
+        result = await async_setup_component(
             hass,
             device_tracker.DOMAIN,
             {
@@ -33,8 +34,10 @@ def meraki_client(event_loop, hass, hass_client):
                 }
             },
         )
-    )
+        await hass.async_block_till_done()
+        return result
 
+    assert loop.run_until_complete(setup_and_wait())
     return loop.run_until_complete(hass_client())
 
 

--- a/tests/components/mqtt_json/test_device_tracker.py
+++ b/tests/components/mqtt_json/test_device_tracker.py
@@ -61,6 +61,8 @@ async def test_setup_fails_without_mqtt_being_setup(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
+    await hass.async_block_till_done()
+
     assert "MQTT integration is not available" in caplog.text
 
 
@@ -83,6 +85,7 @@ async def test_ensure_device_tracker_platform_validation(hass: HomeAssistant) ->
             DT_DOMAIN,
             {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
         )
+        await hass.async_block_till_done()
         assert mock_sp.call_count == 1
 
 
@@ -97,6 +100,7 @@ async def test_json_message(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
+    await hass.async_block_till_done()
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     state = hass.states.get("device_tracker.zanzito")
@@ -117,6 +121,7 @@ async def test_non_json_message(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
+    await hass.async_block_till_done()
 
     caplog.set_level(logging.ERROR)
     caplog.clear()
@@ -138,6 +143,7 @@ async def test_incomplete_message(
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: topic}}},
     )
+    await hass.async_block_till_done()
 
     caplog.set_level(logging.ERROR)
     caplog.clear()
@@ -161,6 +167,8 @@ async def test_single_level_wildcard_topic(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
+    await hass.async_block_till_done()
+
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     state = hass.states.get("device_tracker.zanzito")
@@ -180,6 +188,8 @@ async def test_multi_level_wildcard_topic(hass: HomeAssistant) -> None:
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
+    await hass.async_block_till_done()
+
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     state = hass.states.get("device_tracker.zanzito")
@@ -200,6 +210,8 @@ async def test_single_level_wildcard_topic_not_matching(hass: HomeAssistant) -> 
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
+    await hass.async_block_till_done()
+
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id) is None
@@ -218,6 +230,8 @@ async def test_multi_level_wildcard_topic_not_matching(hass: HomeAssistant) -> N
         DT_DOMAIN,
         {DT_DOMAIN: {CONF_PLATFORM: "mqtt_json", "devices": {dev_id: subscription}}},
     )
+    await hass.async_block_till_done()
+
     async_fire_mqtt_message(hass, topic, location)
     await hass.async_block_till_done()
     assert hass.states.get(entity_id) is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Legacy `device_tracker` platforms are now loaded in a tracked task which allows anything waiting on `device_tracker` (such as a config entry that uses the device_tracker platform) to proceed.  This makes the `device_tracker` base platform similar to how the other entity platforms setups work in that it does not wait for the platforms to finish `async_setup` https://github.com/home-assistant/core/blob/fcdb7039f9b26ee09c43d94d5f59b0378f9e478c/homeassistant/helpers/entity_component.py#L151

This also allows us to remove the deadlock workaround of adding device_tracker to `hass.config.components` in its setup.

Once I did this I realized `device_tracker` really did have a long startup time on my system and it wasn't because it was waiting for legacy platforms, it was because the `known_devices.yaml` had grown to a large size and was taking a long time to load.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
