### PR TITLE
Add Lutron Serena tilt only wood blinds

### DIFF
--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -30,7 +30,7 @@ class LutronCasetaCoverBase(LutronCasetaDeviceUpdatableEntity, CoverEntity):
         await self._smartbridge.stop_cover(self.device_id)
 
 
-class LutronCasetaCover(LutronCasetaCoverBase):
+class LutronCasetaShade(LutronCasetaCoverBase):
     """Representation of a Lutron shade with open/close functionality."""
 
     _attr_supported_features = (
@@ -113,14 +113,14 @@ class LutronCasetaTiltOnlyBlind(LutronCasetaCoverBase):
 
 PYLUTRON_TYPE_TO_CLASSES = {
     "SerenaTiltOnlyWoodBlind": LutronCasetaTiltOnlyBlind,
-    "SerenaHoneycombShade": LutronCasetaCover,
-    "SerenaRollerShade": LutronCasetaCover,
-    "TriathlonHoneycombShade": LutronCasetaCover,
-    "TriathlonRollerShade": LutronCasetaCover,
-    "QsWirelessShade": LutronCasetaCover,
-    "QsWirelessHorizontalSheerBlind": LutronCasetaCover,
-    "Shade": LutronCasetaCover,
-    "PalladiomWireFreeShade": LutronCasetaCover,
+    "SerenaHoneycombShade": LutronCasetaShade,
+    "SerenaRollerShade": LutronCasetaShade,
+    "TriathlonHoneycombShade": LutronCasetaShade,
+    "TriathlonRollerShade": LutronCasetaShade,
+    "QsWirelessShade": LutronCasetaShade,
+    "QsWirelessHorizontalSheerBlind": LutronCasetaShade,
+    "Shade": LutronCasetaShade,
+    "PalladiomWireFreeShade": LutronCasetaShade,
 }
 
 
@@ -139,7 +139,7 @@ async def async_setup_entry(
     cover_devices = bridge.get_devices_by_domain(DOMAIN)
     async_add_entities(
         # default to standard LutronCasetaCover type if the pylutron type is not yet mapped
-        PYLUTRON_TYPE_TO_CLASSES.get(cover_device["type"], LutronCasetaCover)(
+        PYLUTRON_TYPE_TO_CLASSES.get(cover_device["type"], LutronCasetaShade)(
             cover_device, data
         )
         for cover_device in cover_devices

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -94,7 +94,7 @@ class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover."""
-        await self._smartbridge.lower_cover(self.device_id)
+        await self._smartbridge.set_tilt(self.device_id, 0)
         await self.async_update()
         self.async_write_ha_state()
 

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -22,8 +22,16 @@ from .models import LutronCasetaData
 _LOGGER = logging.getLogger(__name__)
 
 
-class LutronCasetaCover(LutronCasetaDeviceUpdatableEntity, CoverEntity):
-    """Representation of a Lutron shade."""
+class LutronCasetaCoverBase(LutronCasetaDeviceUpdatableEntity, CoverEntity):
+    """Representation of a Lutron cover base class."""
+
+    async def async_stop_cover(self, **kwargs: Any) -> None:
+        """Stop the cover."""
+        await self._smartbridge.stop_cover(self.device_id)
+
+
+class LutronCasetaCover(LutronCasetaCoverBase):
+    """Representation of a Lutron shade with open/close functionality."""
 
     _attr_supported_features = (
         CoverEntityFeature.OPEN
@@ -42,10 +50,6 @@ class LutronCasetaCover(LutronCasetaDeviceUpdatableEntity, CoverEntity):
     def current_cover_position(self) -> int:
         """Return the current position of cover."""
         return self._device["current_state"]
-
-    async def async_stop_cover(self, **kwargs: Any) -> None:
-        """Top the cover."""
-        await self._smartbridge.stop_cover(self.device_id)
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
@@ -66,7 +70,7 @@ class LutronCasetaCover(LutronCasetaDeviceUpdatableEntity, CoverEntity):
             await self._smartbridge.set_value(self.device_id, position)
 
 
-class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
+class LutronCasetaTiltOnlyBlind(LutronCasetaCoverBase):
     """Representation of a Lutron tilt only blind."""
 
     _attr_supported_features = (
@@ -87,10 +91,6 @@ class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
     def current_cover_tilt_position(self) -> int:
         """Return the current position of cover."""
         return self._device["tilt"]
-
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
-        """Top the cover."""
-        await self._smartbridge.stop_cover(self.device_id)
 
     async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover."""
@@ -119,19 +119,9 @@ PYLUTRON_TYPE_TO_CLASSES = {
     "TriathlonRollerShade": LutronCasetaCover,
     "QsWirelessShade": LutronCasetaCover,
     "QsWirelessHorizontalSheerBlind": LutronCasetaCover,
-    # "QsWirelessWoodBlind": LutronCasetaCover, # implement tilt and lift wood blind
-    # "RightDrawDrape": LutronCasetaCover, # implement drape
     "Shade": LutronCasetaCover,
     "PalladiomWireFreeShade": LutronCasetaCover,
 }
-
-
-def _map_covertype_pylutron_to_ha(pylutron_name):
-    try:
-        return PYLUTRON_TYPE_TO_CLASSES[pylutron_name]
-    except KeyError:
-        _LOGGER.error("%s cover type not implemented" | format(pylutron_name))
-        return None
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for Lutron (Caseta) Serena Wood Blinds, which are a tilt only blind. Currently all Lutron Caseta cover objects are handled as shades which is incorrect.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The current implementation creates each device an object that only supports open/close as a SHADE type. Lutron Serena wood blinds are a tilt only blind so they should not use a plain open/close but instead TILT functions. This adds the additional type to support a device with tilt only operation. 
In addition this change maps the pylutron types to classes. I left comments for Sivoia QS Wood Blinds and RightDrawDrape as I do not own these products so I cannot test the implementation, but I don't expect they work correctly today anyhow.
Addresses the following issues:
- https://github.com/home-assistant/core/issues/65815
- https://github.com/home-assistant/core/issues/81524
- https://github.com/home-assistant/core/issues/81525
- https://github.com/home-assistant/core/issues/93679

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/31957

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
