### PR TITLE
Add WebSocket support for handling labels on areas registry

### DIFF
--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -42,6 +42,7 @@ def websocket_list_areas(
         vol.Optional("aliases"): list,
         vol.Optional("floor_id"): str,
         vol.Optional("icon"): str,
+        vol.Optional("labels"): list,
         vol.Required("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
     }
@@ -63,6 +64,10 @@ def websocket_create_area(
     if "aliases" in data:
         # Convert aliases to a set
         data["aliases"] = set(data["aliases"])
+
+    if "labels" in data:
+        # Convert labels to a set
+        data["labels"] = set(data["labels"])
 
     try:
         entry = registry.async_create(**data)
@@ -103,6 +108,7 @@ def websocket_delete_area(
         vol.Required("area_id"): str,
         vol.Optional("floor_id"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(str, None),
+        vol.Optional("labels"): list,
         vol.Optional("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
     }
@@ -125,6 +131,10 @@ def websocket_update_area(
         # Convert aliases to a set
         data["aliases"] = set(data["aliases"])
 
+    if "labels" in data:
+        # Convert labels to a set
+        data["labels"] = set(data["labels"])
+
     try:
         entry = registry.async_update(**data)
     except ValueError as err:
@@ -141,6 +151,7 @@ def _entry_dict(entry: AreaEntry) -> dict[str, Any]:
         "area_id": entry.id,
         "floor_id": entry.floor_id,
         "icon": entry.icon,
+        "labels": list(entry.labels),
         "name": entry.name,
         "picture": entry.picture,
     }

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -108,7 +108,7 @@ def websocket_delete_area(
         vol.Required("area_id"): str,
         vol.Optional("floor_id"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(str, None),
-        vol.Optional("labels"): [str]],
+        vol.Optional("labels"): [str],
         vol.Optional("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
     }

--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -42,7 +42,7 @@ def websocket_list_areas(
         vol.Optional("aliases"): list,
         vol.Optional("floor_id"): str,
         vol.Optional("icon"): str,
-        vol.Optional("labels"): list,
+        vol.Optional("labels"): [str],
         vol.Required("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
     }
@@ -108,7 +108,7 @@ def websocket_delete_area(
         vol.Required("area_id"): str,
         vol.Optional("floor_id"): vol.Any(str, None),
         vol.Optional("icon"): vol.Any(str, None),
-        vol.Optional("labels"): list,
+        vol.Optional("labels"): [str]],
         vol.Optional("name"): str,
         vol.Optional("picture"): vol.Any(str, None),
     }

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -31,6 +31,7 @@ async def test_list_areas(
         icon="mdi:garage",
         picture="/image/example.png",
         floor_id="first_floor",
+        labels={"label_1", "label_2"},
     )
 
     await client.send_json_auto_id({"type": "config/area_registry/list"})
@@ -42,6 +43,7 @@ async def test_list_areas(
             "area_id": area1.id,
             "floor_id": None,
             "icon": None,
+            "labels": [],
             "name": "mock 1",
             "picture": None,
         },
@@ -50,6 +52,7 @@ async def test_list_areas(
             "area_id": area2.id,
             "floor_id": "first_floor",
             "icon": "mdi:garage",
+            "labels": unordered(["label_1", "label_2"]),
             "name": "mock 2",
             "picture": "/image/example.png",
         },
@@ -72,6 +75,7 @@ async def test_create_area(
         "area_id": ANY,
         "floor_id": None,
         "icon": None,
+        "labels": [],
         "name": "mock",
         "picture": None,
     }
@@ -83,6 +87,7 @@ async def test_create_area(
             "aliases": ["alias_1", "alias_2"],
             "floor_id": "first_floor",
             "icon": "mdi:garage",
+            "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
             "type": "config/area_registry/create",
@@ -96,6 +101,7 @@ async def test_create_area(
         "area_id": ANY,
         "floor_id": "first_floor",
         "icon": "mdi:garage",
+        "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
     }
@@ -166,6 +172,7 @@ async def test_update_area(
             "area_id": area.id,
             "floor_id": "first_floor",
             "icon": "mdi:garage",
+            "labels": ["label_1", "label_2"],
             "name": "mock 2",
             "picture": "/image/example.png",
             "type": "config/area_registry/update",
@@ -179,6 +186,7 @@ async def test_update_area(
         "area_id": area.id,
         "floor_id": "first_floor",
         "icon": "mdi:garage",
+        "labels": unordered(["label_1", "label_2"]),
         "name": "mock 2",
         "picture": "/image/example.png",
     }
@@ -190,6 +198,7 @@ async def test_update_area(
             "area_id": area.id,
             "floor_id": None,
             "icon": None,
+            "labels": [],
             "picture": None,
             "type": "config/area_registry/update",
         }
@@ -202,6 +211,7 @@ async def test_update_area(
         "area_id": area.id,
         "floor_id": None,
         "icon": None,
+        "labels": [],
         "name": "mock 2",
         "picture": None,
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add WebSocket support to area registry for setting/getting labels on areas.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
