### PR TITLE
Fix system_info importing hassio in the event loop

### DIFF
--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -7,12 +7,14 @@ from getpass import getuser
 import logging
 import os
 import platform
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
 from homeassistant.util.package import is_docker_env, is_virtual_env
+
+from .importlib import async_import_module
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,9 +33,11 @@ cached_get_user = cache(getuser)
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
-    # Local import to avoid circular dependencies
-    # pylint: disable-next=import-outside-toplevel
-    from homeassistant.components import hassio
+    if TYPE_CHECKING:
+        # pylint: disable-next=import-outside-toplevel
+        from homeassistant.components import hassio
+    else:
+        hassio = await async_import_module(hass, "homeassistant.components.hassio")
 
     is_hassio = hassio.is_hassio(hass)
 

--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -33,6 +33,10 @@ cached_get_user = cache(getuser)
 @bind_hass
 async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return info about the system."""
+    # Local import to avoid circular dependencies
+    # We use the import helper because hassio
+    # may not be loaded yet and we don't want to
+    # do blocking I/O in the event loop to import it.
     if TYPE_CHECKING:
         # pylint: disable-next=import-outside-toplevel
         from homeassistant.components import hassio

--- a/tests/helpers/test_system_info.py
+++ b/tests/helpers/test_system_info.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from homeassistant.components import hassio
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.system_info import async_get_system_info, is_official_image
@@ -39,8 +40,8 @@ async def test_get_system_info_supervisor_not_available(
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
-    ), patch("homeassistant.components.hassio.is_hassio", return_value=True), patch(
-        "homeassistant.components.hassio.get_info", return_value=None
+    ), patch.object(hassio, "is_hassio", return_value=True), patch.object(
+        hassio, "get_info", return_value=None
     ), patch("homeassistant.helpers.system_info.cached_get_user", return_value="root"):
         info = await async_get_system_info(hass)
         assert isinstance(info, dict)
@@ -57,7 +58,7 @@ async def test_get_system_info_supervisor_not_loaded(hass: HomeAssistant) -> Non
         "homeassistant.helpers.system_info.is_docker_env", return_value=True
     ), patch(
         "homeassistant.helpers.system_info.is_official_image", return_value=True
-    ), patch("homeassistant.components.hassio.get_info", return_value=None), patch.dict(
+    ), patch.object(hassio, "get_info", return_value=None), patch.dict(
         os.environ, {"SUPERVISOR": "127.0.0.1"}
     ):
         info = await async_get_system_info(hass)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This one can get unluckly and hassio is not loaded yet


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
