### PR TITLE
Remove deprecated `hass.components` from group light tests and use fixture

### DIFF
--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -45,6 +45,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_capture_events, get_fixture_path
+from tests.fixtures.pytest.light import MockLight, SetupLightPlatformCallable
 
 
 async def test_default_state(
@@ -261,21 +262,21 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
 
 
 async def test_brightness(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test brightness reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.BRIGHTNESS}
     entity0.color_mode = ColorMode.BRIGHTNESS
     entity0.brightness = 255
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.BRIGHTNESS}
     entity1.color_mode = ColorMode.BRIGHTNESS
 
@@ -333,21 +334,23 @@ async def test_brightness(
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness"]
 
 
-async def test_color_hs(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+async def test_color_hs(
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
+) -> None:
     """Test hs color reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.HS}
     entity0.color_mode = ColorMode.HS
     entity0.brightness = 255
     entity0.hs_color = (0, 100)
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.HS}
     entity1.color_mode = ColorMode.HS
 
@@ -403,21 +406,23 @@ async def test_color_hs(hass: HomeAssistant, enable_custom_integrations: None) -
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgb(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+async def test_color_rgb(
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
+) -> None:
     """Test rgbw color reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGB}
     entity0.color_mode = ColorMode.RGB
     entity0.brightness = 255
     entity0.rgb_color = (0, 64, 128)
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.RGB}
     entity1.color_mode = ColorMode.RGB
     entity1.brightness = 255
@@ -476,22 +481,22 @@ async def test_color_rgb(hass: HomeAssistant, enable_custom_integrations: None) 
 
 
 async def test_color_rgbw(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbw color reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGBW}
     entity0.color_mode = ColorMode.RGBW
     entity0.brightness = 255
     entity0.rgbw_color = (0, 64, 128, 255)
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.RGBW}
     entity1.color_mode = ColorMode.RGBW
     entity1.brightness = 255
@@ -550,22 +555,22 @@ async def test_color_rgbw(
 
 
 async def test_color_rgbww(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test rgbww color reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGBWW}
     entity0.color_mode = ColorMode.RGBWW
     entity0.brightness = 255
     entity0.rgbww_color = (0, 32, 64, 128, 255)
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.RGBWW}
     entity1.color_mode = ColorMode.RGBWW
     entity1.brightness = 255
@@ -623,20 +628,22 @@ async def test_color_rgbww(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_white(hass: HomeAssistant, enable_custom_integrations: None) -> None:
+async def test_white(
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
+) -> None:
     """Test white reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_ON))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.HS, ColorMode.WHITE}
     entity0.color_mode = ColorMode.WHITE
     entity0.brightness = 255
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.HS, ColorMode.WHITE}
     entity1.color_mode = ColorMode.WHITE
     entity1.brightness = 128
@@ -681,22 +688,22 @@ async def test_white(hass: HomeAssistant, enable_custom_integrations: None) -> N
 
 
 async def test_color_temp(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color temp reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity0.color_mode = ColorMode.COLOR_TEMP
     entity0.brightness = 255
     entity0.color_temp_kelvin = 2
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity1.color_mode = ColorMode.COLOR_TEMP
 
@@ -752,25 +759,25 @@ async def test_color_temp(
 
 
 async def test_emulated_color_temp_group(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test emulated color temperature in a group."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+        MockLight("test3", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("test3", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity0.color_mode = ColorMode.COLOR_TEMP
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     entity1.color_mode = ColorMode.COLOR_TEMP
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {ColorMode.HS}
     entity2.color_mode = ColorMode.HS
 
@@ -818,26 +825,26 @@ async def test_emulated_color_temp_group(
 
 
 async def test_min_max_mireds(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test min/max mireds reporting.
 
     min/max mireds is reported both when light is on and off
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity0.color_mode = ColorMode.COLOR_TEMP
     entity0.color_temp_kelvin = 2
     entity0._attr_min_color_temp_kelvin = 2
     entity0._attr_max_color_temp_kelvin = 5
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity1.color_mode = ColorMode.COLOR_TEMP
     entity1._attr_min_color_temp_kelvin = 1
@@ -999,25 +1006,25 @@ async def test_effect(hass: HomeAssistant) -> None:
 
 
 async def test_supported_color_modes(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test supported_color_modes reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+        MockLight("test3", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("test3", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     entity0.color_mode = ColorMode.UNKNOWN
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.RGBW, ColorMode.RGBWW}
     entity1.color_mode = ColorMode.UNKNOWN
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {ColorMode.BRIGHTNESS}
     entity2.color_mode = ColorMode.UNKNOWN
 
@@ -1049,25 +1056,25 @@ async def test_supported_color_modes(
 
 
 async def test_color_mode(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test color_mode reporting."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_OFF),
+        MockLight("test3", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("test3", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     entity0.color_mode = ColorMode.COLOR_TEMP
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     entity1.color_mode = ColorMode.COLOR_TEMP
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
     entity2.color_mode = ColorMode.HS
 
@@ -1124,40 +1131,40 @@ async def test_color_mode(
 
 
 async def test_color_mode2(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
 ) -> None:
     """Test onoff color_mode and brightness are given lowest priority."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("test1", STATE_ON),
+        MockLight("test2", STATE_ON),
+        MockLight("test3", STATE_ON),
+        MockLight("test4", STATE_ON),
+        MockLight("test5", STATE_ON),
+        MockLight("test6", STATE_ON),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("test1", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test2", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test3", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test4", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test5", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("test6", STATE_ON))
-
-    entity = platform.ENTITIES[0]
+    entity = entities[0]
     entity.supported_color_modes = {ColorMode.COLOR_TEMP}
     entity.color_mode = ColorMode.COLOR_TEMP
 
-    entity = platform.ENTITIES[1]
+    entity = entities[1]
     entity.supported_color_modes = {ColorMode.BRIGHTNESS}
     entity.color_mode = ColorMode.BRIGHTNESS
 
-    entity = platform.ENTITIES[2]
+    entity = entities[2]
     entity.supported_color_modes = {ColorMode.BRIGHTNESS}
     entity.color_mode = ColorMode.BRIGHTNESS
 
-    entity = platform.ENTITIES[3]
+    entity = entities[3]
     entity.supported_color_modes = {ColorMode.ONOFF}
     entity.color_mode = ColorMode.ONOFF
 
-    entity = platform.ENTITIES[4]
+    entity = entities[4]
     entity.supported_color_modes = {ColorMode.ONOFF}
     entity.color_mode = ColorMode.ONOFF
 
-    entity = platform.ENTITIES[5]
+    entity = entities[5]
     entity.supported_color_modes = {ColorMode.ONOFF}
     entity.color_mode = ColorMode.ONOFF
 
@@ -1248,29 +1255,31 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("supported_color_modes", [ColorMode.HS, ColorMode.RGB])
 async def test_service_calls(
-    hass: HomeAssistant, enable_custom_integrations: None, supported_color_modes
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    supported_color_modes,
 ) -> None:
     """Test service calls."""
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
+    entities = [
+        MockLight("bed_light", STATE_ON),
+        MockLight("ceiling_lights", STATE_OFF),
+        MockLight("kitchen_lights", STATE_OFF),
+    ]
+    setup_light_platform(entities)
 
-    platform.ENTITIES.append(platform.MockLight("bed_light", STATE_ON))
-    platform.ENTITIES.append(platform.MockLight("ceiling_lights", STATE_OFF))
-    platform.ENTITIES.append(platform.MockLight("kitchen_lights", STATE_OFF))
-
-    entity0 = platform.ENTITIES[0]
+    entity0 = entities[0]
     entity0.supported_color_modes = {supported_color_modes}
     entity0.color_mode = supported_color_modes
     entity0.brightness = 255
     entity0.rgb_color = (0, 64, 128)
 
-    entity1 = platform.ENTITIES[1]
+    entity1 = entities[1]
     entity1.supported_color_modes = {supported_color_modes}
     entity1.color_mode = supported_color_modes
     entity1.brightness = 255
     entity1.rgb_color = (255, 128, 64)
 
-    entity2 = platform.ENTITIES[2]
+    entity2 = entities[2]
     entity2.supported_color_modes = {supported_color_modes}
     entity2.color_mode = supported_color_modes
     entity2.brightness = 255


### PR DESCRIPTION
## Proposed change
Use the new `setup_light_platform` fixture in group light tests to get rid of the deprecated `hass.components`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
