### PR TITLE
Remove deprecated `hass.components` from conversation tests and use light setup fixture

### DIFF
--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -22,10 +22,10 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
-from ..light.common import MockLight, SetupLightPlatformCallable
 from . import expose_entity, expose_new
 
 from tests.common import MockConfigEntry, MockUser, async_mock_service
+from tests.components.light.common import MockLight, SetupLightPlatformCallable
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 AGENT_ID_OPTIONS = [None, conversation.HOME_ASSISTANT_AGENT]

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -22,6 +22,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.setup import async_setup_component
 
+from ..light.common import MockLight, SetupLightPlatformCallable
 from . import expose_entity, expose_new
 
 from tests.common import MockConfigEntry, MockUser, async_mock_service
@@ -256,7 +257,7 @@ async def test_http_processing_intent_entity_renamed(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API with entities renamed later.
@@ -264,13 +265,11 @@ async def test_http_processing_intent_entity_renamed(
     We want to ensure that renaming an entity later busts the cache
     so that the new name is used.
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-
-    entity = platform.MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    platform.ENTITIES.append(entity)
+    setup_light_platform(hass, [entity])
+
     assert await async_setup_component(
         hass,
         LIGHT_DOMAIN,
@@ -347,7 +346,7 @@ async def test_http_processing_intent_entity_exposed(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API with manual expose.
@@ -355,13 +354,11 @@ async def test_http_processing_intent_entity_exposed(
     We want to ensure that manually exposing an entity later busts the cache
     so that the new setting is used.
     """
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-
-    entity = platform.MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    platform.ENTITIES.append(entity)
+    setup_light_platform(hass, [entity])
+
     assert await async_setup_component(
         hass,
         LIGHT_DOMAIN,
@@ -452,20 +449,18 @@ async def test_http_processing_intent_conversion_not_expose_new(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API when not exposing new entities."""
     # Disable exposing new entities to the default agent
     expose_new(hass, False)
 
-    platform = getattr(hass.components, "test.light")
-    platform.init(empty=True)
-
-    entity = platform.MockLight("kitchen light", "on")
+    entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    platform.ENTITIES.append(entity)
+    setup_light_platform(hass, [entity])
+
     assert await async_setup_component(
         hass,
         LIGHT_DOMAIN,


### PR DESCRIPTION
## Proposed change
Remove the deprecated `hass.components` from conversation tests and make use of the new light entity component setup fixture

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
