### PR TITLE
Fix Sonos play imported playlists

### DIFF
--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -493,6 +493,20 @@ def get_media(
     """Fetch media/album."""
     search_type = MEDIA_TYPES_TO_SONOS.get(search_type, search_type)
 
+    if search_type == "playlists":
+        # Format is S:TITLE or S:ITEM_ID
+        splits = item_id.split(":")
+        title = splits[1] if len(splits) > 1 else None
+        playlist = next(
+            (
+                p
+                for p in media_library.get_playlists()
+                if (item_id == p.item_id or title == p.title)
+            ),
+            None,
+        )
+        return playlist
+
     if not item_id.startswith("A:ALBUM") and search_type == SONOS_ALBUM:
         item_id = "A:ALBUMARTIST/" + "/".join(item_id.split("/")[2:])
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -626,13 +626,13 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
                 soco.play_uri(media_id, force_radio=is_radio)
         elif media_type == MediaType.PLAYLIST:
             if media_id.startswith("S:"):
-                item = media_browser.get_media(self.media.library, media_id, media_type)
-                soco.play_uri(item.get_uri())
-                return
-            try:
+                playlist = media_browser.get_media(
+                    self.media.library, media_id, media_type
+                )
+            else:
                 playlists = soco.get_sonos_playlists(complete_result=True)
-                playlist = next(p for p in playlists if p.title == media_id)
-            except StopIteration:
+                playlist = next((p for p in playlists if p.title == media_id), None)
+            if not playlist:
                 _LOGGER.error('Could not find a Sonos playlist named "%s"', media_id)
             else:
                 soco.clear_queue()

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -1,5 +1,13 @@
 """Tests for the Sonos Media Player platform."""
 
+import logging
+
+import pytest
+
+from homeassistant.components.media_player import (
+    DOMAIN as MP_DOMAIN,
+    SERVICE_PLAY_MEDIA,
+)
 from homeassistant.const import STATE_IDLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import (
@@ -7,6 +15,8 @@ from homeassistant.helpers.device_registry import (
     CONNECTION_UPNP,
     DeviceRegistry,
 )
+
+from .conftest import SoCoMockFactory
 
 
 async def test_device_registry(
@@ -53,3 +63,110 @@ async def test_entity_basic(
     assert attributes["friendly_name"] == "Zone A"
     assert attributes["is_volume_muted"] is False
     assert attributes["volume_level"] == 0.19
+
+
+class _MockMusicServiceItem:
+    """Mocks a Soco MusicServiceItem."""
+
+    def __init__(
+        self,
+        title: str,
+        item_id: str,
+        parent_id: str,
+        item_class: str,
+    ) -> None:
+        """Initialize the mock item."""
+        self.title = title
+        self.item_id = item_id
+        self.item_class = item_class
+        self.parent_id = parent_id
+
+    def get_uri(self) -> str:
+        """Return URI."""
+        return self.item_id.replace("S://", "x-file-cifs://")
+
+
+_mock_playlists = [
+    _MockMusicServiceItem(
+        "playlist1",
+        "S://192.168.1.68/music/iTunes/iTunes%20Music%20Library.xml#GUID_1",
+        "A:PLAYLISTS",
+        "object.container.playlistContainer",
+    ),
+    _MockMusicServiceItem(
+        "playlist2",
+        "S://192.168.1.68/music/iTunes/iTunes%20Music%20Library.xml#GUID_2",
+        "A:PLAYLISTS",
+        "object.container.playlistContainer",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("media_content_id", "expected_item_id"),
+    [
+        (
+            _mock_playlists[0].item_id,
+            _mock_playlists[0].item_id,
+        ),
+        (
+            f"S:{_mock_playlists[1].title}",
+            _mock_playlists[1].item_id,
+        ),
+    ],
+)
+async def test_play_media_music_library_playlist(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    discover,
+    media_content_id,
+    expected_item_id,
+) -> None:
+    """Test that playlists can be found by id or title."""
+    soco_mock = soco_factory.mock_list.get("192.168.42.2")
+    soco_mock.music_library.get_playlists.return_value = _mock_playlists
+
+    await hass.services.async_call(
+        MP_DOMAIN,
+        SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.zone_a",
+            "media_content_type": "playlist",
+            "media_content_id": media_content_id,
+        },
+        blocking=True,
+    )
+
+    assert soco_mock.clear_queue.call_count == 1
+    assert soco_mock.add_to_queue.call_count == 1
+    assert soco_mock.add_to_queue.call_args_list[0].args[0].item_id == expected_item_id
+    assert soco_mock.play_from_queue.call_count == 1
+
+
+async def test_play_media_music_library_playlist_dne(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    async_autosetup_sonos,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test error handling when attempting to play a non-existent playlist ."""
+    media_content_id = "S:nonexistent"
+    soco_mock = soco_factory.mock_list.get("192.168.42.2")
+    soco_mock.music_library.get_playlists.return_value = _mock_playlists
+
+    with caplog.at_level(logging.ERROR):
+        caplog.clear()
+        await hass.services.async_call(
+            MP_DOMAIN,
+            SERVICE_PLAY_MEDIA,
+            {
+                "entity_id": "media_player.zone_a",
+                "media_content_type": "playlist",
+                "media_content_id": media_content_id,
+            },
+            blocking=True,
+        )
+    assert soco_mock.play_uri.call_count == 0
+    assert media_content_id in caplog.text
+    assert "playlist" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Users are unable to play imported playlists from a Sonos music library.  The playlists appear in the media browser under the "playlist" category.  Pressing the play button on these may cause an error to be logged.  Additionally users are may be unable to use the play_media service to play an imported playlist.  This fixes both issues.

Example Service Calls

This first one uses the media content id, this is what the media browser passes in to the play_media call.

```
service: media_player.play_media
target:
  entity_id: media_player.porch
data:
  media_content_id: S://10.0.0.1/music/iTunes/iTunes%20Music%20Library.xml#E08E1F02702D121C
  media_content_type: playlist
```

Because the above call requires knowledge of an opaque identifier which I could only discover in the debugger; the service also allow using the "title" which is the name shown in the media browser.

```
service: media_player.play_media
target:
  entity_id: media_player.porch
data:
  media_content_id: S:myplaylist
  media_content_type: playlist
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #84539
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
