### PR TITLE
2024.3.3

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.4.0
         with:
-          cosign-release: "v2.0.2"
+          cosign-release: "v2.2.3"
 
       - name: Login to DockerHub
         uses: docker/login-action@v3.0.0

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -26,7 +26,7 @@
   "iot_class": "local_push",
   "loggers": ["axis"],
   "quality_scale": "platinum",
-  "requirements": ["axis==57"],
+  "requirements": ["axis==58"],
   "ssdp": [
     {
       "manufacturer": "AXIS"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -16,7 +16,7 @@ from .helpers.deprecation import (
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 3
-PATCH_VERSION: Final = "2"
+PATCH_VERSION: Final = "3"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.3.2"
+version     = "2024.3.3"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ aurorapy==0.2.7
 # avion==0.10
 
 # homeassistant.components.axis
-axis==57
+axis==58
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.11.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -454,7 +454,7 @@ auroranoaa==0.0.3
 aurorapy==0.2.7
 
 # homeassistant.components.axis
-axis==57
+axis==58
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.11.1


### PR DESCRIPTION
- Update cosign to 2.2.3 ([@frenck] - [#113996]) (dependency)
- Bump axis to v58 ([@Kane610] - [#114008]) ([axis docs]) (dependency)


[#113996]: https://github.com/home-assistant/core/pull/113996
[#114008]: https://github.com/home-assistant/core/pull/114008
[@frenck]: https://github.com/frenck
[@Kane610]: https://github.com/Kane610
[axis docs]: /integrations/axis/

Documentation PR: <https://github.com/home-assistant/home-assistant.io/pull/32004>