### PR TITLE
Enable Ruff rule PT007

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -704,9 +704,6 @@ voluptuous = "vol"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
-parametrize-names-type = "tuple"
-parametrize-values-row-type = "tuple"
-parametrize-values-type = "list"
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "async_timeout".msg = "use asyncio.timeout instead"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -658,6 +658,7 @@ ignore = [
     "PLR0915", # Too many statements ({statements} > {max_statements})
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
     "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+    "PT004", # Fixture {fixture} does not return anything, add leading underscore
     "SIM102", # Use a single if statement instead of nested if statements
     "SIM108", # Use ternary operator {contents} instead of if-else-block
     "SIM115", # Use context handler for opening files
@@ -682,8 +683,6 @@ ignore = [
     "PLE0605",
 
     # temporarily disabled
-    "PT004",
-    "PT007",
     "PT011",
     "PT018",
     "PT012",
@@ -705,6 +704,9 @@ voluptuous = "vol"
 
 [tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
+parametrize-names-type = "tuple"
+parametrize-values-row-type = "tuple"
+parametrize-values-type = "list"
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
 "async_timeout".msg = "use asyncio.timeout instead"

--- a/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_config_flow.py
@@ -14,7 +14,7 @@ from tests.common import MockConfigEntry
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, platform
 ) -> None:
@@ -62,7 +62,7 @@ def get_suggested(schema, key):
     raise Exception
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_options(hass: HomeAssistant, platform) -> None:
     """Test reconfiguring."""
     input_sensor_1_entity_id = "sensor.input1"

--- a/script/scaffold/templates/config_flow_helper/tests/test_init.py
+++ b/script/scaffold/templates/config_flow_helper/tests/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
     platform: str,

--- a/script/scaffold/templates/device_action/tests/test_device_action.py
+++ b/script/scaffold/templates/device_action/tests/test_device_action.py
@@ -50,12 +50,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/airly/test_init.py
+++ b/tests/components/airly/test_init.py
@@ -196,7 +196,7 @@ async def test_unload_entry(
     assert not hass.data.get(DOMAIN)
 
 
-@pytest.mark.parametrize("old_identifier", ((DOMAIN, 123, 456), (DOMAIN, "123", "456")))
+@pytest.mark.parametrize("old_identifier", [(DOMAIN, 123, 456), (DOMAIN, "123", "456")])
 async def test_migrate_device_entry(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/alarm_control_panel/test_device_action.py
+++ b/tests/components/alarm_control_panel/test_device_action.py
@@ -132,12 +132,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/alarm_control_panel/test_device_condition.py
+++ b/tests/components/alarm_control_panel/test_device_condition.py
@@ -139,12 +139,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/alarm_control_panel/test_device_trigger.py
+++ b/tests/components/alarm_control_panel/test_device_trigger.py
@@ -131,12 +131,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/apcupsd/test_init.py
+++ b/tests/components/apcupsd/test_init.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 @pytest.mark.parametrize(
     "status",
-    (
+    [
         # Contains "SERIALNO" and "UPSNAME" fields.
         # We should create devices for the entities and prefix their IDs with "MyUPS".
         MOCK_STATUS,
@@ -31,7 +31,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
         # Does not contain either "SERIALNO" field.
         # We should _not_ create devices for the entities and their IDs will not have prefixes.
         MOCK_MINIMAL_STATUS,
-    ),
+    ],
 )
 async def test_async_setup_entry(hass: HomeAssistant, status: OrderedDict) -> None:
     """Test a successful setup entry."""
@@ -53,7 +53,7 @@ async def test_async_setup_entry(hass: HomeAssistant, status: OrderedDict) -> No
 
 @pytest.mark.parametrize(
     "status",
-    (
+    [
         # We should not create device entries if SERIALNO is not reported.
         MOCK_MINIMAL_STATUS,
         # We should set the device name to be the friendly UPSNAME field if available.
@@ -62,7 +62,7 @@ async def test_async_setup_entry(hass: HomeAssistant, status: OrderedDict) -> No
         MOCK_MINIMAL_STATUS | {"SERIALNO": "XXXX"},
         # We should create all fields of the device entry if they are available.
         MOCK_STATUS,
-    ),
+    ],
 )
 async def test_device_entry(
     hass: HomeAssistant, status: OrderedDict, device_registry: dr.DeviceRegistry
@@ -139,7 +139,7 @@ async def test_multiple_integrations_different_devices(hass: HomeAssistant) -> N
 
 @pytest.mark.parametrize(
     "error",
-    (OSError(), asyncio.IncompleteReadError(partial=b"", expected=0)),
+    [OSError(), asyncio.IncompleteReadError(partial=b"", expected=0)],
 )
 async def test_connection_error(hass: HomeAssistant, error: Exception) -> None:
     """Test connection error during integration setup."""

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -754,7 +754,7 @@ async def test_automation_stops(hass: HomeAssistant, calls, service) -> None:
     assert len(calls) == (1 if service == "turn_off_no_stop" else 0)
 
 
-@pytest.mark.parametrize("extra_config", ({}, {"id": "sun"}))
+@pytest.mark.parametrize("extra_config", [{}, {"id": "sun"}])
 async def test_reload_unchanged_does_not_stop(
     hass: HomeAssistant, calls, extra_config
 ) -> None:
@@ -962,7 +962,7 @@ async def test_reload_identical_automations_without_id(
 
 @pytest.mark.parametrize(
     "automation_config",
-    (
+    [
         {
             "trigger": {"platform": "event", "event_type": "test_event"},
             "action": [{"service": "test.automation"}],
@@ -1029,7 +1029,7 @@ async def test_reload_identical_automations_without_id(
                 },
             },
         },
-    ),
+    ],
 )
 async def test_reload_unchanged_automation(
     hass: HomeAssistant, calls, automation_config
@@ -1065,7 +1065,7 @@ async def test_reload_unchanged_automation(
         assert len(calls) == 2
 
 
-@pytest.mark.parametrize("extra_config", ({}, {"id": "sun"}))
+@pytest.mark.parametrize("extra_config", [{}, {"id": "sun"}])
 async def test_reload_automation_when_blueprint_changes(
     hass: HomeAssistant, calls, extra_config
 ) -> None:
@@ -1362,7 +1362,7 @@ async def test_automation_not_trigger_on_bootstrap(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("broken_config", "problem", "details"),
-    (
+    [
         (
             {},
             "could not be validated",
@@ -1403,7 +1403,7 @@ async def test_automation_not_trigger_on_bootstrap(hass: HomeAssistant) -> None:
             "failed to setup actions",
             "Unknown entity registry entry abcdabcdabcdabcdabcdabcdabcdabcd.",
         ),
-    ),
+    ],
 )
 async def test_automation_bad_config_validation(
     hass: HomeAssistant,
@@ -2141,7 +2141,7 @@ async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
 
 @pytest.mark.parametrize(
     ("blueprint_inputs", "problem", "details"),
-    (
+    [
         (
             # No input
             {},
@@ -2167,7 +2167,7 @@ async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
                 " data['action'][0]['service']"
             ),
         ),
-    ),
+    ],
 )
 async def test_blueprint_automation_bad_config(
     hass: HomeAssistant,
@@ -2350,21 +2350,21 @@ async def test_trigger_condition_explicit_id(hass: HomeAssistant, calls) -> None
 
 @pytest.mark.parametrize(
     ("automation_mode", "automation_runs"),
-    (
+    [
         (SCRIPT_MODE_PARALLEL, 2),
         (SCRIPT_MODE_QUEUED, 2),
         (SCRIPT_MODE_RESTART, 2),
         (SCRIPT_MODE_SINGLE, 1),
-    ),
+    ],
 )
 @pytest.mark.parametrize(
     ("script_mode", "script_warning_msg"),
-    (
+    [
         (SCRIPT_MODE_PARALLEL, "script1: Maximum number of runs exceeded"),
         (SCRIPT_MODE_QUEUED, "script1: Disallowed recursion detected"),
         (SCRIPT_MODE_RESTART, "script1: Disallowed recursion detected"),
         (SCRIPT_MODE_SINGLE, "script1: Already running"),
-    ),
+    ],
 )
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])
 async def test_recursive_automation_starting_script(

--- a/tests/components/backup/test_websocket.py
+++ b/tests/components/backup/test_websocket.py
@@ -27,10 +27,10 @@ def sync_access_token_proxy(
 
 @pytest.mark.parametrize(
     "with_hassio",
-    (
+    [
         pytest.param(True, id="with_hassio"),
         pytest.param(False, id="without_hassio"),
-    ),
+    ],
 )
 async def test_info(
     hass: HomeAssistant,
@@ -54,10 +54,10 @@ async def test_info(
 
 @pytest.mark.parametrize(
     "with_hassio",
-    (
+    [
         pytest.param(True, id="with_hassio"),
         pytest.param(False, id="without_hassio"),
-    ),
+    ],
 )
 async def test_remove(
     hass: HomeAssistant,
@@ -80,10 +80,10 @@ async def test_remove(
 
 @pytest.mark.parametrize(
     "with_hassio",
-    (
+    [
         pytest.param(True, id="with_hassio"),
         pytest.param(False, id="without_hassio"),
-    ),
+    ],
 )
 async def test_generate(
     hass: HomeAssistant,
@@ -111,10 +111,10 @@ async def test_generate(
 )
 @pytest.mark.parametrize(
     ("with_hassio"),
-    (
+    [
         pytest.param(True, id="with_hassio"),
         pytest.param(False, id="without_hassio"),
-    ),
+    ],
 )
 async def test_backup_end(
     hass: HomeAssistant,
@@ -145,10 +145,10 @@ async def test_backup_end(
 )
 @pytest.mark.parametrize(
     ("with_hassio"),
-    (
+    [
         pytest.param(True, id="with_hassio"),
         pytest.param(False, id="without_hassio"),
-    ),
+    ],
 )
 async def test_backup_start(
     hass: HomeAssistant,
@@ -174,11 +174,11 @@ async def test_backup_start(
 
 @pytest.mark.parametrize(
     "exception",
-    (
+    [
         TimeoutError(),
         HomeAssistantError("Boom"),
         Exception("Boom"),
-    ),
+    ],
 )
 async def test_backup_end_excepion(
     hass: HomeAssistant,
@@ -203,11 +203,11 @@ async def test_backup_end_excepion(
 
 @pytest.mark.parametrize(
     "exception",
-    (
+    [
         TimeoutError(),
         HomeAssistantError("Boom"),
         Exception("Boom"),
-    ),
+    ],
 )
 async def test_backup_start_excepion(
     hass: HomeAssistant,

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -82,12 +82,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -82,12 +82,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -119,10 +119,10 @@ async def test_fetch_blueprint_from_community_url(
 
 @pytest.mark.parametrize(
     "url",
-    (
+    [
         "https://raw.githubusercontent.com/balloob/home-assistant-config/main/blueprints/automation/motion_light.yaml",
         "https://github.com/balloob/home-assistant-config/blob/main/blueprints/automation/motion_light.yaml",
-    ),
+    ],
 )
 async def test_fetch_blueprint_from_github_url(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, url: str

--- a/tests/components/blueprint/test_schemas.py
+++ b/tests/components/blueprint/test_schemas.py
@@ -12,7 +12,7 @@ _LOGGER = logging.getLogger(__name__)
 
 @pytest.mark.parametrize(
     "blueprint",
-    (
+    [
         # Test allow extra
         {
             "trigger": "Test allow extra",
@@ -52,7 +52,7 @@ _LOGGER = logging.getLogger(__name__)
                 },
             }
         },
-    ),
+    ],
 )
 def test_blueprint_schema(blueprint) -> None:
     """Test different schemas."""
@@ -65,7 +65,7 @@ def test_blueprint_schema(blueprint) -> None:
 
 @pytest.mark.parametrize(
     "blueprint",
-    (
+    [
         # no domain
         {"blueprint": {}},
         # non existing key in blueprint
@@ -94,7 +94,7 @@ def test_blueprint_schema(blueprint) -> None:
                 },
             }
         },
-    ),
+    ],
 )
 def test_blueprint_schema_invalid(blueprint) -> None:
     """Test different schemas."""
@@ -104,11 +104,11 @@ def test_blueprint_schema_invalid(blueprint) -> None:
 
 @pytest.mark.parametrize(
     "bp_instance",
-    (
+    [
         {"path": "hello.yaml"},
         {"path": "hello.yaml", "input": {}},
         {"path": "hello.yaml", "input": {"hello": None}},
-    ),
+    ],
 )
 def test_blueprint_instance_fields(bp_instance) -> None:
     """Test blueprint instance fields."""

--- a/tests/components/blueprint/test_websocket_api.py
+++ b/tests/components/blueprint/test_websocket_api.py
@@ -400,7 +400,7 @@ async def test_delete_non_exist_file_blueprint(
 
 @pytest.mark.parametrize(
     "automation_config",
-    (
+    [
         {
             "automation": {
                 "use_blueprint": {
@@ -413,7 +413,7 @@ async def test_delete_non_exist_file_blueprint(
                 }
             }
         },
-    ),
+    ],
 )
 async def test_delete_blueprint_in_use_by_automation(
     hass: HomeAssistant,
@@ -446,7 +446,7 @@ async def test_delete_blueprint_in_use_by_automation(
 
 @pytest.mark.parametrize(
     "script_config",
-    (
+    [
         {
             "script": {
                 "test_script": {
@@ -459,7 +459,7 @@ async def test_delete_blueprint_in_use_by_automation(
                 }
             }
         },
-    ),
+    ],
 )
 async def test_delete_blueprint_in_use_by_script(
     hass: HomeAssistant,

--- a/tests/components/button/test_device_action.py
+++ b/tests/components/button/test_device_action.py
@@ -50,12 +50,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -59,12 +59,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass,

--- a/tests/components/cast/test_helpers.py
+++ b/tests/components/cast/test_helpers.py
@@ -17,7 +17,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 @pytest.mark.parametrize(
     ("url", "fixture", "content_type"),
-    (
+    [
         (
             "http://a.files.bbci.co.uk/media/live/manifesto/audio/simulcast/hls/nonuk/sbr_low/ak/bbc_radio_fourfm.m3u8",
             "bbc_radio_fourfm.m3u8",
@@ -33,7 +33,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
             "rthkaudio2.m3u8",
             None,
         ),
-    ),
+    ],
 )
 async def test_hls_playlist_supported(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, url, fixture, content_type
@@ -47,7 +47,7 @@ async def test_hls_playlist_supported(
 
 @pytest.mark.parametrize(
     ("url", "fixture", "content_type", "expected_playlist"),
-    (
+    [
         (
             "https://sverigesradio.se/topsy/direkt/209-hi-mp3.m3u",
             "209-hi-mp3.m3u",
@@ -96,7 +96,7 @@ async def test_hls_playlist_supported(
                 )
             ],
         ),
-    ),
+    ],
 )
 async def test_parse_playlist(
     hass: HomeAssistant,
@@ -115,7 +115,7 @@ async def test_parse_playlist(
 
 @pytest.mark.parametrize(
     ("url", "fixture"),
-    (
+    [
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_invalid_entries.pls"),
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_invalid_file.pls"),
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_invalid_version.pls"),
@@ -126,7 +126,7 @@ async def test_parse_playlist(
         ("http://sverigesradio.se/164-hi-aac.pls", "164-hi-aac_no_version.pls"),
         ("https://sverigesradio.se/209-hi-mp3.m3u", "209-hi-mp3_bad_url.m3u"),
         ("https://sverigesradio.se/209-hi-mp3.m3u", "empty.m3u"),
-    ),
+    ],
 )
 async def test_parse_bad_playlist(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, url, fixture
@@ -139,10 +139,10 @@ async def test_parse_bad_playlist(
 
 @pytest.mark.parametrize(
     ("url", "exc"),
-    (
+    [
         ("http://sverigesradio.se/164-hi-aac.pls", TimeoutError),
         ("http://sverigesradio.se/164-hi-aac.pls", client_exceptions.ClientError),
-    ),
+    ],
 )
 async def test_parse_http_error(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, url, exc

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -754,7 +754,7 @@ async def test_entity_availability(hass: HomeAssistant) -> None:
     assert state.state == "unavailable"
 
 
-@pytest.mark.parametrize(("port", "entry_type"), ((8009, None), (12345, None)))
+@pytest.mark.parametrize(("port", "entry_type"), [(8009, None), (12345, None)])
 async def test_device_registry(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -1261,7 +1261,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistant, quick_play_mock) 
 
 @pytest.mark.parametrize(
     ("url", "fixture", "playlist_item"),
-    (
+    [
         # Test title is extracted from m3u playlist
         (
             "https://sverigesradio.se/topsy/direkt/209-hi-mp3.m3u",
@@ -1307,7 +1307,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistant, quick_play_mock) 
                 "media_type": "audio",
             },
         ),
-    ),
+    ],
 )
 async def test_entity_play_media_playlist(
     hass: HomeAssistant,

--- a/tests/components/climate/test_device_action.py
+++ b/tests/components/climate/test_device_action.py
@@ -97,12 +97,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -101,12 +101,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -88,12 +88,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/cloudflare/test_init.py
+++ b/tests/components/cloudflare/test_init.py
@@ -39,7 +39,7 @@ async def test_unload_entry(hass: HomeAssistant, cfupdate) -> None:
 
 @pytest.mark.parametrize(
     "side_effect",
-    (pycfdns.ComunicationException(),),
+    [pycfdns.ComunicationException()],
 )
 async def test_async_setup_raises_entry_not_ready(
     hass: HomeAssistant, cfupdate, side_effect

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -35,7 +35,7 @@ async def setup_automation(
     )
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 async def test_get_automation_config(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -58,7 +58,7 @@ async def test_get_automation_config(
     assert result == {"id": "moon"}
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 async def test_update_automation_config(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -97,7 +97,7 @@ async def test_update_automation_config(
     assert new_data[1] == {"id": "moon", "trigger": [], "condition": [], "action": []}
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 @pytest.mark.parametrize(
     ("updated_config", "validation_error"),
     [
@@ -179,7 +179,7 @@ async def test_update_automation_config_with_error(
     assert validation_error not in caplog.text
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 @pytest.mark.parametrize(
     ("updated_config", "validation_error"),
     [
@@ -236,7 +236,7 @@ async def test_update_automation_config_with_blueprint_substitution_error(
     assert validation_error not in caplog.text
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 async def test_update_remove_key_automation_config(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -275,7 +275,7 @@ async def test_update_remove_key_automation_config(
     assert new_data[1] == {"id": "moon", "trigger": [], "condition": [], "action": []}
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 async def test_bad_formatted_automations(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -323,7 +323,7 @@ async def test_bad_formatted_automations(
 
 @pytest.mark.parametrize(
     "automation_config",
-    (
+    [
         [
             {
                 "id": "sun",
@@ -336,7 +336,7 @@ async def test_bad_formatted_automations(
                 "action": {"service": "test.automation"},
             },
         ],
-    ),
+    ],
 )
 async def test_delete_automation(
     hass: HomeAssistant,
@@ -378,7 +378,7 @@ async def test_delete_automation(
     assert len(entity_registry.entities) == 1
 
 
-@pytest.mark.parametrize("automation_config", ({},))
+@pytest.mark.parametrize("automation_config", [{}])
 async def test_api_calls_require_admin(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -329,11 +329,11 @@ async def test_reload_entry_in_setup_retry(
 
 @pytest.mark.parametrize(
     ("type_filter", "result"),
-    (
+    [
         (None, {"hello", "another", "world"}),
         ("integration", {"hello", "another"}),
         ("helper", {"world"}),
-    ),
+    ],
 )
 async def test_available_flows(
     hass: HomeAssistant, client, type_filter, result

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -128,13 +128,13 @@ async def test_list_devices(
 @pytest.mark.parametrize(
     ("payload_key", "payload_value"),
     [
-        ["area_id", "12345A"],
-        ["area_id", None],
-        ["disabled_by", dr.DeviceEntryDisabler.USER],
-        ["disabled_by", "user"],
-        ["disabled_by", None],
-        ["name_by_user", "Test Friendly Name"],
-        ["name_by_user", None],
+        ("area_id", "12345A"),
+        ("area_id", None),
+        ("disabled_by", dr.DeviceEntryDisabler.USER),
+        ("disabled_by", "user"),
+        ("disabled_by", None),
+        ("name_by_user", "Test Friendly Name"),
+        ("name_by_user", None),
     ],
 )
 async def test_update_device(

--- a/tests/components/config/test_scene.py
+++ b/tests/components/config/test_scene.py
@@ -21,7 +21,7 @@ async def setup_scene(hass, scene_config):
     assert await async_setup_component(hass, "scene", {"scene": scene_config})
 
 
-@pytest.mark.parametrize("scene_config", ({},))
+@pytest.mark.parametrize("scene_config", [{}])
 async def test_create_scene(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -68,7 +68,7 @@ async def test_create_scene(
     ]
 
 
-@pytest.mark.parametrize("scene_config", ({},))
+@pytest.mark.parametrize("scene_config", [{}])
 async def test_update_scene(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -116,7 +116,7 @@ async def test_update_scene(
     ]
 
 
-@pytest.mark.parametrize("scene_config", ({},))
+@pytest.mark.parametrize("scene_config", [{}])
 async def test_bad_formatted_scene(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -176,12 +176,12 @@ async def test_bad_formatted_scene(
 
 @pytest.mark.parametrize(
     "scene_config",
-    (
+    [
         [
             {"id": "light_on", "name": "Light on", "entities": {}},
             {"id": "light_off", "name": "Light off", "entities": {}},
         ],
-    ),
+    ],
 )
 async def test_delete_scene(
     hass: HomeAssistant,
@@ -225,7 +225,7 @@ async def test_delete_scene(
     assert len(entity_registry.entities) == 1
 
 
-@pytest.mark.parametrize("scene_config", ({},))
+@pytest.mark.parametrize("scene_config", [{}])
 async def test_api_calls_require_admin(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/config/test_script.py
+++ b/tests/components/config/test_script.py
@@ -29,7 +29,7 @@ async def setup_script(hass, script_config, stub_blueprint_populate):
     assert await async_setup_component(hass, "script", {"script": script_config})
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 async def test_get_script_config(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
 ) -> None:
@@ -52,7 +52,7 @@ async def test_get_script_config(
     assert result == {"alias": "Moon"}
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 async def test_update_script_config(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
 ) -> None:
@@ -88,7 +88,7 @@ async def test_update_script_config(
     assert new_data["moon"] == {"alias": "Moon updated", "sequence": []}
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 async def test_invalid_object_id(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
 ) -> None:
@@ -122,7 +122,7 @@ async def test_invalid_object_id(
     assert new_data == {}
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 @pytest.mark.parametrize(
     ("updated_config", "validation_error"),
     [
@@ -182,7 +182,7 @@ async def test_update_script_config_with_error(
     assert validation_error not in caplog.text
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 @pytest.mark.parametrize(
     ("updated_config", "validation_error"),
     [
@@ -237,7 +237,7 @@ async def test_update_script_config_with_blueprint_substitution_error(
     assert validation_error not in caplog.text
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 async def test_update_remove_key_script_config(
     hass: HomeAssistant, hass_client: ClientSessionGenerator, hass_config_store
 ) -> None:
@@ -275,12 +275,12 @@ async def test_update_remove_key_script_config(
 
 @pytest.mark.parametrize(
     "script_config",
-    (
+    [
         {
             "one": {"alias": "Light on", "sequence": []},
             "two": {"alias": "Light off", "sequence": []},
         },
-    ),
+    ],
 )
 async def test_delete_script(
     hass: HomeAssistant,
@@ -320,7 +320,7 @@ async def test_delete_script(
     assert len(entity_registry.entities) == 1
 
 
-@pytest.mark.parametrize("script_config", ({},))
+@pytest.mark.parametrize("script_config", [{}])
 async def test_api_calls_require_admin(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -502,8 +502,8 @@ async def test_http_processing_intent_conversion_not_expose_new(
 
 
 @pytest.mark.parametrize("agent_id", AGENT_ID_OPTIONS)
-@pytest.mark.parametrize("sentence", ("turn on kitchen", "turn kitchen on"))
-@pytest.mark.parametrize("conversation_id", ("my_new_conversation", None))
+@pytest.mark.parametrize("sentence", ["turn on kitchen", "turn kitchen on"])
+@pytest.mark.parametrize("conversation_id", ["my_new_conversation", None])
 async def test_turn_on_intent(
     hass: HomeAssistant, init_components, conversation_id, sentence, agent_id, snapshot
 ) -> None:
@@ -550,7 +550,7 @@ async def test_service_fails(hass: HomeAssistant, init_components) -> None:
         )
 
 
-@pytest.mark.parametrize("sentence", ("turn off kitchen", "turn kitchen off"))
+@pytest.mark.parametrize("sentence", ["turn off kitchen", "turn kitchen off"])
 async def test_turn_off_intent(hass: HomeAssistant, init_components, sentence) -> None:
     """Test calling the turn on intent."""
     hass.states.async_set("light.kitchen", "on")

--- a/tests/components/cover/test_device_action.py
+++ b/tests/components/cover/test_device_action.py
@@ -94,12 +94,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -123,12 +123,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -124,12 +124,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/demo/test_sensor.py
+++ b/tests/components/demo/test_sensor.py
@@ -26,7 +26,7 @@ async def sensor_only() -> None:
         yield
 
 
-@pytest.mark.parametrize(("entity_id", "delta"), (("sensor.total_energy_kwh", 0.5),))
+@pytest.mark.parametrize(("entity_id", "delta"), [("sensor.total_energy_kwh", 0.5)])
 async def test_energy_sensor(
     hass: HomeAssistant, entity_id, delta, freezer: FrozenDateTimeFactory
 ) -> None:
@@ -47,7 +47,7 @@ async def test_energy_sensor(
     assert state.state == str(delta)
 
 
-@pytest.mark.parametrize(("entity_id", "delta"), (("sensor.total_energy_kwh", 0.5),))
+@pytest.mark.parametrize(("entity_id", "delta"), [("sensor.total_energy_kwh", 0.5)])
 async def test_restore_state(
     hass: HomeAssistant, entity_id, delta, freezer: FrozenDateTimeFactory
 ) -> None:

--- a/tests/components/derivative/test_config_flow.py
+++ b/tests/components/derivative/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(hass: HomeAssistant, platform) -> None:
     """Test the config flow."""
     input_sensor_entity_id = "sensor.input"
@@ -74,7 +74,7 @@ def get_suggested(schema, key):
     raise Exception
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_options(hass: HomeAssistant, platform) -> None:
     """Test reconfiguring."""
     # Setup the config entry

--- a/tests/components/derivative/test_init.py
+++ b/tests/components/derivative/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -64,12 +64,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -96,12 +96,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/devolo_home_network/test_button.py
+++ b/tests/components/devolo_home_network/test_button.py
@@ -40,26 +40,26 @@ async def test_button_setup(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("name", "api_name", "trigger_method"),
     [
-        [
+        (
             "identify_device_with_a_blinking_led",
             "plcnet",
             "async_identify_device_start",
-        ],
-        [
+        ),
+        (
             "start_plc_pairing",
             "plcnet",
             "async_pair_device",
-        ],
-        [
+        ),
+        (
             "restart_device",
             "device",
             "async_restart",
-        ],
-        [
+        ),
+        (
             "start_wps",
             "device",
             "async_start_wps",
-        ],
+        ),
     ],
 )
 @pytest.mark.freeze_time("2023-01-13 12:00:00+00:00")

--- a/tests/components/devolo_home_network/test_config_flow.py
+++ b/tests/components/devolo_home_network/test_config_flow.py
@@ -64,7 +64,7 @@ async def test_form(hass: HomeAssistant, info: dict[str, Any]) -> None:
 
 @pytest.mark.parametrize(
     ("exception_type", "expected_error"),
-    [[DeviceNotFound(IP), "cannot_connect"], [Exception, "unknown"]],
+    [(DeviceNotFound(IP), "cannot_connect"), (Exception, "unknown")],
 )
 async def test_form_error(hass: HomeAssistant, exception_type, expected_error) -> None:
     """Test we handle errors."""

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -95,15 +95,15 @@ async def test_hass_stop(hass: HomeAssistant, mock_device: MockDevice) -> None:
 @pytest.mark.parametrize(
     ("device", "expected_platforms"),
     [
-        [
+        (
             "mock_device",
             (BINARY_SENSOR, BUTTON, DEVICE_TRACKER, IMAGE, SENSOR, SWITCH, UPDATE),
-        ],
-        [
+        ),
+        (
             "mock_repeater_device",
             (BUTTON, DEVICE_TRACKER, IMAGE, SENSOR, SWITCH, UPDATE),
-        ],
-        ["mock_nonwifi_device", (BINARY_SENSOR, BUTTON, SENSOR, SWITCH, UPDATE)],
+        ),
+        ("mock_nonwifi_device", (BINARY_SENSOR, BUTTON, SENSOR, SWITCH, UPDATE)),
     ],
 )
 async def test_platforms(

--- a/tests/components/devolo_home_network/test_sensor.py
+++ b/tests/components/devolo_home_network/test_sensor.py
@@ -66,21 +66,21 @@ async def test_sensor_setup(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     ("name", "get_method", "interval"),
     [
-        [
+        (
             "connected_wifi_clients",
             "async_get_wifi_connected_station",
             SHORT_UPDATE_INTERVAL,
-        ],
-        [
+        ),
+        (
             "neighboring_wifi_networks",
             "async_get_wifi_neighbor_access_points",
             LONG_UPDATE_INTERVAL,
-        ],
-        [
+        ),
+        (
             "connected_plc_devices",
             "async_get_network_overview",
             LONG_UPDATE_INTERVAL,
-        ],
+        ),
     ],
 )
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/devolo_home_network/test_switch.py
+++ b/tests/components/devolo_home_network/test_switch.py
@@ -247,8 +247,8 @@ async def test_update_enable_leds(
 @pytest.mark.parametrize(
     ("name", "get_method", "update_interval"),
     [
-        ["enable_guest_wifi", "async_get_wifi_guest_access", SHORT_UPDATE_INTERVAL],
-        ["enable_leds", "async_get_led_setting", SHORT_UPDATE_INTERVAL],
+        ("enable_guest_wifi", "async_get_wifi_guest_access", SHORT_UPDATE_INTERVAL),
+        ("enable_leds", "async_get_led_setting", SHORT_UPDATE_INTERVAL),
     ],
 )
 async def test_device_failure(
@@ -284,8 +284,8 @@ async def test_device_failure(
 @pytest.mark.parametrize(
     ("name", "set_method"),
     [
-        ["enable_guest_wifi", "async_set_wifi_guest_access"],
-        ["enable_leds", "async_set_led_setting"],
+        ("enable_guest_wifi", "async_set_wifi_guest_access"),
+        ("enable_leds", "async_set_led_setting"),
     ],
 )
 async def test_auth_failed(

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -272,7 +272,7 @@ async def test_setup_entry_no_options(
 
 @pytest.mark.parametrize(
     "core_state",
-    (CoreState.not_running, CoreState.running),
+    [CoreState.not_running, CoreState.running],
 )
 async def test_setup_entry_with_options(
     hass: HomeAssistant,
@@ -1261,7 +1261,7 @@ async def test_playback_update_state(
 
 @pytest.mark.parametrize(
     "core_state",
-    (CoreState.not_running, CoreState.running),
+    [CoreState.not_running, CoreState.running],
 )
 async def test_unavailable_device(
     hass: HomeAssistant,
@@ -1388,7 +1388,7 @@ async def test_unavailable_device(
 
 @pytest.mark.parametrize(
     "core_state",
-    (CoreState.not_running, CoreState.running),
+    [CoreState.not_running, CoreState.running],
 )
 async def test_become_available(
     hass: HomeAssistant,
@@ -1479,7 +1479,7 @@ async def test_become_available(
 
 @pytest.mark.parametrize(
     "core_state",
-    (CoreState.not_running, CoreState.running),
+    [CoreState.not_running, CoreState.running],
 )
 async def test_alive_but_gone(
     hass: HomeAssistant,
@@ -2329,7 +2329,7 @@ async def test_config_update_mac_address(
 
 @pytest.mark.parametrize(
     "core_state",
-    (CoreState.not_running, CoreState.running),
+    [CoreState.not_running, CoreState.running],
 )
 async def test_connections_restored(
     hass: HomeAssistant,

--- a/tests/components/dormakaba_dkey/test_config_flow.py
+++ b/tests/components/dormakaba_dkey/test_config_flow.py
@@ -222,10 +222,10 @@ async def test_bluetooth_step_already_in_progress(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
-    ),
+    ],
 )
 async def test_bluetooth_step_cannot_connect(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth step and we cannot connect."""
@@ -261,10 +261,10 @@ async def test_bluetooth_step_cannot_connect(hass: HomeAssistant, exc, error) ->
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (dkey_errors.InvalidActivationCode, "invalid_code"),
         (dkey_errors.WrongActivationCode, "wrong_code"),
-    ),
+    ],
 )
 async def test_bluetooth_step_cannot_associate(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth step and we cannot associate."""

--- a/tests/components/dremel_3d_printer/test_button.py
+++ b/tests/components/dremel_3d_printer/test_button.py
@@ -16,11 +16,11 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.parametrize(
     ("button", "function"),
-    (
+    [
         ("cancel", "stop"),
         ("pause", "pause"),
         ("resume", "resume"),
-    ),
+    ],
 )
 async def test_buttons(
     hass: HomeAssistant,

--- a/tests/components/elvia/test_config_flow.py
+++ b/tests/components/elvia/test_config_flow.py
@@ -198,12 +198,12 @@ async def test_abort_when_metering_point_id_exist(
 
 @pytest.mark.parametrize(
     ("side_effect", "base_error"),
-    (
+    [
         (ElviaError.ElviaException("Boom"), "unknown"),
         (ElviaError.AuthError("Boom", 403, {}, ""), "invalid_auth"),
         (ElviaError.ElviaServerException("Boom", 500, {}, ""), "unknown"),
         (ElviaError.ElviaClientException("Boom"), "unknown"),
-    ),
+    ],
 )
 async def test_form_exceptions(
     recorder_mock: Recorder,

--- a/tests/components/energy/test_sensor.py
+++ b/tests/components/energy/test_sensor.py
@@ -988,7 +988,7 @@ async def test_cost_sensor_handle_late_price_sensor(
 
 @pytest.mark.parametrize(
     "unit",
-    (UnitOfVolume.CUBIC_FEET, UnitOfVolume.CUBIC_METERS),
+    [UnitOfVolume.CUBIC_FEET, UnitOfVolume.CUBIC_METERS],
 )
 async def test_cost_sensor_handle_gas(
     setup_integration, hass: HomeAssistant, hass_storage: dict[str, Any], unit
@@ -1086,12 +1086,12 @@ async def test_cost_sensor_handle_gas_kwh(
 
 @pytest.mark.parametrize(
     ("unit_system", "usage_unit", "growth"),
-    (
+    [
         # 1 cubic foot = 7.47 gl, 100 ft3 growth @ 0.5/ft3:
         (US_CUSTOMARY_SYSTEM, UnitOfVolume.CUBIC_FEET, 374.025974025974),
         (US_CUSTOMARY_SYSTEM, UnitOfVolume.GALLONS, 50.0),
         (METRIC_SYSTEM, UnitOfVolume.CUBIC_METERS, 50.0),
-    ),
+    ],
 )
 async def test_cost_sensor_handle_water(
     setup_integration,

--- a/tests/components/energy/test_validate.py
+++ b/tests/components/energy/test_validate.py
@@ -690,7 +690,7 @@ async def test_validation_grid_auto_cost_entity_errors(
 
 @pytest.mark.parametrize(
     ("state", "unit", "expected"),
-    (
+    [
         (
             "123,123.12",
             "$/kWh",
@@ -711,7 +711,7 @@ async def test_validation_grid_auto_cost_entity_errors(
                 },
             },
         ),
-    ),
+    ],
 )
 async def test_validation_grid_price_errors(
     hass: HomeAssistant, mock_energy_manager, mock_get_metadata, state, unit, expected

--- a/tests/components/esphome/test_binary_sensor.py
+++ b/tests/components/esphome/test_binary_sensor.py
@@ -45,7 +45,7 @@ async def test_assist_in_progress(
 
 
 @pytest.mark.parametrize(
-    "binary_state", ((True, STATE_ON), (False, STATE_OFF), (None, STATE_UNKNOWN))
+    "binary_state", [(True, STATE_ON), (False, STATE_OFF), (None, STATE_UNKNOWN)]
 )
 async def test_binary_sensor_generic_entity(
     hass: HomeAssistant,

--- a/tests/components/fan/test_device_action.py
+++ b/tests/components/fan/test_device_action.py
@@ -58,12 +58,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -64,12 +64,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -69,12 +69,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -92,7 +92,7 @@ async def test_chain(
         assert state.state == "18.05"
 
 
-@pytest.mark.parametrize("missing", (True, False))
+@pytest.mark.parametrize("missing", [True, False])
 async def test_chain_history(
     recorder_mock: Recorder,
     hass: HomeAssistant,

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -167,11 +167,11 @@ async def test_sensors(
 
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.power_production_next_12hours",
         "sensor.power_production_next_24hours",
         "sensor.power_production_next_hour",
-    ),
+    ],
 )
 async def test_disabled_by_default(
     hass: HomeAssistant,

--- a/tests/components/google_assistant/test_helpers.py
+++ b/tests/components/google_assistant/test_helpers.py
@@ -404,7 +404,7 @@ async def test_config_local_sdk_allow_min_version(
     ) not in caplog.text
 
 
-@pytest.mark.parametrize("version", (None, "2.1.4"))
+@pytest.mark.parametrize("version", [None, "2.1.4"])
 async def test_config_local_sdk_warn_version(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -3306,11 +3306,11 @@ async def test_openclose_cover_valve_no_position(
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         cover.CoverDeviceClass.DOOR,
         cover.CoverDeviceClass.GARAGE,
         cover.CoverDeviceClass.GATE,
-    ),
+    ],
 )
 async def test_openclose_cover_secure(hass: HomeAssistant, device_class) -> None:
     """Test OpenClose trait support for cover domain."""
@@ -3372,13 +3372,13 @@ async def test_openclose_cover_secure(hass: HomeAssistant, device_class) -> None
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         binary_sensor.BinarySensorDeviceClass.DOOR,
         binary_sensor.BinarySensorDeviceClass.GARAGE_DOOR,
         binary_sensor.BinarySensorDeviceClass.LOCK,
         binary_sensor.BinarySensorDeviceClass.OPENING,
         binary_sensor.BinarySensorDeviceClass.WINDOW,
-    ),
+    ],
 )
 async def test_openclose_binary_sensor(hass: HomeAssistant, device_class) -> None:
     """Test OpenClose trait support for binary_sensor domain."""
@@ -3816,7 +3816,7 @@ async def test_transport_control(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         STATE_OFF,
         STATE_IDLE,
         STATE_PLAYING,
@@ -3825,7 +3825,7 @@ async def test_transport_control(
         STATE_STANDBY,
         STATE_UNAVAILABLE,
         STATE_UNKNOWN,
-    ),
+    ],
 )
 async def test_media_state(hass: HomeAssistant, state) -> None:
     """Test the MediaStateTrait."""

--- a/tests/components/google_mail/test_services.py
+++ b/tests/components/google_mail/test_services.py
@@ -62,10 +62,10 @@ async def test_set_vacation(
 
 @pytest.mark.parametrize(
     ("side_effect"),
-    (
+    [
         (RefreshError,),
         (ClientResponseError("", (), status=400),),
-    ),
+    ],
 )
 async def test_reauth_trigger(
     hass: HomeAssistant,

--- a/tests/components/gree/test_climate.py
+++ b/tests/components/gree/test_climate.py
@@ -514,7 +514,7 @@ async def test_update_target_temperature(
 
 
 @pytest.mark.parametrize(
-    "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
+    "preset", [PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE]
 )
 async def test_send_preset_mode(
     hass: HomeAssistant, discovery, device, mock_now, preset
@@ -554,7 +554,7 @@ async def test_send_invalid_preset_mode(
 
 
 @pytest.mark.parametrize(
-    "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
+    "preset", [PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE]
 )
 async def test_send_preset_mode_device_timeout(
     hass: HomeAssistant, discovery, device, mock_now, preset
@@ -577,7 +577,7 @@ async def test_send_preset_mode_device_timeout(
 
 
 @pytest.mark.parametrize(
-    "preset", (PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE)
+    "preset", [PRESET_AWAY, PRESET_ECO, PRESET_SLEEP, PRESET_BOOST, PRESET_NONE]
 )
 async def test_update_preset_mode(
     hass: HomeAssistant, discovery, device, mock_now, preset
@@ -597,14 +597,14 @@ async def test_update_preset_mode(
 
 @pytest.mark.parametrize(
     "hvac_mode",
-    (
+    [
         HVACMode.OFF,
         HVACMode.AUTO,
         HVACMode.COOL,
         HVACMode.DRY,
         HVACMode.FAN_ONLY,
         HVACMode.HEAT,
-    ),
+    ],
 )
 async def test_send_hvac_mode(
     hass: HomeAssistant, discovery, device, mock_now, hvac_mode
@@ -626,7 +626,7 @@ async def test_send_hvac_mode(
 
 @pytest.mark.parametrize(
     "hvac_mode",
-    (HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT),
+    [HVACMode.AUTO, HVACMode.COOL, HVACMode.DRY, HVACMode.FAN_ONLY, HVACMode.HEAT],
 )
 async def test_send_hvac_mode_device_timeout(
     hass: HomeAssistant, discovery, device, mock_now, hvac_mode
@@ -650,14 +650,14 @@ async def test_send_hvac_mode_device_timeout(
 
 @pytest.mark.parametrize(
     "hvac_mode",
-    (
+    [
         HVACMode.OFF,
         HVACMode.AUTO,
         HVACMode.COOL,
         HVACMode.DRY,
         HVACMode.FAN_ONLY,
         HVACMode.HEAT,
-    ),
+    ],
 )
 async def test_update_hvac_mode(
     hass: HomeAssistant, discovery, device, mock_now, hvac_mode
@@ -675,7 +675,7 @@ async def test_update_hvac_mode(
 
 @pytest.mark.parametrize(
     "fan_mode",
-    (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
+    [FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH],
 )
 async def test_send_fan_mode(
     hass: HomeAssistant, discovery, device, mock_now, fan_mode
@@ -716,7 +716,7 @@ async def test_send_invalid_fan_mode(
 
 @pytest.mark.parametrize(
     "fan_mode",
-    (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
+    [FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH],
 )
 async def test_send_fan_mode_device_timeout(
     hass: HomeAssistant, discovery, device, mock_now, fan_mode
@@ -740,7 +740,7 @@ async def test_send_fan_mode_device_timeout(
 
 @pytest.mark.parametrize(
     "fan_mode",
-    (FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH),
+    [FAN_AUTO, FAN_LOW, FAN_MEDIUM_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH],
 )
 async def test_update_fan_mode(
     hass: HomeAssistant, discovery, device, mock_now, fan_mode
@@ -756,7 +756,7 @@ async def test_update_fan_mode(
 
 
 @pytest.mark.parametrize(
-    "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
+    "swing_mode", [SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL]
 )
 async def test_send_swing_mode(
     hass: HomeAssistant, discovery, device, mock_now, swing_mode
@@ -796,7 +796,7 @@ async def test_send_invalid_swing_mode(
 
 
 @pytest.mark.parametrize(
-    "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
+    "swing_mode", [SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL]
 )
 async def test_send_swing_mode_device_timeout(
     hass: HomeAssistant, discovery, device, mock_now, swing_mode
@@ -819,7 +819,7 @@ async def test_send_swing_mode_device_timeout(
 
 
 @pytest.mark.parametrize(
-    "swing_mode", (SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL)
+    "swing_mode", [SWING_OFF, SWING_BOTH, SWING_VERTICAL, SWING_HORIZONTAL]
 )
 async def test_update_swing_mode(
     hass: HomeAssistant, discovery, device, mock_now, swing_mode

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -26,7 +26,7 @@ from tests.typing import WebSocketGenerator
         "extra_options",
         "extra_attrs",
     ),
-    (
+    [
         ("binary_sensor", "on", "on", {}, {}, {"all": False}, {}),
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
@@ -56,7 +56,7 @@ from tests.typing import WebSocketGenerator
             {},
         ),
         ("switch", "on", "on", {}, {}, {}, {}),
-    ),
+    ],
 )
 async def test_config_flow(
     hass: HomeAssistant,
@@ -129,11 +129,11 @@ async def test_config_flow(
 
 
 @pytest.mark.parametrize(
-    ("hide_members", "hidden_by"), ((False, None), (True, "integration"))
+    ("hide_members", "hidden_by"), [(False, None), (True, "integration")]
 )
 @pytest.mark.parametrize(
     ("group_type", "extra_input"),
-    (
+    [
         ("binary_sensor", {"all": False}),
         ("cover", {}),
         ("event", {}),
@@ -142,7 +142,7 @@ async def test_config_flow(
         ("lock", {}),
         ("media_player", {}),
         ("switch", {}),
-    ),
+    ],
 )
 async def test_config_flow_hides_members(
     hass: HomeAssistant,
@@ -210,7 +210,7 @@ def get_suggested(schema, key):
 
 @pytest.mark.parametrize(
     ("group_type", "member_state", "extra_options", "options_options"),
-    (
+    [
         ("binary_sensor", "on", {"all": False}, {}),
         ("cover", "open", {}, {}),
         ("event", "2021-01-01T23:59:59.123+00:00", {}, {}),
@@ -225,7 +225,7 @@ def get_suggested(schema, key):
             {"ignore_non_numeric": False, "type": "sum"},
         ),
         ("switch", "on", {"all": False}, {}),
-    ),
+    ],
 )
 async def test_options(
     hass: HomeAssistant, group_type, member_state, extra_options, options_options
@@ -316,7 +316,7 @@ async def test_options(
 
 @pytest.mark.parametrize(
     ("group_type", "extra_options", "extra_options_after", "advanced"),
-    (
+    [
         ("light", {"all": False}, {"all": False}, False),
         ("light", {"all": True}, {"all": True}, False),
         ("light", {"all": False}, {"all": False}, True),
@@ -325,7 +325,7 @@ async def test_options(
         ("switch", {"all": True}, {"all": True}, False),
         ("switch", {"all": False}, {"all": False}, True),
         ("switch", {"all": True}, {"all": False}, True),
-    ),
+    ],
 )
 async def test_all_options(
     hass: HomeAssistant, group_type, extra_options, extra_options_after, advanced
@@ -387,14 +387,14 @@ async def test_all_options(
 
 @pytest.mark.parametrize(
     ("hide_members", "hidden_by_initial", "hidden_by"),
-    (
+    [
         (False, er.RegistryEntryHider.INTEGRATION, None),
         (True, None, er.RegistryEntryHider.INTEGRATION),
-    ),
+    ],
 )
 @pytest.mark.parametrize(
     ("group_type", "extra_input"),
-    (
+    [
         ("binary_sensor", {"all": False}),
         ("cover", {}),
         ("event", {}),
@@ -403,7 +403,7 @@ async def test_all_options(
         ("lock", {}),
         ("media_player", {}),
         ("switch", {}),
-    ),
+    ],
 )
 async def test_options_flow_hides_members(
     hass: HomeAssistant,

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1626,7 +1626,7 @@ async def test_plant_group(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("group_type", "member_state", "extra_options"),
-    (
+    [
         ("binary_sensor", "on", {"all": False}),
         ("cover", "open", {}),
         ("fan", "on", {}),
@@ -1642,7 +1642,7 @@ async def test_plant_group(hass: HomeAssistant) -> None:
                 "state_class": "measurement",
             },
         ),
-    ),
+    ],
 )
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
@@ -1689,24 +1689,24 @@ async def test_setup_and_remove_config_entry(
 
 @pytest.mark.parametrize(
     ("hide_members", "hidden_by_initial", "hidden_by"),
-    (
+    [
         (False, er.RegistryEntryHider.INTEGRATION, er.RegistryEntryHider.INTEGRATION),
         (False, None, None),
         (False, er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
         (True, er.RegistryEntryHider.INTEGRATION, None),
         (True, None, None),
         (True, er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
-    ),
+    ],
 )
 @pytest.mark.parametrize(
     ("group_type", "extra_options"),
-    (
+    [
         ("binary_sensor", {"all": False}),
         ("cover", {}),
         ("fan", {}),
         ("light", {"all": False}),
         ("media_player", {}),
-    ),
+    ],
 )
 async def test_unhide_members_on_remove(
     hass: HomeAssistant,

--- a/tests/components/hassio/test_handler.py
+++ b/tests/components/hassio/test_handler.py
@@ -315,9 +315,9 @@ async def test_api_ingress_panels(
 @pytest.mark.parametrize(
     ("api_call", "method", "payload"),
     [
-        ["retrieve_discovery_messages", "GET", None],
-        ["refresh_updates", "POST", None],
-        ["update_diagnostics", "POST", True],
+        ("retrieve_discovery_messages", "GET", None),
+        ("refresh_updates", "POST", None),
+        ("update_diagnostics", "POST", True),
     ],
 )
 async def test_api_headers(

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -116,7 +116,7 @@ async def origin_step_result_fixture(
 
 @pytest.mark.parametrize(
     "menu_options",
-    (["origin_coordinates", "origin_entity"],),
+    [["origin_coordinates", "origin_entity"]],
 )
 @pytest.mark.usefixtures("valid_response")
 async def test_step_user(hass: HomeAssistant, menu_options) -> None:

--- a/tests/components/history/test_websocket_api.py
+++ b/tests/components/history/test_websocket_api.py
@@ -1332,7 +1332,7 @@ async def test_history_stream_live_with_future_end_time(
     ) == listeners_without_writes(init_listeners)
 
 
-@pytest.mark.parametrize("include_start_time_state", (True, False))
+@pytest.mark.parametrize("include_start_time_state", [True, False])
 async def test_history_stream_before_history_starts(
     recorder_mock: Recorder,
     hass: HomeAssistant,

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -60,7 +60,7 @@ async def setup_comp(hass):
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_entity_removal(
     hass: HomeAssistant, calls, below
@@ -90,7 +90,7 @@ async def test_if_not_fires_on_entity_removal(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_below(
     hass: HomeAssistant, calls, below
@@ -139,7 +139,7 @@ async def test_if_fires_on_entity_change_below(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_below_uuid(
     hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, below
@@ -193,7 +193,7 @@ async def test_if_fires_on_entity_change_below_uuid(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_over_to_below(
     hass: HomeAssistant, calls, below
@@ -224,7 +224,7 @@ async def test_if_fires_on_entity_change_over_to_below(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entities_change_over_to_below(
     hass: HomeAssistant, calls, below
@@ -259,7 +259,7 @@ async def test_if_fires_on_entities_change_over_to_below(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_entity_change_below_to_below(
     hass: HomeAssistant, calls, below
@@ -302,7 +302,7 @@ async def test_if_not_fires_on_entity_change_below_to_below(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_below_fires_on_entity_change_to_equal(
     hass: HomeAssistant, calls, below
@@ -333,7 +333,7 @@ async def test_if_not_below_fires_on_entity_change_to_equal(
 
 
 @pytest.mark.parametrize(
-    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_initial_entity_below(
     hass: HomeAssistant, calls, below
@@ -364,7 +364,7 @@ async def test_if_not_fires_on_initial_entity_below(
 
 
 @pytest.mark.parametrize(
-    "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "above", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_initial_entity_above(
     hass: HomeAssistant, calls, above
@@ -395,7 +395,7 @@ async def test_if_not_fires_on_initial_entity_above(
 
 
 @pytest.mark.parametrize(
-    "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+    "above", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_above(
     hass: HomeAssistant, calls, above
@@ -448,7 +448,7 @@ async def test_if_fires_on_entity_unavailable_at_startup(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_fires_on_entity_change_below_to_above(
     hass: HomeAssistant, calls, above
 ) -> None:
@@ -478,7 +478,7 @@ async def test_if_fires_on_entity_change_below_to_above(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_above_to_above(
     hass: HomeAssistant, calls, above
 ) -> None:
@@ -513,7 +513,7 @@ async def test_if_not_fires_on_entity_change_above_to_above(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_not_above_fires_on_entity_change_to_equal(
     hass: HomeAssistant, calls, above
 ) -> None:
@@ -545,12 +545,12 @@ async def test_if_not_above_fires_on_entity_change_to_equal(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (5, 10),
         (5, "input_number.value_10"),
         ("input_number.value_5", 10),
         ("input_number.value_5", "input_number.value_10"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_below_range(
     hass: HomeAssistant, calls, above, below
@@ -582,12 +582,12 @@ async def test_if_fires_on_entity_change_below_range(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (5, 10),
         (5, "input_number.value_10"),
         ("input_number.value_5", 10),
         ("input_number.value_5", "input_number.value_10"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_below_above_range(
     hass: HomeAssistant, calls, above, below
@@ -616,12 +616,12 @@ async def test_if_fires_on_entity_change_below_above_range(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (5, 10),
         (5, "input_number.value_10"),
         ("input_number.value_5", 10),
         ("input_number.value_5", "input_number.value_10"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_over_to_below_range(
     hass: HomeAssistant, calls, above, below
@@ -654,12 +654,12 @@ async def test_if_fires_on_entity_change_over_to_below_range(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (5, 10),
         (5, "input_number.value_10"),
         ("input_number.value_5", 10),
         ("input_number.value_5", "input_number.value_10"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_over_to_below_above_range(
     hass: HomeAssistant, calls, above, below
@@ -690,7 +690,7 @@ async def test_if_fires_on_entity_change_over_to_below_above_range(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (100, "input_number.value_100"))
+@pytest.mark.parametrize("below", [100, "input_number.value_100"])
 async def test_if_not_fires_if_entity_not_match(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -745,7 +745,7 @@ async def test_if_not_fires_and_warns_if_below_entity_unknown(
     assert caplog.record_tuples[0][1] == logging.WARNING
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_fires_on_entity_change_below_with_attribute(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -773,7 +773,7 @@ async def test_if_fires_on_entity_change_below_with_attribute(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_not_below_with_attribute(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -798,7 +798,7 @@ async def test_if_not_fires_on_entity_change_not_below_with_attribute(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_fires_on_attribute_change_with_attribute_below(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -827,7 +827,7 @@ async def test_if_fires_on_attribute_change_with_attribute_below(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -853,7 +853,7 @@ async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_with_attribute_below(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -879,7 +879,7 @@ async def test_if_not_fires_on_entity_change_with_attribute_below(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_with_not_attribute_below(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -905,7 +905,7 @@ async def test_if_not_fires_on_entity_change_with_not_attribute_below(
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
     hass: HomeAssistant, calls, below
 ) -> None:
@@ -937,7 +937,7 @@ async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_template_list(hass: HomeAssistant, calls, below) -> None:
     """Test template list."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
@@ -963,7 +963,7 @@ async def test_template_list(hass: HomeAssistant, calls, below) -> None:
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10.0, "input_number.value_10"))
+@pytest.mark.parametrize("below", [10.0, "input_number.value_10"])
 async def test_template_string(hass: HomeAssistant, calls, below) -> None:
     """Test template string."""
     assert await async_setup_component(
@@ -1036,12 +1036,12 @@ async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_action(hass: HomeAssistant, calls, above, below) -> None:
     """Test if action."""
@@ -1084,12 +1084,12 @@ async def test_if_action(hass: HomeAssistant, calls, above, below) -> None:
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls, above, below) -> None:
     """Test for setup failure for bad for."""
@@ -1140,12 +1140,12 @@ async def test_if_fails_setup_for_without_above_below(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_not_fires_on_entity_change_with_for(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1180,12 +1180,12 @@ async def test_if_not_fires_on_entity_change_with_for(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_not_fires_on_entities_change_with_for_after_stop(
     hass: HomeAssistant, calls, above, below
@@ -1241,12 +1241,12 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_with_for_attribute_change(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1287,12 +1287,12 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_entity_change_with_for(
     hass: HomeAssistant, calls, above, below
@@ -1325,7 +1325,7 @@ async def test_if_fires_on_entity_change_with_for(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     hass.states.async_set("test.entity", "0")
@@ -1368,12 +1368,12 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> 
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_entities_change_no_overlap(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1423,12 +1423,12 @@ async def test_if_fires_on_entities_change_no_overlap(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_entities_change_overlap(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1489,12 +1489,12 @@ async def test_if_fires_on_entities_change_overlap(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_change_with_for_template_1(
     hass: HomeAssistant, calls, above, below
@@ -1530,12 +1530,12 @@ async def test_if_fires_on_change_with_for_template_1(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_change_with_for_template_2(
     hass: HomeAssistant, calls, above, below
@@ -1571,12 +1571,12 @@ async def test_if_fires_on_change_with_for_template_2(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_change_with_for_template_3(
     hass: HomeAssistant, calls, above, below
@@ -1650,12 +1650,12 @@ async def test_if_not_fires_on_error_with_for_template(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) -> None:
     """Test for invalid for template."""
@@ -1687,12 +1687,12 @@ async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) ->
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    (
+    [
         (8, 12),
         (8, "input_number.value_12"),
         ("input_number.value_8", 12),
         ("input_number.value_8", "input_number.value_12"),
-    ),
+    ],
 )
 async def test_if_fires_on_entities_change_overlap_for_template(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1788,7 +1788,7 @@ async def test_schema_unacceptable_entities(hass: HomeAssistant) -> None:
         )
 
 
-@pytest.mark.parametrize("above", (3, "input_number.value_3"))
+@pytest.mark.parametrize("above", [3, "input_number.value_3"])
 async def test_attribute_if_fires_on_entity_change_with_both_filters(
     hass: HomeAssistant, calls, above
 ) -> None:
@@ -1817,7 +1817,7 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("above", (3, "input_number.value_3"))
+@pytest.mark.parametrize("above", [3, "input_number.value_3"])
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     hass: HomeAssistant, calls, above
 ) -> None:
@@ -1855,7 +1855,7 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
 
 @pytest.mark.parametrize(
     ("above", "below"),
-    ((8, 12),),
+    [(8, 12)],
 )
 async def test_variables_priority(
     hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
@@ -1912,7 +1912,7 @@ async def test_variables_priority(
     assert calls[0].data["some"] == "test.entity_1 - 0:00:05"
 
 
-@pytest.mark.parametrize("multiplier", (1, 5))
+@pytest.mark.parametrize("multiplier", [1, 5])
 async def test_template_variable(hass: HomeAssistant, calls, multiplier) -> None:
     """Test template variable."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})

--- a/tests/components/homeassistant_alerts/test_init.py
+++ b/tests/components/homeassistant_alerts/test_init.py
@@ -42,7 +42,7 @@ async def setup_repairs(hass):
 
 @pytest.mark.parametrize(
     ("ha_version", "supervisor_info", "expected_alerts"),
-    (
+    [
         (
             "2022.7.0",
             {"version": "2022.11.0"},
@@ -93,7 +93,7 @@ async def setup_repairs(hass):
                 ("sochain", "sochain"),
             ],
         ),
-    ),
+    ],
 )
 async def test_alerts(
     hass: HomeAssistant,
@@ -182,7 +182,7 @@ async def test_alerts(
         "initial_alerts",
         "late_alerts",
     ),
-    (
+    [
         (
             "2022.7.0",
             {"version": "2022.11.0"},
@@ -282,7 +282,7 @@ async def test_alerts(
                 ("sochain", "sochain"),
             ],
         ),
-    ),
+    ],
 )
 async def test_alerts_refreshed_on_component_load(
     hass: HomeAssistant,
@@ -399,7 +399,7 @@ async def test_alerts_refreshed_on_component_load(
 
 @pytest.mark.parametrize(
     ("ha_version", "fixture", "expected_alerts"),
-    (
+    [
         (
             "2022.7.0",
             "alerts_no_integrations.json",
@@ -415,7 +415,7 @@ async def test_alerts_refreshed_on_component_load(
                 ("hikvision", "hikvision"),
             ],
         ),
-    ),
+    ],
 )
 async def test_bad_alerts(
     hass: HomeAssistant,
@@ -503,7 +503,7 @@ async def test_no_alerts(
 
 @pytest.mark.parametrize(
     ("ha_version", "fixture_1", "expected_alerts_1", "fixture_2", "expected_alerts_2"),
-    (
+    [
         (
             "2022.7.0",
             "alerts_1.json",
@@ -564,7 +564,7 @@ async def test_no_alerts(
                 ("sochain", "sochain"),
             ],
         ),
-    ),
+    ],
 )
 async def test_alerts_change(
     hass: HomeAssistant,

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -53,7 +53,7 @@ def mock_zha_config_flow_setup() -> Generator[None, None, None]:
 
 
 @pytest.mark.parametrize(
-    ("onboarded", "num_entries", "num_flows"), ((False, 1, 0), (True, 0, 1))
+    ("onboarded", "num_entries", "num_flows"), [(False, 1, 0), (True, 0, 1)]
 )
 async def test_setup_entry(
     mock_zha_config_flow_setup,

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -16,7 +16,7 @@ from tests.common import MockConfigEntry, MockModule, mock_integration
 
 
 @pytest.mark.parametrize(
-    ("onboarded", "num_entries", "num_flows"), ((False, 1, 0), (True, 0, 1))
+    ("onboarded", "num_entries", "num_flows"), [(False, 1, 0), (True, 0, 1)]
 )
 async def test_setup_entry(
     hass: HomeAssistant, onboarded, num_entries, num_flows, addon_store_info

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -615,7 +615,7 @@ async def test_light_restore(
 @pytest.mark.parametrize(
     ("supported_color_modes", "state_props", "turn_on_props_with_brightness"),
     [
-        [
+        (
             [ColorMode.COLOR_TEMP, ColorMode.RGBW],
             {
                 ATTR_RGBW_COLOR: (128, 50, 0, 255),
@@ -625,8 +625,8 @@ async def test_light_restore(
                 ATTR_COLOR_MODE: ColorMode.RGBW,
             },
             {ATTR_HS_COLOR: (145, 75), ATTR_BRIGHTNESS_PCT: 25},
-        ],
-        [
+        ),
+        (
             [ColorMode.COLOR_TEMP, ColorMode.RGBWW],
             {
                 ATTR_RGBWW_COLOR: (128, 50, 0, 255, 255),
@@ -636,7 +636,7 @@ async def test_light_restore(
                 ATTR_COLOR_MODE: ColorMode.RGBWW,
             },
             {ATTR_HS_COLOR: (145, 75), ATTR_BRIGHTNESS_PCT: 25},
-        ],
+        ),
     ],
 )
 async def test_light_rgb_with_color_temp(
@@ -735,7 +735,7 @@ async def test_light_rgb_with_color_temp(
 @pytest.mark.parametrize(
     ("supported_color_modes", "state_props", "turn_on_props_with_brightness"),
     [
-        [
+        (
             [ColorMode.RGBW],
             {
                 ATTR_RGBW_COLOR: (128, 50, 0, 255),
@@ -745,8 +745,8 @@ async def test_light_rgb_with_color_temp(
                 ATTR_COLOR_MODE: ColorMode.RGBW,
             },
             {ATTR_RGBW_COLOR: (0, 0, 0, 191)},
-        ],
-        [
+        ),
+        (
             [ColorMode.RGBWW],
             {
                 ATTR_RGBWW_COLOR: (128, 50, 0, 255, 255),
@@ -756,7 +756,7 @@ async def test_light_rgb_with_color_temp(
                 ATTR_COLOR_MODE: ColorMode.RGBWW,
             },
             {ATTR_RGBWW_COLOR: (0, 0, 0, 165, 26)},
-        ],
+        ),
     ],
 )
 async def test_light_rgbwx_with_color_temp_and_brightness(
@@ -932,7 +932,7 @@ async def test_light_rgb_or_w_lights(
 @pytest.mark.parametrize(
     ("supported_color_modes", "state_props"),
     [
-        [
+        (
             [ColorMode.COLOR_TEMP, ColorMode.RGBW],
             {
                 ATTR_RGBW_COLOR: (128, 50, 0, 255),
@@ -941,8 +941,8 @@ async def test_light_rgb_or_w_lights(
                 ATTR_BRIGHTNESS: 255,
                 ATTR_COLOR_MODE: ColorMode.RGBW,
             },
-        ],
-        [
+        ),
+        (
             [ColorMode.COLOR_TEMP, ColorMode.RGBWW],
             {
                 ATTR_RGBWW_COLOR: (128, 50, 0, 255, 255),
@@ -951,7 +951,7 @@ async def test_light_rgb_or_w_lights(
                 ATTR_BRIGHTNESS: 255,
                 ATTR_COLOR_MODE: ColorMode.RGBWW,
             },
-        ],
+        ),
     ],
 )
 async def test_light_rgb_with_white_switch_to_temp(

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -30,11 +30,11 @@ async def mock_http_client(hass: HomeAssistant, aiohttp_client: ClientSessionGen
 
 @pytest.mark.parametrize(
     ("url", "canonical_url"),
-    (
+    [
         ("//a", "//a"),
         ("///a", "///a"),
         ("/c:\\a\\b", "/c:%5Ca%5Cb"),
-    ),
+    ],
 )
 async def test_static_path_blocks_anchors(
     hass: HomeAssistant,

--- a/tests/components/huawei_lte/test_config_flow.py
+++ b/tests/components/huawei_lte/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_already_configured(
 
 @pytest.mark.parametrize(
     ("exception", "errors", "data_patch"),
-    (
+    [
         (ConnectionError(), {CONF_URL: "unknown"}, {}),
         (requests.exceptions.SSLError(), {CONF_URL: "ssl_error_try_plain"}, {}),
         (
@@ -110,7 +110,7 @@ async def test_already_configured(
             {CONF_URL: "ssl_error_try_unverified"},
             {CONF_VERIFY_SSL: True},
         ),
-    ),
+    ],
 )
 async def test_connection_errors(
     hass: HomeAssistant,
@@ -158,7 +158,7 @@ def login_requests_mock(requests_mock):
 
 @pytest.mark.parametrize(
     ("request_outcome", "fixture_override", "errors"),
-    (
+    [
         (
             {
                 "text": f"<error><code>{LoginErrorEnum.USERNAME_WRONG}</code><message/></error>",
@@ -202,7 +202,7 @@ def login_requests_mock(requests_mock):
             {},
             {CONF_URL: "connection_timeout"},
         ),
-    ),
+    ],
 )
 async def test_login_error(
     hass: HomeAssistant, login_requests_mock, request_outcome, fixture_override, errors
@@ -224,7 +224,7 @@ async def test_login_error(
     assert result["errors"] == errors
 
 
-@pytest.mark.parametrize("scheme", ("http", "https"))
+@pytest.mark.parametrize("scheme", ["http", "https"])
 async def test_success(hass: HomeAssistant, login_requests_mock, scheme: str) -> None:
     """Test successful flow provides entry creation data."""
     user_input = {
@@ -257,7 +257,7 @@ async def test_success(hass: HomeAssistant, login_requests_mock, scheme: str) ->
 
 @pytest.mark.parametrize(
     ("requests_mock_request_kwargs", "upnp_data", "expected_result"),
-    (
+    [
         (
             {
                 "method": ANY,
@@ -304,7 +304,7 @@ async def test_success(hass: HomeAssistant, login_requests_mock, scheme: str) ->
                 "reason": "unsupported_device",
             },
         ),
-    ),
+    ],
 )
 async def test_ssdp(
     hass: HomeAssistant,
@@ -346,7 +346,7 @@ async def test_ssdp(
 
 @pytest.mark.parametrize(
     ("login_response_text", "expected_result", "expected_entry_data"),
-    (
+    [
         (
             "<response>OK</response>",
             {
@@ -364,7 +364,7 @@ async def test_ssdp(
             },
             {**FIXTURE_USER_INPUT, CONF_PASSWORD: "invalid-password"},
         ),
-    ),
+    ],
 )
 async def test_reauth(
     hass: HomeAssistant,

--- a/tests/components/huawei_lte/test_device_tracker.py
+++ b/tests/components/huawei_lte/test_device_tracker.py
@@ -7,13 +7,13 @@ from homeassistant.components.huawei_lte import device_tracker
 
 @pytest.mark.parametrize(
     ("value", "expected"),
-    (
+    [
         ("HTTP", "http"),
         ("ID", "id"),
         ("IPAddress", "ip_address"),
         ("HTTPResponse", "http_response"),
         ("foo_bar", "foo_bar"),
-    ),
+    ],
 )
 def test_better_snakecase(value, expected) -> None:
     """Test that better snakecase works better."""

--- a/tests/components/huawei_lte/test_sensor.py
+++ b/tests/components/huawei_lte/test_sensor.py
@@ -11,11 +11,11 @@ from homeassistant.const import (
 
 @pytest.mark.parametrize(
     ("value", "expected"),
-    (
+    [
         ("-71 dBm", (-71, SIGNAL_STRENGTH_DECIBELS_MILLIWATT)),
         ("15dB", (15, SIGNAL_STRENGTH_DECIBELS)),
         (">=-51dBm", (-51, SIGNAL_STRENGTH_DECIBELS_MILLIWATT)),
-    ),
+    ],
 )
 def test_format_default(value, expected) -> None:
     """Test that default formatter copes with expected values."""

--- a/tests/components/humidifier/test_device_action.py
+++ b/tests/components/humidifier/test_device_action.py
@@ -95,12 +95,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -103,12 +103,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -103,12 +103,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/humidifier/test_intent.py
+++ b/tests/components/humidifier/test_intent.py
@@ -186,7 +186,7 @@ async def test_intent_set_mode_tests_feature(hass: HomeAssistant) -> None:
     assert len(mode_calls) == 0
 
 
-@pytest.mark.parametrize("available_modes", (["home", "away"], None))
+@pytest.mark.parametrize("available_modes", [["home", "away"], None])
 async def test_intent_set_unknown_mode(
     hass: HomeAssistant, available_modes: list[str] | None
 ) -> None:

--- a/tests/components/improv_ble/test_config_flow.py
+++ b/tests/components/improv_ble/test_config_flow.py
@@ -363,11 +363,11 @@ async def test_bluetooth_step_already_in_progress(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
-    ),
+    ],
 )
 async def test_can_identify_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -398,11 +398,11 @@ async def test_can_identify_fails(hass: HomeAssistant, exc, error) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
-    ),
+    ],
 )
 async def test_identify_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -441,11 +441,11 @@ async def test_identify_fails(hass: HomeAssistant, exc, error) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
-    ),
+    ],
 )
 async def test_need_authorization_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -485,11 +485,11 @@ async def test_need_authorization_fails(hass: HomeAssistant, exc, error) -> None
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
-    ),
+    ],
 )
 async def test_authorize_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -577,12 +577,12 @@ async def _test_provision_error(hass: HomeAssistant, exc) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (BleakError, "cannot_connect"),
         (Exception, "unknown"),
         (improv_ble_errors.CharacteristicMissingError, "characteristic_missing"),
         (improv_ble_errors.ProvisioningFailed(Error.UNKNOWN_ERROR), "unknown"),
-    ),
+    ],
 )
 async def test_provision_fails(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -595,7 +595,7 @@ async def test_provision_fails(hass: HomeAssistant, exc, error) -> None:
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    ((improv_ble_errors.ProvisioningFailed(Error.NOT_AUTHORIZED), "unknown"),),
+    [(improv_ble_errors.ProvisioningFailed(Error.NOT_AUTHORIZED), "unknown")],
 )
 async def test_provision_not_authorized(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""
@@ -619,12 +619,12 @@ async def test_provision_not_authorized(hass: HomeAssistant, exc, error) -> None
 
 @pytest.mark.parametrize(
     ("exc", "error"),
-    (
+    [
         (
             improv_ble_errors.ProvisioningFailed(Error.UNABLE_TO_CONNECT),
             "unable_to_connect",
         ),
-    ),
+    ],
 )
 async def test_provision_retry(hass: HomeAssistant, exc, error) -> None:
     """Test bluetooth flow with error."""

--- a/tests/components/integration/test_config_flow.py
+++ b/tests/components/integration/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(hass: HomeAssistant, platform) -> None:
     """Test the config flow."""
     input_sensor_entity_id = "sensor.input"
@@ -74,7 +74,7 @@ def get_suggested(schema, key):
     raise Exception
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_options(hass: HomeAssistant, platform) -> None:
     """Test reconfiguring."""
     # Setup the config entry

--- a/tests/components/integration/test_init.py
+++ b/tests/components/integration/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/justnimbus/test_config_flow.py
+++ b/tests/components/justnimbus/test_config_flow.py
@@ -28,7 +28,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("side_effect", "errors"),
-    (
+    [
         (
             InvalidClientID(client_id="test_id"),
             {"base": "invalid_auth"},
@@ -41,7 +41,7 @@ async def test_form(hass: HomeAssistant) -> None:
             RuntimeError,
             {"base": "unknown"},
         ),
-    ),
+    ],
 )
 async def test_form_errors(
     hass: HomeAssistant,

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -83,12 +83,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -69,12 +69,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -69,12 +69,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -438,7 +438,7 @@ async def test_services(
 
 @pytest.mark.parametrize(
     ("profile_name", "last_call", "expected_data"),
-    (
+    [
         (
             "test",
             "turn_on",
@@ -501,7 +501,7 @@ async def test_services(
                 light.ATTR_TRANSITION: 5.3,
             },
         ),
-    ),
+    ],
 )
 async def test_light_profiles(
     hass: HomeAssistant,
@@ -591,7 +591,7 @@ async def test_default_profiles_group(
         "expected_params_state_was_off",
         "expected_params_state_was_on",
     ),
-    (
+    [
         (
             # No turn on params, should apply profile
             {},
@@ -774,7 +774,7 @@ async def test_default_profiles_group(
                 light.ATTR_TRANSITION: 1,
             },
         ),
-    ),
+    ],
 )
 async def test_default_profiles_light(
     hass: HomeAssistant,
@@ -1128,7 +1128,7 @@ invalid_no_brightness_no_color_no_transition,,,
         assert invalid_profile_name not in profiles.data
 
 
-@pytest.mark.parametrize("light_state", (STATE_ON, STATE_OFF))
+@pytest.mark.parametrize("light_state", [STATE_ON, STATE_OFF])
 async def test_light_backwards_compatibility_supported_color_modes(
     hass: HomeAssistant, light_state, enable_custom_integrations: None
 ) -> None:

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -127,7 +127,7 @@ async def test_reproducing_states(
 
 @pytest.mark.parametrize(
     "color_mode",
-    (
+    [
         light.ColorMode.COLOR_TEMP,
         light.ColorMode.BRIGHTNESS,
         light.ColorMode.HS,
@@ -138,7 +138,7 @@ async def test_reproducing_states(
         light.ColorMode.UNKNOWN,
         light.ColorMode.WHITE,
         light.ColorMode.XY,
-    ),
+    ],
 )
 async def test_filter_color_modes(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, color_mode
@@ -195,7 +195,7 @@ async def test_filter_color_modes(
 
 @pytest.mark.parametrize(
     "saved_state",
-    (
+    [
         NONE_BRIGHTNESS,
         NONE_EFFECT,
         NONE_COLOR_TEMP,
@@ -204,7 +204,7 @@ async def test_filter_color_modes(
         NONE_RGBW_COLOR,
         NONE_RGBWW_COLOR,
         NONE_XY_COLOR,
-    ),
+    ],
 )
 async def test_filter_none(hass: HomeAssistant, saved_state) -> None:
     """Test filtering of parameters which are None."""

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -47,10 +47,10 @@ async def test_unload_entry(hass: HomeAssistant, mock_account: MagicMock) -> Non
 
 @pytest.mark.parametrize(
     ("side_effect", "expected_state"),
-    (
+    [
         (LitterRobotLoginException, ConfigEntryState.SETUP_ERROR),
         (LitterRobotException, ConfigEntryState.SETUP_RETRY),
-    ),
+    ],
 )
 async def test_entry_not_setup(
     hass: HomeAssistant,

--- a/tests/components/lock/test_device_action.py
+++ b/tests/components/lock/test_device_action.py
@@ -90,12 +90,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -77,12 +77,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -76,12 +76,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/lovelace/test_dashboard.py
+++ b/tests/components/lovelace/test_dashboard.py
@@ -181,7 +181,7 @@ async def test_lovelace_from_yaml(
     assert len(events) == 1
 
 
-@pytest.mark.parametrize("url_path", ("test-panel", "test-panel-no-sidebar"))
+@pytest.mark.parametrize("url_path", ["test-panel", "test-panel-no-sidebar"])
 async def test_dashboard_from_yaml(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, url_path
 ) -> None:

--- a/tests/components/lutron_caseta/test_config_flow.py
+++ b/tests/components/lutron_caseta/test_config_flow.py
@@ -473,7 +473,7 @@ async def test_zeroconf_not_lutron_device(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "source", (config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT)
+    "source", [config_entries.SOURCE_ZEROCONF, config_entries.SOURCE_HOMEKIT]
 )
 async def test_zeroconf(hass: HomeAssistant, source, tmp_path: Path) -> None:
     """Test starting a flow from discovery."""

--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -79,12 +79,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -87,12 +87,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/media_player/test_init.py
+++ b/tests/components/media_player/test_init.py
@@ -240,14 +240,14 @@ async def test_group_members_available_when_off(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("input", "expected"),
-    (
+    [
         (True, MediaPlayerEnqueue.ADD),
         (False, MediaPlayerEnqueue.PLAY),
         ("play", MediaPlayerEnqueue.PLAY),
         ("next", MediaPlayerEnqueue.NEXT),
         ("add", MediaPlayerEnqueue.ADD),
         ("replace", MediaPlayerEnqueue.REPLACE),
-    ),
+    ],
 )
 async def test_enqueue_rewrite(hass: HomeAssistant, input, expected) -> None:
     """Test that group_members are still available when media_player is off."""

--- a/tests/components/min_max/test_config_flow.py
+++ b/tests/components/min_max/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(hass: HomeAssistant, platform: str) -> None:
     """Test the config flow."""
     input_sensors = ["sensor.input_one", "sensor.input_two"]
@@ -66,7 +66,7 @@ def get_suggested(schema, key):
     raise Exception
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_options(hass: HomeAssistant, platform: str) -> None:
     """Test reconfiguring."""
     hass.states.async_set("sensor.input_one", "10")

--- a/tests/components/min_max/test_init.py
+++ b/tests/components/min_max/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -120,7 +120,7 @@ async def test_create_cloud_hook_on_setup(
     await _test_create_cloud_hook(hass, hass_admin_user, {}, True, additional_steps)
 
 
-@pytest.mark.parametrize("exception", (CloudNotAvailable, ValueError))
+@pytest.mark.parametrize("exception", [CloudNotAvailable, ValueError])
 async def test_remove_cloudhook(
     hass: HomeAssistant,
     hass_admin_user: MockUser,

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -19,10 +19,10 @@ from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 @pytest.mark.parametrize(
     ("unit_system", "state_unit", "state1", "state2"),
-    (
+    [
         (METRIC_SYSTEM, UnitOfTemperature.CELSIUS, "100", "123"),
         (US_CUSTOMARY_SYSTEM, UnitOfTemperature.FAHRENHEIT, "212", "253"),
-    ),
+    ],
 )
 async def test_sensor(
     hass: HomeAssistant,
@@ -128,7 +128,7 @@ async def test_sensor(
 
 @pytest.mark.parametrize(
     ("unique_id", "unit_system", "state_unit", "state1", "state2"),
-    (
+    [
         ("battery_temperature", METRIC_SYSTEM, UnitOfTemperature.CELSIUS, "100", "123"),
         (
             "battery_temperature",
@@ -145,7 +145,7 @@ async def test_sensor(
             "212",
             "123",
         ),
-    ),
+    ],
 )
 async def test_sensor_migration(
     hass: HomeAssistant,

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -348,13 +348,13 @@ async def test_webhook_returns_error_incorrect_json(
 
 @pytest.mark.parametrize(
     ("msg", "generate_response"),
-    (
+    [
         (RENDER_TEMPLATE, lambda hass: {"one": "Hello world"}),
         (
             {"type": "get_zones", "data": {}},
             lambda hass: [hass.states.get("zone.home").as_dict()],
         ),
-    ),
+    ],
 )
 async def test_webhook_handle_decryption(
     hass: HomeAssistant, webhook_client, create_registrations, msg, generate_response

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -1328,24 +1328,24 @@ async def mock_modbus_read_pymodbus_fixture(
 @pytest.mark.parametrize(
     ("do_domain", "do_group", "do_type", "do_scan_interval"),
     [
-        [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_HOLDING, 10],
-        [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_INPUT, 10],
-        [BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_DISCRETE, 10],
-        [BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_COIL, 1],
+        (SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_HOLDING, 10),
+        (SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_INPUT, 10),
+        (BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_DISCRETE, 10),
+        (BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_COIL, 1),
     ],
 )
 @pytest.mark.parametrize(
     ("do_return", "do_exception", "do_expect_state", "do_expect_value"),
     [
-        [ReadResult([1]), None, STATE_ON, "1"],
-        [IllegalFunctionRequest(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE],
-        [ExceptionResponse(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE],
-        [
+        (ReadResult([1]), None, STATE_ON, "1"),
+        (IllegalFunctionRequest(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE),
+        (ExceptionResponse(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE),
+        (
             ReadResult([1]),
             ModbusException("fail read_"),
             STATE_UNAVAILABLE,
             STATE_UNAVAILABLE,
-        ],
+        ),
     ],
 )
 async def test_pb_read(

--- a/tests/components/netgear_lte/test_config_flow.py
+++ b/tests/components/netgear_lte/test_config_flow.py
@@ -40,7 +40,7 @@ async def test_flow_user_form(hass: HomeAssistant, connection: None) -> None:
     assert result["context"]["unique_id"] == "FFFFFFFFFFFFF"
 
 
-@pytest.mark.parametrize("source", (SOURCE_USER, SOURCE_IMPORT))
+@pytest.mark.parametrize("source", [SOURCE_USER, SOURCE_IMPORT])
 async def test_flow_already_configured(
     hass: HomeAssistant, setup_integration: None, source: str
 ) -> None:

--- a/tests/components/nextbus/test_config_flow.py
+++ b/tests/components/nextbus/test_config_flow.py
@@ -70,11 +70,11 @@ async def test_import_config(
 
 @pytest.mark.parametrize(
     ("override", "expected_reason"),
-    (
+    [
         ({CONF_AGENCY: "not muni"}, "invalid_agency"),
         ({CONF_ROUTE: "not F"}, "invalid_route"),
         ({CONF_STOP: "not 5650"}, "invalid_stop"),
-    ),
+    ],
 )
 async def test_import_config_invalid(
     hass: HomeAssistant,

--- a/tests/components/nextbus/test_sensor.py
+++ b/tests/components/nextbus/test_sensor.py
@@ -274,10 +274,10 @@ async def test_direction_list(
 
 @pytest.mark.parametrize(
     "client_exception",
-    (
+    [
         NextBusHTTPError("failed", HTTPError("url", 500, "error", MagicMock(), None)),
         NextBusFormatError("failed"),
-    ),
+    ],
 )
 async def test_prediction_exceptions(
     hass: HomeAssistant,
@@ -312,10 +312,10 @@ async def test_custom_name(
 
 @pytest.mark.parametrize(
     "prediction_results",
-    (
+    [
         {},
         {"Error": "Failed"},
-    ),
+    ],
 )
 async def test_no_predictions(
     hass: HomeAssistant,

--- a/tests/components/nextbus/test_util.py
+++ b/tests/components/nextbus/test_util.py
@@ -9,11 +9,11 @@ from homeassistant.components.nextbus.util import listify, maybe_first
 
 @pytest.mark.parametrize(
     ("input", "expected"),
-    (
+    [
         ("foo", ["foo"]),
         (["foo"], ["foo"]),
         (None, []),
-    ),
+    ],
 )
 def test_listify(input: Any, expected: list[Any]) -> None:
     """Test input listification."""
@@ -22,13 +22,13 @@ def test_listify(input: Any, expected: list[Any]) -> None:
 
 @pytest.mark.parametrize(
     ("input", "expected"),
-    (
+    [
         ([], []),
         (None, None),
         ("test", "test"),
         (["test"], "test"),
         (["test", "second"], "test"),
-    ),
+    ],
 )
 def test_maybe_first(input: list[Any] | None, expected: Any) -> None:
     """Test maybe getting the first thing from a list."""

--- a/tests/components/nibe_heatpump/test_config_flow.py
+++ b/tests/components/nibe_heatpump/test_config_flow.py
@@ -146,10 +146,10 @@ async def test_nibegw_address_inuse(hass: HomeAssistant, mock_connection: Mock) 
 
 @pytest.mark.parametrize(
     ("connection_type", "data"),
-    (
+    [
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
-    ),
+    ],
 )
 async def test_read_timeout(
     hass: HomeAssistant, mock_connection: Mock, connection_type: str, data: dict
@@ -167,10 +167,10 @@ async def test_read_timeout(
 
 @pytest.mark.parametrize(
     ("connection_type", "data"),
-    (
+    [
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
-    ),
+    ],
 )
 async def test_write_timeout(
     hass: HomeAssistant, mock_connection: Mock, connection_type: str, data: dict
@@ -188,10 +188,10 @@ async def test_write_timeout(
 
 @pytest.mark.parametrize(
     ("connection_type", "data"),
-    (
+    [
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
-    ),
+    ],
 )
 async def test_unexpected_exception(
     hass: HomeAssistant, mock_connection: Mock, connection_type: str, data: dict
@@ -209,10 +209,10 @@ async def test_unexpected_exception(
 
 @pytest.mark.parametrize(
     ("connection_type", "data"),
-    (
+    [
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
-    ),
+    ],
 )
 async def test_nibegw_invalid_host(
     hass: HomeAssistant, mock_connection: Mock, connection_type: str, data: dict
@@ -233,10 +233,10 @@ async def test_nibegw_invalid_host(
 
 @pytest.mark.parametrize(
     ("connection_type", "data"),
-    (
+    [
         ("nibegw", MOCK_FLOW_NIBEGW_USERDATA),
         ("modbus", MOCK_FLOW_MODBUS_USERDATA),
-    ),
+    ],
 )
 async def test_model_missing_coil(
     hass: HomeAssistant, mock_connection: Mock, connection_type: str, data: dict

--- a/tests/components/number/test_device_action.py
+++ b/tests/components/number/test_device_action.py
@@ -62,12 +62,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/oncue/test_sensor.py
+++ b/tests/components/oncue/test_sensor.py
@@ -25,8 +25,8 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("patcher", "connections"),
     [
-        [_patch_login_and_data, {("mac", "c9:24:22:6f:14:00")}],
-        [_patch_login_and_data_offline_device, set()],
+        (_patch_login_and_data, {("mac", "c9:24:22:6f:14:00")}),
+        (_patch_login_and_data_offline_device, set()),
     ],
 )
 async def test_sensors(hass: HomeAssistant, patcher, connections) -> None:
@@ -152,8 +152,8 @@ async def test_sensors(hass: HomeAssistant, patcher, connections) -> None:
 @pytest.mark.parametrize(
     ("patcher", "connections"),
     [
-        [_patch_login_and_data_unavailable_device, set()],
-        [_patch_login_and_data_unavailable, {("mac", "c9:24:22:6f:14:00")}],
+        (_patch_login_and_data_unavailable_device, set()),
+        (_patch_login_and_data_unavailable, {("mac", "c9:24:22:6f:14:00")}),
     ],
 )
 async def test_sensors_unavailable(hass: HomeAssistant, patcher, connections) -> None:

--- a/tests/components/p1_monitor/test_sensor.py
+++ b/tests/components/p1_monitor/test_sensor.py
@@ -239,7 +239,7 @@ async def test_no_watermeter(
 
 @pytest.mark.parametrize(
     "entity_id",
-    ("sensor.smartmeter_gas_consumption",),
+    ["sensor.smartmeter_gas_consumption"],
 )
 async def test_smartmeter_disabled_by_default(
     hass: HomeAssistant, init_integration: MockConfigEntry, entity_id: str

--- a/tests/components/panel_iframe/test_init.py
+++ b/tests/components/panel_iframe/test_init.py
@@ -9,10 +9,10 @@ from homeassistant.setup import async_setup_component
 
 @pytest.mark.parametrize(
     "config_to_try",
-    (
+    [
         {"invalid space": {"url": "https://home-assistant.io"}},
         {"router": {"url": "not-a-url"}},
-    ),
+    ],
 )
 async def test_wrong_config(hass: HomeAssistant, config_to_try) -> None:
     """Test setup with wrong configuration."""

--- a/tests/components/ping/test_config_flow.py
+++ b/tests/components/ping/test_config_flow.py
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry
 
 @pytest.mark.parametrize(
     ("host", "expected_title"),
-    (("192.618.178.1", "192.618.178.1"),),
+    [("192.618.178.1", "192.618.178.1")],
 )
 @pytest.mark.usefixtures("patch_setup")
 async def test_form(hass: HomeAssistant, host, expected_title) -> None:
@@ -49,7 +49,7 @@ async def test_form(hass: HomeAssistant, host, expected_title) -> None:
 
 @pytest.mark.parametrize(
     ("host", "count", "expected_title"),
-    (("192.618.178.1", 10, "192.618.178.1"),),
+    [("192.618.178.1", 10, "192.618.178.1")],
 )
 @pytest.mark.usefixtures("patch_setup")
 async def test_options(hass: HomeAssistant, host, count, expected_title) -> None:

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -60,7 +60,7 @@ async def test_form_source_user(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-@pytest.mark.parametrize("exc", (PowerwallUnreachableError, TimeoutError))
+@pytest.mark.parametrize("exc", [PowerwallUnreachableError, TimeoutError])
 async def test_form_cannot_connect(hass: HomeAssistant, exc: Exception) -> None:
     """Test we handle cannot connect error."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/prusalink/test_button.py
+++ b/tests/components/prusalink/test_button.py
@@ -22,10 +22,10 @@ def setup_button_platform_only():
 
 @pytest.mark.parametrize(
     ("object_id", "method"),
-    (
+    [
         ("mock_title_cancel_job", "cancel_job"),
         ("mock_title_pause_job", "pause_job"),
-    ),
+    ],
 )
 async def test_button_pause_cancel(
     hass: HomeAssistant,
@@ -68,10 +68,10 @@ async def test_button_pause_cancel(
 
 @pytest.mark.parametrize(
     ("object_id", "method"),
-    (
+    [
         ("mock_title_cancel_job", "cancel_job"),
         ("mock_title_resume_job", "resume_job"),
-    ),
+    ],
 )
 async def test_button_resume_cancel(
     hass: HomeAssistant,

--- a/tests/components/random/test_config_flow.py
+++ b/tests/components/random/test_config_flow.py
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
         "extra_input",
         "extra_options",
     ),
-    (
+    [
         (
             "binary_sensor",
             {},
@@ -47,7 +47,7 @@ from tests.common import MockConfigEntry
             {},
             {"minimum": 0, "maximum": 20},
         ),
-    ),
+    ],
 )
 async def test_config_flow(
     hass: HomeAssistant,
@@ -135,7 +135,7 @@ async def test_wrong_uom(
         "extra_options",
         "options_options",
     ),
-    (
+    [
         (
             "sensor",
             {
@@ -151,7 +151,7 @@ async def test_wrong_uom(
                 "unit_of_measurement": UnitOfPower.WATT,
             },
         ),
-    ),
+    ],
 )
 async def test_options(
     hass: HomeAssistant,

--- a/tests/components/recorder/auto_repairs/events/test_schema.py
+++ b/tests/components/recorder/auto_repairs/events/test_schema.py
@@ -12,7 +12,7 @@ from tests.typing import RecorderInstanceGenerator
 
 
 @pytest.mark.parametrize("enable_schema_validation", [True])
-@pytest.mark.parametrize("db_engine", ("mysql", "postgresql"))
+@pytest.mark.parametrize("db_engine", ["mysql", "postgresql"])
 async def test_validate_db_schema_fix_float_issue(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/auto_repairs/states/test_schema.py
+++ b/tests/components/recorder/auto_repairs/states/test_schema.py
@@ -12,7 +12,7 @@ from tests.typing import RecorderInstanceGenerator
 
 
 @pytest.mark.parametrize("enable_schema_validation", [True])
-@pytest.mark.parametrize("db_engine", ("mysql", "postgresql"))
+@pytest.mark.parametrize("db_engine", ["mysql", "postgresql"])
 async def test_validate_db_schema_fix_float_issue(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/auto_repairs/statistics/test_schema.py
+++ b/tests/components/recorder/auto_repairs/statistics/test_schema.py
@@ -42,8 +42,8 @@ async def test_validate_db_schema_fix_utf8_issue(
 
 
 @pytest.mark.parametrize("enable_schema_validation", [True])
-@pytest.mark.parametrize("table", ("statistics_short_term", "statistics"))
-@pytest.mark.parametrize("db_engine", ("mysql", "postgresql"))
+@pytest.mark.parametrize("table", ["statistics_short_term", "statistics"])
+@pytest.mark.parametrize("db_engine", ["mysql", "postgresql"])
 async def test_validate_db_schema_fix_float_issue(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/auto_repairs/test_schema.py
+++ b/tests/components/recorder/auto_repairs/test_schema.py
@@ -23,7 +23,7 @@ from tests.typing import RecorderInstanceGenerator
 
 
 @pytest.mark.parametrize("enable_schema_validation", [True])
-@pytest.mark.parametrize("db_engine", ("mysql", "postgresql"))
+@pytest.mark.parametrize("db_engine", ["mysql", "postgresql"])
 async def test_validate_db_schema(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -274,11 +274,11 @@ async def test_saving_state(recorder_mock: Recorder, hass: HomeAssistant) -> Non
 
 @pytest.mark.parametrize(
     ("dialect_name", "expected_attributes"),
-    (
+    [
         (SupportedDialect.MYSQL, {"test_attr": 5, "test_attr_10": "silly\0stuff"}),
         (SupportedDialect.POSTGRESQL, {"test_attr": 5, "test_attr_10": "silly"}),
         (SupportedDialect.SQLITE, {"test_attr": 5, "test_attr_10": "silly\0stuff"}),
-    ),
+    ],
 )
 async def test_saving_state_with_nul(
     recorder_mock: Recorder, hass: HomeAssistant, dialect_name, expected_attributes
@@ -2116,14 +2116,14 @@ async def test_async_block_till_done(
 
 @pytest.mark.parametrize(
     ("db_url", "echo"),
-    (
+    [
         ("sqlite://blabla", None),
         ("mariadb://blabla", False),
         ("mysql://blabla", False),
         ("mariadb+pymysql://blabla", False),
         ("mysql+pymysql://blabla", False),
         ("postgresql://blabla", False),
-    ),
+    ],
 )
 async def test_disable_echo(
     hass: HomeAssistant, db_url, echo, caplog: pytest.LogCaptureFixture
@@ -2148,7 +2148,7 @@ async def test_disable_echo(
 
 @pytest.mark.parametrize(
     ("config_url", "expected_connect_args"),
-    (
+    [
         (
             "mariadb://user:password@SERVER_IP/DB_NAME",
             {"charset": "utf8mb4"},
@@ -2181,7 +2181,7 @@ async def test_disable_echo(
             "sqlite://blabla",
             {},
         ),
-    ),
+    ],
 )
 async def test_mysql_missing_utf8mb4(
     hass: HomeAssistant, config_url, expected_connect_args
@@ -2209,11 +2209,11 @@ async def test_mysql_missing_utf8mb4(
 
 @pytest.mark.parametrize(
     "config_url",
-    (
+    [
         "mysql://user:password@SERVER_IP/DB_NAME",
         "mysql://user:password@SERVER_IP/DB_NAME?charset=utf8mb4",
         "mysql://user:password@SERVER_IP/DB_NAME?blah=bleh&charset=other",
-    ),
+    ],
 )
 async def test_connect_args_priority(hass: HomeAssistant, config_url) -> None:
     """Test connect_args has priority over URL query."""

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -381,7 +381,7 @@ async def test_purge_old_statistics_runs(
         assert statistics_runs.count() == 1
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_method(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
@@ -506,7 +506,7 @@ async def test_purge_method(
     )
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_edge_case(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
@@ -749,7 +749,7 @@ async def test_purge_cutoff_date(
         assert state_attributes.count() == 0
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_filtered_states(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
@@ -944,7 +944,7 @@ async def test_purge_filtered_states(
         assert session.query(StateAttributes).count() == 0
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_filtered_states_to_empty(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
@@ -998,7 +998,7 @@ async def test_purge_filtered_states_to_empty(
     await async_wait_purge_done(hass)
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_without_state_attributes_filtered_states_to_empty(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/test_purge_v32_schema.py
+++ b/tests/components/recorder/test_purge_v32_schema.py
@@ -349,7 +349,7 @@ async def test_purge_old_statistics_runs(
         assert statistics_runs.count() == 1
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_method(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,
@@ -469,7 +469,7 @@ async def test_purge_method(
     )
 
 
-@pytest.mark.parametrize("use_sqlite", (True, False), indirect=True)
+@pytest.mark.parametrize("use_sqlite", [True, False], indirect=True)
 async def test_purge_edge_case(
     async_setup_recorder_instance: RecorderInstanceGenerator,
     hass: HomeAssistant,

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -682,13 +682,13 @@ def test_statistics_duplicated(
         caplog.clear()
 
 
-@pytest.mark.parametrize("last_reset_str", ("2022-01-01T00:00:00+02:00", None))
+@pytest.mark.parametrize("last_reset_str", ["2022-01-01T00:00:00+02:00", None])
 @pytest.mark.parametrize(
     ("source", "statistic_id", "import_fn"),
-    (
+    [
         ("test", "test:total_energy_import", async_add_external_statistics),
         ("recorder", "sensor.total_energy_import", async_import_statistics),
-    ),
+    ],
 )
 async def test_import_statistics(
     recorder_mock: Recorder,

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -216,7 +216,7 @@ async def test_statistics_during_period(
 
 
 @pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
-@pytest.mark.parametrize("offset", (0, 1, 2))
+@pytest.mark.parametrize("offset", [0, 1, 2])
 async def test_statistic_during_period(
     recorder_mock: Recorder,
     hass: HomeAssistant,
@@ -797,7 +797,7 @@ async def test_statistic_during_period_hole(
 @pytest.mark.freeze_time(datetime.datetime(2022, 10, 21, 7, 25, tzinfo=datetime.UTC))
 @pytest.mark.parametrize(
     ("calendar_period", "start_time", "end_time"),
-    (
+    [
         (
             {"period": "hour"},
             "2022-10-21T07:00:00+00:00",
@@ -848,7 +848,7 @@ async def test_statistic_during_period_hole(
             "2021-01-01T08:00:00+00:00",
             "2022-01-01T08:00:00+00:00",
         ),
-    ),
+    ],
 )
 async def test_statistic_during_period_calendar(
     recorder_mock: Recorder,
@@ -2393,10 +2393,10 @@ async def test_get_statistics_metadata(
 
 @pytest.mark.parametrize(
     ("source", "statistic_id"),
-    (
+    [
         ("test", "test:total_energy_import"),
         ("recorder", "sensor.total_energy_import"),
-    ),
+    ],
 )
 async def test_import_statistics(
     recorder_mock: Recorder,
@@ -2607,10 +2607,10 @@ async def test_import_statistics(
 
 @pytest.mark.parametrize(
     ("source", "statistic_id"),
-    (
+    [
         ("test", "test:total_energy_import"),
         ("recorder", "sensor.total_energy_import"),
-    ),
+    ],
 )
 async def test_adjust_sum_statistics_energy(
     recorder_mock: Recorder,
@@ -2800,10 +2800,10 @@ async def test_adjust_sum_statistics_energy(
 
 @pytest.mark.parametrize(
     ("source", "statistic_id"),
-    (
+    [
         ("test", "test:total_gas"),
         ("recorder", "sensor.total_gas"),
-    ),
+    ],
 )
 async def test_adjust_sum_statistics_gas(
     recorder_mock: Recorder,
@@ -3000,14 +3000,14 @@ async def test_adjust_sum_statistics_gas(
         "valid_units",
         "invalid_units",
     ),
-    (
+    [
         ("kWh", "kWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),
         ("MWh", "MWh", "energy", 1, ("Wh", "kWh", "MWh"), ("ft³", "m³", "cats", None)),
         ("m³", "m³", "volume", 1, ("ft³", "m³"), ("Wh", "kWh", "MWh", "cats", None)),
         ("ft³", "ft³", "volume", 1, ("ft³", "m³"), ("Wh", "kWh", "MWh", "cats", None)),
         ("dogs", "dogs", None, 1, ("dogs",), ("cats", None)),
         (None, None, "unitless", 1, (None,), ("cats",)),
-    ),
+    ],
 )
 async def test_adjust_sum_statistics_errors(
     recorder_mock: Recorder,

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -63,12 +63,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -69,12 +69,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -69,12 +69,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/repairs/test_init.py
+++ b/tests/components/repairs/test_init.py
@@ -125,7 +125,7 @@ async def test_create_update_issue(
     )
 
 
-@pytest.mark.parametrize("ha_version", ("2022.9.cat", "In the future: 2023.1.1"))
+@pytest.mark.parametrize("ha_version", ["2022.9.cat", "In the future: 2023.1.1"])
 async def test_create_issue_invalid_version(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, ha_version
 ) -> None:

--- a/tests/components/repairs/test_websocket_api.py
+++ b/tests/components/repairs/test_websocket_api.py
@@ -270,10 +270,10 @@ async def test_fix_non_existing_issue(
 
 @pytest.mark.parametrize(
     ("domain", "step", "description_placeholders"),
-    (
+    [
         ("fake_integration", "custom_step", None),
         ("fake_integration_default_handler", "confirm", {"abc": "123"}),
-    ),
+    ],
 )
 async def test_fix_issue(
     hass: HomeAssistant,

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -162,11 +162,11 @@ async def test_setup_encoding(hass: HomeAssistant) -> None:
 @respx.mock
 @pytest.mark.parametrize(
     ("ssl_cipher_list", "ssl_cipher_list_expected"),
-    (
+    [
         ("python_default", SSLCipherList.PYTHON_DEFAULT),
         ("intermediate", SSLCipherList.INTERMEDIATE),
         ("modern", SSLCipherList.MODERN),
-    ),
+    ],
 )
 async def test_setup_ssl_ciphers(
     hass: HomeAssistant, ssl_cipher_list: str, ssl_cipher_list_expected: SSLCipherList

--- a/tests/components/rfxtrx/test_binary_sensor.py
+++ b/tests/components/rfxtrx/test_binary_sensor.py
@@ -98,7 +98,7 @@ async def test_pt2262_unconfigured(hass: HomeAssistant, rfxtrx) -> None:
 
 @pytest.mark.parametrize(
     ("state", "event"),
-    [["on", "0b1100cd0213c7f230010f71"], ["off", "0b1100cd0213c7f230000f71"]],
+    [("on", "0b1100cd0213c7f230010f71"), ("off", "0b1100cd0213c7f230000f71")],
 )
 async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
     """State restoration."""

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -67,15 +67,15 @@ def _get_expected_actions(data):
 @pytest.mark.parametrize(
     ("device", "expected"),
     [
-        [
+        (
             DEVICE_LIGHTING_1,
             list(_get_expected_actions(RFXtrx.lowlevel.Lighting1.COMMANDS)),
-        ],
-        [
+        ),
+        (
             DEVICE_BLINDS_1,
             list(_get_expected_actions(RFXtrx.lowlevel.RollerTrol.COMMANDS)),
-        ],
-        [DEVICE_TEMPHUM_1, []],
+        ),
+        (DEVICE_TEMPHUM_1, []),
     ],
 )
 async def test_get_actions(
@@ -115,21 +115,21 @@ async def test_get_actions(
 @pytest.mark.parametrize(
     ("device", "config", "expected"),
     [
-        [
+        (
             DEVICE_LIGHTING_1,
             {"type": "send_command", "subtype": "On"},
             "0710000045050100",
-        ],
-        [
+        ),
+        (
             DEVICE_LIGHTING_1,
             {"type": "send_command", "subtype": "Off"},
             "0710000045050000",
-        ],
-        [
+        ),
+        (
             DEVICE_BLINDS_1,
             {"type": "send_command", "subtype": "Stop"},
             "09190000009ba8010200",
-        ],
+        ),
     ],
 )
 async def test_action(

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -61,7 +61,7 @@ async def setup_entry(hass, devices):
 @pytest.mark.parametrize(
     ("event", "expected"),
     [
-        [
+        (
             EVENT_LIGHTING_1,
             [
                 {"type": "command", "subtype": subtype}
@@ -76,7 +76,7 @@ async def setup_entry(hass, devices):
                     "Illegal command",
                 ]
             ],
-        ]
+        )
     ],
 )
 async def test_get_triggers(

--- a/tests/components/rfxtrx/test_light.py
+++ b/tests/components/rfxtrx/test_light.py
@@ -91,7 +91,7 @@ async def test_one_light(hass: HomeAssistant, rfxtrx) -> None:
 
 
 @pytest.mark.parametrize(
-    ("state", "brightness"), [["on", 100], ["on", 50], ["off", None]]
+    ("state", "brightness"), [("on", 100), ("on", 50), ("off", None)]
 )
 async def test_state_restore(hass: HomeAssistant, rfxtrx, state, brightness) -> None:
     """State restoration."""

--- a/tests/components/rfxtrx/test_sensor.py
+++ b/tests/components/rfxtrx/test_sensor.py
@@ -52,7 +52,7 @@ async def test_one_sensor(hass: HomeAssistant, rfxtrx) -> None:
 
 @pytest.mark.parametrize(
     ("state", "event"),
-    [["18.4", "0a520801070100b81b0279"], ["17.9", "0a52085e070100b31b0279"]],
+    [("18.4", "0a520801070100b81b0279"), ("17.9", "0a52085e070100b31b0279")],
 )
 async def test_state_restore(hass: HomeAssistant, rfxtrx, state, event) -> None:
     """State restoration."""

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -118,7 +118,7 @@ async def test_invalid_config(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("schedule", "error"),
-    (
+    [
         (
             [
                 {CONF_FROM: "00:00:00", CONF_TO: "23:59:59"},
@@ -153,7 +153,7 @@ async def test_invalid_config(hass: HomeAssistant) -> None:
             ],
             "Invalid time range, from 06:00:00 is after 05:00:00",
         ),
-    ),
+    ],
 )
 async def test_invalid_schedules(
     hass: HomeAssistant,
@@ -419,10 +419,10 @@ async def test_non_adjacent_within_day(
 
 @pytest.mark.parametrize(
     "schedule",
-    (
+    [
         {CONF_FROM: "00:00:00", CONF_TO: "24:00"},
         {CONF_FROM: "00:00:00", CONF_TO: "24:00:00"},
-    ),
+    ],
 )
 async def test_to_midnight(
     hass: HomeAssistant,
@@ -595,11 +595,11 @@ async def test_ws_delete(
 @pytest.mark.freeze_time("2022-08-10 20:10:00-07:00")
 @pytest.mark.parametrize(
     ("to", "next_event", "saved_to"),
-    (
+    [
         ("23:59:59", "2022-08-10T23:59:59-07:00", "23:59:59"),
         ("24:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
         ("24:00:00", "2022-08-11T00:00:00-07:00", "24:00:00"),
-    ),
+    ],
 )
 async def test_update(
     hass: HomeAssistant,
@@ -665,11 +665,11 @@ async def test_update(
 @pytest.mark.freeze_time("2022-08-11 8:52:00-07:00")
 @pytest.mark.parametrize(
     ("to", "next_event", "saved_to"),
-    (
+    [
         ("14:00:00", "2022-08-15T14:00:00-07:00", "14:00:00"),
         ("24:00", "2022-08-16T00:00:00-07:00", "24:00:00"),
         ("24:00:00", "2022-08-16T00:00:00-07:00", "24:00:00"),
-    ),
+    ],
 )
 async def test_ws_create(
     hass: HomeAssistant,

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -196,7 +196,7 @@ async def test_setup_with_invalid_configs(
 
 @pytest.mark.parametrize(
     ("object_id", "broken_config", "problem", "details"),
-    (
+    [
         (
             "Bad Script",
             {},
@@ -212,7 +212,7 @@ async def test_setup_with_invalid_configs(
                 "reload, toggle, turn_off, turn_on. Got 'turn_on'"
             ),
         ),
-    ),
+    ],
 )
 async def test_bad_config_validation_critical(
     hass: HomeAssistant,
@@ -252,7 +252,7 @@ async def test_bad_config_validation_critical(
 
 @pytest.mark.parametrize(
     ("object_id", "broken_config", "problem", "details"),
-    (
+    [
         (
             "bad_script",
             {},
@@ -272,7 +272,7 @@ async def test_bad_config_validation_critical(
             "failed to setup actions",
             "Unknown entity registry entry abcdabcdabcdabcdabcdabcdabcdabcd.",
         ),
-    ),
+    ],
 )
 async def test_bad_config_validation(
     hass: HomeAssistant,
@@ -424,7 +424,7 @@ async def test_reload_unchanged_does_not_stop(hass: HomeAssistant, calls) -> Non
 
 @pytest.mark.parametrize(
     "script_config",
-    (
+    [
         {
             "test": {
                 "sequence": [{"service": "test.script"}],
@@ -458,7 +458,7 @@ async def test_reload_unchanged_does_not_stop(hass: HomeAssistant, calls) -> Non
                 }
             }
         },
-    ),
+    ],
 )
 async def test_reload_unchanged_script(
     hass: HomeAssistant, calls, script_config
@@ -1182,12 +1182,12 @@ async def test_script_restore_last_triggered(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("script_mode", "warning_msg"),
-    (
+    [
         (SCRIPT_MODE_PARALLEL, "Maximum number of runs exceeded"),
         (SCRIPT_MODE_QUEUED, "Disallowed recursion detected"),
         (SCRIPT_MODE_RESTART, "Disallowed recursion detected"),
         (SCRIPT_MODE_SINGLE, "Already running"),
-    ),
+    ],
 )
 async def test_recursive_script(
     hass: HomeAssistant, script_mode, warning_msg, caplog: pytest.LogCaptureFixture
@@ -1232,12 +1232,12 @@ async def test_recursive_script(
 
 @pytest.mark.parametrize(
     ("script_mode", "warning_msg"),
-    (
+    [
         (SCRIPT_MODE_PARALLEL, "Maximum number of runs exceeded"),
         (SCRIPT_MODE_QUEUED, "Disallowed recursion detected"),
         (SCRIPT_MODE_RESTART, "Disallowed recursion detected"),
         (SCRIPT_MODE_SINGLE, "Already running"),
-    ),
+    ],
 )
 async def test_recursive_script_indirect(
     hass: HomeAssistant, script_mode, warning_msg, caplog: pytest.LogCaptureFixture
@@ -1539,7 +1539,7 @@ async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
 
 @pytest.mark.parametrize(
     ("blueprint_inputs", "problem", "details"),
-    (
+    [
         (
             # No input
             {},
@@ -1562,7 +1562,7 @@ async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
             "Blueprint 'Call service' generated invalid script",
             "value should be a string for dictionary value @ data['sequence'][0]['service']",
         ),
-    ),
+    ],
 )
 async def test_blueprint_script_bad_config(
     hass: HomeAssistant,
@@ -1621,7 +1621,7 @@ async def test_blueprint_script_fails_substitution(
     )
 
 
-@pytest.mark.parametrize("response", ({"value": 5}, '{"value": 5}'))
+@pytest.mark.parametrize("response", [{"value": 5}, '{"value": 5}'])
 async def test_responses(hass: HomeAssistant, response: Any) -> None:
     """Test we can get responses."""
     mock_restore_cache(hass, ())

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -63,12 +63,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,
@@ -115,7 +115,7 @@ async def test_get_actions_hidden_auxiliary(
     assert actions == unordered(expected_actions)
 
 
-@pytest.mark.parametrize("action_type", ("select_first", "select_last"))
+@pytest.mark.parametrize("action_type", ["select_first", "select_last"])
 async def test_action_select_first_last(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -164,7 +164,7 @@ async def test_action_select_first_last(
     assert select_calls[0].data == {"entity_id": entry.entity_id}
 
 
-@pytest.mark.parametrize("action_type", ("select_first", "select_last"))
+@pytest.mark.parametrize("action_type", ["select_first", "select_last"])
 async def test_action_select_first_last_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/select/test_device_condition.py
+++ b/tests/components/select/test_device_condition.py
@@ -67,12 +67,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -67,12 +67,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -131,12 +131,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,
@@ -225,13 +225,13 @@ async def test_get_conditions_no_state(
 
 @pytest.mark.parametrize(
     ("state_class", "unit", "condition_types"),
-    (
+    [
         (SensorStateClass.MEASUREMENT, None, ["is_value"]),
         (SensorStateClass.TOTAL, None, ["is_value"]),
         (SensorStateClass.TOTAL_INCREASING, None, ["is_value"]),
         (SensorStateClass.MEASUREMENT, "dogs", ["is_value"]),
         (None, None, []),
-    ),
+    ],
 )
 async def test_get_conditions_no_unit_or_stateclass(
     hass: HomeAssistant,

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -133,12 +133,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,
@@ -182,13 +182,13 @@ async def test_get_triggers_hidden_auxiliary(
 
 @pytest.mark.parametrize(
     ("state_class", "unit", "trigger_types"),
-    (
+    [
         (SensorStateClass.MEASUREMENT, None, ["value"]),
         (SensorStateClass.TOTAL, None, ["value"]),
         (SensorStateClass.TOTAL_INCREASING, None, ["value"]),
         (SensorStateClass.MEASUREMENT, "dogs", ["value"]),
         (None, None, []),
-    ),
+    ],
 )
 async def test_get_triggers_no_unit_or_stateclass(
     hass: HomeAssistant,

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -130,7 +130,7 @@ async def test_temperature_conversion(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == state_unit
 
 
-@pytest.mark.parametrize("device_class", (None, SensorDeviceClass.PRESSURE))
+@pytest.mark.parametrize("device_class", [None, SensorDeviceClass.PRESSURE])
 async def test_temperature_conversion_wrong_device_class(
     hass: HomeAssistant, device_class, enable_custom_integrations: None
 ) -> None:
@@ -154,7 +154,7 @@ async def test_temperature_conversion_wrong_device_class(
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.FAHRENHEIT
 
 
-@pytest.mark.parametrize("state_class", ("measurement", "total_increasing"))
+@pytest.mark.parametrize("state_class", ["measurement", "total_increasing"])
 async def test_deprecated_last_reset(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
@@ -1785,11 +1785,11 @@ async def test_invalid_enumeration_entity_without_device_class(
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         SensorDeviceClass.DATE,
         SensorDeviceClass.ENUM,
         SensorDeviceClass.TIMESTAMP,
-    ),
+    ],
 )
 async def test_non_numeric_device_class_with_unit_of_measurement(
     hass: HomeAssistant,
@@ -1819,7 +1819,7 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         SensorDeviceClass.APPARENT_POWER,
         SensorDeviceClass.AQI,
         SensorDeviceClass.ATMOSPHERIC_PRESSURE,
@@ -1864,7 +1864,7 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
         SensorDeviceClass.WATER,
         SensorDeviceClass.WEIGHT,
         SensorDeviceClass.WIND_SPEED,
-    ),
+    ],
 )
 async def test_device_classes_with_invalid_unit_of_measurement(
     hass: HomeAssistant,
@@ -1952,7 +1952,7 @@ async def test_non_numeric_validation_error(
 
 
 @pytest.mark.parametrize(
-    ("device_class", "state_class", "unit", "precision"), ((None, None, None, 1),)
+    ("device_class", "state_class", "unit", "precision"), [(None, None, None, 1)]
 )
 @pytest.mark.parametrize(
     ("native_value", "expected"),

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -90,13 +90,13 @@ async def test_sensors(
 
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.sonarr_commands",
         "sensor.sonarr_disk_space",
         "sensor.sonarr_queue",
         "sensor.sonarr_shows",
         "sensor.sonarr_wanted",
-    ),
+    ],
 )
 async def test_disabled_by_default_sensors(
     hass: HomeAssistant,

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -300,7 +300,7 @@ async def test_stream_audio(
 )
 @pytest.mark.parametrize(
     ("header", "status", "error"),
-    (
+    [
         (None, 400, "Missing X-Speech-Content header"),
         (
             (
@@ -331,7 +331,7 @@ async def test_stream_audio(
             400,
             "Missing language in X-Speech-Content header",
         ),
-    ),
+    ],
 )
 async def test_metadata_errors(
     hass: HomeAssistant,

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -64,12 +64,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -69,12 +69,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -69,12 +69,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/switch_as_x/test_config_flow.py
+++ b/tests/components/switch_as_x/test_config_flow.py
@@ -67,10 +67,10 @@ async def test_config_flow(
 
 @pytest.mark.parametrize(
     ("hidden_by_before", "hidden_by_after"),
-    (
+    [
         (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
         (None, er.RegistryEntryHider.INTEGRATION),
-    ),
+    ],
 )
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
 async def test_config_flow_registered_entity(

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -70,14 +70,14 @@ async def test_config_entry_unregistered_uuid(
 
 @pytest.mark.parametrize(
     ("target_domain", "state_on", "state_off"),
-    (
+    [
         (Platform.COVER, STATE_OPEN, STATE_CLOSED),
         (Platform.FAN, STATE_ON, STATE_OFF),
         (Platform.LIGHT, STATE_ON, STATE_OFF),
         (Platform.LOCK, STATE_UNLOCKED, STATE_LOCKED),
         (Platform.SIREN, STATE_ON, STATE_OFF),
         (Platform.VALVE, STATE_OPEN, STATE_CLOSED),
-    ),
+    ],
 )
 async def test_entity_registry_events(
     hass: HomeAssistant, target_domain: str, state_on: str, state_off: str
@@ -407,10 +407,10 @@ async def test_setup_and_remove_config_entry(
 
 @pytest.mark.parametrize(
     ("hidden_by_before", "hidden_by_after"),
-    (
+    [
         (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
         (er.RegistryEntryHider.INTEGRATION, None),
-    ),
+    ],
 )
 @pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
 async def test_reset_hidden_by(

--- a/tests/components/tasmota/test_cover.py
+++ b/tests/components/tasmota/test_cover.py
@@ -297,7 +297,7 @@ async def test_controlling_state_via_mqtt_tilt(
     assert state.attributes["current_position"] == 100
 
 
-@pytest.mark.parametrize("tilt", ("", ',"Tilt":0'))
+@pytest.mark.parametrize("tilt", ["", ',"Tilt":0'])
 async def test_controlling_state_via_mqtt_inverted(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_tasmota, tilt
 ) -> None:

--- a/tests/components/technove/test_binary_sensor.py
+++ b/tests/components/technove/test_binary_sensor.py
@@ -43,7 +43,7 @@ async def test_sensors(
 
 @pytest.mark.parametrize(
     "entity_id",
-    ("binary_sensor.technove_station_static_ip",),
+    ["binary_sensor.technove_station_static_ip"],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_disabled_by_default_binary_sensors(

--- a/tests/components/technove/test_sensor.py
+++ b/tests/components/technove/test_sensor.py
@@ -45,10 +45,10 @@ async def test_sensors(
 
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.technove_station_signal_strength",
         "sensor.technove_station_wi_fi_network_name",
-    ),
+    ],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_disabled_by_default_sensors(

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -26,7 +26,7 @@ from tests.typing import WebSocketGenerator
         "extra_options",
         "extra_attrs",
     ),
-    (
+    [
         (
             "binary_sensor",
             "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}",
@@ -47,7 +47,7 @@ from tests.typing import WebSocketGenerator
             {},
             {},
         ),
-    ),
+    ],
 )
 async def test_config_flow(
     hass: HomeAssistant,
@@ -142,7 +142,7 @@ def get_suggested(schema, key):
         "extra_options",
         "options_options",
     ),
-    (
+    [
         (
             "binary_sensor",
             "{{ states('binary_sensor.one') == 'on' or states('binary_sensor.two') == 'on' }}",
@@ -161,7 +161,7 @@ def get_suggested(schema, key):
             {},
             {},
         ),
-    ),
+    ],
 )
 async def test_options(
     hass: HomeAssistant,
@@ -261,7 +261,7 @@ async def test_options(
         "extra_attributes",
         "listeners",
     ),
-    (
+    [
         (
             "binary_sensor",
             "{{ states.binary_sensor.one.state == 'on' or states.binary_sensor.two.state == 'on' }}",
@@ -280,7 +280,7 @@ async def test_options(
             [{}, {}],
             [["one", "two"], ["one", "two"]],
         ),
-    ),
+    ],
 )
 async def test_config_flow_preview(
     hass: HomeAssistant,
@@ -644,13 +644,13 @@ async def test_config_flow_preview_template_error(
         "state_template",
         "extra_user_input",
     ),
-    (
+    [
         (
             "sensor",
             "{{ states('sensor.one') }}",
             {"unit_of_measurement": "°C"},
         ),
-    ),
+    ],
 )
 async def test_config_flow_preview_bad_state(
     hass: HomeAssistant,

--- a/tests/components/text/test_device_action.py
+++ b/tests/components/text/test_device_action.py
@@ -62,12 +62,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/thread/test_discovery.py
+++ b/tests/components/thread/test_discovery.py
@@ -194,7 +194,7 @@ async def test_discover_routers_unconfigured(
 
 
 @pytest.mark.parametrize(
-    "data", (ROUTER_DISCOVERY_HASS_BAD_DATA, ROUTER_DISCOVERY_HASS_MISSING_DATA)
+    "data", [ROUTER_DISCOVERY_HASS_BAD_DATA, ROUTER_DISCOVERY_HASS_MISSING_DATA]
 )
 async def test_discover_routers_bad_or_missing_optional_data(
     hass: HomeAssistant, mock_async_zeroconf: None, data

--- a/tests/components/threshold/test_config_flow.py
+++ b/tests/components/threshold/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_config_flow(hass: HomeAssistant) -> None:
     assert config_entry.title == "My threshold sensor"
 
 
-@pytest.mark.parametrize(("extra_input_data", "error"), (({}, "need_lower_upper"),))
+@pytest.mark.parametrize(("extra_input_data", "error"), [({}, "need_lower_upper")])
 async def test_fail(hass: HomeAssistant, extra_input_data, error) -> None:
     """Test not providing lower or upper limit fails."""
     input_sensor = "sensor.input"

--- a/tests/components/threshold/test_init.py
+++ b/tests/components/threshold/test_init.py
@@ -9,7 +9,7 @@ from homeassistant.helpers import entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("binary_sensor",))
+@pytest.mark.parametrize("platform", ["binary_sensor"])
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant,
     platform: str,

--- a/tests/components/tod/test_binary_sensor.py
+++ b/tests/components/tod/test_binary_sensor.py
@@ -823,7 +823,7 @@ async def test_dst6(
 
 
 @pytest.mark.freeze_time("2019-01-10 18:43:00")
-@pytest.mark.parametrize("hass_time_zone", ("UTC",))
+@pytest.mark.parametrize("hass_time_zone", ["UTC"])
 async def test_simple_before_after_does_not_loop_utc_not_in_range(
     hass: HomeAssistant,
 ) -> None:
@@ -849,7 +849,7 @@ async def test_simple_before_after_does_not_loop_utc_not_in_range(
 
 
 @pytest.mark.freeze_time("2019-01-10 22:43:00")
-@pytest.mark.parametrize("hass_time_zone", ("UTC",))
+@pytest.mark.parametrize("hass_time_zone", ["UTC"])
 async def test_simple_before_after_does_not_loop_utc_in_range(
     hass: HomeAssistant,
 ) -> None:
@@ -875,7 +875,7 @@ async def test_simple_before_after_does_not_loop_utc_in_range(
 
 
 @pytest.mark.freeze_time("2019-01-11 06:00:00")
-@pytest.mark.parametrize("hass_time_zone", ("UTC",))
+@pytest.mark.parametrize("hass_time_zone", ["UTC"])
 async def test_simple_before_after_does_not_loop_utc_fire_at_before(
     hass: HomeAssistant,
 ) -> None:
@@ -901,7 +901,7 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_before(
 
 
 @pytest.mark.freeze_time("2019-01-10 22:00:00")
-@pytest.mark.parametrize("hass_time_zone", ("UTC",))
+@pytest.mark.parametrize("hass_time_zone", ["UTC"])
 async def test_simple_before_after_does_not_loop_utc_fire_at_after(
     hass: HomeAssistant,
 ) -> None:
@@ -927,7 +927,7 @@ async def test_simple_before_after_does_not_loop_utc_fire_at_after(
 
 
 @pytest.mark.freeze_time("2019-01-10 22:00:00")
-@pytest.mark.parametrize("hass_time_zone", ("UTC",))
+@pytest.mark.parametrize("hass_time_zone", ["UTC"])
 async def test_simple_before_after_does_not_loop_utc_both_before_now(
     hass: HomeAssistant,
 ) -> None:
@@ -953,7 +953,7 @@ async def test_simple_before_after_does_not_loop_utc_both_before_now(
 
 
 @pytest.mark.freeze_time("2019-01-10 17:43:00+01:00")
-@pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
+@pytest.mark.parametrize("hass_time_zone", ["Europe/Berlin"])
 async def test_simple_before_after_does_not_loop_berlin_not_in_range(
     hass: HomeAssistant,
 ) -> None:
@@ -979,7 +979,7 @@ async def test_simple_before_after_does_not_loop_berlin_not_in_range(
 
 
 @pytest.mark.freeze_time("2019-01-11 00:43:00+01:00")
-@pytest.mark.parametrize("hass_time_zone", ("Europe/Berlin",))
+@pytest.mark.parametrize("hass_time_zone", ["Europe/Berlin"])
 async def test_simple_before_after_does_not_loop_berlin_in_range(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/tod/test_config_flow.py
+++ b/tests/components/tod/test_config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(hass: HomeAssistant, platform) -> None:
     """Test the config flow."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -227,23 +227,11 @@ async def test_list_todo_items(
     [
         ({}, [ITEM_1, ITEM_2]),
         (
-            [
-                {"status": [TodoItemStatus.COMPLETED, TodoItemStatus.NEEDS_ACTION]},
-                [ITEM_1, ITEM_2],
-            ]
+            {"status": [TodoItemStatus.COMPLETED, TodoItemStatus.NEEDS_ACTION]},
+            [ITEM_1, ITEM_2],
         ),
-        (
-            [
-                {"status": [TodoItemStatus.NEEDS_ACTION]},
-                [ITEM_1],
-            ]
-        ),
-        (
-            [
-                {"status": [TodoItemStatus.COMPLETED]},
-                [ITEM_2],
-            ]
-        ),
+        ({"status": [TodoItemStatus.NEEDS_ACTION]}, [ITEM_1]),
+        ({"status": [TodoItemStatus.COMPLETED]}, [ITEM_2]),
     ],
 )
 async def test_get_items_service(
@@ -390,7 +378,7 @@ async def test_add_item_service_invalid_input(
 
 @pytest.mark.parametrize(
     ("supported_entity_feature", "item_data", "expected_item"),
-    (
+    [
         (
             TodoListEntityFeature.SET_DUE_DATE_ON_ITEM,
             {"item": "New item", "due_date": "2023-11-13"},
@@ -436,7 +424,7 @@ async def test_add_item_service_invalid_input(
                 description="Submit revised draft",
             ),
         ),
-    ),
+    ],
 )
 async def test_add_item_service_extended_fields(
     hass: HomeAssistant,
@@ -695,7 +683,7 @@ async def test_update_todo_item_field_unsupported(
 
 @pytest.mark.parametrize(
     ("supported_entity_feature", "update_data", "expected_update"),
-    (
+    [
         (
             TodoListEntityFeature.SET_DUE_DATE_ON_ITEM,
             {"due_date": "2023-11-13"},
@@ -726,7 +714,7 @@ async def test_update_todo_item_field_unsupported(
                 description="Submit revised draft",
             ),
         ),
-    ),
+    ],
 )
 async def test_update_todo_item_extended_fields(
     hass: HomeAssistant,
@@ -756,7 +744,7 @@ async def test_update_todo_item_extended_fields(
 
 @pytest.mark.parametrize(
     ("test_entity_items", "update_data", "expected_update"),
-    (
+    [
         (
             [TodoItem(uid="1", summary="Summary", description="description")],
             {"description": "Submit revised draft"},
@@ -804,7 +792,7 @@ async def test_update_todo_item_extended_fields(
             {"due_datetime": None},
             TodoItem(uid="1", summary="Summary"),
         ),
-    ),
+    ],
     ids=[
         "overwrite_description",
         "overwrite_empty_description",

--- a/tests/components/traccar_server/test_config_flow.py
+++ b/tests/components/traccar_server/test_config_flow.py
@@ -67,10 +67,10 @@ async def test_form(
 
 @pytest.mark.parametrize(
     ("side_effect", "error"),
-    (
+    [
         (TraccarException, "cannot_connect"),
         (Exception, "unknown"),
-    ),
+    ],
 )
 async def test_form_cannot_connect(
     hass: HomeAssistant,
@@ -154,7 +154,7 @@ async def test_options(
 
 @pytest.mark.parametrize(
     ("imported", "data", "options"),
-    (
+    [
         (
             {
                 CONF_HOST: "1.1.1.1",
@@ -223,7 +223,7 @@ async def test_options(
                 CONF_MAX_ACCURACY: 0,
             },
         ),
-    ),
+    ],
 )
 async def test_import_from_yaml(
     hass: HomeAssistant,

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1327,12 +1327,12 @@ async def test_tags_with_wave() -> None:
 )
 @pytest.mark.parametrize(
     ("engine", "language", "options", "cache", "result_query"),
-    (
+    [
         (None, None, None, None, ""),
         (None, "de_DE", None, None, "language=de_DE"),
         (None, "de_DE", {"voice": "henk"}, None, "language=de_DE&voice=henk"),
         (None, "de_DE", None, True, "cache=true&language=de_DE"),
-    ),
+    ],
 )
 async def test_generate_media_source_id(
     hass: HomeAssistant,
@@ -1367,11 +1367,11 @@ async def test_generate_media_source_id(
 )
 @pytest.mark.parametrize(
     ("engine", "language", "options"),
-    (
+    [
         ("not-loaded-engine", None, None),
         (None, "unsupported-language", None),
         (None, None, {"option": "not-supported"}),
-    ),
+    ],
 )
 async def test_generate_media_source_id_invalid_options(
     hass: HomeAssistant,

--- a/tests/components/update/test_device_trigger.py
+++ b/tests/components/update/test_device_trigger.py
@@ -68,12 +68,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (er.RegistryEntryHider.INTEGRATION, None),
         (er.RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/utility_meter/test_config_flow.py
+++ b/tests/components/utility_meter/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.parametrize("platform", ("sensor",))
+@pytest.mark.parametrize("platform", ["sensor"])
 async def test_config_flow(hass: HomeAssistant, platform) -> None:
     """Test the config flow."""
     input_sensor_entity_id = "sensor.input"

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -62,10 +62,10 @@ async def test_restore_state(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     "meter",
-    (
+    [
         ["select.energy_bill"],
         "select.energy_bill",
-    ),
+    ],
 )
 async def test_services(hass: HomeAssistant, meter) -> None:
     """Test energy sensor reset service."""
@@ -385,7 +385,7 @@ async def test_setup_missing_discovery(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("tariffs", "expected_entities"),
-    (
+    [
         (
             [],
             ["sensor.electricity_meter"],
@@ -398,7 +398,7 @@ async def test_setup_missing_discovery(hass: HomeAssistant) -> None:
                 "select.electricity_meter",
             ],
         ),
-    ),
+    ],
 )
 async def test_setup_and_remove_config_entry(
     hass: HomeAssistant, tariffs: str, expected_entities: list[str]

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -61,7 +61,7 @@ def set_utc(hass: HomeAssistant):
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -86,7 +86,7 @@ def set_utc(hass: HomeAssistant):
                 "tariffs": ["onpeak", "midpeak", "offpeak"],
             },
         ),
-    ),
+    ],
 )
 async def test_state(hass: HomeAssistant, yaml_config, config_entry_config) -> None:
     """Test utility sensor state."""
@@ -235,7 +235,7 @@ async def test_state(hass: HomeAssistant, yaml_config, config_entry_config) -> N
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -261,7 +261,7 @@ async def test_state(hass: HomeAssistant, yaml_config, config_entry_config) -> N
                 "always_available": True,
             },
         ),
-    ),
+    ],
 )
 async def test_state_always_available(
     hass: HomeAssistant, yaml_config, config_entry_config
@@ -335,7 +335,7 @@ async def test_state_always_available(
 
 @pytest.mark.parametrize(
     "yaml_config",
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -347,7 +347,7 @@ async def test_state_always_available(
             },
             None,
         ),
-    ),
+    ],
 )
 async def test_not_unique_tariffs(hass: HomeAssistant, yaml_config) -> None:
     """Test utility sensor state initializtion."""
@@ -356,7 +356,7 @@ async def test_not_unique_tariffs(hass: HomeAssistant, yaml_config) -> None:
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -381,7 +381,7 @@ async def test_not_unique_tariffs(hass: HomeAssistant, yaml_config) -> None:
                 "tariffs": ["onpeak", "midpeak", "offpeak"],
             },
         ),
-    ),
+    ],
 )
 async def test_init(hass: HomeAssistant, yaml_config, config_entry_config) -> None:
     """Test utility sensor state initializtion."""
@@ -456,7 +456,7 @@ async def test_unique_id(
 
 @pytest.mark.parametrize(
     ("yaml_config", "entity_id", "name"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -493,7 +493,7 @@ async def test_unique_id(
             "sensor.energy_bill",
             "energy_bill",
         ),
-    ),
+    ],
 )
 async def test_entity_name(hass: HomeAssistant, yaml_config, entity_id, name) -> None:
     """Test utility sensor state initializtion."""
@@ -511,7 +511,7 @@ async def test_entity_name(hass: HomeAssistant, yaml_config, entity_id, name) ->
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_configs"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -551,7 +551,7 @@ async def test_entity_name(hass: HomeAssistant, yaml_config, entity_id, name) ->
                 },
             ],
         ),
-    ),
+    ],
 )
 async def test_device_class(
     hass: HomeAssistant, yaml_config, config_entry_configs
@@ -604,7 +604,7 @@ async def test_device_class(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -629,7 +629,7 @@ async def test_device_class(
                 "tariffs": ["onpeak", "midpeak", "offpeak", "superpeak"],
             },
         ),
-    ),
+    ],
 )
 async def test_restore_state(
     hass: HomeAssistant, yaml_config, config_entry_config
@@ -775,7 +775,7 @@ async def test_restore_state(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -799,7 +799,7 @@ async def test_restore_state(
                 "tariffs": [],
             },
         ),
-    ),
+    ],
 )
 async def test_service_reset_no_tariffs(
     hass: HomeAssistant, yaml_config, config_entry_config
@@ -866,7 +866,7 @@ async def test_service_reset_no_tariffs(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -891,7 +891,7 @@ async def test_service_reset_no_tariffs(
                 "tariffs": [],
             },
         ),
-    ),
+    ],
 )
 async def test_net_consumption(
     hass: HomeAssistant, yaml_config, config_entry_config
@@ -938,7 +938,7 @@ async def test_net_consumption(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -962,7 +962,7 @@ async def test_net_consumption(
                 "tariffs": [],
             },
         ),
-    ),
+    ],
 )
 async def test_non_net_consumption(
     hass: HomeAssistant,
@@ -1023,7 +1023,7 @@ async def test_non_net_consumption(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -1048,7 +1048,7 @@ async def test_non_net_consumption(
                 "tariffs": [],
             },
         ),
-    ),
+    ],
 )
 async def test_delta_values(
     hass: HomeAssistant,
@@ -1135,7 +1135,7 @@ async def test_delta_values(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -1160,7 +1160,7 @@ async def test_delta_values(
                 "tariffs": [],
             },
         ),
-    ),
+    ],
 )
 async def test_non_periodically_resetting(
     hass: HomeAssistant, yaml_config, config_entry_config
@@ -1267,7 +1267,7 @@ async def test_non_periodically_resetting(
 
 @pytest.mark.parametrize(
     ("yaml_config", "config_entry_config"),
-    (
+    [
         (
             {
                 "utility_meter": {
@@ -1293,7 +1293,7 @@ async def test_non_periodically_resetting(
                 "tariffs": ["low", "high"],
             },
         ),
-    ),
+    ],
 )
 async def test_non_periodically_resetting_meter_with_tariffs(
     hass: HomeAssistant, yaml_config, config_entry_config

--- a/tests/components/vacuum/test_device_action.py
+++ b/tests/components/vacuum/test_device_action.py
@@ -57,12 +57,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -69,12 +69,12 @@ async def test_get_conditions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_conditions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -69,12 +69,12 @@ async def test_get_triggers(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_triggers_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/water_heater/test_device_action.py
+++ b/tests/components/water_heater/test_device_action.py
@@ -57,12 +57,12 @@ async def test_get_actions(
 
 @pytest.mark.parametrize(
     ("hidden_by", "entity_category"),
-    (
+    [
         (RegistryEntryHider.INTEGRATION, None),
         (RegistryEntryHider.USER, None),
         (None, EntityCategory.CONFIG),
         (None, EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 async def test_get_actions_hidden_auxiliary(
     hass: HomeAssistant,

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -110,14 +110,14 @@ class MockWeatherEntity(WeatherEntity):
 
 
 @pytest.mark.parametrize(
-    "native_unit", (UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS)
+    "native_unit", [UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS]
 )
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfTemperature.CELSIUS, METRIC_SYSTEM),
         (UnitOfTemperature.FAHRENHEIT, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_temperature(
     hass: HomeAssistant,
@@ -190,13 +190,13 @@ async def test_temperature(
     )
 
 
-@pytest.mark.parametrize("native_unit", (None,))
+@pytest.mark.parametrize("native_unit", [None])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfTemperature.CELSIUS, METRIC_SYSTEM),
         (UnitOfTemperature.FAHRENHEIT, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_temperature_no_unit(
     hass: HomeAssistant,
@@ -259,10 +259,10 @@ async def test_temperature_no_unit(
 
 @pytest.mark.parametrize(
     ("state_unit", "unit_system", "native_unit"),
-    (
+    [
         (UnitOfPressure.HPA, METRIC_SYSTEM, UnitOfPressure.INHG),
         (UnitOfPressure.INHG, US_CUSTOMARY_SYSTEM, UnitOfPressure.INHG),
-    ),
+    ],
 )
 async def test_pressure(
     hass: HomeAssistant,
@@ -298,10 +298,10 @@ async def test_pressure(
     assert float(forecast[ATTR_FORECAST_PRESSURE]) == pytest.approx(expected, rel=1e-2)
 
 
-@pytest.mark.parametrize("native_unit", (None,))
+@pytest.mark.parametrize("native_unit", [None])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    ((UnitOfPressure.HPA, METRIC_SYSTEM), (UnitOfPressure.INHG, US_CUSTOMARY_SYSTEM)),
+    [(UnitOfPressure.HPA, METRIC_SYSTEM), (UnitOfPressure.INHG, US_CUSTOMARY_SYSTEM)],
 )
 async def test_pressure_no_unit(
     hass: HomeAssistant,
@@ -339,18 +339,18 @@ async def test_pressure_no_unit(
 
 @pytest.mark.parametrize(
     "native_unit",
-    (
+    [
         UnitOfSpeed.MILES_PER_HOUR,
         UnitOfSpeed.KILOMETERS_PER_HOUR,
         UnitOfSpeed.METERS_PER_SECOND,
-    ),
+    ],
 )
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfSpeed.KILOMETERS_PER_HOUR, METRIC_SYSTEM),
         (UnitOfSpeed.MILES_PER_HOUR, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_wind_speed(
     hass: HomeAssistant,
@@ -390,18 +390,18 @@ async def test_wind_speed(
 
 @pytest.mark.parametrize(
     "native_unit",
-    (
+    [
         UnitOfSpeed.MILES_PER_HOUR,
         UnitOfSpeed.KILOMETERS_PER_HOUR,
         UnitOfSpeed.METERS_PER_SECOND,
-    ),
+    ],
 )
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfSpeed.KILOMETERS_PER_HOUR, METRIC_SYSTEM),
         (UnitOfSpeed.MILES_PER_HOUR, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_wind_gust_speed(
     hass: HomeAssistant,
@@ -442,13 +442,13 @@ async def test_wind_gust_speed(
     )
 
 
-@pytest.mark.parametrize("native_unit", (None,))
+@pytest.mark.parametrize("native_unit", [None])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfSpeed.KILOMETERS_PER_HOUR, METRIC_SYSTEM),
         (UnitOfSpeed.MILES_PER_HOUR, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_wind_speed_no_unit(
     hass: HomeAssistant,
@@ -486,13 +486,13 @@ async def test_wind_speed_no_unit(
     )
 
 
-@pytest.mark.parametrize("native_unit", (UnitOfLength.MILES, UnitOfLength.KILOMETERS))
+@pytest.mark.parametrize("native_unit", [UnitOfLength.MILES, UnitOfLength.KILOMETERS])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfLength.KILOMETERS, METRIC_SYSTEM),
         (UnitOfLength.MILES, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_visibility(
     hass: HomeAssistant,
@@ -525,13 +525,13 @@ async def test_visibility(
     )
 
 
-@pytest.mark.parametrize("native_unit", (None,))
+@pytest.mark.parametrize("native_unit", [None])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfLength.KILOMETERS, METRIC_SYSTEM),
         (UnitOfLength.MILES, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_visibility_no_unit(
     hass: HomeAssistant,
@@ -564,13 +564,13 @@ async def test_visibility_no_unit(
     )
 
 
-@pytest.mark.parametrize("native_unit", (UnitOfLength.INCHES, UnitOfLength.MILLIMETERS))
+@pytest.mark.parametrize("native_unit", [UnitOfLength.INCHES, UnitOfLength.MILLIMETERS])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfLength.MILLIMETERS, METRIC_SYSTEM),
         (UnitOfLength.INCHES, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_precipitation(
     hass: HomeAssistant,
@@ -608,13 +608,13 @@ async def test_precipitation(
     )
 
 
-@pytest.mark.parametrize("native_unit", (None,))
+@pytest.mark.parametrize("native_unit", [None])
 @pytest.mark.parametrize(
     ("state_unit", "unit_system"),
-    (
+    [
         (UnitOfLength.MILLIMETERS, METRIC_SYSTEM),
         (UnitOfLength.INCHES, US_CUSTOMARY_SYSTEM),
-    ),
+    ],
 )
 async def test_precipitation_no_unit(
     hass: HomeAssistant,

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -206,7 +206,7 @@ async def test_return_response_error(hass: HomeAssistant, websocket_client) -> N
     assert msg["error"]["code"] == "unknown_error"
 
 
-@pytest.mark.parametrize("command", ("call_service", "call_service_action"))
+@pytest.mark.parametrize("command", ["call_service", "call_service_action"])
 async def test_call_service_blocking(
     hass: HomeAssistant, websocket_client: MockHAClientWebSocket, command
 ) -> None:
@@ -2509,7 +2509,7 @@ async def test_integration_setup_info(
 
 @pytest.mark.parametrize(
     ("key", "config"),
-    (
+    [
         ("trigger", {"platform": "event", "event_type": "hello"}),
         ("trigger", [{"platform": "event", "event_type": "hello"}]),
         (
@@ -2522,7 +2522,7 @@ async def test_integration_setup_info(
         ),
         ("action", {"service": "domain_test.test_service"}),
         ("action", [{"service": "domain_test.test_service"}]),
-    ),
+    ],
 )
 async def test_validate_config_works(
     websocket_client: MockHAClientWebSocket, key, config
@@ -2539,7 +2539,7 @@ async def test_validate_config_works(
 
 @pytest.mark.parametrize(
     ("key", "config", "error"),
-    (
+    [
         (
             "trigger",
             {"platform": "non_existing", "event_type": "hello"},
@@ -2563,7 +2563,7 @@ async def test_validate_config_works(
             {"non_existing": "domain_test.test_service"},
             "Unable to determine action @ data[0]",
         ),
-    ),
+    ],
 )
 async def test_validate_config_invalid(
     websocket_client: MockHAClientWebSocket, key, config, error

--- a/tests/components/whois/test_sensor.py
+++ b/tests/components/whois/test_sensor.py
@@ -22,7 +22,7 @@ pytestmark = [
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.home_assistant_io_admin",
         "sensor.home_assistant_io_created",
         "sensor.home_assistant_io_days_until_expiration",
@@ -32,7 +32,7 @@ pytestmark = [
         "sensor.home_assistant_io_registrant",
         "sensor.home_assistant_io_registrar",
         "sensor.home_assistant_io_reseller",
-    ),
+    ],
 )
 async def test_whois_sensors(
     hass: HomeAssistant,
@@ -67,13 +67,13 @@ async def test_whois_sensors_missing_some_attrs(
 
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.home_assistant_io_admin",
         "sensor.home_assistant_io_owner",
         "sensor.home_assistant_io_registrant",
         "sensor.home_assistant_io_registrar",
         "sensor.home_assistant_io_reseller",
-    ),
+    ],
 )
 async def test_disabled_by_default_sensors(
     hass: HomeAssistant, entity_id: str, entity_registry: er.EntityRegistry
@@ -88,7 +88,7 @@ async def test_disabled_by_default_sensors(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.home_assistant_io_admin",
         "sensor.home_assistant_io_created",
         "sensor.home_assistant_io_days_until_expiration",
@@ -98,7 +98,7 @@ async def test_disabled_by_default_sensors(
         "sensor.home_assistant_io_registrant",
         "sensor.home_assistant_io_registrar",
         "sensor.home_assistant_io_reseller",
-    ),
+    ],
 )
 async def test_no_data(
     hass: HomeAssistant, mock_whois: MagicMock, entity_id: str

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -495,15 +495,15 @@ async def test_cloud_disconnect(
 @pytest.mark.parametrize(
     ("body", "expected_code"),
     [
-        [{"userid": 0, "appli": NotificationCategory.WEIGHT.value}, 0],  # Success
-        [{"userid": None, "appli": 1}, 0],  # Success, we ignore the user_id.
-        [{}, 12],  # No request body.
-        [{"userid": "GG"}, 20],  # appli not provided.
-        [{"userid": 0}, 20],  # appli not provided.
-        [
+        ({"userid": 0, "appli": NotificationCategory.WEIGHT.value}, 0),  # Success
+        ({"userid": None, "appli": 1}, 0),  # Success, we ignore the user_id.
+        ({}, 12),  # No request body.
+        ({"userid": "GG"}, 20),  # appli not provided.
+        ({"userid": 0}, 20),  # appli not provided.
+        (
             {"userid": 11, "appli": NotificationCategory.WEIGHT.value},
             0,
-        ],  # Success, we ignore the user_id
+        ),  # Success, we ignore the user_id
     ],
 )
 async def test_webhook_post(

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -123,14 +123,14 @@ async def test_sensors(
 
 @pytest.mark.parametrize(
     "entity_id",
-    (
+    [
         "sensor.wled_rgb_light_uptime",
         "sensor.wled_rgb_light_free_memory",
         "sensor.wled_rgb_light_wi_fi_signal",
         "sensor.wled_rgb_light_wi_fi_rssi",
         "sensor.wled_rgb_light_wi_fi_channel",
         "sensor.wled_rgb_light_wi_fi_bssid",
-    ),
+    ],
 )
 @pytest.mark.usefixtures("init_integration")
 async def test_disabled_by_default_sensors(

--- a/tests/components/zeversolar/test_config_flow.py
+++ b/tests/components/zeversolar/test_config_flow.py
@@ -31,7 +31,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("side_effect", "errors"),
-    (
+    [
         (
             ZeverSolarHTTPNotFound,
             {"base": "invalid_host"},
@@ -48,7 +48,7 @@ async def test_form(hass: HomeAssistant) -> None:
             RuntimeError,
             {"base": "unknown"},
         ),
-    ),
+    ],
 )
 async def test_form_errors(
     hass: HomeAssistant,

--- a/tests/components/zha/test_climate.py
+++ b/tests/components/zha/test_climate.py
@@ -523,14 +523,14 @@ async def test_climate_hvac_action_pi_demand(
 
 @pytest.mark.parametrize(
     ("sys_mode", "hvac_mode"),
-    (
+    [
         (Thermostat.SystemMode.Auto, HVACMode.HEAT_COOL),
         (Thermostat.SystemMode.Cool, HVACMode.COOL),
         (Thermostat.SystemMode.Heat, HVACMode.HEAT),
         (Thermostat.SystemMode.Pre_cooling, HVACMode.COOL),
         (Thermostat.SystemMode.Fan_only, HVACMode.FAN_ONLY),
         (Thermostat.SystemMode.Dry, HVACMode.DRY),
-    ),
+    ],
 )
 async def test_hvac_mode(
     hass: HomeAssistant, device_climate, sys_mode, hvac_mode
@@ -560,7 +560,7 @@ async def test_hvac_mode(
 
 @pytest.mark.parametrize(
     ("seq_of_op", "modes"),
-    (
+    [
         (0xFF, {HVACMode.OFF}),
         (0x00, {HVACMode.OFF, HVACMode.COOL}),
         (0x01, {HVACMode.OFF, HVACMode.COOL}),
@@ -568,7 +568,7 @@ async def test_hvac_mode(
         (0x03, {HVACMode.OFF, HVACMode.HEAT}),
         (0x04, {HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL}),
         (0x05, {HVACMode.OFF, HVACMode.COOL, HVACMode.HEAT, HVACMode.HEAT_COOL}),
-    ),
+    ],
 )
 async def test_hvac_modes(
     hass: HomeAssistant, device_climate_mock, seq_of_op, modes
@@ -585,12 +585,12 @@ async def test_hvac_modes(
 
 @pytest.mark.parametrize(
     ("sys_mode", "preset", "target_temp"),
-    (
+    [
         (Thermostat.SystemMode.Heat, None, 22),
         (Thermostat.SystemMode.Heat, PRESET_AWAY, 16),
         (Thermostat.SystemMode.Cool, None, 25),
         (Thermostat.SystemMode.Cool, PRESET_AWAY, 27),
-    ),
+    ],
 )
 async def test_target_temperature(
     hass: HomeAssistant,
@@ -628,11 +628,11 @@ async def test_target_temperature(
 
 @pytest.mark.parametrize(
     ("preset", "unoccupied", "target_temp"),
-    (
+    [
         (None, 1800, 17),
         (PRESET_AWAY, 1800, 18),
         (PRESET_AWAY, None, None),
-    ),
+    ],
 )
 async def test_target_temperature_high(
     hass: HomeAssistant, device_climate_mock, preset, unoccupied, target_temp
@@ -664,11 +664,11 @@ async def test_target_temperature_high(
 
 @pytest.mark.parametrize(
     ("preset", "unoccupied", "target_temp"),
-    (
+    [
         (None, 1600, 21),
         (PRESET_AWAY, 1600, 16),
         (PRESET_AWAY, None, None),
-    ),
+    ],
 )
 async def test_target_temperature_low(
     hass: HomeAssistant, device_climate_mock, preset, unoccupied, target_temp
@@ -700,14 +700,14 @@ async def test_target_temperature_low(
 
 @pytest.mark.parametrize(
     ("hvac_mode", "sys_mode"),
-    (
+    [
         (HVACMode.AUTO, None),
         (HVACMode.COOL, Thermostat.SystemMode.Cool),
         (HVACMode.DRY, None),
         (HVACMode.FAN_ONLY, None),
         (HVACMode.HEAT, Thermostat.SystemMode.Heat),
         (HVACMode.HEAT_COOL, Thermostat.SystemMode.Auto),
-    ),
+    ],
 )
 async def test_set_hvac_mode(
     hass: HomeAssistant, device_climate, hvac_mode, sys_mode

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -999,7 +999,7 @@ async def test_hardware_already_setup(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "data", (None, {}, {"radio_type": "best_radio"}, {"radio_type": "efr32"})
+    "data", [None, {}, {"radio_type": "best_radio"}, {"radio_type": "efr32"}]
 )
 async def test_hardware_invalid_data(hass: HomeAssistant, data) -> None:
     """Test onboarding flow -- invalid data."""

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -267,7 +267,7 @@ async def test_ota_sw_version(hass: HomeAssistant, ota_zha_device) -> None:
 
 @pytest.mark.parametrize(
     ("device", "last_seen_delta", "is_available"),
-    (
+    [
         ("zigpy_device", 0, True),
         (
             "zigpy_device",
@@ -305,7 +305,7 @@ async def test_ota_sw_version(hass: HomeAssistant, ota_zha_device) -> None:
             CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY + 2,
             False,
         ),
-    ),
+    ],
 )
 async def test_device_restore_availability(
     hass: HomeAssistant,

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -464,13 +464,13 @@ async def test_zha_group_fan_entity_failure_state(
 
 @pytest.mark.parametrize(
     ("plug_read", "expected_state", "expected_percentage"),
-    (
+    [
         (None, STATE_OFF, None),
         ({"fan_mode": 0}, STATE_OFF, 0),
         ({"fan_mode": 1}, STATE_ON, 33),
         ({"fan_mode": 2}, STATE_ON, 66),
         ({"fan_mode": 3}, STATE_ON, 100),
-    ),
+    ],
 )
 async def test_fan_init(
     hass: HomeAssistant,
@@ -645,7 +645,7 @@ async def test_fan_ikea(
         "ikea_expected_percentage",
         "ikea_preset_mode",
     ),
-    (
+    [
         (None, STATE_OFF, None, None),
         ({"fan_mode": 0}, STATE_OFF, 0, None),
         ({"fan_mode": 1}, STATE_ON, 10, PRESET_MODE_AUTO),
@@ -658,7 +658,7 @@ async def test_fan_ikea(
         ({"fan_mode": 40}, STATE_ON, 80, "Speed 4"),
         ({"fan_mode": 45}, STATE_ON, 90, "Speed 4.5"),
         ({"fan_mode": 50}, STATE_ON, 100, "Speed 5"),
-    ),
+    ],
 )
 async def test_fan_ikea_init(
     hass: HomeAssistant,
@@ -828,7 +828,7 @@ async def test_fan_kof(
 
 @pytest.mark.parametrize(
     ("plug_read", "expected_state", "expected_percentage", "expected_preset"),
-    (
+    [
         (None, STATE_OFF, None, None),
         ({"fan_mode": 0}, STATE_OFF, 0, None),
         ({"fan_mode": 1}, STATE_ON, 25, None),
@@ -836,7 +836,7 @@ async def test_fan_kof(
         ({"fan_mode": 3}, STATE_ON, 75, None),
         ({"fan_mode": 4}, STATE_ON, 100, None),
         ({"fan_mode": 6}, STATE_ON, None, PRESET_MODE_SMART),
-    ),
+    ],
 )
 async def test_fan_kof_init(
     hass: HomeAssistant,

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -52,7 +52,7 @@ def config_entry_v1(hass):
     )
 
 
-@pytest.mark.parametrize("config", ({}, {DOMAIN: {}}))
+@pytest.mark.parametrize("config", [{}, {DOMAIN: {}}])
 @patch("homeassistant.components.zha.async_setup_entry", AsyncMock(return_value=True))
 async def test_migration_from_v1_no_baudrate(
     hass: HomeAssistant, config_entry_v1, config
@@ -106,12 +106,12 @@ async def test_migration_from_v1_wrong_baudrate(
 )
 @pytest.mark.parametrize(
     "zha_config",
-    (
+    [
         {},
         {CONF_USB_PATH: "str"},
         {CONF_RADIO_TYPE: "ezsp"},
         {CONF_RADIO_TYPE: "ezsp", CONF_USB_PATH: "str"},
-    ),
+    ],
 )
 async def test_config_depreciation(hass: HomeAssistant, zha_config) -> None:
     """Test config option depreciation."""

--- a/tests/components/zha/test_number.py
+++ b/tests/components/zha/test_number.py
@@ -192,14 +192,14 @@ async def test_number(
 
 @pytest.mark.parametrize(
     ("attr", "initial_value", "new_value"),
-    (
+    [
         ("on_off_transition_time", 20, 5),
         ("on_level", 255, 50),
         ("on_transition_time", 5, 1),
         ("off_transition_time", 5, 1),
         ("default_move_rate", 1, 5),
         ("start_up_current_level", 254, 125),
-    ),
+    ],
 )
 async def test_level_control_number(
     hass: HomeAssistant,
@@ -324,7 +324,7 @@ async def test_level_control_number(
 
 @pytest.mark.parametrize(
     ("attr", "initial_value", "new_value"),
-    (("start_up_color_temperature", 500, 350),),
+    [("start_up_color_temperature", 500, 350)],
 )
 async def test_color_number(
     hass: HomeAssistant,

--- a/tests/components/zha/test_registries.py
+++ b/tests/components/zha/test_registries.py
@@ -395,14 +395,14 @@ def entity_registry():
 
 @pytest.mark.parametrize(
     ("manufacturer", "model", "quirk_id", "match_name"),
-    (
+    [
         ("random manufacturer", "random model", "random.class", "OnOff"),
         ("random manufacturer", MODEL, "random.class", "OnOffModel"),
         (MANUFACTURER, "random model", "random.class", "OnOffManufacturer"),
         ("random manufacturer", "random model", QUIRK_ID, "OnOffQuirk"),
         (MANUFACTURER, MODEL, "random.class", "OnOffModelManufacturer"),
         (MANUFACTURER, "some model", "random.class", "OnOffMultimodel"),
-    ),
+    ],
 )
 def test_weighted_match(
     cluster_handler,

--- a/tests/components/zha/test_sensor.py
+++ b/tests/components/zha/test_sensor.py
@@ -378,7 +378,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
         "unsupported_attrs",
         "initial_sensor_state",
     ),
-    (
+    [
         (
             measurement.RelativeHumidity.cluster_id,
             "humidity",
@@ -563,7 +563,7 @@ async def async_test_pi_heating_demand(hass, cluster, entity_id):
             None,
             STATE_UNKNOWN,
         ),
-    ),
+    ],
 )
 async def test_sensor(
     hass: HomeAssistant,
@@ -808,7 +808,7 @@ async def test_electrical_measurement_init(
 
 @pytest.mark.parametrize(
     ("cluster_id", "unsupported_attributes", "entity_ids", "missing_entity_ids"),
-    (
+    [
         (
             homeautomation.ElectricalMeasurement.cluster_id,
             {"apparent_power", "rms_voltage", "rms_current"},
@@ -877,7 +877,7 @@ async def test_electrical_measurement_init(
             },
             {},
         ),
-    ),
+    ],
 )
 async def test_unsupported_attributes_sensor(
     hass: HomeAssistant,
@@ -919,7 +919,7 @@ async def test_unsupported_attributes_sensor(
 
 @pytest.mark.parametrize(
     ("raw_uom", "raw_value", "expected_state", "expected_uom"),
-    (
+    [
         (
             1,
             12320,
@@ -1004,7 +1004,7 @@ async def test_unsupported_attributes_sensor(
             "5.01",
             UnitOfVolume.LITERS,
         ),
-    ),
+    ],
 )
 async def test_se_summation_uom(
     hass: HomeAssistant,
@@ -1052,7 +1052,7 @@ async def test_se_summation_uom(
 
 @pytest.mark.parametrize(
     ("raw_measurement_type", "expected_type"),
-    (
+    [
         (1, "ACTIVE_MEASUREMENT"),
         (8, "PHASE_A_MEASUREMENT"),
         (9, "ACTIVE_MEASUREMENT, PHASE_A_MEASUREMENT"),
@@ -1063,7 +1063,7 @@ async def test_se_summation_uom(
                 " PHASE_A_MEASUREMENT"
             ),
         ),
-    ),
+    ],
 )
 async def test_elec_measurement_sensor_type(
     hass: HomeAssistant,
@@ -1127,7 +1127,7 @@ async def test_elec_measurement_sensor_polling(
 
 @pytest.mark.parametrize(
     "supported_attributes",
-    (
+    [
         set(),
         {
             "active_power",
@@ -1152,7 +1152,7 @@ async def test_elec_measurement_sensor_polling(
             "rms_voltage",
             "rms_voltage_max",
         },
-    ),
+    ],
 )
 async def test_elec_measurement_skip_unsupported_attribute(
     hass: HomeAssistant,

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -499,7 +499,7 @@ async def app_controller(
 
 @pytest.mark.parametrize(
     ("params", "duration", "node"),
-    (
+    [
         ({}, 60, None),
         ({ATTR_DURATION: 30}, 30, None),
         (
@@ -512,7 +512,7 @@ async def app_controller(
             60,
             zigpy.types.EUI64.convert("aa:bb:cc:dd:aa:bb:cc:d1"),
         ),
-    ),
+    ],
 )
 async def test_permit_ha12(
     hass: HomeAssistant,
@@ -743,7 +743,7 @@ async def test_ws_permit_with_install_code_fail(
 
 @pytest.mark.parametrize(
     ("params", "duration", "node"),
-    (
+    [
         ({}, 60, None),
         ({ATTR_DURATION: 30}, 30, None),
         (
@@ -756,7 +756,7 @@ async def test_ws_permit_with_install_code_fail(
             60,
             zigpy.types.EUI64.convert("aa:bb:cc:dd:aa:bb:cc:d1"),
         ),
-    ),
+    ],
 )
 async def test_ws_permit_ha12(
     app_controller: ControllerApplication, zha_client, params, duration, node

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1397,7 +1397,7 @@ def test_key_value_schemas_with_default() -> None:
 
 @pytest.mark.parametrize(
     ("config", "error"),
-    (
+    [
         ({"delay": "{{ invalid"}, "should be format 'HH:MM'"),
         ({"wait_template": "{{ invalid"}, "invalid template"),
         ({"condition": "invalid"}, "Unexpected value for condition: 'invalid'"),
@@ -1432,7 +1432,7 @@ def test_key_value_schemas_with_default() -> None:
             },
             "not allowed to add a response to an error stop action",
         ),
-    ),
+    ],
 )
 def test_script(caplog: pytest.LogCaptureFixture, config: dict, error: str) -> None:
     """Test script validation is user friendly."""

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2304,7 +2304,7 @@ async def test_entries_for_label(
         "placeholders",
         "expected_device_name",
     ),
-    (
+    [
         (None, None, None, "Device Bla"),
         (
             "test_device",
@@ -2334,7 +2334,7 @@ async def test_entries_for_label(
             {"placeholder": "special"},
             "English dev special",
         ),
-    ),
+    ],
 )
 async def test_device_name_translation_placeholders(
     hass: HomeAssistant,
@@ -2381,7 +2381,7 @@ async def test_device_name_translation_placeholders(
         "expectation",
         "expected_error",
     ),
-    (
+    [
         (
             "test_device",
             {
@@ -2426,7 +2426,7 @@ async def test_device_name_translation_placeholders(
                 "not match the name '{placeholder} English dev'"
             ),
         ),
-    ),
+    ],
 )
 async def test_device_name_translation_placeholders_errors(
     hass: HomeAssistant,

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -933,10 +933,10 @@ async def test_entity_category_property(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("value", "expected"),
-    (
+    [
         ("config", entity.EntityCategory.CONFIG),
         ("diagnostic", entity.EntityCategory.DIAGNOSTIC),
-    ),
+    ],
 )
 def test_entity_category_schema(value, expected) -> None:
     """Test entity category schema."""
@@ -946,7 +946,7 @@ def test_entity_category_schema(value, expected) -> None:
     assert isinstance(result, entity.EntityCategory)
 
 
-@pytest.mark.parametrize("value", (None, "non_existing"))
+@pytest.mark.parametrize("value", [None, "non_existing"])
 def test_entity_category_schema_error(value) -> None:
     """Test entity category schema."""
     schema = vol.Schema(entity.ENTITY_CATEGORIES_SCHEMA)
@@ -1007,14 +1007,14 @@ async def _test_friendly_name(
         "device_name",
         "expected_friendly_name",
     ),
-    (
+    [
         (False, "Entity Blu", "Device Bla", "Entity Blu"),
         (False, None, "Device Bla", None),
         (True, "Entity Blu", "Device Bla", "Device Bla Entity Blu"),
         (True, None, "Device Bla", "Device Bla"),
         (True, "Entity Blu", UNDEFINED, "Entity Blu"),
         (True, "Entity Blu", None, "Mock Title Entity Blu"),
-    ),
+    ],
 )
 async def test_friendly_name_attr(
     hass: HomeAssistant,
@@ -1044,14 +1044,14 @@ async def test_friendly_name_attr(
 
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
-    (
+    [
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
         (True, UNDEFINED, "Device Bla None"),
-    ),
+    ],
 )
 async def test_friendly_name_description(
     hass: HomeAssistant,
@@ -1081,14 +1081,14 @@ async def test_friendly_name_description(
 
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
-    (
+    [
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
         (True, UNDEFINED, "Device Bla English cls"),
-    ),
+    ],
 )
 async def test_friendly_name_description_device_class_name(
     hass: HomeAssistant,
@@ -1150,7 +1150,7 @@ async def test_friendly_name_description_device_class_name(
         "placeholders",
         "expected_friendly_name",
     ),
-    (
+    [
         (False, None, None, None, "Entity Blu"),
         (True, None, None, None, "Device Bla Entity Blu"),
         (
@@ -1186,7 +1186,7 @@ async def test_friendly_name_description_device_class_name(
             {"placeholder": "special"},
             "Device Bla English ent special",
         ),
-    ),
+    ],
 )
 async def test_entity_name_translation_placeholders(
     hass: HomeAssistant,
@@ -1239,7 +1239,7 @@ async def test_entity_name_translation_placeholders(
         "release_channel",
         "expected_error",
     ),
-    (
+    [
         (
             "test_entity",
             {
@@ -1279,7 +1279,7 @@ async def test_entity_name_translation_placeholders(
                 "not match the name '{placeholder} English ent'"
             ),
         ),
-    ),
+    ],
 )
 async def test_entity_name_translation_placeholder_errors(
     hass: HomeAssistant,
@@ -1341,14 +1341,14 @@ async def test_entity_name_translation_placeholder_errors(
 
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
-    (
+    [
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
         (True, "Entity Blu", "Device Bla Entity Blu"),
         (True, None, "Device Bla"),
         (True, UNDEFINED, "Device Bla None"),
-    ),
+    ],
 )
 async def test_friendly_name_property(
     hass: HomeAssistant,
@@ -1377,7 +1377,7 @@ async def test_friendly_name_property(
 
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_friendly_name"),
-    (
+    [
         (False, "Entity Blu", "Entity Blu"),
         (False, None, None),
         (False, UNDEFINED, None),
@@ -1385,7 +1385,7 @@ async def test_friendly_name_property(
         (True, None, "Device Bla"),
         # Won't use the device class name because the entity overrides the name property
         (True, UNDEFINED, "Device Bla None"),
-    ),
+    ],
 )
 async def test_friendly_name_property_device_class_name(
     hass: HomeAssistant,
@@ -1438,10 +1438,10 @@ async def test_friendly_name_property_device_class_name(
 
 @pytest.mark.parametrize(
     ("has_entity_name", "expected_friendly_name"),
-    (
+    [
         (False, None),
         (True, "Device Bla English cls"),
-    ),
+    ],
 )
 async def test_friendly_name_device_class_name(
     hass: HomeAssistant,
@@ -1497,7 +1497,7 @@ async def test_friendly_name_device_class_name(
         "expected_friendly_name2",
         "expected_friendly_name3",
     ),
-    (
+    [
         (
             "Entity Blu",
             "Device Bla Entity Blu",
@@ -1510,7 +1510,7 @@ async def test_friendly_name_device_class_name(
             "Device Bla2",
             "New Device",
         ),
-    ),
+    ],
 )
 async def test_friendly_name_updated(
     hass: HomeAssistant,

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1711,7 +1711,7 @@ async def test_register_entity_service_limited_to_matching_platforms(
     }
 
 
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_invalid_entity_id(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, update_before_add: bool
 ) -> None:
@@ -1738,7 +1738,7 @@ class MockBlockingEntity(MockEntity):
         await asyncio.sleep(1000)
 
 
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_setup_entry_with_entities_that_block_forever(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
@@ -1784,7 +1784,7 @@ class MockCancellingEntity(MockEntity):
         raise asyncio.CancelledError
 
 
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_cancellation_is_not_blocked(
     hass: HomeAssistant,
     update_before_add: bool,
@@ -1813,7 +1813,7 @@ async def test_cancellation_is_not_blocked(
     assert full_name not in hass.config.components
 
 
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_two_platforms_add_same_entity(
     hass: HomeAssistant, update_before_add: bool
 ) -> None:
@@ -1868,14 +1868,14 @@ class SlowEntity(MockEntity):
 
 @pytest.mark.parametrize(
     ("has_entity_name", "entity_name", "expected_entity_id"),
-    (
+    [
         (False, "Entity Blu", "test_domain.entity_blu"),
         (False, None, "test_domain.test_qwer"),  # Set to <platform>_<unique_id>
         (True, "Entity Blu", "test_domain.device_bla_entity_blu"),
         (True, None, "test_domain.device_bla"),
-    ),
+    ],
 )
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_entity_name_influences_entity_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -1921,15 +1921,15 @@ async def test_entity_name_influences_entity_id(
 
 @pytest.mark.parametrize(
     ("language", "has_entity_name", "expected_entity_id"),
-    (
+    [
         ("en", False, "test_domain.test_qwer"),  # Set to <platform>_<unique_id>
         ("en", True, "test_domain.device_bla_english_name"),
         ("sv", True, "test_domain.device_bla_swedish_name"),
         # Chinese uses english for entity_id
         ("cn", True, "test_domain.device_bla_english_name"),
-    ),
+    ],
 )
-@pytest.mark.parametrize("update_before_add", (True, False))
+@pytest.mark.parametrize("update_before_add", [True, False])
 async def test_translated_entity_name_influences_entity_id(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -1998,7 +1998,7 @@ async def test_translated_entity_name_influences_entity_id(
 
 @pytest.mark.parametrize(
     ("language", "has_entity_name", "device_class", "expected_entity_id"),
-    (
+    [
         ("en", False, None, "test_domain.test_qwer"),  # Set to <platform>_<unique_id>
         (
             "en",
@@ -2010,7 +2010,7 @@ async def test_translated_entity_name_influences_entity_id(
         ("sv", True, "test_class", "test_domain.device_bla_swedish_cls"),
         # Chinese uses english for entity_id
         ("cn", True, "test_class", "test_domain.device_bla_english_cls"),
-    ),
+    ],
 )
 async def test_translated_device_class_name_influences_entity_id(
     hass: HomeAssistant,

--- a/tests/helpers/test_integration_platform.py
+++ b/tests/helpers/test_integration_platform.py
@@ -190,7 +190,7 @@ async def _process_platform_coro(
 
 @pytest.mark.no_fail_on_log_exception
 @pytest.mark.parametrize(
-    "process_platform", (_process_platform_callback, _process_platform_coro)
+    "process_platform", [_process_platform_callback, _process_platform_coro]
 )
 async def test_process_integration_platforms_non_compliant(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, process_platform: Callable

--- a/tests/helpers/test_json.py
+++ b/tests/helpers/test_json.py
@@ -34,7 +34,7 @@ TEST_JSON_A = {"a": 1, "B": "two"}
 TEST_JSON_B = {"a": "one", "B": 2}
 
 
-@pytest.mark.parametrize("encoder", (DefaultHASSJSONEncoder, ExtendedJSONEncoder))
+@pytest.mark.parametrize("encoder", [DefaultHASSJSONEncoder, ExtendedJSONEncoder])
 def test_json_encoder(hass: HomeAssistant, encoder: type[json.JSONEncoder]) -> None:
     """Test the JSON encoders."""
     ha_json_enc = encoder()

--- a/tests/helpers/test_registry.py
+++ b/tests/helpers/test_registry.py
@@ -29,12 +29,12 @@ class SampleRegistry(BaseRegistry):
 
 @pytest.mark.parametrize(
     "long_delay_state",
-    (
+    [
         CoreState.not_running,
         CoreState.starting,
         CoreState.stopped,
         CoreState.final_write,
-    ),
+    ],
 )
 async def test_async_schedule_save(
     hass: HomeAssistant,

--- a/tests/helpers/test_schema_config_entry_flow.py
+++ b/tests/helpers/test_schema_config_entry_flow.py
@@ -104,7 +104,7 @@ async def test_name(hass: HomeAssistant, entity_registry: er.EntityRegistry) -> 
     assert wrapped_entity_config_entry_title(hass, entry.id) == "Custom Name"
 
 
-@pytest.mark.parametrize("marker", (vol.Required, vol.Optional))
+@pytest.mark.parametrize("marker", [vol.Required, vol.Optional])
 async def test_config_flow_advanced_option(
     hass: HomeAssistant, manager: data_entry_flow.FlowManager, marker
 ) -> None:
@@ -199,7 +199,7 @@ async def test_config_flow_advanced_option(
         assert isinstance(option, str)
 
 
-@pytest.mark.parametrize("marker", (vol.Required, vol.Optional))
+@pytest.mark.parametrize("marker", [vol.Required, vol.Optional])
 async def test_options_flow_advanced_option(
     hass: HomeAssistant, manager: data_entry_flow.FlowManager, marker
 ) -> None:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -5020,10 +5020,10 @@ async def test_stop_action(
 
 @pytest.mark.parametrize(
     ("error", "error_dict", "logmsg", "script_execution"),
-    (
+    [
         (True, {"error": "In the name of love"}, "Error", "aborted"),
         (False, {}, "Stop", "finished"),
-    ),
+    ],
 )
 async def test_stop_action_subscript(
     hass: HomeAssistant,

--- a/tests/helpers/test_selector.py
+++ b/tests/helpers/test_selector.py
@@ -13,10 +13,10 @@ FAKE_UUID = "a266a680b608c32770e6c45bfe6b8411"
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         {"device": None},
         {"entity": None},
-    ),
+    ],
 )
 def test_valid_base_schema(schema) -> None:
     """Test base schema validation."""
@@ -25,14 +25,14 @@ def test_valid_base_schema(schema) -> None:
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         None,
         "not_a_dict",
         {},
         {"non_existing": {}},
         # Two keys
         {"device": {}, "entity": {}},
-    ),
+    ],
 )
 def test_invalid_base_schema(schema) -> None:
     """Test base schema validation."""
@@ -79,7 +79,7 @@ def _test_selector(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (None, ("abc123",), (None,)),
         ({}, ("abc123",), (None,)),
         ({"integration": "zha"}, ("abc123",), (None,)),
@@ -147,7 +147,7 @@ def _test_selector(
             ("abc123",),
             (None,),
         ),
-    ),
+    ],
 )
 def test_device_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test device selector."""
@@ -156,7 +156,7 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         ({}, ("sensor.abc123", FAKE_UUID), (None, "abc123")),
         ({"integration": "zha"}, ("sensor.abc123", FAKE_UUID), (None, "abc123")),
         ({"domain": "light"}, ("light.abc123", FAKE_UUID), (None, "sensor.abc123")),
@@ -266,7 +266,7 @@ def test_device_selector_schema(schema, valid_selections, invalid_selections) ->
             ("light.abc123", "blah.blah", FAKE_UUID),
             (None,),
         ),
-    ),
+    ],
 )
 def test_entity_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test entity selector."""
@@ -275,7 +275,7 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         # Feature should be string specifying an enum member, not an int
         {"filter": [{"supported_features": [1]}]},
         # Invalid feature
@@ -284,7 +284,7 @@ def test_entity_selector_schema(schema, valid_selections, invalid_selections) ->
         {"filter": [{"supported_features": ["blah.FooEntityFeature.blah"]}]},
         # Unknown feature enum member
         {"filter": [{"supported_features": ["light.LightEntityFeature.blah"]}]},
-    ),
+    ],
 )
 def test_entity_selector_schema_error(schema) -> None:
     """Test number selector."""
@@ -294,7 +294,7 @@ def test_entity_selector_schema_error(schema) -> None:
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         ({}, ("abc123",), (None,)),
         ({"entity": {}}, ("abc123",), (None,)),
         ({"entity": {"domain": "light"}}, ("abc123",), (None,)),
@@ -352,7 +352,7 @@ def test_entity_selector_schema_error(schema) -> None:
             ((["abc123", "def456"],)),
             (None, "abc123", ["abc123", None]),
         ),
-    ),
+    ],
 )
 def test_area_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test area selector."""
@@ -361,13 +361,13 @@ def test_area_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("23ouih2iu23ou2", "2j4hp3uy4p87wyrpiuhk34"),
             (None, True, 1),
         ),
-    ),
+    ],
 )
 def test_assist_pipeline_selector_schema(
     schema, valid_selections, invalid_selections
@@ -378,7 +378,7 @@ def test_assist_pipeline_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"min": 10, "max": 50},
             (
@@ -398,7 +398,7 @@ def test_assist_pipeline_selector_schema(
         ({"mode": "box"}, (10,), ()),
         ({"mode": "box", "step": "any"}, (), ()),
         ({"mode": "slider", "min": 0, "max": 1, "step": "any"}, (), ()),
-    ),
+    ],
 )
 def test_number_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test number selector."""
@@ -407,10 +407,10 @@ def test_number_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         {},  # Must have mandatory fields
         {"mode": "slider"},  # Must have min+max in slider mode
-    ),
+    ],
 )
 def test_number_selector_schema_error(schema) -> None:
     """Test number selector."""
@@ -420,7 +420,7 @@ def test_number_selector_schema_error(schema) -> None:
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("abc123",), (None,)),),
+    [({}, ("abc123",), (None,))],
 )
 def test_addon_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test add-on selector."""
@@ -429,7 +429,7 @@ def test_addon_selector_schema(schema, valid_selections, invalid_selections) -> 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("abc123", "/backup"), (None, "abc@123", "abc 123", "")),),
+    [({}, ("abc123", "/backup"), (None, "abc@123", "abc 123", ""))],
 )
 def test_backup_location_selector_schema(
     schema, valid_selections, invalid_selections
@@ -440,7 +440,7 @@ def test_backup_location_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, (1, "one", None), ()),),  # Everything can be coerced to bool
+    [({}, (1, "one", None), ())],  # Everything can be coerced to bool
 )
 def test_boolean_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test boolean selector."""
@@ -455,7 +455,7 @@ def test_boolean_selector_schema(schema, valid_selections, invalid_selections) -
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("6b68b250388cbe0d620c92dd3acc93ec", "76f2e8f9a6491a1b580b3a8967c27ddd"),
@@ -466,7 +466,7 @@ def test_boolean_selector_schema(schema, valid_selections, invalid_selections) -
             ("6b68b250388cbe0d620c92dd3acc93ec", "76f2e8f9a6491a1b580b3a8967c27ddd"),
             (None, True, 1),
         ),
-    ),
+    ],
 )
 def test_config_entry_selector_schema(
     schema, valid_selections, invalid_selections
@@ -477,7 +477,7 @@ def test_config_entry_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("NL", "DE"),
@@ -488,7 +488,7 @@ def test_config_entry_selector_schema(
             ("NL", "DE"),
             (None, True, 1, "sv", "en"),
         ),
-    ),
+    ],
 )
 def test_country_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test country selector."""
@@ -497,7 +497,7 @@ def test_country_selector_schema(schema, valid_selections, invalid_selections) -
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("00:00:00",), ("blah", None)),),
+    [({}, ("00:00:00",), ("blah", None))],
 )
 def test_time_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test time selector."""
@@ -506,13 +506,13 @@ def test_time_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"entity_id": "sensor.abc"},
             ("on", "armed"),
             (None, True, 1),
         ),
-    ),
+    ],
 )
 def test_state_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test state selector."""
@@ -521,7 +521,7 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         ({}, ({"entity_id": ["sensor.abc123"]},), ("abc123", None)),
         ({"entity": {}}, (), ()),
         ({"entity": {"domain": "light"}}, (), ()),
@@ -566,7 +566,7 @@ def test_state_selector_schema(schema, valid_selections, invalid_selections) -> 
             (),
             (),
         ),
-    ),
+    ],
 )
 def test_target_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test target selector."""
@@ -575,7 +575,7 @@ def test_target_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("abc123",), ()),),
+    [({}, ("abc123",), ())],
 )
 def test_action_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test action sequence selector."""
@@ -584,7 +584,7 @@ def test_action_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("abc123",), ()),),
+    [({}, ("abc123",), ())],
 )
 def test_object_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test object selector."""
@@ -593,7 +593,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         ({}, ("abc123",), (None,)),
         ({"multiline": True}, (), ()),
         ({"multiline": False, "type": "email"}, (), ()),
@@ -603,7 +603,7 @@ def test_object_selector_schema(schema, valid_selections, invalid_selections) ->
             (["abc123", "def456"],),
             ("abc123", None, ["abc123", None]),
         ),
-    ),
+    ],
 )
 def test_text_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test text selector."""
@@ -612,7 +612,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"options": ["red", "green", "blue"]},
             ("red", "green", "blue"),
@@ -681,7 +681,7 @@ def test_text_selector_schema(schema, valid_selections, invalid_selections) -> N
             ("red", "blue"),
             (0, None, ["red"]),
         ),
-    ),
+    ],
 )
 def test_select_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test select selector."""
@@ -690,14 +690,14 @@ def test_select_selector_schema(schema, valid_selections, invalid_selections) ->
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         {},  # Must have options
         {"options": {"hello": "World"}},  # Options must be a list
         # Options must be strings or value / label pairs
         {"options": [{"hello": "World"}]},
         # Options must all be of the same type
         {"options": ["red", {"value": "green", "label": "Emerald Green"}]},
-    ),
+    ],
 )
 def test_select_selector_schema_error(schema) -> None:
     """Test select selector."""
@@ -707,7 +707,7 @@ def test_select_selector_schema_error(schema) -> None:
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"entity_id": "sensor.abc"},
             ("friendly_name", "device_class"),
@@ -718,7 +718,7 @@ def test_select_selector_schema_error(schema) -> None:
             ("device_class", "state_class"),
             (None,),
         ),
-    ),
+    ],
 )
 def test_attribute_selector_schema(
     schema, valid_selections, invalid_selections
@@ -729,7 +729,7 @@ def test_attribute_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (
@@ -743,7 +743,7 @@ def test_attribute_selector_schema(
             ({"seconds": 10}, {"days": 10}),
             (None, {}),
         ),
-    ),
+    ],
 )
 def test_duration_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test duration selector."""
@@ -752,13 +752,13 @@ def test_duration_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("mdi:abc",),
             (None,),
         ),
-    ),
+    ],
 )
 def test_icon_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test icon selector."""
@@ -767,7 +767,7 @@ def test_icon_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("abc",),
@@ -778,7 +778,7 @@ def test_icon_selector_schema(schema, valid_selections, invalid_selections) -> N
             ("abc",),
             (None,),
         ),
-    ),
+    ],
 )
 def test_theme_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test theme selector."""
@@ -787,7 +787,7 @@ def test_theme_selector_schema(schema, valid_selections, invalid_selections) -> 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (
@@ -805,7 +805,7 @@ def test_theme_selector_schema(schema, valid_selections, invalid_selections) -> 
             ),
             (None, "abc", {}),
         ),
-    ),
+    ],
 )
 def test_media_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test media selector."""
@@ -826,7 +826,7 @@ def test_media_selector_schema(schema, valid_selections, invalid_selections) -> 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("nl", "fr"),
@@ -837,7 +837,7 @@ def test_media_selector_schema(schema, valid_selections, invalid_selections) -> 
             ("nl", "fr"),
             (None, True, 1, "de", "en"),
         ),
-    ),
+    ],
 )
 def test_language_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test language selector."""
@@ -846,7 +846,7 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (
@@ -873,7 +873,7 @@ def test_language_selector_schema(schema, valid_selections, invalid_selections) 
                 {"longitude": 1.0},
             ),
         ),
-    ),
+    ],
 )
 def test_location_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test location selector."""
@@ -883,13 +883,13 @@ def test_location_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ([0, 0, 0], [255, 255, 255], [0.0, 0.0, 0.0], [255.0, 255.0, 255.0]),
             (None, "abc", [0, 0, "nil"], (255, 255, 255)),
         ),
-    ),
+    ],
 )
 def test_rgb_color_selector_schema(
     schema, valid_selections, invalid_selections
@@ -901,7 +901,7 @@ def test_rgb_color_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (100, 100.0),
@@ -922,7 +922,7 @@ def test_rgb_color_selector_schema(
             (1000, 2000),
             (999, 2001),
         ),
-    ),
+    ],
 )
 def test_color_tempselector_schema(
     schema, valid_selections, invalid_selections
@@ -934,13 +934,13 @@ def test_color_tempselector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("2022-03-24",),
             (None, "abc", "00:00", "2022-03-24 00:00", "2022-03-32"),
         ),
-    ),
+    ],
 )
 def test_date_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test date selector."""
@@ -950,13 +950,13 @@ def test_date_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("2022-03-24 00:00", "2022-03-24"),
             (None, "abc", "00:00", "2022-03-24 24:01"),
         ),
-    ),
+    ],
 )
 def test_datetime_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test datetime selector."""
@@ -966,7 +966,7 @@ def test_datetime_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (({}, ("abc123", "{{ now() }}"), (None, "{{ incomplete }", "{% if True %}Hi!")),),
+    [({}, ("abc123", "{{ now() }}"), (None, "{{ incomplete }", "{% if True %}Hi!"))],
 )
 def test_template_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test template selector."""
@@ -975,13 +975,13 @@ def test_template_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"accept": "image/*"},
             ("0182a1b99dbc5ae24aecd90c346605fa",),
             (None, "not-a-uuid", "abcd", 1),
         ),
-    ),
+    ],
 )
 def test_file_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test file selector."""
@@ -991,7 +991,7 @@ def test_file_selector_schema(schema, valid_selections, invalid_selections) -> N
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"value": True, "label": "Blah"},
             (True, 1),
@@ -1022,7 +1022,7 @@ def test_file_selector_schema(schema, valid_selections, invalid_selections) -> N
             ("dog",),
             (None, False, True, 0, 1, "abc", "def"),
         ),
-    ),
+    ],
 )
 def test_constant_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test constant selector."""
@@ -1031,11 +1031,11 @@ def test_constant_selector_schema(schema, valid_selections, invalid_selections) 
 
 @pytest.mark.parametrize(
     "schema",
-    (
+    [
         {},  # Value is mandatory
         {"value": []},  # Value must be str, int or bool
         {"value": 123, "label": 123},  # Label must be str
-    ),
+    ],
 )
 def test_constant_selector_schema_error(schema) -> None:
     """Test constant selector."""
@@ -1045,7 +1045,7 @@ def test_constant_selector_schema_error(schema) -> None:
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             ("home_assistant", "2j4hp3uy4p87wyrpiuhk34"),
@@ -1056,7 +1056,7 @@ def test_constant_selector_schema_error(schema) -> None:
             ("home_assistant", "2j4hp3uy4p87wyrpiuhk34"),
             (None, True, 1),
         ),
-    ),
+    ],
 )
 def test_conversation_agent_selector_schema(
     schema, valid_selections, invalid_selections
@@ -1067,7 +1067,7 @@ def test_conversation_agent_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (
@@ -1082,7 +1082,7 @@ def test_conversation_agent_selector_schema(
             ),
             ("abc"),
         ),
-    ),
+    ],
 )
 def test_condition_selector_schema(
     schema, valid_selections, invalid_selections
@@ -1093,7 +1093,7 @@ def test_condition_selector_schema(
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {},
             (
@@ -1108,7 +1108,7 @@ def test_condition_selector_schema(
             ),
             ("abc"),
         ),
-    ),
+    ],
 )
 def test_trigger_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test trigger sequence selector."""
@@ -1117,7 +1117,7 @@ def test_trigger_selector_schema(schema, valid_selections, invalid_selections) -
 
 @pytest.mark.parametrize(
     ("schema", "valid_selections", "invalid_selections"),
-    (
+    [
         (
             {"data": "test", "scale": 5},
             ("test",),
@@ -1137,7 +1137,7 @@ def test_trigger_selector_schema(schema, valid_selections, invalid_selections) -
             ("test",),
             (True, 1, []),
         ),
-    ),
+    ],
 )
 def test_qr_code_selector_schema(schema, valid_selections, invalid_selections) -> None:
     """Test QR code selector."""

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -487,7 +487,7 @@ async def test_service_call_entry_id(
     assert dict(calls[0].data) == {"entity_id": ["hello.world"]}
 
 
-@pytest.mark.parametrize("target", ("all", "none"))
+@pytest.mark.parametrize("target", ["all", "none"])
 async def test_service_call_all_none(hass: HomeAssistant, target) -> None:
     """Test service call targeting all."""
     calls = async_mock_service(hass, "test_domain", "test_service")

--- a/tests/helpers/test_singleton.py
+++ b/tests/helpers/test_singleton.py
@@ -13,7 +13,7 @@ def mock_hass():
     return Mock(data={})
 
 
-@pytest.mark.parametrize("result", (object(), {}, []))
+@pytest.mark.parametrize("result", [object(), {}, []])
 async def test_singleton_async(mock_hass, result) -> None:
     """Test singleton with async function."""
 
@@ -29,7 +29,7 @@ async def test_singleton_async(mock_hass, result) -> None:
     assert mock_hass.data["test_key"] is result1
 
 
-@pytest.mark.parametrize("result", (object(), {}, []))
+@pytest.mark.parametrize("result", [object(), {}, []])
 def test_singleton(mock_hass, result) -> None:
     """Test singleton with function."""
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1140,14 +1140,14 @@ def test_timestamp_local(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     "input",
-    (
+    [
         "2021-06-03 13:00:00.000000+00:00",
         "1986-07-09T12:00:00Z",
         "2016-10-19 15:22:05.588122+0100",
         "2016-10-19",
         "2021-01-01 00:00:01",
         "invalid",
-    ),
+    ],
 )
 def test_as_datetime(hass: HomeAssistant, input) -> None:
     """Test converting a timestamp string to a date object."""
@@ -1466,11 +1466,11 @@ def test_max(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     "attribute",
-    (
+    [
         "a",
         "b",
         "c",
-    ),
+    ],
 )
 def test_min_max_attribute(hass: HomeAssistant, attribute) -> None:
     """Test the min and max filters with attribute."""

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -112,7 +112,7 @@ def test__load_translations_files_by_language(
 
 @pytest.mark.parametrize(
     ("language", "expected_translation", "expected_errors"),
-    (
+    [
         (
             "en",
             {
@@ -154,7 +154,7 @@ def test__load_translations_files_by_language(
                 "component.test.entity.switch.outlet.name",
             ],
         ),
-    ),
+    ],
 )
 async def test_load_translations_files_invalid_localized_placeholders(
     hass: HomeAssistant,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -865,7 +865,7 @@ async def test_loading_configuration(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     ("minor_version", "users", "user_data", "default_language"),
-    (
+    [
         (2, (), {}, "en"),
         (2, ({"is_owner": True},), {}, "en"),
         (
@@ -894,7 +894,7 @@ async def test_loading_configuration(hass: HomeAssistant) -> None:
             {"user1": {"language": {"language": "sv"}}},
             "en",
         ),
-    ),
+    ],
 )
 async def test_language_default(
     hass: HomeAssistant,

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1455,13 +1455,13 @@ async def test_entry_setup_succeed(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         config_entries.ConfigEntryState.LOADED,
         config_entries.ConfigEntryState.SETUP_ERROR,
         config_entries.ConfigEntryState.MIGRATION_ERROR,
         config_entries.ConfigEntryState.SETUP_RETRY,
         config_entries.ConfigEntryState.FAILED_UNLOAD,
-    ),
+    ],
 )
 async def test_entry_setup_invalid_state(
     hass: HomeAssistant,
@@ -1506,11 +1506,11 @@ async def test_entry_unload_succeed(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         config_entries.ConfigEntryState.NOT_LOADED,
         config_entries.ConfigEntryState.SETUP_ERROR,
         config_entries.ConfigEntryState.SETUP_RETRY,
-    ),
+    ],
 )
 async def test_entry_unload_failed_to_load(
     hass: HomeAssistant,
@@ -1532,10 +1532,10 @@ async def test_entry_unload_failed_to_load(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         config_entries.ConfigEntryState.MIGRATION_ERROR,
         config_entries.ConfigEntryState.FAILED_UNLOAD,
-    ),
+    ],
 )
 async def test_entry_unload_invalid_state(
     hass: HomeAssistant,
@@ -1588,11 +1588,11 @@ async def test_entry_reload_succeed(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         config_entries.ConfigEntryState.NOT_LOADED,
         config_entries.ConfigEntryState.SETUP_ERROR,
         config_entries.ConfigEntryState.SETUP_RETRY,
-    ),
+    ],
 )
 async def test_entry_reload_not_loaded(
     hass: HomeAssistant,
@@ -1627,10 +1627,10 @@ async def test_entry_reload_not_loaded(
 
 @pytest.mark.parametrize(
     "state",
-    (
+    [
         config_entries.ConfigEntryState.MIGRATION_ERROR,
         config_entries.ConfigEntryState.FAILED_UNLOAD,
-    ),
+    ],
 )
 async def test_entry_reload_error(
     hass: HomeAssistant,
@@ -2928,7 +2928,7 @@ async def test_async_setup_update_entry(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize(
     "discovery_source",
-    (
+    [
         (config_entries.SOURCE_BLUETOOTH, BaseServiceInfo()),
         (config_entries.SOURCE_DISCOVERY, {}),
         (config_entries.SOURCE_SSDP, BaseServiceInfo()),
@@ -2940,7 +2940,7 @@ async def test_async_setup_update_entry(hass: HomeAssistant) -> None:
             config_entries.SOURCE_HASSIO,
             HassioServiceInfo(config={}, name="Test", slug="test", uuid="1234"),
         ),
-    ),
+    ],
 )
 async def test_flow_with_default_discovery(
     hass: HomeAssistant,
@@ -4836,7 +4836,7 @@ async def test_directly_mutating_blocked(
 
 @pytest.mark.parametrize(
     "field",
-    (
+    [
         "data",
         "options",
         "title",
@@ -4844,7 +4844,7 @@ async def test_directly_mutating_blocked(
         "pref_disable_polling",
         "minor_version",
         "version",
-    ),
+    ],
 )
 async def test_report_direct_mutation_of_config_entry(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, field: str

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2865,7 +2865,7 @@ async def test_state_changed_events_to_not_leak_contexts(hass: HomeAssistant) ->
     assert len(_get_by_type("homeassistant.core.Context")) == init_count
 
 
-@pytest.mark.parametrize("eager_start", (True, False))
+@pytest.mark.parametrize("eager_start", [True, False])
 async def test_background_task(hass: HomeAssistant, eager_start: bool) -> None:
     """Test background tasks being quit."""
     result = asyncio.Future()
@@ -2936,7 +2936,7 @@ async def test_shutdown_does_not_block_on_shielded_tasks(
     sleep_task.cancel()
 
 
-@pytest.mark.parametrize("eager_start", (True, False))
+@pytest.mark.parametrize("eager_start", [True, False])
 async def test_cancellable_hassjob(hass: HomeAssistant, eager_start: bool) -> None:
     """Simulate a shutdown, ensure cancellable jobs are cancelled."""
     job = MagicMock()

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -908,7 +908,7 @@ async def test_abort_raises_unknown_flow_if_not_in_progress(manager) -> None:
 
 @pytest.mark.parametrize(
     "menu_options",
-    (["target1", "target2"], {"target1": "Target 1", "target2": "Target 2"}),
+    [["target1", "target2"], {"target1": "Target 1", "target2": "Target 2"}],
 )
 async def test_show_menu(hass: HomeAssistant, manager, menu_options) -> None:
     """Test show menu."""

--- a/tests/util/test_unit_system.py
+++ b/tests/util/test_unit_system.py
@@ -337,7 +337,7 @@ def test_get_unit_system_invalid(key: str) -> None:
 
 @pytest.mark.parametrize(
     ("device_class", "original_unit", "state_unit"),
-    (
+    [
         # Test atmospheric pressure
         (
             SensorDeviceClass.ATMOSPHERIC_PRESSURE,
@@ -477,7 +477,7 @@ def test_get_unit_system_invalid(key: str) -> None:
             UnitOfSpeed.KILOMETERS_PER_HOUR,
         ),
         (SensorDeviceClass.WIND_SPEED, "very_fast", None),
-    ),
+    ],
 )
 def test_get_metric_converted_unit_(
     device_class: SensorDeviceClass,
@@ -537,7 +537,7 @@ UNCONVERTED_UNITS_METRIC_SYSTEM = {
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         SensorDeviceClass.ATMOSPHERIC_PRESSURE,
         SensorDeviceClass.DISTANCE,
         SensorDeviceClass.GAS,
@@ -547,7 +547,7 @@ UNCONVERTED_UNITS_METRIC_SYSTEM = {
         SensorDeviceClass.SPEED,
         SensorDeviceClass.VOLUME,
         SensorDeviceClass.WATER,
-    ),
+    ],
 )
 def test_metric_converted_units(device_class: SensorDeviceClass) -> None:
     """Test unit conversion rules are in place for all units."""
@@ -565,7 +565,7 @@ def test_metric_converted_units(device_class: SensorDeviceClass) -> None:
 
 @pytest.mark.parametrize(
     ("device_class", "original_unit", "state_unit"),
-    (
+    [
         # Test atmospheric pressure
         (
             SensorDeviceClass.ATMOSPHERIC_PRESSURE,
@@ -697,7 +697,7 @@ def test_metric_converted_units(device_class: SensorDeviceClass) -> None:
         (SensorDeviceClass.WIND_SPEED, UnitOfSpeed.KNOTS, None),
         (SensorDeviceClass.WIND_SPEED, UnitOfSpeed.MILES_PER_HOUR, None),
         (SensorDeviceClass.WIND_SPEED, "very_fast", None),
-    ),
+    ],
 )
 def test_get_us_converted_unit(
     device_class: SensorDeviceClass,
@@ -748,7 +748,7 @@ UNCONVERTED_UNITS_US_SYSTEM = {
 
 @pytest.mark.parametrize(
     "device_class",
-    (
+    [
         SensorDeviceClass.ATMOSPHERIC_PRESSURE,
         SensorDeviceClass.DISTANCE,
         SensorDeviceClass.GAS,
@@ -758,7 +758,7 @@ UNCONVERTED_UNITS_US_SYSTEM = {
         SensorDeviceClass.SPEED,
         SensorDeviceClass.VOLUME,
         SensorDeviceClass.WATER,
-    ),
+    ],
 )
 def test_imperial_converted_units(device_class: SensorDeviceClass) -> None:
     """Test unit conversion rules are in place for all units."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This enables the Ruff rule PT007 and fixes the occurrences.

This rule makes the parameter types to `@pytest.mark.parametrize` consistent.

I used the combination with the least fixes needed:

```
$ ruff check --statistics
566     PT007   Wrong values type in `@pytest.mark.parametrize` expected `list` of `tuple`
$ ruff check --statistics
7830    PT007   Wrong values type in `@pytest.mark.parametrize` expected `list` of `list`
$ ruff check --statistics
10891   PT007   Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `list`
$ ruff check --statistics
3627    PT007   Wrong values type in `@pytest.mark.parametrize` expected `tuple` of `tuple`
```

Because there is/was no autofix for this rule available, I wrote one here https://github.com/astral-sh/ruff/pull/10461 and used it to fix it (and checked every file manually afterwards)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
