### PR TITLE
Use a constant to reference `homeassistant` domain

### DIFF
--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -3,10 +3,12 @@
 import voluptuous as vol
 
 from homeassistant.const import CONF_EVENT, CONF_PLATFORM
-from homeassistant.core import CALLBACK_TYPE, DOMAIN, HassJob, HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
+
+from ..const import DOMAIN
 
 EVENT_START = "start"
 EVENT_SHUTDOWN = "shutdown"

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -3,12 +3,7 @@
 import voluptuous as vol
 
 from homeassistant.const import CONF_EVENT, CONF_PLATFORM
-from homeassistant.core import (
-    CALLBACK_TYPE,
-    DOMAIN as CONF_CORE,
-    HassJob,
-    HomeAssistant,
-)
+from homeassistant.core import CALLBACK_TYPE, DOMAIN, HassJob, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -18,7 +13,7 @@ EVENT_SHUTDOWN = "shutdown"
 
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_PLATFORM): CONF_CORE,
+        vol.Required(CONF_PLATFORM): DOMAIN,
         vol.Required(CONF_EVENT): vol.Any(EVENT_START, EVENT_SHUTDOWN),
     }
 )
@@ -41,7 +36,7 @@ async def async_attach_trigger(
             {
                 "trigger": {
                     **trigger_data,
-                    "platform": CONF_CORE,
+                    "platform": DOMAIN,
                     "event": event,
                     "description": "Home Assistant stopping",
                 }
@@ -56,7 +51,7 @@ async def async_attach_trigger(
             {
                 "trigger": {
                     **trigger_data,
-                    "platform": CONF_CORE,
+                    "platform": DOMAIN,
                     "event": event,
                     "description": "Home Assistant starting",
                 }

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -3,7 +3,12 @@
 import voluptuous as vol
 
 from homeassistant.const import CONF_EVENT, CONF_PLATFORM
-from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant
+from homeassistant.core import (
+    CALLBACK_TYPE,
+    DOMAIN as CONF_CORE,
+    HassJob,
+    HomeAssistant,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -13,7 +18,7 @@ EVENT_SHUTDOWN = "shutdown"
 
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_PLATFORM): "homeassistant",
+        vol.Required(CONF_PLATFORM): CONF_CORE,
         vol.Required(CONF_EVENT): vol.Any(EVENT_START, EVENT_SHUTDOWN),
     }
 )
@@ -36,7 +41,7 @@ async def async_attach_trigger(
             {
                 "trigger": {
                     **trigger_data,
-                    "platform": "homeassistant",
+                    "platform": CONF_CORE,
                     "event": event,
                     "description": "Home Assistant stopping",
                 }
@@ -51,7 +56,7 @@ async def async_attach_trigger(
             {
                 "trigger": {
                     **trigger_data,
-                    "platform": "homeassistant",
+                    "platform": CONF_CORE,
                     "event": event,
                     "description": "Home Assistant starting",
                 }

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -80,6 +80,7 @@ YAML_CONFIG_FILE = "configuration.yaml"
 VERSION_FILE = ".HA_VERSION"
 CONFIG_DIR_NAME = ".homeassistant"
 DATA_CUSTOMIZE = "hass_customize"
+DOMAIN_HA = "homeassistant"
 
 AUTOMATION_CONFIG_PATH = "automations.yaml"
 SCRIPT_CONFIG_PATH = "scripts.yaml"
@@ -247,12 +248,12 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 
 def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> None:
     if currency not in HISTORIC_CURRENCIES:
-        ir.async_delete_issue(hass, CONF_CORE, "historic_currency")
+        ir.async_delete_issue(hass, DOMAIN_HA, "historic_currency")
         return
 
     ir.async_create_issue(
         hass,
-        CONF_CORE,
+        DOMAIN_HA,
         "historic_currency",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -264,12 +265,12 @@ def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> Non
 
 def _raise_issue_if_no_country(hass: HomeAssistant, country: str | None) -> None:
     if country is not None:
-        ir.async_delete_issue(hass, CONF_CORE, "country_not_configured")
+        ir.async_delete_issue(hass, DOMAIN_HA, "country_not_configured")
         return
 
     ir.async_create_issue(
         hass,
-        CONF_CORE,
+        DOMAIN_HA,
         "country_not_configured",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -288,7 +289,7 @@ def _raise_issue_if_legacy_templates(
     if legacy_templates:
         ir.async_create_issue(
             hass,
-            CONF_CORE,
+            DOMAIN_HA,
             "legacy_templates_true",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -297,12 +298,12 @@ def _raise_issue_if_legacy_templates(
         )
         return
 
-    ir.async_delete_issue(hass, CONF_CORE, "legacy_templates_true")
+    ir.async_delete_issue(hass, DOMAIN_HA, "legacy_templates_true")
 
     if legacy_templates is False:
         ir.async_create_issue(
             hass,
-            CONF_CORE,
+            DOMAIN_HA,
             "legacy_templates_false",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -310,7 +311,7 @@ def _raise_issue_if_legacy_templates(
             translation_key="legacy_templates_false",
         )
     else:
-        ir.async_delete_issue(hass, CONF_CORE, "legacy_templates_false")
+        ir.async_delete_issue(hass, DOMAIN_HA, "legacy_templates_false")
 
 
 def _validate_currency(data: Any) -> Any:

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -58,7 +58,7 @@ from .const import (
     LEGACY_CONF_WHITELIST_EXTERNAL_DIRS,
     __version__,
 )
-from .core import DOMAIN as DOMAIN_HA, ConfigSource, HomeAssistant, callback
+from .core import DOMAIN as HA_DOMAIN, ConfigSource, HomeAssistant, callback
 from .exceptions import ConfigValidationError, HomeAssistantError
 from .generated.currencies import HISTORIC_CURRENCIES
 from .helpers import config_validation as cv, issue_registry as ir
@@ -247,12 +247,12 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 
 def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> None:
     if currency not in HISTORIC_CURRENCIES:
-        ir.async_delete_issue(hass, DOMAIN_HA, "historic_currency")
+        ir.async_delete_issue(hass, HA_DOMAIN, "historic_currency")
         return
 
     ir.async_create_issue(
         hass,
-        DOMAIN_HA,
+        HA_DOMAIN,
         "historic_currency",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -264,12 +264,12 @@ def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> Non
 
 def _raise_issue_if_no_country(hass: HomeAssistant, country: str | None) -> None:
     if country is not None:
-        ir.async_delete_issue(hass, DOMAIN_HA, "country_not_configured")
+        ir.async_delete_issue(hass, HA_DOMAIN, "country_not_configured")
         return
 
     ir.async_create_issue(
         hass,
-        DOMAIN_HA,
+        HA_DOMAIN,
         "country_not_configured",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -288,7 +288,7 @@ def _raise_issue_if_legacy_templates(
     if legacy_templates:
         ir.async_create_issue(
             hass,
-            DOMAIN_HA,
+            HA_DOMAIN,
             "legacy_templates_true",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -297,12 +297,12 @@ def _raise_issue_if_legacy_templates(
         )
         return
 
-    ir.async_delete_issue(hass, DOMAIN_HA, "legacy_templates_true")
+    ir.async_delete_issue(hass, HA_DOMAIN, "legacy_templates_true")
 
     if legacy_templates is False:
         ir.async_create_issue(
             hass,
-            DOMAIN_HA,
+            HA_DOMAIN,
             "legacy_templates_false",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -310,7 +310,7 @@ def _raise_issue_if_legacy_templates(
             translation_key="legacy_templates_false",
         )
     else:
-        ir.async_delete_issue(hass, DOMAIN_HA, "legacy_templates_false")
+        ir.async_delete_issue(hass, HA_DOMAIN, "legacy_templates_false")
 
 
 def _validate_currency(data: Any) -> Any:
@@ -503,12 +503,12 @@ async def async_hass_config_yaml(hass: HomeAssistant) -> dict:
     for invalid_domain in invalid_domains:
         config.pop(invalid_domain)
 
-    core_config = config.get(DOMAIN_HA, {})
+    core_config = config.get(HA_DOMAIN, {})
     try:
         await merge_packages_config(hass, config, core_config.get(CONF_PACKAGES, {}))
     except vol.Invalid as exc:
         suffix = ""
-        if annotation := find_annotation(config, [DOMAIN_HA, CONF_PACKAGES, *exc.path]):
+        if annotation := find_annotation(config, [HA_DOMAIN, CONF_PACKAGES, *exc.path]):
             suffix = f" at {_relpath(hass, annotation[0])}, line {annotation[1]}"
         _LOGGER.error(
             "Invalid package configuration '%s'%s: %s", CONF_PACKAGES, suffix, exc
@@ -731,7 +731,7 @@ def stringify_invalid(
         )
     else:
         message_prefix = f"Invalid config for '{domain}'"
-    if domain != DOMAIN_HA and link:
+    if domain != HA_DOMAIN and link:
         message_suffix = f", please check the docs at {link}"
     else:
         message_suffix = ""
@@ -814,7 +814,7 @@ def format_homeassistant_error(
     if annotation := find_annotation(config, [domain]):
         message_prefix += f" at {_relpath(hass, annotation[0])}, line {annotation[1]}"
     message = f"{message_prefix}: {str(exc) or repr(exc)}"
-    if domain != DOMAIN_HA and link:
+    if domain != HA_DOMAIN and link:
         message += f", please check the docs at {link}"
 
     return message
@@ -933,7 +933,7 @@ async def async_process_ha_core_config(hass: HomeAssistant, config: dict) -> Non
     cust_glob = OrderedDict(config[CONF_CUSTOMIZE_GLOB])
 
     for name, pkg in config[CONF_PACKAGES].items():
-        if (pkg_cust := pkg.get(DOMAIN_HA)) is None:
+        if (pkg_cust := pkg.get(HA_DOMAIN)) is None:
             continue
 
         try:
@@ -957,7 +957,7 @@ def _log_pkg_error(
 ) -> None:
     """Log an error while merging packages."""
     message_prefix = f"Setup of package '{package}'"
-    if annotation := find_annotation(config, [DOMAIN_HA, CONF_PACKAGES, package]):
+    if annotation := find_annotation(config, [HA_DOMAIN, CONF_PACKAGES, package]):
         message_prefix += f" at {_relpath(hass, annotation[0])}, line {annotation[1]}"
 
     _LOGGER.error("%s failed: %s", message_prefix, message)
@@ -1072,7 +1072,7 @@ async def merge_packages_config(
             continue
 
         for comp_name, comp_conf in pack_conf.items():
-            if comp_name == DOMAIN_HA:
+            if comp_name == HA_DOMAIN:
                 continue
             try:
                 domain = cv.domain_key(comp_name)
@@ -1305,7 +1305,7 @@ def async_drop_config_annotations(
 
     # Don't drop annotations from the homeassistant integration because it may
     # have configuration for other integrations as packages.
-    if integration.domain in config and integration.domain != DOMAIN_HA:
+    if integration.domain in config and integration.domain != HA_DOMAIN:
         drop_config_annotations_rec(config[integration.domain])
     return config
 

--- a/homeassistant/config.py
+++ b/homeassistant/config.py
@@ -247,12 +247,12 @@ CUSTOMIZE_CONFIG_SCHEMA = vol.Schema(
 
 def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> None:
     if currency not in HISTORIC_CURRENCIES:
-        ir.async_delete_issue(hass, "homeassistant", "historic_currency")
+        ir.async_delete_issue(hass, CONF_CORE, "historic_currency")
         return
 
     ir.async_create_issue(
         hass,
-        "homeassistant",
+        CONF_CORE,
         "historic_currency",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -264,12 +264,12 @@ def _raise_issue_if_historic_currency(hass: HomeAssistant, currency: str) -> Non
 
 def _raise_issue_if_no_country(hass: HomeAssistant, country: str | None) -> None:
     if country is not None:
-        ir.async_delete_issue(hass, "homeassistant", "country_not_configured")
+        ir.async_delete_issue(hass, CONF_CORE, "country_not_configured")
         return
 
     ir.async_create_issue(
         hass,
-        "homeassistant",
+        CONF_CORE,
         "country_not_configured",
         is_fixable=False,
         learn_more_url="homeassistant://config/general",
@@ -288,7 +288,7 @@ def _raise_issue_if_legacy_templates(
     if legacy_templates:
         ir.async_create_issue(
             hass,
-            "homeassistant",
+            CONF_CORE,
             "legacy_templates_true",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -297,12 +297,12 @@ def _raise_issue_if_legacy_templates(
         )
         return
 
-    ir.async_delete_issue(hass, "homeassistant", "legacy_templates_true")
+    ir.async_delete_issue(hass, CONF_CORE, "legacy_templates_true")
 
     if legacy_templates is False:
         ir.async_create_issue(
             hass,
-            "homeassistant",
+            CONF_CORE,
             "legacy_templates_false",
             is_fixable=False,
             breaks_in_ha_version="2024.7.0",
@@ -310,7 +310,7 @@ def _raise_issue_if_legacy_templates(
             translation_key="legacy_templates_false",
         )
     else:
-        ir.async_delete_issue(hass, "homeassistant", "legacy_templates_false")
+        ir.async_delete_issue(hass, CONF_CORE, "legacy_templates_false")
 
 
 def _validate_currency(data: Any) -> Any:

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -14,7 +14,7 @@ from homeassistant import loader
 from homeassistant.config import (  # type: ignore[attr-defined]
     CONF_PACKAGES,
     CORE_CONFIG_SCHEMA,
-    DOMAIN_HA,
+    HA_DOMAIN,
     YAML_CONFIG_FILE,
     config_per_platform,
     extract_domain_configs,
@@ -158,10 +158,10 @@ async def async_check_ha_config_file(  # noqa: C901
         return result.add_error(f"Error loading {config_path}: {err}")
 
     # Extract and validate core [homeassistant] config
-    core_config = config.pop(DOMAIN_HA, {})
+    core_config = config.pop(HA_DOMAIN, {})
     try:
         core_config = CORE_CONFIG_SCHEMA(core_config)
-        result[DOMAIN_HA] = core_config
+        result[HA_DOMAIN] = core_config
 
         # Merge packages
         await merge_packages_config(
@@ -169,8 +169,8 @@ async def async_check_ha_config_file(  # noqa: C901
         )
     except vol.Invalid as err:
         result.add_error(
-            format_schema_error(hass, err, DOMAIN_HA, core_config),
-            DOMAIN_HA,
+            format_schema_error(hass, err, HA_DOMAIN, core_config),
+            HA_DOMAIN,
             core_config,
         )
         core_config = {}

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -12,9 +12,9 @@ import voluptuous as vol
 
 from homeassistant import loader
 from homeassistant.config import (  # type: ignore[attr-defined]
-    CONF_CORE,
     CONF_PACKAGES,
     CORE_CONFIG_SCHEMA,
+    DOMAIN_HA,
     YAML_CONFIG_FILE,
     config_per_platform,
     extract_domain_configs,
@@ -158,10 +158,10 @@ async def async_check_ha_config_file(  # noqa: C901
         return result.add_error(f"Error loading {config_path}: {err}")
 
     # Extract and validate core [homeassistant] config
-    core_config = config.pop(CONF_CORE, {})
+    core_config = config.pop(DOMAIN_HA, {})
     try:
         core_config = CORE_CONFIG_SCHEMA(core_config)
-        result[CONF_CORE] = core_config
+        result[DOMAIN_HA] = core_config
 
         # Merge packages
         await merge_packages_config(
@@ -169,8 +169,8 @@ async def async_check_ha_config_file(  # noqa: C901
         )
     except vol.Invalid as err:
         result.add_error(
-            format_schema_error(hass, err, CONF_CORE, core_config),
-            CONF_CORE,
+            format_schema_error(hass, err, DOMAIN_HA, core_config),
+            DOMAIN_HA,
             core_config,
         )
         core_config = {}

--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -14,7 +14,6 @@ from homeassistant import loader
 from homeassistant.config import (  # type: ignore[attr-defined]
     CONF_PACKAGES,
     CORE_CONFIG_SCHEMA,
-    HA_DOMAIN,
     YAML_CONFIG_FILE,
     config_per_platform,
     extract_domain_configs,
@@ -23,7 +22,7 @@ from homeassistant.config import (  # type: ignore[attr-defined]
     load_yaml_config_file,
     merge_packages_config,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import DOMAIN as HA_DOMAIN, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.requirements import (
     RequirementsNotFound,

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 
-from homeassistant.core import DOMAIN as CONF_CORE
+from homeassistant.core import DOMAIN
 
 from .model import Config, Integration
 
@@ -12,7 +12,7 @@ CONFIG_SCHEMA_IGNORE = {
     # Configuration under the homeassistant key is a special case, it's handled by
     # conf_util.async_process_ha_core_config already during bootstrapping, not by
     # a schema in the homeassistant integration.
-    CONF_CORE,
+    DOMAIN,
 }
 
 

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 
-from homeassistant.core import DOMAIN
+from homeassistant.core import DOMAIN as HA_DOMAIN
 
 from .model import Config, Integration
 
@@ -12,7 +12,7 @@ CONFIG_SCHEMA_IGNORE = {
     # Configuration under the homeassistant key is a special case, it's handled by
     # conf_util.async_process_ha_core_config already during bootstrapping, not by
     # a schema in the homeassistant integration.
-    DOMAIN,
+    HA_DOMAIN,
 }
 
 

--- a/script/hassfest/config_schema.py
+++ b/script/hassfest/config_schema.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 import ast
 
+from homeassistant.core import DOMAIN as CONF_CORE
+
 from .model import Config, Integration
 
 CONFIG_SCHEMA_IGNORE = {
     # Configuration under the homeassistant key is a special case, it's handled by
     # conf_util.async_process_ha_core_config already during bootstrapping, not by
     # a schema in the homeassistant integration.
-    "homeassistant",
+    CONF_CORE,
 }
 
 

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -468,7 +468,7 @@ async def test_config_schema_via_packages(hass: HomeAssistant) -> None:
         "pack_11": {"rest": {"resource": "http://url1"}},
         "pack_list": {"rest": [{"resource": "http://url2"}]},
     }
-    config = {hass_config.DOMAIN_HA: {hass_config.CONF_PACKAGES: packages}}
+    config = {hass_config.HA_DOMAIN: {hass_config.CONF_PACKAGES: packages}}
     await hass_config.merge_packages_config(hass, config, packages)
 
     assert len(config) == 2

--- a/tests/components/rest/test_init.py
+++ b/tests/components/rest/test_init.py
@@ -468,7 +468,7 @@ async def test_config_schema_via_packages(hass: HomeAssistant) -> None:
         "pack_11": {"rest": {"resource": "http://url1"}},
         "pack_list": {"rest": [{"resource": "http://url2"}]},
     }
-    config = {hass_config.CONF_CORE: {hass_config.CONF_PACKAGES: packages}}
+    config = {hass_config.DOMAIN_HA: {hass_config.CONF_PACKAGES: packages}}
     await hass_config.merge_packages_config(hass, config, packages)
 
     assert len(config) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1041,7 +1041,7 @@ async def test_check_ha_config_file_wrong(mock_check, hass: HomeAssistant) -> No
     "hass_config",
     [
         {
-            config_util.CONF_CORE: {
+            config_util.DOMAIN_HA: {
                 config_util.CONF_PACKAGES: {
                     "pack_dict": {"input_boolean": {"ib1": None}}
                 }
@@ -1058,7 +1058,7 @@ async def test_async_hass_config_yaml_merge(
     conf = await config_util.async_hass_config_yaml(hass)
 
     assert merge_log_err.call_count == 0
-    assert conf[config_util.CONF_CORE].get(config_util.CONF_PACKAGES) is not None
+    assert conf[config_util.DOMAIN_HA].get(config_util.CONF_PACKAGES) is not None
     assert len(conf) == 3
     assert len(conf["input_boolean"]) == 2
     assert len(conf["light"]) == 1
@@ -1086,7 +1086,7 @@ async def test_merge(merge_log_err, hass: HomeAssistant) -> None:
         },
     }
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "light": {"platform": "test"},
         "automation": [],
@@ -1113,7 +1113,7 @@ async def test_merge_try_falsy(merge_log_err, hass: HomeAssistant) -> None:
         "pack_list2": {"light": OrderedDict()},
     }
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "automation": {"do": "something"},
         "light": {"some": "light"},
     }
@@ -1136,7 +1136,7 @@ async def test_merge_new(merge_log_err, hass: HomeAssistant) -> None:
             "api": {},
         },
     }
-    config = {config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages}}
+    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert merge_log_err.call_count == 0
@@ -1154,7 +1154,7 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
         "pack_2": {"light": {"ib1": None}},  # light gets merged - ensure_list
     }
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "input_select": [{"ib2": None}],
         "light": [{"platform": "two"}],
@@ -1170,13 +1170,13 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
 async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if we have a merge for a comp that may occur only once. Keys."""
     packages = {"pack_2": {"api": None}}
-    config = {config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages}, "api": None}
+    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}, "api": None}
     await config_util.merge_packages_config(hass, config, packages)
     assert config["api"] == OrderedDict()
 
     packages = {"pack_2": {"api": {"key_3": 3}}}
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "api": {"key_1": 1, "key_2": 2},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1185,7 +1185,7 @@ async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     # Duplicate keys error
     packages = {"pack_2": {"api": {"key": 2}}}
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "api": {"key": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1200,7 +1200,7 @@ async def test_merge_once_only_lists(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "api": {"list_1": ["item_1"]},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1223,7 +1223,7 @@ async def test_merge_once_only_dictionaries(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "api": {"dict_1": {"key_1": 1, "dict_1.1": {"key_1.1": 1.1}}},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1257,7 +1257,7 @@ async def test_merge_duplicate_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if keys in dicts are duplicates."""
     packages = {"pack_1": {"input_select": {"ib1": None}}}
     config = {
-        config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages},
+        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
         "input_select": {"ib1": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1417,7 +1417,7 @@ async def test_merge_split_component_definition(hass: HomeAssistant) -> None:
         "pack_1": {"light one": {"l1": None}},
         "pack_2": {"light two": {"l2": None}, "light three": {"l3": None}},
     }
-    config = {config_util.CONF_CORE: {config_util.CONF_PACKAGES: packages}}
+    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert len(config) == 4
@@ -2308,7 +2308,7 @@ async def test_packages_schema_validation_error(
     ]
     assert error_records == snapshot
 
-    assert len(config[config_util.CONF_CORE][config_util.CONF_PACKAGES]) == 0
+    assert len(config[config_util.DOMAIN_HA][config_util.CONF_PACKAGES]) == 0
 
 
 def test_extract_domain_configs() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,12 @@ from homeassistant.const import (
     CONF_UNIT_SYSTEM_METRIC,
     __version__,
 )
-from homeassistant.core import ConfigSource, HomeAssistant, HomeAssistantError
+from homeassistant.core import (
+    DOMAIN as HA_DOMAIN,
+    ConfigSource,
+    HomeAssistant,
+    HomeAssistantError,
+)
 from homeassistant.exceptions import ConfigValidationError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
 import homeassistant.helpers.check_config as check_config
@@ -1041,7 +1046,7 @@ async def test_check_ha_config_file_wrong(mock_check, hass: HomeAssistant) -> No
     "hass_config",
     [
         {
-            config_util.HA_DOMAIN: {
+            HA_DOMAIN: {
                 config_util.CONF_PACKAGES: {
                     "pack_dict": {"input_boolean": {"ib1": None}}
                 }
@@ -1058,7 +1063,7 @@ async def test_async_hass_config_yaml_merge(
     conf = await config_util.async_hass_config_yaml(hass)
 
     assert merge_log_err.call_count == 0
-    assert conf[config_util.HA_DOMAIN].get(config_util.CONF_PACKAGES) is not None
+    assert conf[HA_DOMAIN].get(config_util.CONF_PACKAGES) is not None
     assert len(conf) == 3
     assert len(conf["input_boolean"]) == 2
     assert len(conf["light"]) == 1
@@ -1086,7 +1091,7 @@ async def test_merge(merge_log_err, hass: HomeAssistant) -> None:
         },
     }
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "light": {"platform": "test"},
         "automation": [],
@@ -1113,7 +1118,7 @@ async def test_merge_try_falsy(merge_log_err, hass: HomeAssistant) -> None:
         "pack_list2": {"light": OrderedDict()},
     }
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "automation": {"do": "something"},
         "light": {"some": "light"},
     }
@@ -1136,7 +1141,7 @@ async def test_merge_new(merge_log_err, hass: HomeAssistant) -> None:
             "api": {},
         },
     }
-    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
+    config = {HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert merge_log_err.call_count == 0
@@ -1154,7 +1159,7 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
         "pack_2": {"light": {"ib1": None}},  # light gets merged - ensure_list
     }
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "input_select": [{"ib2": None}],
         "light": [{"platform": "two"}],
@@ -1170,13 +1175,13 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
 async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if we have a merge for a comp that may occur only once. Keys."""
     packages = {"pack_2": {"api": None}}
-    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}, "api": None}
+    config = {HA_DOMAIN: {config_util.CONF_PACKAGES: packages}, "api": None}
     await config_util.merge_packages_config(hass, config, packages)
     assert config["api"] == OrderedDict()
 
     packages = {"pack_2": {"api": {"key_3": 3}}}
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"key_1": 1, "key_2": 2},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1185,7 +1190,7 @@ async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     # Duplicate keys error
     packages = {"pack_2": {"api": {"key": 2}}}
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"key": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1200,7 +1205,7 @@ async def test_merge_once_only_lists(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"list_1": ["item_1"]},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1223,7 +1228,7 @@ async def test_merge_once_only_dictionaries(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"dict_1": {"key_1": 1, "dict_1.1": {"key_1.1": 1.1}}},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1257,7 +1262,7 @@ async def test_merge_duplicate_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if keys in dicts are duplicates."""
     packages = {"pack_1": {"input_select": {"ib1": None}}}
     config = {
-        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
+        HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_select": {"ib1": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1417,7 +1422,7 @@ async def test_merge_split_component_definition(hass: HomeAssistant) -> None:
         "pack_1": {"light one": {"l1": None}},
         "pack_2": {"light two": {"l2": None}, "light three": {"l3": None}},
     }
-    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
+    config = {HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert len(config) == 4
@@ -2308,7 +2313,7 @@ async def test_packages_schema_validation_error(
     ]
     assert error_records == snapshot
 
-    assert len(config[config_util.HA_DOMAIN][config_util.CONF_PACKAGES]) == 0
+    assert len(config[HA_DOMAIN][config_util.CONF_PACKAGES]) == 0
 
 
 def test_extract_domain_configs() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1041,7 +1041,7 @@ async def test_check_ha_config_file_wrong(mock_check, hass: HomeAssistant) -> No
     "hass_config",
     [
         {
-            config_util.DOMAIN_HA: {
+            config_util.HA_DOMAIN: {
                 config_util.CONF_PACKAGES: {
                     "pack_dict": {"input_boolean": {"ib1": None}}
                 }
@@ -1058,7 +1058,7 @@ async def test_async_hass_config_yaml_merge(
     conf = await config_util.async_hass_config_yaml(hass)
 
     assert merge_log_err.call_count == 0
-    assert conf[config_util.DOMAIN_HA].get(config_util.CONF_PACKAGES) is not None
+    assert conf[config_util.HA_DOMAIN].get(config_util.CONF_PACKAGES) is not None
     assert len(conf) == 3
     assert len(conf["input_boolean"]) == 2
     assert len(conf["light"]) == 1
@@ -1086,7 +1086,7 @@ async def test_merge(merge_log_err, hass: HomeAssistant) -> None:
         },
     }
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "light": {"platform": "test"},
         "automation": [],
@@ -1113,7 +1113,7 @@ async def test_merge_try_falsy(merge_log_err, hass: HomeAssistant) -> None:
         "pack_list2": {"light": OrderedDict()},
     }
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "automation": {"do": "something"},
         "light": {"some": "light"},
     }
@@ -1136,7 +1136,7 @@ async def test_merge_new(merge_log_err, hass: HomeAssistant) -> None:
             "api": {},
         },
     }
-    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}}
+    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert merge_log_err.call_count == 0
@@ -1154,7 +1154,7 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
         "pack_2": {"light": {"ib1": None}},  # light gets merged - ensure_list
     }
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_boolean": {"ib2": None},
         "input_select": [{"ib2": None}],
         "light": [{"platform": "two"}],
@@ -1170,13 +1170,13 @@ async def test_merge_type_mismatch(merge_log_err, hass: HomeAssistant) -> None:
 async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if we have a merge for a comp that may occur only once. Keys."""
     packages = {"pack_2": {"api": None}}
-    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}, "api": None}
+    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}, "api": None}
     await config_util.merge_packages_config(hass, config, packages)
     assert config["api"] == OrderedDict()
 
     packages = {"pack_2": {"api": {"key_3": 3}}}
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"key_1": 1, "key_2": 2},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1185,7 +1185,7 @@ async def test_merge_once_only_keys(merge_log_err, hass: HomeAssistant) -> None:
     # Duplicate keys error
     packages = {"pack_2": {"api": {"key": 2}}}
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"key": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1200,7 +1200,7 @@ async def test_merge_once_only_lists(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"list_1": ["item_1"]},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1223,7 +1223,7 @@ async def test_merge_once_only_dictionaries(hass: HomeAssistant) -> None:
         }
     }
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "api": {"dict_1": {"key_1": 1, "dict_1.1": {"key_1.1": 1.1}}},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1257,7 +1257,7 @@ async def test_merge_duplicate_keys(merge_log_err, hass: HomeAssistant) -> None:
     """Test if keys in dicts are duplicates."""
     packages = {"pack_1": {"input_select": {"ib1": None}}}
     config = {
-        config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages},
+        config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages},
         "input_select": {"ib1": 1},
     }
     await config_util.merge_packages_config(hass, config, packages)
@@ -1417,7 +1417,7 @@ async def test_merge_split_component_definition(hass: HomeAssistant) -> None:
         "pack_1": {"light one": {"l1": None}},
         "pack_2": {"light two": {"l2": None}, "light three": {"l3": None}},
     }
-    config = {config_util.DOMAIN_HA: {config_util.CONF_PACKAGES: packages}}
+    config = {config_util.HA_DOMAIN: {config_util.CONF_PACKAGES: packages}}
     await config_util.merge_packages_config(hass, config, packages)
 
     assert len(config) == 4
@@ -2308,7 +2308,7 @@ async def test_packages_schema_validation_error(
     ]
     assert error_records == snapshot
 
-    assert len(config[config_util.DOMAIN_HA][config_util.CONF_PACKAGES]) == 0
+    assert len(config[config_util.HA_DOMAIN][config_util.CONF_PACKAGES]) == 0
 
 
 def test_extract_domain_configs() -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use constant `HA_DOMAIN` a reference to the `homeassistant` domain or platform for ...
- ... referencing the issue registry for the `homeassistant` domain in `config.py`
- ... referencing the `homeassistant` domain in `CONFIG_SCHEMA_IGNORE` and `script/hassfest/config_schema`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
