### PR TITLE
Generate ConfigValidationError message from English translations

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -163,7 +163,7 @@
       "message": "Error importing config platform {domain}: {error}"
     },
     "config_validation_err": {
-      "message": "Invalid config for integration {domain} at {config_file}, line {line}: {error}. Check the logs for more information."
+      "message": "Invalid config for integration {domain} at {config_file}, line {line}: {error}."
     },
     "config_validator_unknown_err": {
       "message": "Unknown error calling {domain} config validator - {error}."
@@ -178,7 +178,7 @@
       "message": "Value {value} for property {property_name} has a maximum length of {max_length} characters."
     },
     "platform_component_load_err": {
-      "message": "Platform error: {domain} - {error}. Check the logs for more information."
+      "message": "Platform error: {domain} - {error}."
     },
     "platform_component_load_exc": {
       "message": "[%key:component::homeassistant::exceptions::platform_component_load_err::message%]"

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -171,7 +171,7 @@
     "config_schema_unknown_err": {
       "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."
     },
-    "integration_config_error": {
+    "multiple_integration_config_errors": {
       "message": "Failed to process config for integration {domain} due to multiple ({errors}) errors. Check the logs for more information."
     },
     "max_length_exceeded": {

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -166,10 +166,10 @@
       "message": "Invalid config for integration {domain} at {config_file}, line {line}: {error}. Check the logs for more information."
     },
     "config_validator_unknown_err": {
-      "message": "Unknown error calling {domain} config validator. Check the logs for more information."
+      "message": "Unknown error calling {domain} config validator - {error}."
     },
     "config_schema_unknown_err": {
-      "message": "Unknown error calling {domain} CONFIG_SCHEMA. Check the logs for more information."
+      "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."
     },
     "integration_config_error": {
       "message": "Failed to process config for integration {domain} due to multiple ({errors}) errors. Check the logs for more information."
@@ -181,13 +181,13 @@
       "message": "Platform error: {domain} - {error}. Check the logs for more information."
     },
     "platform_component_load_exc": {
-      "message": "Platform error: {domain} - {error}. Check the logs for more information."
+      "message": "[%key:component::homeassistant::exceptions::platform_component_load_err::message%]"
     },
     "platform_config_validation_err": {
       "message": "Invalid config for {domain} from integration {p_name} at file {config_file}, line {line}: {error}. Check the logs for more information."
     },
     "platform_schema_validator_err": {
-      "message": "Unknown error when validating config for {domain} from integration {p_name}"
+      "message": "Unknown error when validating config for {domain} from integration {p_name} - {error}."
     },
     "service_not_found": {
       "message": "Service {domain}.{service} not found."

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -136,7 +136,7 @@ class ConfigErrorTranslationKey(StrEnum):
     PLATFORM_SCHEMA_VALIDATOR_ERR = "platform_schema_validator_err"
 
     # translation key in case multiple errors occurred
-    INTEGRATION_CONFIG_ERROR = "integration_config_error"
+    MULTIPLE_INTEGRATION_CONFIG_ERRORS = "multiple_integration_config_errors"
 
 
 _CONFIG_LOG_SHOW_STACK_TRACE: dict[ConfigErrorTranslationKey, bool] = {
@@ -1332,7 +1332,7 @@ def async_handle_component_errors(
     if len(config_exception_info) == 1:
         translation_key = platform_exception.translation_key
     else:
-        translation_key = ConfigErrorTranslationKey.INTEGRATION_CONFIG_ERROR
+        translation_key = ConfigErrorTranslationKey.MULTIPLE_INTEGRATION_CONFIG_ERRORS
         errors = str(len(config_exception_info))
         placeholders = {
             "domain": domain,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1183,7 +1183,11 @@ def _get_log_message_and_stack_print_pref(
     platform_config = platform_exception.config
     link = platform_exception.integration_link
 
-    placeholders: dict[str, str] = {"domain": domain, "error": str(exception)}
+    placeholders: dict[str, str] = {
+        "domain": domain,
+        "error": str(exception),
+        "p_name": platform_path,
+    }
 
     log_message_mapping: dict[ConfigErrorTranslationKey, tuple[str, bool]] = {
         ConfigErrorTranslationKey.COMPONENT_IMPORT_ERR: (
@@ -1350,16 +1354,12 @@ def async_handle_component_errors(
     else:
         translation_key = ConfigErrorTranslationKey.INTEGRATION_CONFIG_ERROR
         errors = str(len(config_exception_info))
-        log_message = (
-            f"Failed to process component config for integration {domain} "
-            f"due to multiple errors ({errors}), check the logs for more information."
-        )
         placeholders = {
             "domain": domain,
             "errors": errors,
         }
     raise ConfigValidationError(
-        str(log_message),
+        translation_key,
         [platform_exception.exception for platform_exception in config_exception_info],
         translation_domain="homeassistant",
         translation_key=translation_key,

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -63,6 +63,7 @@ from .exceptions import ConfigValidationError, HomeAssistantError
 from .generated.currencies import HISTORIC_CURRENCIES
 from .helpers import config_validation as cv, issue_registry as ir
 from .helpers.entity_values import EntityValues
+from .helpers.translation import async_get_exception_message
 from .helpers.typing import ConfigType
 from .loader import ComponentProtocol, Integration, IntegrationNotFound
 from .requirements import RequirementsNotFound, async_get_integration_with_requirements
@@ -1225,13 +1226,11 @@ def _get_log_message_and_stack_print_pref(
             show_stack_trace = True
         return (log_message, show_stack_trace, placeholders)
 
-    # Get the log message from the translation cache
-    log_message = str(
-        HomeAssistantError(
-            translation_domain="homeassistant",
-            translation_key=platform_exception.translation_key,
-            translation_placeholders=placeholders,
-        )
+    # Generate the log message from the English translations
+    log_message = async_get_exception_message(
+        CONF_CORE,
+        platform_exception.translation_key,
+        translation_placeholders=placeholders,
     )
 
     return (log_message, show_stack_trace, placeholders)
@@ -1342,7 +1341,7 @@ def async_handle_component_errors(
     raise ConfigValidationError(
         translation_key,
         [platform_exception.exception for platform_exception in config_exception_info],
-        translation_domain="homeassistant",
+        translation_domain=CONF_CORE,
         translation_key=translation_key,
         translation_placeholders=placeholders,
     )

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -1228,7 +1228,7 @@ def _get_log_message_and_stack_print_pref(
 
     # Generate the log message from the English translations
     log_message = async_get_exception_message(
-        CONF_CORE,
+        HA_DOMAIN,
         platform_exception.translation_key,
         translation_placeholders=placeholders,
     )
@@ -1341,8 +1341,7 @@ def async_handle_component_errors(
     raise ConfigValidationError(
         translation_key,
         [platform_exception.exception for platform_exception in config_exception_info],
-        translation_domain=CONF_CORE,
-        translation_key=translation_key,
+        translation_domain=HA_DOMAIN,
         translation_placeholders=placeholders,
     )
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -130,7 +130,6 @@ class ConfigErrorTranslationKey(StrEnum):
     CONFIG_PLATFORM_IMPORT_ERR = "config_platform_import_err"
     CONFIG_VALIDATOR_UNKNOWN_ERR = "config_validator_unknown_err"
     CONFIG_SCHEMA_UNKNOWN_ERR = "config_schema_unknown_err"
-    PLATFORM_VALIDATOR_UNKNOWN_ERR = "platform_validator_unknown_err"
     PLATFORM_COMPONENT_LOAD_ERR = "platform_component_load_err"
     PLATFORM_COMPONENT_LOAD_EXC = "platform_component_load_exc"
     PLATFORM_SCHEMA_VALIDATOR_ERR = "platform_schema_validator_err"
@@ -1199,16 +1198,13 @@ def _get_log_message_and_stack_print_pref(
             False,
         ),
         ConfigErrorTranslationKey.CONFIG_VALIDATOR_UNKNOWN_ERR: (
-            f"Unknown error calling {domain} config validator",
+            f"Unknown error calling {domain} config validator. "
+            "Check the logs for more information",
             True,
         ),
         ConfigErrorTranslationKey.CONFIG_SCHEMA_UNKNOWN_ERR: (
-            f"Unknown error calling {domain} CONFIG_SCHEMA",
-            True,
-        ),
-        ConfigErrorTranslationKey.PLATFORM_VALIDATOR_UNKNOWN_ERR: (
-            f"Unknown error validating {platform_path} platform config with {domain} "
-            "component platform schema",
+            f"Unknown error calling {domain} CONFIG_SCHEMA. "
+            "Check the logs for more information",
             True,
         ),
         ConfigErrorTranslationKey.PLATFORM_COMPONENT_LOAD_ERR: (
@@ -1220,8 +1216,8 @@ def _get_log_message_and_stack_print_pref(
             True,
         ),
         ConfigErrorTranslationKey.PLATFORM_SCHEMA_VALIDATOR_ERR: (
-            f"Unknown error validating config for {platform_path} platform "
-            f"for {domain} component with PLATFORM_SCHEMA",
+            f"Unknown error when validating config for {domain} "
+            f"from integration {platform_path} - {exception}",
             True,
         ),
     }

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -87,16 +87,16 @@ class ConfigValidationError(HomeAssistantError, ExceptionGroup[Exception]):
 
     def __init__(
         self,
-        _translation_key: str,
+        message_translation_key: str,
         exceptions: list[Exception],
         translation_domain: str | None = None,
         translation_placeholders: dict[str, str] | None = None,
     ) -> None:
         """Initialize exception."""
         super().__init__(
-            *(_translation_key, exceptions),
+            *(message_translation_key, exceptions),
             translation_domain=translation_domain,
-            translation_key=_translation_key,
+            translation_key=message_translation_key,
             translation_placeholders=translation_placeholders,
         )
         self.generate_message = True

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -85,7 +85,21 @@ class HomeAssistantError(Exception):
 class ConfigValidationError(HomeAssistantError, ExceptionGroup[Exception]):
     """A validation exception occurred when validating the configuration."""
 
-    generate_message: bool = True
+    def __init__(
+        self,
+        _translation_key: str,
+        exceptions: list[Exception],
+        translation_domain: str | None = None,
+        translation_placeholders: dict[str, str] | None = None,
+    ) -> None:
+        """Initialize exception."""
+        super().__init__(
+            *(_translation_key, exceptions),
+            translation_domain=translation_domain,
+            translation_key=_translation_key,
+            translation_placeholders=translation_placeholders,
+        )
+        self.generate_message = True
 
 
 class ServiceValidationError(HomeAssistantError):

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -85,22 +85,7 @@ class HomeAssistantError(Exception):
 class ConfigValidationError(HomeAssistantError, ExceptionGroup[Exception]):
     """A validation exception occurred when validating the configuration."""
 
-    def __init__(
-        self,
-        message: str,
-        exceptions: list[Exception],
-        translation_domain: str | None = None,
-        translation_key: str | None = None,
-        translation_placeholders: dict[str, str] | None = None,
-    ) -> None:
-        """Initialize exception."""
-        super().__init__(
-            *(message, exceptions),
-            translation_domain=translation_domain,
-            translation_key=translation_key,
-            translation_placeholders=translation_placeholders,
-        )
-        self._message = message
+    generate_message: bool = True
 
 
 class ServiceValidationError(HomeAssistantError):

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -466,7 +466,7 @@ def _async_get_translations_cache(hass: HomeAssistant) -> _TranslationCache:
     return cache
 
 
-_DIRECT_MAPPED_CATEGORIES = {"state", "entity_component", "exceptions", "services"}
+_DIRECT_MAPPED_CATEGORIES = {"state", "entity_component", "services"}
 
 
 @callback

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -466,7 +466,7 @@ def _async_get_translations_cache(hass: HomeAssistant) -> _TranslationCache:
     return cache
 
 
-_DIRECT_MAPPED_CATEGORIES = {"state", "entity_component", "services"}
+_DIRECT_MAPPED_CATEGORIES = {"state", "entity_component", "exceptions", "services"}
 
 
 @callback

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -1,4 +1,19 @@
 # serializer version: 1
+# name: test_component_config_error_processing[exception_info_list0-bla-messages0-False-component_import_err]
+  'Unable to import test_domain: bla'
+# ---
+# name: test_component_config_error_processing[exception_info_list1-bla-messages1-True-config_validation_err]
+  'Invalid config for integration test_domain at configuration.yaml, line 140: bla. Check the logs for more information'
+# ---
+# name: test_component_config_error_processing[exception_info_list2-bla @ data['path']-messages2-False-config_validation_err]
+  "Invalid config for integration test_domain at configuration.yaml, line 140: bla @ data['path']. Check the logs for more information"
+# ---
+# name: test_component_config_error_processing[exception_info_list3-bla @ data['path']-messages3-False-platform_config_validation_err]
+  "Invalid config for test_domain from integration test_domain at file configuration.yaml, line 140: bla @ data['path']. Check the logs for more information"
+# ---
+# name: test_component_config_error_processing[exception_info_list4-bla-messages4-False-platform_component_load_err]
+  'Platform error: test_domain - bla. Check the logs for more information'
+# ---
 # name: test_component_config_validation_error[basic]
   list([
     dict({
@@ -63,7 +78,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator',
+      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
     }),
   ])
 # ---
@@ -131,7 +146,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator',
+      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
     }),
   ])
 # ---
@@ -247,7 +262,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator',
+      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
     }),
   ])
 # ---
@@ -291,7 +306,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator',
+      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
     }),
     dict({
       'has_exc_info': False,
@@ -342,7 +357,27 @@
     ''',
     "Invalid config for 'custom_validator_ok_2' at configuration.yaml, line 52: required key 'host' not provided, please check the docs at https://www.home-assistant.io/integrations/custom_validator_ok_2",
     "Invalid config for 'custom_validator_bad_1' at configuration.yaml, line 55: broken, please check the docs at https://www.home-assistant.io/integrations/custom_validator_bad_1",
-    'Unknown error calling custom_validator_bad_2 config validator',
+    'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+  ])
+# ---
+# name: test_individual_packages_schema_validation_errors[packages_dict]
+  list([
+    "Setup of package 'should_be_a_dict' at configuration.yaml, line 3 failed: Invalid package definition 'should_be_a_dict': expected a dictionary. Package will not be initialized",
+  ])
+# ---
+# name: test_individual_packages_schema_validation_errors[packages_include_dir_named_dict]
+  list([
+    "Setup of package 'should_be_a_dict' at packages/expected_dict.yaml, line 1 failed: Invalid package definition 'should_be_a_dict': expected a dictionary. Package will not be initialized",
+  ])
+# ---
+# name: test_individual_packages_schema_validation_errors[packages_include_dir_named_slug]
+  list([
+    "Setup of package 'this is not a slug but it should be one' at packages/expected_slug.yaml, line 1 failed: Invalid package definition 'this is not a slug but it should be one': invalid slug this is not a slug but it should be one (try this_is_not_a_slug_but_it_should_be_one). Package will not be initialized",
+  ])
+# ---
+# name: test_individual_packages_schema_validation_errors[packages_slug]
+  list([
+    "Setup of package 'this is not a slug but it should be one' at configuration.yaml, line 3 failed: Invalid package definition 'this is not a slug but it should be one': invalid slug this is not a slug but it should be one (try this_is_not_a_slug_but_it_should_be_one). Package will not be initialized",
   ])
 # ---
 # name: test_package_merge_error[packages]
@@ -379,6 +414,21 @@
 # name: test_package_merge_exception[packages_include_dir_named-error1]
   list([
     "Setup of package 'unknown_integration' at integrations/unknown_integration.yaml, line 1 failed: Integration test_domain caused error: ModuleNotFoundError: No module named 'not_installed_something'",
+  ])
+# ---
+# name: test_packages_schema_validation_error[packages_is_a_list]
+  list([
+    "Invalid package configuration 'packages' at configuration.yaml, line 2: expected a dictionary",
+  ])
+# ---
+# name: test_packages_schema_validation_error[packages_is_a_value]
+  list([
+    "Invalid package configuration 'packages' at configuration.yaml, line 2: expected a dictionary",
+  ])
+# ---
+# name: test_packages_schema_validation_error[packages_is_null]
+  list([
+    "Invalid package configuration 'packages' at configuration.yaml, line 3: expected a dictionary",
   ])
 # ---
 # name: test_yaml_error[basic]
@@ -449,40 +499,5 @@
       mapping values are not allowed here
         in "<BASE_PATH>/fixtures/core/config/yaml_errors/packages_include_dir_named/integrations/adr_0007_1.yaml", line 4, column 9
     ''',
-  ])
-# ---
-# name: test_individual_packages_schema_validation_errors[packages_dict]
-  list([
-    "Setup of package 'should_be_a_dict' at configuration.yaml, line 3 failed: Invalid package definition 'should_be_a_dict': expected a dictionary. Package will not be initialized",
-  ])
-# ---
-# name: test_individual_packages_schema_validation_errors[packages_slug]
-  list([
-    "Setup of package 'this is not a slug but it should be one' at configuration.yaml, line 3 failed: Invalid package definition 'this is not a slug but it should be one': invalid slug this is not a slug but it should be one (try this_is_not_a_slug_but_it_should_be_one). Package will not be initialized",
-  ])
-# ---
-# name: test_individual_packages_schema_validation_errors[packages_include_dir_named_dict]
-  list([
-    "Setup of package 'should_be_a_dict' at packages/expected_dict.yaml, line 1 failed: Invalid package definition 'should_be_a_dict': expected a dictionary. Package will not be initialized",
-  ])
-# ---
-# name: test_individual_packages_schema_validation_errors[packages_include_dir_named_slug]
-  list([
-    "Setup of package 'this is not a slug but it should be one' at packages/expected_slug.yaml, line 1 failed: Invalid package definition 'this is not a slug but it should be one': invalid slug this is not a slug but it should be one (try this_is_not_a_slug_but_it_should_be_one). Package will not be initialized",
-  ])
-# ---
-# name: test_packages_schema_validation_error[packages_is_a_list]
-  list([
-    "Invalid package configuration 'packages' at configuration.yaml, line 2: expected a dictionary",
-  ])
-# ---
-# name: test_packages_schema_validation_error[packages_is_a_value]
-  list([
-    "Invalid package configuration 'packages' at configuration.yaml, line 2: expected a dictionary",
-  ])
-# ---
-# name: test_packages_schema_validation_error[packages_is_null]
-  list([
-    "Invalid package configuration 'packages' at configuration.yaml, line 3: expected a dictionary",
   ])
 # ---

--- a/tests/snapshots/test_config.ambr
+++ b/tests/snapshots/test_config.ambr
@@ -3,16 +3,16 @@
   'Unable to import test_domain: bla'
 # ---
 # name: test_component_config_error_processing[exception_info_list1-bla-messages1-True-config_validation_err]
-  'Invalid config for integration test_domain at configuration.yaml, line 140: bla. Check the logs for more information'
+  'Invalid config for integration test_domain at configuration.yaml, line 140: bla'
 # ---
 # name: test_component_config_error_processing[exception_info_list2-bla @ data['path']-messages2-False-config_validation_err]
-  "Invalid config for integration test_domain at configuration.yaml, line 140: bla @ data['path']. Check the logs for more information"
+  "Invalid config for integration test_domain at configuration.yaml, line 140: bla @ data['path']"
 # ---
 # name: test_component_config_error_processing[exception_info_list3-bla @ data['path']-messages3-False-platform_config_validation_err]
   "Invalid config for test_domain from integration test_domain at file configuration.yaml, line 140: bla @ data['path']. Check the logs for more information"
 # ---
 # name: test_component_config_error_processing[exception_info_list4-bla-messages4-False-platform_component_load_err]
-  'Platform error: test_domain - bla. Check the logs for more information'
+  'Platform error: test_domain - bla'
 # ---
 # name: test_component_config_validation_error[basic]
   list([
@@ -78,7 +78,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+      'message': 'config_validator_unknown_err',
     }),
   ])
 # ---
@@ -146,7 +146,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+      'message': 'config_validator_unknown_err',
     }),
   ])
 # ---
@@ -262,7 +262,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+      'message': 'config_validator_unknown_err',
     }),
   ])
 # ---
@@ -306,7 +306,7 @@
     }),
     dict({
       'has_exc_info': True,
-      'message': 'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+      'message': 'config_validator_unknown_err',
     }),
     dict({
       'has_exc_info': False,
@@ -357,7 +357,7 @@
     ''',
     "Invalid config for 'custom_validator_ok_2' at configuration.yaml, line 52: required key 'host' not provided, please check the docs at https://www.home-assistant.io/integrations/custom_validator_ok_2",
     "Invalid config for 'custom_validator_bad_1' at configuration.yaml, line 55: broken, please check the docs at https://www.home-assistant.io/integrations/custom_validator_bad_1",
-    'Unknown error calling custom_validator_bad_2 config validator. Check the logs for more information',
+    'config_validator_unknown_err',
   ])
 # ---
 # name: test_individual_packages_schema_validation_errors[packages_dict]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1519,7 +1519,7 @@ async def test_component_config_exceptions(
     assert (
         str(ex.value)
         == "Invalid config for integration test_domain at configuration.yaml, "
-        "line 140: broken. Check the logs for more information"
+        "line 140: broken"
     )
     # component.CONFIG_SCHEMA
     caplog.clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1488,8 +1488,7 @@ async def test_component_config_exceptions(
     assert "ValueError: broken" in caplog.text
     assert "Unknown error calling test_domain config validator" in caplog.text
     assert (
-        str(ex.value) == "Unknown error calling test_domain config validator. "
-        "Check the logs for more information"
+        str(ex.value) == "Unknown error calling test_domain config validator - broken"
     )
     test_integration = Mock(
         domain="test_domain",
@@ -1550,10 +1549,7 @@ async def test_component_config_exceptions(
             raise_on_failure=True,
         )
     assert "Unknown error calling test_domain CONFIG_SCHEMA" in caplog.text
-    assert (
-        str(ex.value) == "Unknown error calling test_domain CONFIG_SCHEMA. "
-        "Check the logs for more information"
-    )
+    assert str(ex.value) == "Unknown error calling test_domain CONFIG_SCHEMA - broken"
     # component.PLATFORM_SCHEMA
     caplog.clear()
     test_integration = Mock(
@@ -1574,8 +1570,8 @@ async def test_component_config_exceptions(
     ) == {"test_domain": []}
     assert "ValueError: broken" in caplog.text
     assert (
-        "Unknown error validating config for test_platform platform "
-        "for test_domain component with PLATFORM_SCHEMA"
+        "Unknown error when validating config for test_domain "
+        "from integration test_platform - broken"
     ) in caplog.text
     caplog.clear()
     with pytest.raises(HomeAssistantError) as ex:
@@ -1586,12 +1582,12 @@ async def test_component_config_exceptions(
             raise_on_failure=True,
         )
     assert (
-        "Unknown error validating config for test_platform platform "
-        "for test_domain component with PLATFORM_SCHEMA"
+        "Unknown error when validating config for test_domain "
+        "from integration test_platform - broken"
     ) in caplog.text
     assert str(ex.value) == (
         "Unknown error when validating config for test_domain "
-        "from integration test_platform"
+        "from integration test_platform - broken"
     )
 
     # platform.PLATFORM_SCHEMA
@@ -1619,8 +1615,8 @@ async def test_component_config_exceptions(
         ) == {"test_domain": []}
         assert "ValueError: broken" in caplog.text
         assert (
-            "Unknown error validating config for test_platform platform for test_domain"
-            " component with PLATFORM_SCHEMA"
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform - broken"
         ) in caplog.text
         caplog.clear()
         with pytest.raises(HomeAssistantError) as ex:
@@ -1632,12 +1628,12 @@ async def test_component_config_exceptions(
             )
         assert (
             "Unknown error when validating config for test_domain "
-            "from integration test_platform" in str(ex.value)
+            "from integration test_platform - broken" in str(ex.value)
         )
         assert "ValueError: broken" in caplog.text
         assert (
-            "Unknown error validating config for test_platform platform for test_domain"
-            " component with PLATFORM_SCHEMA" in caplog.text
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform - broken" in caplog.text
         )
         # Test multiple platform failures
         assert await config_util.async_process_component_and_handle_errors(
@@ -1648,12 +1644,8 @@ async def test_component_config_exceptions(
         ) == {"test_domain": []}
         assert "ValueError: broken" in caplog.text
         assert (
-            "Unknown error validating config for test_platform1 platform "
-            "for test_domain component with PLATFORM_SCHEMA"
-        ) in caplog.text
-        assert (
-            "Unknown error validating config for test_platform2 platform "
-            "for test_domain component with PLATFORM_SCHEMA"
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform - broken"
         ) in caplog.text
         caplog.clear()
         with pytest.raises(HomeAssistantError) as ex:
@@ -1670,12 +1662,12 @@ async def test_component_config_exceptions(
         )
         assert "ValueError: broken" in caplog.text
         assert (
-            "Unknown error validating config for test_platform1 platform "
-            "for test_domain component with PLATFORM_SCHEMA"
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform1 - broken"
         ) in caplog.text
         assert (
-            "Unknown error validating config for test_platform2 platform "
-            "for test_domain component with PLATFORM_SCHEMA"
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform2 - broken"
         ) in caplog.text
 
     # async_get_platform("domain") raising on ImportError
@@ -1897,6 +1889,7 @@ async def test_component_config_error_processing(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
     exception_info_list: list[config_util.ConfigExceptionInfo],
+    snapshot: SnapshotAssertion,
     error: str,
     messages: list[str],
     show_stack_trace: bool,
@@ -1926,7 +1919,7 @@ async def test_component_config_error_processing(
     records = [record for record in caplog.records if record.msg == messages[0]]
     assert len(records) == 1
     assert (records[0].exc_info is not None) == show_stack_trace
-    assert error in str(ex.value)
+    assert str(ex.value) == snapshot
     assert ex.value.translation_key == translation_key
     assert ex.value.translation_domain == "homeassistant"
     assert ex.value.translation_placeholders["domain"] == "test_domain"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ import homeassistant.helpers.check_config as check_config
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import Integration, async_get_integration
+from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import (
     _CONF_UNIT_SYSTEM_US_CUSTOMARY,
     METRIC_SYSTEM,
@@ -51,6 +52,7 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 from homeassistant.util.yaml import SECRET_YAML
+from homeassistant.util.yaml.objects import NodeDictClass
 
 from .common import (
     MockModule,
@@ -371,6 +373,14 @@ async def mock_custom_validator_integrations_with_docs(
             f"{domain}.config",
             Mock(async_validate_config=AsyncMock(side_effect=exception)),
         )
+
+
+class ConfigTestClass(NodeDictClass):
+    """Test class for config with wrapper."""
+
+    __dict__ = {"__config_file__": "configuration.yaml", "__line__": 140}
+    __line__ = 140
+    __config_file__ = "configuration.yaml"
 
 
 async def test_create_default_config(hass: HomeAssistant) -> None:
@@ -1435,7 +1445,24 @@ async def test_component_config_exceptions(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test unexpected exceptions validating component config."""
-    # Config validator
+
+    # Create test config with embedded info
+    test_config = ConfigTestClass({"test_domain": {}})
+    test_platform_config = ConfigTestClass(
+        {"test_domain": {"platform": "test_platform"}}
+    )
+    test_multi_platform_config = ConfigTestClass(
+        {
+            "test_domain": [
+                {"platform": "test_platform1"},
+                {"platform": "test_platform2"},
+            ]
+        },
+    )
+
+    # Make sure the exception translation cache is loaded
+    await async_setup_component(hass, "homeassistant", {})
+
     test_integration = Mock(
         domain="test_domain",
         async_get_component=AsyncMock(),
@@ -1447,7 +1474,7 @@ async def test_component_config_exceptions(
     )
     assert (
         await config_util.async_process_component_and_handle_errors(
-            hass, {}, integration=test_integration
+            hass, test_config, integration=test_integration
         )
         is None
     )
@@ -1456,12 +1483,14 @@ async def test_component_config_exceptions(
     caplog.clear()
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
-            hass, {}, integration=test_integration, raise_on_failure=True
+            hass, test_config, integration=test_integration, raise_on_failure=True
         )
     assert "ValueError: broken" in caplog.text
     assert "Unknown error calling test_domain config validator" in caplog.text
-    assert str(ex.value) == "Unknown error calling test_domain config validator"
-
+    assert (
+        str(ex.value) == "Unknown error calling test_domain config validator. "
+        "Check the logs for more information"
+    )
     test_integration = Mock(
         domain="test_domain",
         async_get_platform=AsyncMock(
@@ -1476,17 +1505,23 @@ async def test_component_config_exceptions(
     caplog.clear()
     assert (
         await config_util.async_process_component_and_handle_errors(
-            hass, {}, integration=test_integration, raise_on_failure=False
+            hass, test_config, integration=test_integration, raise_on_failure=False
         )
         is None
     )
-    assert "Invalid config for 'test_domain': broken" in caplog.text
+    assert (
+        "Invalid config for 'test_domain' at ../../configuration.yaml, "
+        "line 140: broken, please check the docs at" in caplog.text
+    )
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
-            hass, {}, integration=test_integration, raise_on_failure=True
+            hass, test_config, integration=test_integration, raise_on_failure=True
         )
-    assert "Invalid config for 'test_domain': broken" in str(ex.value)
-
+    assert (
+        str(ex.value)
+        == "Invalid config for integration test_domain at configuration.yaml, "
+        "line 140: broken. Check the logs for more information"
+    )
     # component.CONFIG_SCHEMA
     caplog.clear()
     test_integration = Mock(
@@ -1499,23 +1534,26 @@ async def test_component_config_exceptions(
     assert (
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {},
+            test_config,
             integration=test_integration,
             raise_on_failure=False,
         )
         is None
     )
     assert "Unknown error calling test_domain CONFIG_SCHEMA" in caplog.text
+    caplog.clear()
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {},
+            test_config,
             integration=test_integration,
             raise_on_failure=True,
         )
     assert "Unknown error calling test_domain CONFIG_SCHEMA" in caplog.text
-    assert str(ex.value) == "Unknown error calling test_domain CONFIG_SCHEMA"
-
+    assert (
+        str(ex.value) == "Unknown error calling test_domain CONFIG_SCHEMA. "
+        "Check the logs for more information"
+    )
     # component.PLATFORM_SCHEMA
     caplog.clear()
     test_integration = Mock(
@@ -1530,7 +1568,7 @@ async def test_component_config_exceptions(
     )
     assert await config_util.async_process_component_and_handle_errors(
         hass,
-        {"test_domain": {"platform": "test_platform"}},
+        test_platform_config,
         integration=test_integration,
         raise_on_failure=False,
     ) == {"test_domain": []}
@@ -1543,7 +1581,7 @@ async def test_component_config_exceptions(
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {"platform": "test_platform"}},
+            test_platform_config,
             integration=test_integration,
             raise_on_failure=True,
         )
@@ -1552,8 +1590,8 @@ async def test_component_config_exceptions(
         "for test_domain component with PLATFORM_SCHEMA"
     ) in caplog.text
     assert str(ex.value) == (
-        "Unknown error validating config for test_platform platform "
-        "for test_domain component with PLATFORM_SCHEMA"
+        "Unknown error when validating config for test_domain "
+        "from integration test_platform"
     )
 
     # platform.PLATFORM_SCHEMA
@@ -1575,7 +1613,7 @@ async def test_component_config_exceptions(
     ):
         assert await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {"platform": "test_platform"}},
+            test_platform_config,
             integration=test_integration,
             raise_on_failure=False,
         ) == {"test_domain": []}
@@ -1588,14 +1626,14 @@ async def test_component_config_exceptions(
         with pytest.raises(HomeAssistantError) as ex:
             assert await config_util.async_process_component_and_handle_errors(
                 hass,
-                {"test_domain": {"platform": "test_platform"}},
+                test_platform_config,
                 integration=test_integration,
                 raise_on_failure=True,
             )
         assert (
-            "Unknown error validating config for test_platform platform for test_domain"
-            " component with PLATFORM_SCHEMA"
-        ) in str(ex.value)
+            "Unknown error when validating config for test_domain "
+            "from integration test_platform" in str(ex.value)
+        )
         assert "ValueError: broken" in caplog.text
         assert (
             "Unknown error validating config for test_platform platform for test_domain"
@@ -1604,12 +1642,7 @@ async def test_component_config_exceptions(
         # Test multiple platform failures
         assert await config_util.async_process_component_and_handle_errors(
             hass,
-            {
-                "test_domain": [
-                    {"platform": "test_platform1"},
-                    {"platform": "test_platform2"},
-                ]
-            },
+            test_multi_platform_config,
             integration=test_integration,
             raise_on_failure=False,
         ) == {"test_domain": []}
@@ -1626,19 +1659,15 @@ async def test_component_config_exceptions(
         with pytest.raises(HomeAssistantError) as ex:
             assert await config_util.async_process_component_and_handle_errors(
                 hass,
-                {
-                    "test_domain": [
-                        {"platform": "test_platform1"},
-                        {"platform": "test_platform2"},
-                    ]
-                },
+                test_multi_platform_config,
                 integration=test_integration,
                 raise_on_failure=True,
             )
         assert (
-            "Failed to process component config for integration test_domain"
-            " due to multiple errors (2), check the logs for more information."
-        ) in str(ex.value)
+            "Failed to process config for integration test_domain "
+            "due to multiple (2) errors. Check the logs for more information"
+            in str(ex.value)
+        )
         assert "ValueError: broken" in caplog.text
         assert (
             "Unknown error validating config for test_platform1 platform "
@@ -1668,7 +1697,7 @@ async def test_component_config_exceptions(
     ):
         assert await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {"platform": "test_platform"}},
+            test_platform_config,
             integration=test_integration,
             raise_on_failure=False,
         ) == {"test_domain": []}
@@ -1680,7 +1709,7 @@ async def test_component_config_exceptions(
         with pytest.raises(HomeAssistantError) as ex:
             assert await config_util.async_process_component_and_handle_errors(
                 hass,
-                {"test_domain": {"platform": "test_platform"}},
+                test_platform_config,
                 integration=test_integration,
                 raise_on_failure=True,
             )
@@ -1713,7 +1742,7 @@ async def test_component_config_exceptions(
     assert (
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {}},
+            test_config,
             integration=test_integration,
             raise_on_failure=False,
         )
@@ -1726,7 +1755,7 @@ async def test_component_config_exceptions(
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {}},
+            test_config,
             integration=test_integration,
             raise_on_failure=True,
         )
@@ -1751,7 +1780,7 @@ async def test_component_config_exceptions(
     assert (
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {}},
+            test_config,
             integration=test_integration,
             raise_on_failure=False,
         )
@@ -1761,7 +1790,7 @@ async def test_component_config_exceptions(
     with pytest.raises(HomeAssistantError) as ex:
         await config_util.async_process_component_and_handle_errors(
             hass,
-            {"test_domain": {}},
+            test_config,
             integration=test_integration,
             raise_on_failure=True,
         )
@@ -1778,7 +1807,7 @@ async def test_component_config_exceptions(
                     ImportError("bla"),
                     "component_import_err",
                     "test_domain",
-                    {"test_domain": []},
+                    ConfigTestClass({"test_domain": []}),
                     "https://example.com",
                 )
             ],
@@ -1793,13 +1822,14 @@ async def test_component_config_exceptions(
                     HomeAssistantError("bla"),
                     "config_validation_err",
                     "test_domain",
-                    {"test_domain": []},
+                    ConfigTestClass({"test_domain": []}),
                     "https://example.com",
                 )
             ],
             "bla",
             [
-                "Invalid config for 'test_domain': bla, "
+                "Invalid config for 'test_domain' at "
+                "../../configuration.yaml, line 140: bla, "
                 "please check the docs at https://example.com",
                 "bla",
             ],
@@ -1812,14 +1842,15 @@ async def test_component_config_exceptions(
                     vol.Invalid("bla", ["path"]),
                     "config_validation_err",
                     "test_domain",
-                    {"test_domain": []},
+                    ConfigTestClass({"test_domain": []}),
                     "https://example.com",
                 )
             ],
             "bla @ data['path']",
             [
-                "Invalid config for 'test_domain': bla 'path', got None, "
-                "please check the docs at https://example.com",
+                "Invalid config for 'test_domain' at "
+                "../../configuration.yaml, line 140: bla 'path', "
+                "got None, please check the docs at https://example.com",
                 "bla",
             ],
             False,
@@ -1831,14 +1862,15 @@ async def test_component_config_exceptions(
                     vol.Invalid("bla", ["path"]),
                     "platform_config_validation_err",
                     "test_domain",
-                    {"test_domain": []},
+                    ConfigTestClass({"test_domain": []}),
                     "https://alt.example.com",
                 )
             ],
             "bla @ data['path']",
             [
-                "Invalid config for 'test_domain': bla 'path', got None, "
-                "please check the docs at https://alt.example.com",
+                "Invalid config for 'test_domain' at "
+                "../../configuration.yaml, line 140: bla 'path', "
+                "got None, please check the docs at https://alt.example.com",
                 "bla",
             ],
             False,
@@ -1850,7 +1882,7 @@ async def test_component_config_exceptions(
                     ImportError("bla"),
                     "platform_component_load_err",
                     "test_domain",
-                    {"test_domain": []},
+                    ConfigTestClass({"test_domain": []}),
                     "https://example.com",
                 )
             ],
@@ -1864,13 +1896,17 @@ async def test_component_config_exceptions(
 async def test_component_config_error_processing(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    error: str,
     exception_info_list: list[config_util.ConfigExceptionInfo],
+    error: str,
     messages: list[str],
     show_stack_trace: bool,
     translation_key: str,
 ) -> None:
     """Test component config error processing."""
+
+    # Make sure the exception translation cache is loaded
+    await async_setup_component(hass, "homeassistant", {})
+
     test_integration = Mock(
         domain="test_domain",
         documentation="https://example.com",
@@ -1890,7 +1926,7 @@ async def test_component_config_error_processing(
     records = [record for record in caplog.records if record.msg == messages[0]]
     assert len(records) == 1
     assert (records[0].exc_info is not None) == show_stack_trace
-    assert str(ex.value) == messages[0]
+    assert error in str(ex.value)
     assert ex.value.translation_key == translation_key
     assert ex.value.translation_domain == "homeassistant"
     assert ex.value.translation_placeholders["domain"] == "test_domain"
@@ -1902,7 +1938,7 @@ async def test_component_config_error_processing(
         return_value=config_util.IntegrationConfigInfo(None, exception_info_list),
     ):
         await config_util.async_process_component_and_handle_errors(
-            hass, {}, test_integration
+            hass, ConfigTestClass({}), test_integration
         )
     assert all(message in caplog.text for message in messages)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Load ConfigValidationError messages from the translation cache.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
