### PR TITLE
Remove deprecated `hass.components` from flux switch tests and use fixture

### DIFF
--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -23,7 +23,7 @@ from tests.common import (
     async_mock_service,
     mock_restore_cache,
 )
-from tests.fixtures.pytest.light import MockLight, SetupLightPlatformCallable
+from tests.components.light.common import MockLight, SetupLightPlatformCallable
 
 
 @pytest.fixture(autouse=True)
@@ -142,7 +142,7 @@ async def test_flux_when_switch_is_off(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch when it is off."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -195,7 +195,7 @@ async def test_flux_before_sunrise(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -256,7 +256,7 @@ async def test_flux_before_sunrise_known_location(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -316,7 +316,7 @@ async def test_flux_after_sunrise_before_sunset(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunrise and before sunset."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -376,7 +376,7 @@ async def test_flux_after_sunset_before_stop(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -437,7 +437,7 @@ async def test_flux_after_stop_before_sunrise(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after stop and before sunrise."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -497,7 +497,7 @@ async def test_flux_with_custom_start_stop_times(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop times."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -562,7 +562,7 @@ async def test_flux_before_sunrise_stop_next_day(
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -626,7 +626,7 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -692,7 +692,7 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -756,7 +756,7 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -820,7 +820,7 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -881,7 +881,7 @@ async def test_flux_with_custom_colortemps(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -944,7 +944,7 @@ async def test_flux_with_custom_brightness(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1006,7 +1006,7 @@ async def test_flux_with_multiple_lights(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch with multiple light entities."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1089,7 +1089,7 @@ async def test_flux_with_mired(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode mired."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1148,7 +1148,7 @@ async def test_flux_with_rgb(
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode rgb."""
-    setup_light_platform()
+    setup_light_platform(hass, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -23,6 +23,7 @@ from tests.common import (
     async_mock_service,
     mock_restore_cache,
 )
+from tests.fixtures.pytest.light import MockLight, SetupLightPlatformCallable
 
 
 @pytest.fixture(autouse=True)
@@ -136,17 +137,19 @@ async def test_invalid_config_no_lights(hass: HomeAssistant) -> None:
 
 
 async def test_flux_when_switch_is_off(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch when it is off."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -187,17 +190,19 @@ async def test_flux_when_switch_is_off(
 
 
 async def test_flux_before_sunrise(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -246,17 +251,19 @@ async def test_flux_before_sunrise(
 
 
 async def test_flux_before_sunrise_known_location(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -304,17 +311,19 @@ async def test_flux_before_sunrise_known_location(
 
 
 async def test_flux_after_sunrise_before_sunset(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunrise and before sunset."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -362,17 +371,19 @@ async def test_flux_after_sunrise_before_sunset(
 
 
 async def test_flux_after_sunset_before_stop(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -421,17 +432,19 @@ async def test_flux_after_sunset_before_stop(
 
 
 async def test_flux_after_stop_before_sunrise(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after stop and before sunrise."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -479,17 +492,19 @@ async def test_flux_after_stop_before_sunrise(
 
 
 async def test_flux_with_custom_start_stop_times(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop times."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -539,20 +554,22 @@ async def test_flux_with_custom_start_stop_times(
 
 
 async def test_flux_before_sunrise_stop_next_day(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise.
 
     This test has the stop_time on the next day (after midnight).
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -601,20 +618,22 @@ async def test_flux_before_sunrise_stop_next_day(
 
 
 async def test_flux_after_sunrise_before_sunset_stop_next_day(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunrise and before sunset.
 
     This test has the stop_time on the next day (after midnight).
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -664,20 +683,23 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
 
 @pytest.mark.parametrize("x", [0, 1])
 async def test_flux_after_sunset_before_midnight_stop_next_day(
-    hass: HomeAssistant, x, enable_custom_integrations: None
+    hass: HomeAssistant,
+    x,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -726,20 +748,22 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
 
 
 async def test_flux_after_sunset_after_midnight_stop_next_day(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -788,20 +812,22 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
 
 
 async def test_flux_after_stop_before_sunrise_stop_next_day(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after stop and before sunrise.
 
     This test has the stop_time on the next day (after midnight).
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -850,17 +876,19 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
 
 
 async def test_flux_with_custom_colortemps(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -911,17 +939,19 @@ async def test_flux_with_custom_colortemps(
 
 
 async def test_flux_with_custom_brightness(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -971,17 +1001,19 @@ async def test_flux_with_custom_brightness(
 
 
 async def test_flux_with_multiple_lights(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch with multiple light entities."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1, ent2, ent3 = platform.ENTITIES
+    ent1, ent2, ent3 = mock_light_entities
 
     await hass.services.async_call(
         light.DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ent2.entity_id}, blocking=True
@@ -1052,17 +1084,19 @@ async def test_flux_with_multiple_lights(
 
 
 async def test_flux_with_mired(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode mired."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)
@@ -1109,17 +1143,19 @@ async def test_flux_with_mired(
 
 
 async def test_flux_with_rgb(
-    hass: HomeAssistant, enable_custom_integrations: None
+    hass: HomeAssistant,
+    setup_light_platform: SetupLightPlatformCallable,
+    mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode rgb."""
-    platform = getattr(hass.components, "test.light")
-    platform.init()
+    setup_light_platform()
+
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
     )
     await hass.async_block_till_done()
 
-    ent1 = platform.ENTITIES[0]
+    ent1 = mock_light_entities[0]
 
     # Verify initial state of light
     state = hass.states.get(ent1.entity_id)


### PR DESCRIPTION
## Proposed change
Use the new `setup_light_platform` fixture in flux switch tests to get rid of the deprecated `hass.components`

~needs changes after #113892 has been merged~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
