### PR TITLE
Fix missing linked device on Overkiz integration

### DIFF
--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -143,7 +143,9 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return temperature.value_as_float
         return None
 

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
@@ -95,7 +95,9 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return cast(float, temperature.value)
 
         return None

--- a/homeassistant/components/overkiz/climate_entities/atlantic_heat_recovery_ventilation.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_heat_recovery_ventilation.py
@@ -69,7 +69,9 @@ class AtlanticHeatRecoveryVentilation(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return cast(float, temperature.value)
 
         return None

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
@@ -108,7 +108,9 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return cast(float, temperature.value)
 
         return None

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
@@ -65,10 +65,15 @@ class AtlanticPassAPCZoneControlZone(AtlanticPassAPCHeatingZone):
         """Return hvac operation ie. heat, cool, dry, off mode."""
 
         if (
-            state := self.zone_control_device.states[
-                OverkizState.IO_PASS_APC_OPERATING_MODE
-            ]
-        ) is not None and (value := state.value_as_str) is not None:
+            self.zone_control_device is not None
+            and (
+                state := self.zone_control_device.states[
+                    OverkizState.IO_PASS_APC_OPERATING_MODE
+                ]
+            )
+            is not None
+            and (value := state.value_as_str) is not None
+        ):
             return OVERKIZ_TO_HVAC_MODE[value]
         return HVACMode.OFF
 

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_zone_control_zone.py
@@ -24,7 +24,7 @@ OVERKIZ_MODE_TO_PRESET_MODES: dict[str, str] = {
 
 PRESET_MODES_TO_OVERKIZ = {v: k for k, v in OVERKIZ_MODE_TO_PRESET_MODES.items()}
 
-TEMPERATURE_ZONECONTROL_DEVICE_INDEX = 1
+TEMPERATURE_ZONECONTROL_DEVICE_INDEX = 20
 
 
 # Those device depends on a main probe that choose the operating mode (heating, cooling, ...)

--- a/homeassistant/components/overkiz/climate_entities/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate_entities/somfy_heating_temperature_interface.py
@@ -166,7 +166,9 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return temperature.value_as_float
         return None
 

--- a/homeassistant/components/overkiz/climate_entities/somfy_thermostat.py
+++ b/homeassistant/components/overkiz/climate_entities/somfy_thermostat.py
@@ -104,7 +104,9 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return cast(float, temperature.value)
         return None
 

--- a/homeassistant/components/overkiz/climate_entities/valve_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate_entities/valve_heating_temperature_interface.py
@@ -91,7 +91,9 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]:
+        if self.temperature_device is not None and (
+            temperature := self.temperature_device.states[OverkizState.CORE_TEMPERATURE]
+        ):
             return temperature.value_as_float
 
         return None

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -43,11 +43,7 @@ class OverkizExecutor:
 
     def linked_device(self, index: int) -> Device | None:
         """Return Overkiz device sharing the same base url."""
-
-        if (device_key := f"{self.base_device_url}#{index}") in self.coordinator.data:
-            return self.coordinator.data[device_key]
-
-        return None
+        return self.coordinator.data.get(f"{self.base_device_url}#{index}")
 
     def select_command(self, *commands: str) -> str | None:
         """Select first existing command in a list of commands."""

--- a/homeassistant/components/overkiz/executor.py
+++ b/homeassistant/components/overkiz/executor.py
@@ -41,9 +41,13 @@ class OverkizExecutor:
         """Return Overkiz device linked to this entity."""
         return self.coordinator.data[self.device_url]
 
-    def linked_device(self, index: int) -> Device:
+    def linked_device(self, index: int) -> Device | None:
         """Return Overkiz device sharing the same base url."""
-        return self.coordinator.data[f"{self.base_device_url}#{index}"]
+
+        if (device_key := f"{self.base_device_url}#{index}") in self.coordinator.data:
+            return self.coordinator.data[device_key]
+
+        return None
 
     def select_command(self, *commands: str) -> str | None:
         """Select first existing command in a list of commands."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometime overkiz devices are not consistent, sometime temperature is on a different device, sometime on the same device, and sometime there is no temperature.

This fix involve a simple check when we find the linked_device, so that it become optional. If there is no found linked device, temperature can not be found.

It fixes the issue #112731, but it's not perfect, because it does not mean devices are supported, just there will not be a fatal error when devices are unsupported.

It's not the purpose of this PR to add support for new devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112731
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
