### PR TITLE
Implement Identify button and Cloud connection toggle for HomeWizard Watermeter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,14 +8,6 @@
   // Port 5683 udp is used by Shelly integration
   "appPort": ["8123:8123", "5683:5683/udp"],
   "runArgs": ["-e", "GIT_EDITOR=code --wait"],
-  "features": {
-    "ghcr.io/devcontainers/features/sshd:1": {
-      "version": "latest"
-    },
-    "ghcr.io/devcontainers/features/github-cli:1": {
-      "version": "latest"
-    }
-  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,14 @@
   // Port 5683 udp is used by Shelly integration
   "appPort": ["8123:8123", "5683:5683/udp"],
   "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    }
+  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/homeassistant/components/homewizard/coordinator.py
+++ b/homeassistant/components/homewizard/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 from homewizard_energy import HomeWizardEnergy
-from homewizard_energy.const import SUPPORTS_IDENTIFY, SUPPORTS_STATE, SUPPORTS_SYSTEM
+from homewizard_energy.const import SUPPORTS_IDENTIFY, SUPPORTS_STATE
 from homewizard_energy.errors import DisabledError, RequestError, UnsupportedError
 from homewizard_energy.models import Device
 
@@ -53,8 +53,7 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
                 if self.supports_state(data.device):
                     data.state = await self.api.state()
 
-                if self.supports_system(data.device):
-                    data.system = await self.api.system()
+                data.system = await self.api.system()
 
             except UnsupportedError as ex:
                 # Old firmware, ignore
@@ -93,13 +92,6 @@ class HWEnergyDeviceUpdateCoordinator(DataUpdateCoordinator[DeviceResponseEntry]
             device = self.data.device
 
         return device.product_type in SUPPORTS_STATE
-
-    def supports_system(self, device: Device | None = None) -> bool:
-        """Return True if the device supports system."""
-        if device is None:
-            device = self.data.device
-
-        return device.product_type in SUPPORTS_SYSTEM
 
     def supports_identify(self, device: Device | None = None) -> bool:
         """Return True if the device supports identify."""

--- a/homeassistant/components/homewizard/manifest.json
+++ b/homeassistant/components/homewizard/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "local_polling",
   "loggers": ["homewizard_energy"],
   "quality_scale": "platinum",
-  "requirements": ["python-homewizard-energy==4.3.1"],
+  "requirements": ["python-homewizard-energy==v5.0.0"],
   "zeroconf": ["_hwenergy._tcp.local."]
 }

--- a/homeassistant/components/homewizard/switch.py
+++ b/homeassistant/components/homewizard/switch.py
@@ -57,7 +57,7 @@ SWITCHES = [
         key="cloud_connection",
         translation_key="cloud_connection",
         entity_category=EntityCategory.CONFIG,
-        create_fn=lambda coordinator: coordinator.supports_system(),
+        create_fn=lambda _: True,
         available_fn=lambda data: data.system is not None,
         is_on_fn=lambda data: data.system.cloud_enabled if data.system else None,
         set_fn=lambda api, active: api.system_set(cloud_enabled=active),

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2226,7 +2226,7 @@ python-gitlab==1.6.0
 python-homeassistant-analytics==0.6.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==4.3.1
+python-homewizard-energy==v5.0.0
 
 # homeassistant.components.hp_ilo
 python-hpilo==4.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1717,7 +1717,7 @@ python-fullykiosk==0.0.12
 python-homeassistant-analytics==0.6.0
 
 # homeassistant.components.homewizard
-python-homewizard-energy==4.3.1
+python-homewizard-energy==v5.0.0
 
 # homeassistant.components.izone
 python-izone==1.2.9

--- a/tests/components/homewizard/fixtures/HWE-WTR/system.json
+++ b/tests/components/homewizard/fixtures/HWE-WTR/system.json
@@ -1,0 +1,3 @@
+{
+  "cloud_enabled": true
+}

--- a/tests/components/homewizard/snapshots/test_diagnostics.ambr
+++ b/tests/components/homewizard/snapshots/test_diagnostics.ambr
@@ -544,7 +544,9 @@
         'serial': '**REDACTED**',
       }),
       'state': None,
-      'system': None,
+      'system': dict({
+        'cloud_enabled': True,
+      }),
     }),
     'entry': dict({
       'ip_address': '**REDACTED**',

--- a/tests/components/homewizard/snapshots/test_switch.ambr
+++ b/tests/components/homewizard/snapshots/test_switch.ambr
@@ -641,6 +641,86 @@
     'via_device_id': None,
   })
 # ---
+# name: test_switch_entities[HWE-WTR-switch.device_cloud_connection-system_set-cloud_enabled]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Device Cloud connection',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.device_cloud_connection',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[HWE-WTR-switch.device_cloud_connection-system_set-cloud_enabled].1
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.device_cloud_connection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cloud connection',
+    'platform': 'homewizard',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'cloud_connection',
+    'unique_id': 'aabbccddeeff_cloud_connection',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[HWE-WTR-switch.device_cloud_connection-system_set-cloud_enabled].2
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+      tuple(
+        'mac',
+        '3c:39:e7:aa:bb:cc',
+      ),
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'homewizard',
+        '3c39e7aabbcc',
+      ),
+    }),
+    'is_new': False,
+    'labels': set({
+    }),
+    'manufacturer': 'HomeWizard',
+    'model': 'HWE-WTR',
+    'name': 'Device',
+    'name_by_user': None,
+    'serial_number': None,
+    'suggested_area': None,
+    'sw_version': '2.03',
+    'via_device_id': None,
+  })
+# ---
 # name: test_switch_entities[SDM230-switch.device_cloud_connection-system_set-cloud_enabled]
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/components/homewizard/test_button.py
+++ b/tests/components/homewizard/test_button.py
@@ -18,9 +18,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize(
-    "device_fixture", ["HWE-WTR", "SDM230", "SDM630", "HWE-KWH1", "HWE-KWH3"]
-)
+@pytest.mark.parametrize("device_fixture", ["SDM230", "SDM630", "HWE-KWH1", "HWE-KWH3"])
 async def test_identify_button_entity_not_loaded_when_not_available(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/homewizard/test_switch.py
+++ b/tests/components/homewizard/test_switch.py
@@ -42,7 +42,6 @@ pytestmark = [
             [
                 "switch.device",
                 "switch.device_switch_lock",
-                "switch.device_cloud_connection",
             ],
         ),
         (
@@ -93,6 +92,7 @@ async def test_entities_not_created_for_device(
         ("HWE-SKT-21", "switch.device", "state_set", "power_on"),
         ("HWE-SKT-21", "switch.device_switch_lock", "state_set", "switch_lock"),
         ("HWE-SKT-21", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
+        ("HWE-WTR", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
         ("SDM230", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
         ("SDM630", "switch.device_cloud_connection", "system_set", "cloud_enabled"),
         ("HWE-KWH1", "switch.device_cloud_connection", "system_set", "cloud_enabled"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for 'Identify' button and 'Cloud connection' toggle for the HomeWizard Watermeter.

This requires a bumb from the underlying library.
https://github.com/homewizard/python-homewizard-energy/releases/tag/v5.0.0
https://github.com/homewizard/python-homewizard-energy/compare/v4.3.1...v5.0.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] → TODO

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
