### PR TITLE
Remove deprecated `hass.components` from vilfo config flow tests

### DIFF
--- a/tests/components/vilfo/test_config_flow.py
+++ b/tests/components/vilfo/test_config_flow.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import vilfo
 
 from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.vilfo import config_flow
 from homeassistant.components.vilfo.const import DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_ID, CONF_MAC
 from homeassistant.core import HomeAssistant
@@ -173,9 +174,7 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
     ), patch("vilfo.Client.resolve_mac_address", return_value=None):
-        result = await hass.components.vilfo.config_flow.validate_input(
-            hass, data=mock_data
-        )
+        result = await config_flow.validate_input(hass, data=mock_data)
 
     assert result["title"] == mock_data["host"]
     assert result[CONF_HOST] == mock_data["host"]
@@ -187,15 +186,9 @@ async def test_validate_input_returns_data(hass: HomeAssistant) -> None:
     ), patch(
         "vilfo.Client.resolve_firmware_version", return_value=firmware_version
     ), patch("vilfo.Client.resolve_mac_address", return_value=mock_mac):
-        result2 = await hass.components.vilfo.config_flow.validate_input(
-            hass, data=mock_data
-        )
-        result3 = await hass.components.vilfo.config_flow.validate_input(
-            hass, data=mock_data_with_ip
-        )
-        result4 = await hass.components.vilfo.config_flow.validate_input(
-            hass, data=mock_data_with_ipv6
-        )
+        result2 = await config_flow.validate_input(hass, data=mock_data)
+        result3 = await config_flow.validate_input(hass, data=mock_data_with_ip)
+        result4 = await config_flow.validate_input(hass, data=mock_data_with_ipv6)
 
     assert result2["title"] == mock_data["host"]
     assert result2[CONF_HOST] == mock_data["host"]


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
