### PR TITLE
Fetch MaxLengthExceeded exception mesage from the translation cache

### DIFF
--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -175,7 +175,7 @@
       "message": "Failed to process config for integration {domain} due to multiple ({errors}) errors. Check the logs for more information."
     },
     "max_length_exceeded": {
-      "message": "Value {value} for property {property_name} has a max length of {max_length} characters."
+      "message": "Value {value} for property {property_name} has a maximum length of {max_length} characters."
     },
     "platform_component_load_err": {
       "message": "Platform error: {domain} - {error}. Check the logs for more information."

--- a/homeassistant/components/homeassistant/strings.json
+++ b/homeassistant/components/homeassistant/strings.json
@@ -174,6 +174,9 @@
     "integration_config_error": {
       "message": "Failed to process config for integration {domain} due to multiple ({errors}) errors. Check the logs for more information."
     },
+    "max_length_exceeded": {
+      "message": "Value {value} for property {property_name} has a max length of {max_length} characters."
+    },
     "platform_component_load_err": {
       "message": "Platform error: {domain} - {error}. Check the logs for more information."
     },

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -281,14 +281,18 @@ class MaxLengthExceeded(HomeAssistantError):
         """Initialize error."""
         super().__init__(
             self,
-            (
-                f"Value {value} for property {property_name} has a max length of "
-                f"{max_length} characters"
-            ),
+            translation_domain="homeassistant",
+            translation_key="max_length_exceeded",
+            translation_placeholders={
+                "value": value,
+                "property_name": property_name,
+                "max_length": str(max_length),
+            },
         )
         self.value = value
         self.property_name = property_name
         self.max_length = max_length
+        self.generate_message = True
 
 
 class DependencyError(HomeAssistantError):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -57,6 +57,7 @@ from homeassistant.exceptions import (
     ServiceNotFound,
 )
 from homeassistant.helpers.json import json_dumps
+from homeassistant.setup import async_setup_component
 from homeassistant.util.async_ import create_eager_task
 import homeassistant.util.dt as dt_util
 from homeassistant.util.read_only_dict import ReadOnlyDict
@@ -1304,6 +1305,8 @@ async def test_eventbus_coroutine_event_listener(hass: HomeAssistant) -> None:
 async def test_eventbus_max_length_exceeded(hass: HomeAssistant) -> None:
     """Test that an exception is raised when the max character length is exceeded."""
 
+    await async_setup_component(hass, "homeassistant", {})
+
     long_evt_name = (
         "this_event_exceeds_the_max_character_length_even_with_the_new_limit"
     )
@@ -1311,6 +1314,10 @@ async def test_eventbus_max_length_exceeded(hass: HomeAssistant) -> None:
     with pytest.raises(MaxLengthExceeded) as exc_info:
         hass.bus.async_fire(long_evt_name)
 
+    assert (
+        str(exc_info.value)
+        == f"Value {long_evt_name} for property event_type has a max length of 64 characters"
+    )
     assert exc_info.value.property_name == "event_type"
     assert exc_info.value.max_length == 64
     assert exc_info.value.value == long_evt_name

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1327,7 +1327,7 @@ async def test_eventbus_max_length_exceeded(hass: HomeAssistant) -> None:
 
     assert (
         str(exc_info.value)
-        == f"Value {long_evt_name} for property event_type has a max length of 64 characters"
+        == f"Value {long_evt_name} for property event_type has a maximum length of 64 characters"
     )
     assert exc_info.value.property_name == "event_type"
     assert exc_info.value.max_length == 64

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1305,12 +1305,23 @@ async def test_eventbus_coroutine_event_listener(hass: HomeAssistant) -> None:
 async def test_eventbus_max_length_exceeded(hass: HomeAssistant) -> None:
     """Test that an exception is raised when the max character length is exceeded."""
 
-    await async_setup_component(hass, "homeassistant", {})
-
     long_evt_name = (
         "this_event_exceeds_the_max_character_length_even_with_the_new_limit"
     )
 
+    # Without cached translations the translation key is returned
+    with pytest.raises(MaxLengthExceeded) as exc_info:
+        hass.bus.async_fire(long_evt_name)
+
+    assert str(exc_info.value) == "max_length_exceeded"
+    assert exc_info.value.property_name == "event_type"
+    assert exc_info.value.max_length == 64
+    assert exc_info.value.value == long_evt_name
+
+    # Fetch translations
+    await async_setup_component(hass, "homeassistant", {})
+
+    # With cached translations the formatted message is returned
     with pytest.raises(MaxLengthExceeded) as exc_info:
         hass.bus.async_fire(long_evt_name)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
