### PR TITLE
Move legacy notify setup to use tracked tasks

### DIFF
--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -42,6 +42,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
 
     for setup in async_setup_legacy(hass, config):
+        # Tasks are created as tracked tasks to ensure startup
+        # waits for them to finish, but we explicitly do not
+        # want to wait for them to finish here because we want
+        # any config entries that use notify as a base platform
+        # to be able to start with out having to wait for the
+        # legacy platforms to finish setting up.
         hass.async_create_task(setup, eager_start=True)
 
     async def persistent_notification(service: ServiceCall) -> None:

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
-
 import voluptuous as vol
 
 import homeassistant.components.persistent_notification as pn
@@ -43,19 +41,8 @@ PLATFORM_SCHEMA = vol.Schema(
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the notify services."""
 
-    platform_setups = async_setup_legacy(hass, config)
-
-    # We need to add the component here break the deadlock
-    # when setting up integrations from config entries as
-    # they would otherwise wait for notify to be
-    # setup and thus the config entries would not be able to
-    # setup their platforms, but we need to do it after
-    # the dispatcher is connected so we don't miss integrations
-    # that are registered before the dispatcher is connected
-    hass.config.components.add(DOMAIN)
-
-    if platform_setups:
-        await asyncio.wait([asyncio.create_task(setup) for setup in platform_setups])
+    for setup in async_setup_legacy(hass, config):
+        hass.async_create_task(setup, eager_start=True)
 
     async def persistent_notification(service: ServiceCall) -> None:
         """Send notification via the built-in persistent_notify integration."""

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -20,6 +20,7 @@ async def test_bad_config(hass: HomeAssistant) -> None:
     config = {notify.DOMAIN: {"name": "test", "platform": "file"}}
     with assert_setup_component(0) as handle_config:
         assert await async_setup_component(hass, notify.DOMAIN, config)
+        await hass.async_block_till_done()
     assert not handle_config[notify.DOMAIN]
 
 
@@ -49,6 +50,7 @@ async def test_notify_file(
                 }
             },
         )
+        await hass.async_block_till_done()
     assert handle_config[notify.DOMAIN]
 
     freezer.move_to(dt_util.utcnow())

--- a/tests/components/tts/test_notify.py
+++ b/tests/components/tts/test_notify.py
@@ -49,6 +49,7 @@ async def test_setup_legacy_platform(hass: HomeAssistant) -> None:
     }
     with assert_setup_component(1, notify.DOMAIN):
         assert await async_setup_component(hass, notify.DOMAIN, config)
+        await hass.async_block_till_done()
 
     assert hass.services.has_service(notify.DOMAIN, "tts_test")
 
@@ -65,6 +66,7 @@ async def test_setup_platform(hass: HomeAssistant) -> None:
     }
     with assert_setup_component(1, notify.DOMAIN):
         assert await async_setup_component(hass, notify.DOMAIN, config)
+        await hass.async_block_till_done()
 
     assert hass.services.has_service(notify.DOMAIN, "tts_test")
 
@@ -80,6 +82,7 @@ async def test_setup_platform_missing_key(hass: HomeAssistant) -> None:
     }
     with assert_setup_component(0, notify.DOMAIN):
         assert await async_setup_component(hass, notify.DOMAIN, config)
+        await hass.async_block_till_done()
 
     assert not hass.services.has_service(notify.DOMAIN, "tts_test")
 
@@ -106,6 +109,8 @@ async def test_setup_legacy_service(hass: HomeAssistant) -> None:
 
     with assert_setup_component(1, notify.DOMAIN):
         assert await async_setup_component(hass, notify.DOMAIN, config)
+
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         notify.DOMAIN,
@@ -141,6 +146,8 @@ async def test_setup_service(
 
     with assert_setup_component(1, notify.DOMAIN):
         assert await async_setup_component(hass, notify.DOMAIN, config)
+
+    await hass.async_block_till_done()
 
     await hass.services.async_call(
         notify.DOMAIN,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Legacy `notify` platforms are now loaded in a tracked task which allows anything waiting on `notify` (such as a config entry that uses the notify platform) to proceed.  This makes the `device_tracker` base platform similar to how the other entity platforms setups work in that it does not wait for the platforms to finish `async_setup` https://github.com/home-assistant/core/blob/fcdb7039f9b26ee09c43d94d5f59b0378f9e478c/homeassistant/helpers/entity_component.py#L151

This also allows us to remove the deadlock workaround of adding notify to `hass.config.components` in its setup.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
