### PR TITLE
Use snapshot assertion for `websocket_api` and `api` get service tests

### DIFF
--- a/tests/components/api/snapshots/test_init.ambr
+++ b/tests/components/api/snapshots/test_init.ambr
@@ -1,0 +1,5 @@
+# serializer version: 1
+# name: test_api_get_services
+  list([
+  ])
+# ---

--- a/tests/components/api/test_init.py
+++ b/tests/components/api/test_init.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 from aiohttp import ServerDisconnectedError, web
 from aiohttp.test_utils import TestClient
 import pytest
+from syrupy import SnapshotAssertion
 import voluptuous as vol
 
 from homeassistant import const
@@ -296,17 +297,12 @@ async def test_api_get_event_listeners(
 
 
 async def test_api_get_services(
-    hass: HomeAssistant, mock_api_client: TestClient
+    hass: HomeAssistant, mock_api_client: TestClient, snapshot: SnapshotAssertion
 ) -> None:
     """Test if we can get a dict describing current services."""
     resp = await mock_api_client.get(const.URL_API_SERVICES)
     data = await resp.json()
-    local_services = hass.services.async_services()
-
-    for serv_domain in data:
-        local = local_services.pop(serv_domain["domain"])
-
-        assert serv_domain["services"] == local
+    assert data == snapshot
 
 
 async def test_api_call_service_no_data(

--- a/tests/components/websocket_api/snapshots/test_commands.ambr
+++ b/tests/components/websocket_api/snapshots/test_commands.ambr
@@ -1,0 +1,9 @@
+# serializer version: 1
+# name: test_get_services
+  dict({
+  })
+# ---
+# name: test_get_services.1
+  dict({
+  })
+# ---

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -6,6 +6,7 @@ import logging
 from unittest.mock import ANY, AsyncMock, Mock, patch
 
 import pytest
+from syrupy import SnapshotAssertion
 import voluptuous as vol
 
 from homeassistant import config_entries, loader
@@ -690,7 +691,9 @@ async def test_get_states(
 
 
 async def test_get_services(
-    hass: HomeAssistant, websocket_client: MockHAClientWebSocket
+    hass: HomeAssistant,
+    websocket_client: MockHAClientWebSocket,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test get_services command."""
     for id_ in (5, 6):
@@ -700,7 +703,7 @@ async def test_get_services(
         assert msg["id"] == id_
         assert msg["type"] == const.TYPE_RESULT
         assert msg["success"]
-        assert msg["result"] == hass.services.async_services()
+        assert msg["result"] == snapshot
 
 
 async def test_get_config(


### PR DESCRIPTION
## Proposed change
While doing https://github.com/home-assistant/core/pull/105905 I've found that these tests compare the result of a json decoding with an object representation of the services. This currently works because there are no components loaded during the execution of this test that register a service.

When we do https://github.com/home-assistant/core/pull/105905, we register a service in the http component that is loaded for this test, which causes this test to fail because the result of `json.decode` != the object representation.

This PR therefore suggests the use of snapshot assertions, which we can easily update if necessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
