### PR TITLE
Use `mock_platform` for light entity component tests instead of `hass.components`

### DIFF
--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -22,6 +22,7 @@ from tests.common import (
     async_get_device_automations,
     async_mock_service,
 )
+from tests.fixtures.pytest.light import SetupLightPlatformCallable
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -323,7 +324,7 @@ async def test_if_fires_on_for_condition(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls,
-    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
 ) -> None:
     """Test for firing if condition is on with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -342,13 +343,9 @@ async def test_if_fires_on_for_condition(
     point2 = point1 + timedelta(seconds=10)
     point3 = point2 + timedelta(seconds=10)
 
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-
-    platform.init()
+    setup_light_platform()
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
-
-    ent1, ent2, ent3 = platform.ENTITIES
 
     with freeze_time(point1) as freezer:
         assert await async_setup_component(

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1,5 +1,4 @@
 """The tests for the Light component."""
-
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -23,6 +22,7 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.color as color_util
 
 from tests.common import MockEntityPlatform, MockUser, async_mock_service
+from tests.fixtures.pytest.light import MockLight, SetupLightPlatformCallable
 
 orig_Profiles = light.Profiles
 
@@ -108,18 +108,20 @@ async def test_methods(hass: HomeAssistant) -> None:
 
 
 async def test_services(
-    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+    hass: HomeAssistant,
+    mock_light_profiles,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the provided services."""
-    platform = getattr(hass.components, "test.light")
+    setup_light_platform()
 
-    platform.init()
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1, ent2, ent3 = platform.ENTITIES
+    ent1, ent2, ent3 = mock_light_entities
     ent1.supported_color_modes = [light.ColorMode.HS]
     ent3.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
@@ -509,11 +511,11 @@ async def test_light_profiles(
     profile_name,
     expected_data,
     last_call,
-    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test light profiles."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
 
     profile_mock_data = {
         "test": (0.4, 0.6, 100, 0),
@@ -533,7 +535,7 @@ async def test_light_profiles(
     )
     await hass.async_block_till_done()
 
-    ent1, _, _ = platform.ENTITIES
+    ent1, _, _ = mock_light_entities
     ent1.supported_color_modes = [light.ColorMode.HS]
     ent1.supported_features = light.LightEntityFeature.TRANSITION
 
@@ -556,11 +558,13 @@ async def test_light_profiles(
 
 
 async def test_default_profiles_group(
-    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+    hass: HomeAssistant,
+    mock_light_profiles,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test default turn-on light profile for all lights."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -570,7 +574,7 @@ async def test_default_profiles_group(
     profile = light.Profile("group.all_lights.default", 0.4, 0.6, 99, 2)
     mock_light_profiles[profile.name] = profile
 
-    ent, _, _ = platform.ENTITIES
+    ent, _, _ = mock_light_entities
     ent.supported_color_modes = [light.ColorMode.HS]
     ent.supported_features = light.LightEntityFeature.TRANSITION
     await hass.services.async_call(
@@ -780,13 +784,13 @@ async def test_default_profiles_light(
     hass: HomeAssistant,
     mock_light_profiles,
     extra_call_params,
-    enable_custom_integrations: None,
     expected_params_state_was_off,
     expected_params_state_was_on,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test default turn-on light profile for a specific light."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -798,7 +802,7 @@ async def test_default_profiles_light(
     profile = light.Profile("light.ceiling_2.default", 0.6, 0.6, 100, 3)
     mock_light_profiles[profile.name] = profile
 
-    dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", platform.ENTITIES))
+    dev = next(filter(lambda x: x.entity_id == "light.ceiling_2", mock_light_entities))
     dev.supported_color_modes = {
         light.ColorMode.COLOR_TEMP,
         light.ColorMode.HS,
@@ -850,11 +854,13 @@ async def test_default_profiles_light(
 
 
 async def test_light_context(
-    hass: HomeAssistant, hass_admin_user: MockUser, enable_custom_integrations: None
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    setup_light_platform: SetupLightPlatformCallable,
 ) -> None:
     """Test that light context works."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -876,11 +882,13 @@ async def test_light_context(
 
 
 async def test_light_turn_on_auth(
-    hass: HomeAssistant, hass_read_only_user: MockUser, enable_custom_integrations: None
+    hass: HomeAssistant,
+    hass_read_only_user: MockUser,
+    setup_light_platform: SetupLightPlatformCallable,
 ) -> None:
     """Test that light context works."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -900,20 +908,23 @@ async def test_light_turn_on_auth(
 
 
 async def test_light_brightness_step(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test that light context works."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-    platform.ENTITIES.append(platform.MockLight("Test_0", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_1", STATE_ON))
-    entity0 = platform.ENTITIES[0]
+    entities = [
+        MockLight("Test_0", STATE_ON),
+        MockLight("Test_1", STATE_ON),
+    ]
+
+    setup_light_platform(entities)
+
+    entity0 = entities[0]
     entity0.supported_features = light.SUPPORT_BRIGHTNESS
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity0.supported_color_modes = None
     entity0.color_mode = None
     entity0.brightness = 100
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity1.supported_color_modes = None
@@ -970,12 +981,15 @@ async def test_light_brightness_step(
 
 
 async def test_light_brightness_pct_conversion(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test that light brightness percent conversion."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
-    entity = platform.ENTITIES[0]
+    setup_light_platform()
+
+    entity = mock_light_entities[0]
     entity.supported_features = light.SUPPORT_BRIGHTNESS
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity.supported_color_modes = None
@@ -1130,45 +1144,46 @@ invalid_no_brightness_no_color_no_transition,,,
 
 @pytest.mark.parametrize("light_state", [STATE_ON, STATE_OFF])
 async def test_light_backwards_compatibility_supported_color_modes(
-    hass: HomeAssistant, light_state, enable_custom_integrations: None
+    hass: HomeAssistant, light_state, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test supported_color_modes if not implemented by the entity."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_0", light_state),
+        MockLight("Test_1", light_state),
+        MockLight("Test_2", light_state),
+        MockLight("Test_3", light_state),
+        MockLight("Test_4", light_state),
+    ]
 
-    platform.ENTITIES.append(platform.MockLight("Test_0", light_state))
-    platform.ENTITIES.append(platform.MockLight("Test_1", light_state))
-    platform.ENTITIES.append(platform.MockLight("Test_2", light_state))
-    platform.ENTITIES.append(platform.MockLight("Test_3", light_state))
-    platform.ENTITIES.append(platform.MockLight("Test_4", light_state))
+    entity0 = entities[0]
 
-    entity0 = platform.ENTITIES[0]
-
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity1.supported_color_modes = None
     entity1.color_mode = None
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity2.supported_color_modes = None
     entity2.color_mode = None
 
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity3.supported_color_modes = None
     entity3.color_mode = None
 
-    entity4 = platform.ENTITIES[4]
+    entity4 = entities[4]
     entity4.supported_features = (
         light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
     )
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity4.supported_color_modes = None
     entity4.color_mode = None
+
+    setup_light_platform(entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1213,42 +1228,41 @@ async def test_light_backwards_compatibility_supported_color_modes(
 
 
 async def test_light_backwards_compatibility_color_mode(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color_mode if not implemented by the entity."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_0", STATE_ON),
+        MockLight("Test_1", STATE_ON),
+        MockLight("Test_2", STATE_ON),
+        MockLight("Test_3", STATE_ON),
+        MockLight("Test_4", STATE_ON),
+    ]
 
-    platform.ENTITIES.append(platform.MockLight("Test_0", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_2", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_3", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_4", STATE_ON))
+    entity0 = entities[0]
 
-    entity0 = platform.ENTITIES[0]
-
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_features = light.SUPPORT_BRIGHTNESS
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity1.supported_color_modes = None
     entity1.color_mode = None
     entity1.brightness = 100
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity2.supported_color_modes = None
     entity2.color_mode = None
     entity2.color_temp_kelvin = 10000
 
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity3.supported_color_modes = None
     entity3.color_mode = None
     entity3.hs_color = (240, 100)
 
-    entity4 = platform.ENTITIES[4]
+    entity4 = entities[4]
     entity4.supported_features = (
         light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
     )
@@ -1257,6 +1271,8 @@ async def test_light_backwards_compatibility_color_mode(
     entity4.color_mode = None
     entity4.hs_color = (240, 100)
     entity4.color_temp_kelvin = 10000
+
+    setup_light_platform(entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1290,16 +1306,13 @@ async def test_light_backwards_compatibility_color_mode(
 
 
 async def test_light_service_call_rgbw(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbw functionality in service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-
-    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = MockLight("Test_rgbw", STATE_ON)
     entity0.supported_color_modes = {light.ColorMode.RGBW}
+
+    setup_light_platform([entity0])
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1323,24 +1336,24 @@ async def test_light_service_call_rgbw(
 
 
 async def test_light_state_off(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbw color conversion in state updates."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_onoff", STATE_OFF),
+        MockLight("Test_brightness", STATE_OFF),
+        MockLight("Test_ct", STATE_OFF),
+        MockLight("Test_rgbw", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_onoff", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("Test_brightness", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("Test_ct", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.ONOFF}
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.BRIGHTNESS}
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {light.ColorMode.COLOR_TEMP}
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.supported_color_modes = {light.ColorMode.RGBW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
@@ -1396,15 +1409,12 @@ async def test_light_state_off(
 
 
 async def test_light_state_rgbw(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbw color conversion in state updates."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entity0 = MockLight("Test_rgbw", STATE_ON)
+    setup_light_platform([entity0])
 
-    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
     entity0.brightness = 255
     entity0.supported_color_modes = {light.ColorMode.RGBW}
     entity0.color_mode = light.ColorMode.RGBW
@@ -1432,15 +1442,12 @@ async def test_light_state_rgbw(
 
 
 async def test_light_state_rgbww(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbww color conversion in state updates."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entity0 = MockLight("Test_rgbww", STATE_ON)
+    setup_light_platform([entity0])
 
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
     entity0.supported_color_modes = {light.ColorMode.RGBWW}
     entity0.color_mode = light.ColorMode.RGBWW
     entity0.hs_color = "Invalid"  # Should be ignored
@@ -1468,50 +1475,50 @@ async def test_light_state_rgbww(
 
 
 async def test_light_service_call_color_conversion(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color conversion in service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_hs", STATE_ON),
+        MockLight("Test_rgb", STATE_ON),
+        MockLight("Test_xy", STATE_ON),
+        MockLight("Test_all", STATE_ON),
+        MockLight("Test_legacy", STATE_ON),
+        MockLight("Test_rgbw", STATE_ON),
+        MockLight("Test_rgbww", STATE_ON),
+        MockLight("Test_temperature", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_all", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_temperature", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.RGB}
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {light.ColorMode.XY}
 
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.supported_color_modes = {
         light.ColorMode.HS,
         light.ColorMode.RGB,
         light.ColorMode.XY,
     }
 
-    entity4 = platform.ENTITIES[4]
+    entity4 = entities[4]
     entity4.supported_features = light.SUPPORT_COLOR
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity4.supported_color_modes = None
     entity4.color_mode = None
 
-    entity5 = platform.ENTITIES[5]
+    entity5 = entities[5]
     entity5.supported_color_modes = {light.ColorMode.RGBW}
 
-    entity6 = platform.ENTITIES[6]
+    entity6 = entities[6]
     entity6.supported_color_modes = {light.ColorMode.RGBWW}
 
-    entity7 = platform.ENTITIES[7]
+    entity7 = entities[7]
     entity7.supported_color_modes = {light.ColorMode.COLOR_TEMP}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
@@ -1913,46 +1920,46 @@ async def test_light_service_call_color_conversion(
 
 
 async def test_light_service_call_color_conversion_named_tuple(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test a named tuple (RGBColor) is handled correctly."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_hs", STATE_ON),
+        MockLight("Test_rgb", STATE_ON),
+        MockLight("Test_xy", STATE_ON),
+        MockLight("Test_all", STATE_ON),
+        MockLight("Test_legacy", STATE_ON),
+        MockLight("Test_rgbw", STATE_ON),
+        MockLight("Test_rgbww", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_all", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.RGB}
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {light.ColorMode.XY}
 
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.supported_color_modes = {
         light.ColorMode.HS,
         light.ColorMode.RGB,
         light.ColorMode.XY,
     }
 
-    entity4 = platform.ENTITIES[4]
+    entity4 = entities[4]
     entity4.supported_features = light.SUPPORT_COLOR
     # Set color modes to none to trigger backwards compatibility in LightEntity
     entity4.supported_color_modes = None
     entity4.color_mode = None
 
-    entity5 = platform.ENTITIES[5]
+    entity5 = entities[5]
     entity5.supported_color_modes = {light.ColorMode.RGBW}
 
-    entity6 = platform.ENTITIES[6]
+    entity6 = entities[6]
     entity6.supported_color_modes = {light.ColorMode.RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
@@ -1993,23 +2000,23 @@ async def test_light_service_call_color_conversion_named_tuple(
 
 
 async def test_light_service_call_color_temp_emulation(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color conversion in service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_hs_ct", STATE_ON),
+        MockLight("Test_hs", STATE_ON),
+        MockLight("Test_hs_white", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_hs_ct", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_hs_white", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.COLOR_TEMP, light.ColorMode.HS}
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.HS}
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
@@ -2053,22 +2060,22 @@ async def test_light_service_call_color_temp_emulation(
 
 
 async def test_light_service_call_color_temp_conversion(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color temp conversion in service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_rgbww_ct", STATE_ON),
+        MockLight("Test_rgbww", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww_ct", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {
         light.ColorMode.COLOR_TEMP,
         light.ColorMode.RGBWW,
     }
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.RGBWW}
     assert entity1.min_mireds == 153
     assert entity1.max_mireds == 500
@@ -2186,16 +2193,16 @@ async def test_light_service_call_color_temp_conversion(
 
 
 async def test_light_mired_color_temp_conversion(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color temp conversion from K to legacy mired."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_rgbww_ct", STATE_ON),
+        MockLight("Test_rgbww", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww_ct", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {
         light.ColorMode.COLOR_TEMP,
     }
@@ -2234,15 +2241,12 @@ async def test_light_mired_color_temp_conversion(
 
 
 async def test_light_service_call_white_mode(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color_mode white in service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-
-    platform.ENTITIES.append(platform.MockLight("Test_white", STATE_ON))
-    entity0 = platform.ENTITIES[0]
+    entity0 = MockLight("Test_white", STATE_ON)
     entity0.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
+    setup_light_platform([entity0])
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2338,39 +2342,39 @@ async def test_light_service_call_white_mode(
 
 
 async def test_light_state_color_conversion(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color conversion in state updates."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("Test_hs", STATE_ON),
+        MockLight("Test_rgb", STATE_ON),
+        MockLight("Test_xy", STATE_ON),
+        MockLight("Test_legacy", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
     entity0.color_mode = light.ColorMode.HS
     entity0.hs_color = (240, 100)
     entity0.rgb_color = "Invalid"  # Should be ignored
     entity0.xy_color = "Invalid"  # Should be ignored
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {light.ColorMode.RGB}
     entity1.color_mode = light.ColorMode.RGB
     entity1.hs_color = "Invalid"  # Should be ignored
     entity1.rgb_color = (128, 0, 0)
     entity1.xy_color = "Invalid"  # Should be ignored
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {light.ColorMode.XY}
     entity2.color_mode = light.ColorMode.XY
     entity2.hs_color = "Invalid"  # Should be ignored
     entity2.rgb_color = "Invalid"  # Should be ignored
     entity2.xy_color = (0.1, 0.8)
 
-    entity3 = platform.ENTITIES[3]
+    entity3 = entities[3]
     entity3.hs_color = (240, 100)
     entity3.supported_features = light.SUPPORT_COLOR
     # Set color modes to none to trigger backwards compatibility in LightEntity
@@ -2406,18 +2410,20 @@ async def test_light_state_color_conversion(
 
 
 async def test_services_filter_parameters(
-    hass: HomeAssistant, mock_light_profiles, enable_custom_integrations: None
+    hass: HomeAssistant,
+    mock_light_profiles,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test turn_on and turn_off filters unsupported parameters."""
-    platform = getattr(hass.components, "test.light")
+    setup_light_platform()
 
-    platform.init()
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1, _, _ = platform.ENTITIES
+    ent1, _, _ = mock_light_entities
 
     # turn off the light by setting brightness to 0, this should work even if the light
     # doesn't support brightness

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,10 @@ asyncio.set_event_loop_policy(runner.HassEventLoopPolicy(False))
 # Disable fixtures overriding our beautiful policy
 asyncio.set_event_loop_policy = lambda policy: None
 
+pytest_plugins = [
+    "tests.fixtures.pytest.light",
+]
+
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom pytest options."""
@@ -1664,8 +1668,3 @@ def label_registry(hass: HomeAssistant) -> lr.LabelRegistry:
 def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
     """Return snapshot assertion fixture with the Home Assistant extension."""
     return snapshot.use_extension(HomeAssistantSnapshotExtension)
-
-
-pytest_plugins = [
-    "tests.fixtures.pytest.light",
-]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,6 @@ from .test_util.aiohttp import (  # noqa: E402, isort:skip
     mock_aiohttp_client,
 )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 logging.basicConfig(level=logging.INFO)
@@ -1665,3 +1664,8 @@ def label_registry(hass: HomeAssistant) -> lr.LabelRegistry:
 def snapshot(snapshot: SnapshotAssertion) -> SnapshotAssertion:
     """Return snapshot assertion fixture with the Home Assistant extension."""
     return snapshot.use_extension(HomeAssistantSnapshotExtension)
+
+
+pytest_plugins = [
+    "tests.fixtures.pytest.light",
+]

--- a/tests/fixtures/pytest/__init__.py
+++ b/tests/fixtures/pytest/__init__.py
@@ -1,0 +1,1 @@
+"""Fixtures for tests."""

--- a/tests/fixtures/pytest/light.py
+++ b/tests/fixtures/pytest/light.py
@@ -1,0 +1,115 @@
+"""Fixtures for the light entity component tests."""
+from collections.abc import Callable
+
+import pytest
+
+from homeassistant.components.light import DOMAIN, ColorMode, LightEntity
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from tests.common import MockPlatform, MockToggleEntity, mock_platform
+
+TURN_ON_ARG_TO_COLOR_MODE = {
+    "hs_color": ColorMode.HS,
+    "xy_color": ColorMode.XY,
+    "rgb_color": ColorMode.RGB,
+    "rgbw_color": ColorMode.RGBW,
+    "rgbww_color": ColorMode.RGBWW,
+    "color_temp_kelvin": ColorMode.COLOR_TEMP,
+}
+
+
+class MockLight(MockToggleEntity, LightEntity):
+    """Mock light class."""
+
+    _attr_max_color_temp_kelvin = 6500
+    _attr_min_color_temp_kelvin = 2000
+    supported_features = 0
+
+    brightness = None
+    color_temp_kelvin = None
+    hs_color = None
+    rgb_color = None
+    rgbw_color = None
+    rgbww_color = None
+    xy_color = None
+
+    def __init__(
+        self,
+        name,
+        state,
+        unique_id=None,
+        supported_color_modes: set[ColorMode] | None = None,
+    ):
+        """Initialize the mock light."""
+        super().__init__(name, state, unique_id)
+        if supported_color_modes is None:
+            supported_color_modes = {ColorMode.ONOFF}
+        self._attr_supported_color_modes = supported_color_modes
+        color_mode = ColorMode.UNKNOWN
+        if len(supported_color_modes) == 1:
+            color_mode = next(iter(supported_color_modes))
+        self._attr_color_mode = color_mode
+
+    def turn_on(self, **kwargs):
+        """Turn the entity on."""
+        super().turn_on(**kwargs)
+        for key, value in kwargs.items():
+            if key in [
+                "brightness",
+                "hs_color",
+                "xy_color",
+                "rgb_color",
+                "rgbw_color",
+                "rgbww_color",
+                "color_temp_kelvin",
+            ]:
+                setattr(self, key, value)
+            if key == "white":
+                setattr(self, "brightness", value)
+            if key in TURN_ON_ARG_TO_COLOR_MODE:
+                self._attr_color_mode = TURN_ON_ARG_TO_COLOR_MODE[key]
+
+
+SetupLightPlatformCallable = Callable[[list[MockLight] | None], None]
+
+
+@pytest.fixture
+async def mock_light_entities() -> list[MockLight]:
+    """Return mocked light entities."""
+    return [
+        MockLight("Ceiling", STATE_ON),
+        MockLight("Ceiling", STATE_OFF),
+        MockLight(None, STATE_OFF),
+    ]
+
+
+@pytest.fixture
+async def setup_light_platform(
+    hass: HomeAssistant, mock_light_entities: list[MockLight]
+) -> SetupLightPlatformCallable:
+    """Set up the mock light entity platform."""
+
+    def _setup(entities: list[MockLight] | None = None) -> None:
+        """Set up the mock light entity platform."""
+
+        async def async_setup_platform(
+            hass: HomeAssistant,
+            config: ConfigType,
+            async_add_entities: AddEntitiesCallback,
+            discovery_info: DiscoveryInfoType | None = None,
+        ) -> None:
+            """Set up test button platform."""
+            async_add_entities(
+                entities if entities is not None else mock_light_entities
+            )
+
+        mock_platform(
+            hass,
+            f"test.{DOMAIN}",
+            MockPlatform(async_setup_platform=async_setup_platform),
+        )
+
+    return _setup

--- a/tests/fixtures/pytest/light.py
+++ b/tests/fixtures/pytest/light.py
@@ -101,7 +101,7 @@ async def setup_light_platform(
             async_add_entities: AddEntitiesCallback,
             discovery_info: DiscoveryInfoType | None = None,
         ) -> None:
-            """Set up test button platform."""
+            """Set up test light platform."""
             async_add_entities(
                 entities if entities is not None else mock_light_entities
             )


### PR DESCRIPTION
## Proposed change
Use `mock_platform` and fixtures in `light` entity component tests instead of a custom component in `testing_config`. Main reason for this is to get rid of the deprecated `hass.components` use.

I created the fixtures and mocks in a separate file under `tests.fixtures.pytest` and load it as a pytest plugin to not bloat `conftest.py` as these fixtures will be used by other tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
