### PR TITLE
Fix unknown values in onewire

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -144,6 +144,8 @@ class OneWireBinarySensor(OneWireEntity, BinarySensorEntity):
     entity_description: OneWireBinarySensorEntityDescription
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if sensor is on."""
+        if self._state is None:
+            return None
         return bool(self._state)

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -208,8 +208,10 @@ class OneWireSwitch(OneWireEntity, SwitchEntity):
     entity_description: OneWireSwitchEntityDescription
 
     @property
-    def is_on(self) -> bool:
-        """Return true if sensor is on."""
+    def is_on(self) -> bool | None:
+        """Return true if switch is on."""
+        if self._state is None:
+            return None
         return bool(self._state)
 
     def turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -156,7 +156,9 @@ MOCK_OWPROXY_DEVICES = {
             {ATTR_INJECT_READS: b"    1"},
             {ATTR_INJECT_READS: b"    0"},
             {ATTR_INJECT_READS: b"    0"},
-            {ATTR_INJECT_READS: b"    0"},
+            {
+                ATTR_INJECT_READS: ProtocolError,
+            },
             {ATTR_INJECT_READS: b"    0"},
             {ATTR_INJECT_READS: b"    0"},
             {ATTR_INJECT_READS: b"    0"},
@@ -166,7 +168,9 @@ MOCK_OWPROXY_DEVICES = {
             {ATTR_INJECT_READS: b"    1"},
             {ATTR_INJECT_READS: b"    0"},
             {ATTR_INJECT_READS: b"    1"},
-            {ATTR_INJECT_READS: b"    0"},
+            {
+                ATTR_INJECT_READS: ProtocolError,
+            },
             {ATTR_INJECT_READS: b"    1"},
             {ATTR_INJECT_READS: b"    0"},
             {ATTR_INJECT_READS: b"    1"},

--- a/tests/components/onewire/snapshots/test_binary_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_binary_sensor.ambr
@@ -851,13 +851,13 @@
       'attributes': ReadOnlyDict({
         'device_file': '/29.111111111111/sensed.3',
         'friendly_name': '29.111111111111 Sensed 3',
-        'raw_value': 0.0,
+        'raw_value': None,
       }),
       'context': <ANY>,
       'entity_id': 'binary_sensor.29_111111111111_sensed_3',
       'last_changed': <ANY>,
       'last_updated': <ANY>,
-      'state': 'off',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({

--- a/tests/components/onewire/snapshots/test_switch.ambr
+++ b/tests/components/onewire/snapshots/test_switch.ambr
@@ -1271,13 +1271,13 @@
       'attributes': ReadOnlyDict({
         'device_file': '/29.111111111111/PIO.3',
         'friendly_name': '29.111111111111 Programmed input-output 3',
-        'raw_value': 0.0,
+        'raw_value': None,
       }),
       'context': <ANY>,
       'entity_id': 'switch.29_111111111111_programmed_input_output_3',
       'last_changed': <ANY>,
       'last_updated': <ANY>,
-      'state': 'off',
+      'state': 'unknown',
     }),
     StateSnapshot({
       'attributes': ReadOnlyDict({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I spotted this whilst working on a sensor with dodgy wiring.

If there is an error on the reading of the value, the base entity sets the underlying value to `None`, but then the binary sensor and the switch plaforms convert it back to `False`/`off` instead of keeping the `None`/`unknown` value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
