### PR TITLE
Add base entity to romy integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1135,6 +1135,7 @@ omit =
     homeassistant/components/rocketchat/notify.py
     homeassistant/components/romy/__init__.py
     homeassistant/components/romy/coordinator.py
+    homeassistant/components/romy/entity.py
     homeassistant/components/romy/vacuum.py
     homeassistant/components/roomba/__init__.py
     homeassistant/components/roomba/binary_sensor.py

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -13,9 +13,10 @@ class RomyEntity(CoordinatorEntity[RomyVacuumCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, romy: RomyRobot) -> None:
+    def __init__(self, coordinator: RomyVacuumCoordinator) -> None:
         """Initialize ROMY entity."""
-        self.romy = romy
+        super().__init__(coordinator)
+        self.romy = coordinator.romy
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, romy.unique_id)},
             manufacturer="ROMY",

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -1,0 +1,24 @@
+"""Base entity for ROMY."""
+
+from romy import RomyRobot
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN
+
+
+class RomyEntity(Entity):
+    """Base ROMY entity."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, romy: RomyRobot) -> None:
+        """Initialize ROMY entity."""
+        self.romy = romy
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, romy.unique_id)},
+            manufacturer="ROMY",
+            name=romy.name,
+            model=romy.model,
+        )

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -1,11 +1,11 @@
 """Base entity for ROMY."""
 
-from romy import RomyRobot
 
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import RomyVacuumCoordinator
 
 
 class RomyEntity(CoordinatorEntity[RomyVacuumCoordinator]):
@@ -18,8 +18,8 @@ class RomyEntity(CoordinatorEntity[RomyVacuumCoordinator]):
         super().__init__(coordinator)
         self.romy = coordinator.romy
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, romy.unique_id)},
+            identifiers={(DOMAIN, self.romy.unique_id)},
             manufacturer="ROMY",
-            name=romy.name,
-            model=romy.model,
+            name=self.romy.name,
+            model=self.romy.model,
         )

--- a/homeassistant/components/romy/entity.py
+++ b/homeassistant/components/romy/entity.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.entity import Entity
 from .const import DOMAIN
 
 
-class RomyEntity(Entity):
+class RomyEntity(CoordinatorEntity[RomyVacuumCoordinator]):
     """Base ROMY entity."""
 
     _attr_has_entity_name = True

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -70,8 +70,7 @@ class RomyVacuumEntity(
         coordinator: RomyVacuumCoordinator,
     ) -> None:
         """Initialize the ROMY Robot."""
-        RomyEntity.__init__(self, coordinator.romy)
-        CoordinatorEntity.__init__(self, coordinator)
+        super().__init__(coordinator)
         self._attr_unique_id = self.romy.unique_id
 
     @callback

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -6,17 +6,15 @@ https://home-assistant.io/components/vacuum.romy/.
 
 from typing import Any
 
-from romy import RomyRobot
-
 from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOGGER
 from .coordinator import RomyVacuumCoordinator
+from .entity import RomyEntity
 
 FAN_SPEED_NONE = "default"
 FAN_SPEED_NORMAL = "normal"
@@ -55,32 +53,26 @@ async def async_setup_entry(
     """Set up ROMY vacuum cleaner."""
 
     coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([RomyVacuumEntity(coordinator, coordinator.romy)], True)
+    async_add_entities([RomyVacuumEntity(coordinator)], True)
 
 
-class RomyVacuumEntity(CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity):
+class RomyVacuumEntity(
+    RomyEntity, CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity
+):
     """Representation of a ROMY vacuum cleaner robot."""
 
-    _attr_has_entity_name = True
-    _attr_name = None
     _attr_supported_features = SUPPORT_ROMY_ROBOT
     _attr_fan_speed_list = FAN_SPEEDS
+    _attr_name = None
 
     def __init__(
         self,
         coordinator: RomyVacuumCoordinator,
-        romy: RomyRobot,
     ) -> None:
         """Initialize the ROMY Robot."""
-        super().__init__(coordinator)
-        self.romy = romy
+        RomyEntity.__init__(self, coordinator.romy)
+        CoordinatorEntity.__init__(self, coordinator)
         self._attr_unique_id = self.romy.unique_id
-        self._device_info = DeviceInfo(
-            identifiers={(DOMAIN, romy.unique_id)},
-            manufacturer="ROMY",
-            name=romy.name,
-            model=romy.model,
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -10,7 +10,6 @@ from homeassistant.components.vacuum import StateVacuumEntity, VacuumEntityFeatu
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOGGER
 from .coordinator import RomyVacuumCoordinator
@@ -56,9 +55,7 @@ async def async_setup_entry(
     async_add_entities([RomyVacuumEntity(coordinator)])
 
 
-class RomyVacuumEntity(
-    RomyEntity, StateVacuumEntity
-):
+class RomyVacuumEntity(RomyEntity, StateVacuumEntity):
     """Representation of a ROMY vacuum cleaner robot."""
 
     _attr_supported_features = SUPPORT_ROMY_ROBOT

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -53,7 +53,7 @@ async def async_setup_entry(
     """Set up ROMY vacuum cleaner."""
 
     coordinator: RomyVacuumCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    async_add_entities([RomyVacuumEntity(coordinator)], True)
+    async_add_entities([RomyVacuumEntity(coordinator)])
 
 
 class RomyVacuumEntity(

--- a/homeassistant/components/romy/vacuum.py
+++ b/homeassistant/components/romy/vacuum.py
@@ -57,7 +57,7 @@ async def async_setup_entry(
 
 
 class RomyVacuumEntity(
-    RomyEntity, CoordinatorEntity[RomyVacuumCoordinator], StateVacuumEntity
+    RomyEntity, StateVacuumEntity
 ):
     """Representation of a ROMY vacuum cleaner robot."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
created base entity as cleanup to avoid code duplication for other platform which will be added in following branches:
romy_binary_sensor: https://github.com/home-assistant/core/pull/112998
romy_sensor: https://github.com/home-assistant/core/pull/112388

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
