### PR TITLE
Remove deprecated `hass.components` from frontend tests

### DIFF
--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -16,6 +16,8 @@ from homeassistant.components.frontend import (
     DOMAIN,
     EVENT_PANELS_UPDATED,
     THEMES_STORAGE_KEY,
+    async_register_built_in_panel,
+    async_remove_panel,
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.core import HomeAssistant
@@ -417,8 +419,8 @@ async def test_get_panels(
     resp = await mock_http_client.get("/map")
     assert resp.status == HTTPStatus.NOT_FOUND
 
-    hass.components.frontend.async_register_built_in_panel(
-        "map", "Map", "mdi:tooltip-account", require_admin=True
+    async_register_built_in_panel(
+        hass, "map", "Map", "mdi:tooltip-account", require_admin=True
     )
 
     resp = await mock_http_client.get("/map")
@@ -440,7 +442,7 @@ async def test_get_panels(
     assert msg["result"]["map"]["title"] == "Map"
     assert msg["result"]["map"]["require_admin"] is True
 
-    hass.components.frontend.async_remove_panel("map")
+    async_remove_panel(hass, "map")
 
     resp = await mock_http_client.get("/map")
     assert resp.status == HTTPStatus.NOT_FOUND
@@ -454,12 +456,10 @@ async def test_get_panels_non_admin(
     """Test get_panels command."""
     hass_admin_user.groups = []
 
-    hass.components.frontend.async_register_built_in_panel(
-        "map", "Map", "mdi:tooltip-account", require_admin=True
+    async_register_built_in_panel(
+        hass, "map", "Map", "mdi:tooltip-account", require_admin=True
     )
-    hass.components.frontend.async_register_built_in_panel(
-        "history", "History", "mdi:history"
-    )
+    async_register_built_in_panel(hass, "history", "History", "mdi:history")
 
     await ws_client.send_json({"id": 5, "type": "get_panels"})
 


### PR DESCRIPTION
## Proposed change
Remove the deprecated `hass.components` from frontend tests and import the functions of the components directly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
