### PR TITLE
Add home battery storage entities for enphase_envoy

### DIFF
--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -89,8 +89,10 @@ async def async_get_config_entry_diagnostics(
         "system_production_phases": envoy_data.system_production_phases,
         "ctmeter_production": envoy_data.ctmeter_production,
         "ctmeter_consumption": envoy_data.ctmeter_consumption,
+        "ctmeter_storage": envoy_data.ctmeter_storage,
         "ctmeter_production_phases": envoy_data.ctmeter_production_phases,
         "ctmeter_consumption_phases": envoy_data.ctmeter_consumption_phases,
+        "ctmeter_storage_phases": envoy_data.ctmeter_storage_phases,
         "dry_contact_status": envoy_data.dry_contact_status,
         "dry_contact_settings": envoy_data.dry_contact_settings,
         "inverters": envoy_data.inverters,
@@ -108,6 +110,7 @@ async def async_get_config_entry_diagnostics(
         "ct_count": envoy.ct_meter_count,
         "ct_consumption_meter": envoy.consumption_meter_type,
         "ct_production_meter": envoy.production_meter_type,
+        "ct_storage_meter": envoy.storage_meter_type,
     }
 
     diagnostic_data: dict[str, Any] = {

--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -364,6 +364,87 @@ CT_PRODUCTION_PHASE_SENSORS = {
     for phase in range(3)
 }
 
+CT_STORAGE_SENSORS = (
+    EnvoyCTSensorEntityDescription(
+        key="lifetime_battery_discharged",
+        translation_key="lifetime_battery_discharged",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+        suggested_display_precision=3,
+        value_fn=lambda ct: ct.energy_delivered,
+        on_phase=None,
+    ),
+    EnvoyCTSensorEntityDescription(
+        key="lifetime_battery_charged",
+        translation_key="lifetime_battery_charged",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        device_class=SensorDeviceClass.ENERGY,
+        suggested_unit_of_measurement=UnitOfEnergy.MEGA_WATT_HOUR,
+        suggested_display_precision=3,
+        value_fn=lambda ct: ct.energy_received,
+        on_phase=None,
+    ),
+    EnvoyCTSensorEntityDescription(
+        key="battery_discharge",
+        translation_key="battery_discharge",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.POWER,
+        suggested_unit_of_measurement=UnitOfPower.KILO_WATT,
+        suggested_display_precision=3,
+        value_fn=lambda ct: ct.active_power,
+        on_phase=None,
+    ),
+    EnvoyCTSensorEntityDescription(
+        key="storage_voltage",
+        translation_key="storage_ct_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        suggested_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        suggested_display_precision=1,
+        entity_registry_enabled_default=False,
+        value_fn=lambda ct: ct.voltage,
+        on_phase=None,
+    ),
+    EnvoyCTSensorEntityDescription(
+        key="storage_ct_metering_status",
+        translation_key="storage_ct_metering_status",
+        device_class=SensorDeviceClass.ENUM,
+        options=list(CtMeterStatus),
+        entity_registry_enabled_default=False,
+        value_fn=lambda ct: ct.metering_status,
+        on_phase=None,
+    ),
+    EnvoyCTSensorEntityDescription(
+        key="storage_ct_status_flags",
+        translation_key="storage_ct_status_flags",
+        state_class=None,
+        entity_registry_enabled_default=False,
+        value_fn=lambda ct: 0 if ct.status_flags is None else len(ct.status_flags),
+        on_phase=None,
+    ),
+)
+
+
+CT_STORAGE_PHASE_SENSORS = {
+    (on_phase := PHASENAMES[phase]): [
+        replace(
+            sensor,
+            key=f"{sensor.key}_l{phase + 1}",
+            translation_key=f"{sensor.translation_key}_phase",
+            entity_registry_enabled_default=False,
+            on_phase=on_phase,
+            translation_placeholders={"phase_name": f"l{phase + 1}"},
+        )
+        for sensor in list(CT_STORAGE_SENSORS)
+    ]
+    for phase in range(3)
+}
+
 
 @dataclass(frozen=True, kw_only=True)
 class EnvoyEnchargeSensorEntityDescription(SensorEntityDescription):
@@ -560,6 +641,21 @@ async def async_setup_entry(
             for description in CT_PRODUCTION_PHASE_SENSORS[use_phase]
             if phase.measurement_type == CtType.PRODUCTION
         )
+    # Add storage CT entities
+    if ctmeter := envoy_data.ctmeter_storage:
+        entities.extend(
+            EnvoyStorageCTEntity(coordinator, description)
+            for description in CT_STORAGE_SENSORS
+            if ctmeter.measurement_type == CtType.STORAGE
+        )
+    # For each storage ct phase reported add storage ct entities
+    if phase_data := envoy_data.ctmeter_storage_phases:
+        entities.extend(
+            EnvoyStorageCTPhaseEntity(coordinator, description)
+            for use_phase, phase in phase_data.items()
+            for description in CT_STORAGE_PHASE_SENSORS[use_phase]
+            if phase.measurement_type == CtType.STORAGE
+        )
 
     if envoy_data.inverters:
         entities.extend(
@@ -752,6 +848,40 @@ class EnvoyProductionCTPhaseEntity(EnvoySystemSensorEntity):
         if TYPE_CHECKING:
             assert self.entity_description.on_phase
         if (ctmeter := self.data.ctmeter_production_phases) is None:
+            return None
+        return self.entity_description.value_fn(
+            ctmeter[self.entity_description.on_phase]
+        )
+
+
+class EnvoyStorageCTEntity(EnvoySystemSensorEntity):
+    """Envoy net storage CT entity."""
+
+    entity_description: EnvoyCTSensorEntityDescription
+
+    @property
+    def native_value(
+        self,
+    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
+        """Return the state of the CT sensor."""
+        if (ctmeter := self.data.ctmeter_storage) is None:
+            return None
+        return self.entity_description.value_fn(ctmeter)
+
+
+class EnvoyStorageCTPhaseEntity(EnvoySystemSensorEntity):
+    """Envoy net storage CT phase entity."""
+
+    entity_description: EnvoyCTSensorEntityDescription
+
+    @property
+    def native_value(
+        self,
+    ) -> int | float | str | CtType | CtMeterStatus | CtStatusFlags | None:
+        """Return the state of the CT phase sensor."""
+        if TYPE_CHECKING:
+            assert self.entity_description.on_phase
+        if (ctmeter := self.data.ctmeter_storage_phases) is None:
             return None
         return self.entity_description.value_fn(
             ctmeter[self.entity_description.on_phase]

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -170,6 +170,24 @@
       "production_ct_status_flags": {
         "name": "Meter status flags active production CT"
       },
+      "lifetime_battery_discharged": {
+        "name": "Lifetime battery energy discharged"
+      },
+      "lifetime_battery_charged": {
+        "name": "Lifetime battery energy charged"
+      },
+      "battery_discharge": {
+        "name": "Current battery discharge"
+      },
+      "storage_ct_voltage": {
+        "name": "Voltage storage CT"
+      },
+      "storage_ct_metering_status": {
+        "name": "Metering status storage CT"
+      },
+      "storage_ct_status_flags": {
+        "name": "Meter status flags active storage CT"
+      },
       "lifetime_net_consumption_phase": {
         "name": "Lifetime net energy consumption {phase_name}"
       },
@@ -196,6 +214,24 @@
       },
       "production_ct_status_flags_phase": {
         "name": "Meter status flags active production CT {phase_name}"
+      },
+      "lifetime_battery_discharged_phase": {
+        "name": "Lifetime battery energy discharged {phase_name}"
+      },
+      "lifetime_battery_charged_phase": {
+        "name": "Lifetime battery energy charged {phase_name}"
+      },
+      "battery_discharge_phase": {
+        "name": "Current battery discharge {phase_name}"
+      },
+      "storage_ct_voltage_phase": {
+        "name": "Voltage storage CT {phase_name}"
+      },
+      "storage_ct_metering_status_phase": {
+        "name": "Metering status storage CT {phase_name}"
+      },
+      "storage_ct_status_flags_phase": {
+        "name": "Meter status flags active storage CT {phase_name}"
       },
       "reserve_soc": {
         "name": "Reserve battery level"

--- a/tests/components/enphase_envoy/conftest.py
+++ b/tests/components/enphase_envoy/conftest.py
@@ -55,15 +55,18 @@ def config_fixture():
 
 
 @pytest.fixture(name="mock_envoy")
-def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup, mock_auth):
+def mock_envoy_fixture(
+    serial_number,
+    mock_authenticate,
+    mock_setup,
+    mock_auth,
+):
     """Define a mocked Envoy fixture."""
     mock_envoy = Mock(spec=Envoy)
     mock_envoy.serial_number = serial_number
     mock_envoy.firmware = "7.1.2"
     mock_envoy.part_number = "123456789"
-    mock_envoy.envoy_model = (
-        "Envoy, phases: 3, phase mode: three, net-consumption CT, production CT"
-    )
+    mock_envoy.envoy_model = "Envoy, phases: 3, phase mode: three, net-consumption CT, production CT, storage CT"
     mock_envoy.authenticate = mock_authenticate
     mock_envoy.setup = mock_setup
     mock_envoy.auth = mock_auth
@@ -78,9 +81,10 @@ def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup, mock_auth):
     mock_envoy.phase_mode = EnvoyPhaseMode.THREE
     mock_envoy.phase_count = 3
     mock_envoy.active_phase_count = 3
-    mock_envoy.ct_meter_count = 2
+    mock_envoy.ct_meter_count = 3
     mock_envoy.consumption_meter_type = CtType.NET_CONSUMPTION
     mock_envoy.production_meter_type = CtType.PRODUCTION
+    mock_envoy.storage_meter_type = CtType.STORAGE
     mock_envoy.data = EnvoyData(
         system_consumption=EnvoySystemConsumption(
             watt_hours_last_7_days=1234,
@@ -164,6 +168,21 @@ def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup, mock_auth):
             frequency=50.2,
             state=CtState.ENABLED,
             measurement_type=CtType.NET_CONSUMPTION,
+            metering_status=CtMeterStatus.NORMAL,
+            status_flags=[],
+        ),
+        ctmeter_storage=EnvoyMeterData(
+            eid="100000030",
+            timestamp=1708006120,
+            energy_delivered=31234,
+            energy_received=32345,
+            active_power=103,
+            power_factor=0.23,
+            voltage=113,
+            current=0.4,
+            frequency=50.3,
+            state=CtState.ENABLED,
+            measurement_type=CtType.STORAGE,
             metering_status=CtMeterStatus.NORMAL,
             status_flags=[],
         ),
@@ -257,6 +276,53 @@ def mock_envoy_fixture(serial_number, mock_authenticate, mock_setup, mock_auth):
                 frequency=50.2,
                 state=CtState.ENABLED,
                 measurement_type=CtType.NET_CONSUMPTION,
+                metering_status=CtMeterStatus.NORMAL,
+                status_flags=[],
+            ),
+        },
+        ctmeter_storage_phases={
+            PhaseNames.PHASE_1: EnvoyMeterData(
+                eid="100000031",
+                timestamp=1708006121,
+                energy_delivered=312341,
+                energy_received=323451,
+                active_power=22,
+                power_factor=0.32,
+                voltage=113,
+                current=0.4,
+                frequency=50.3,
+                state=CtState.ENABLED,
+                measurement_type=CtType.STORAGE,
+                metering_status=CtMeterStatus.NORMAL,
+                status_flags=[],
+            ),
+            PhaseNames.PHASE_2: EnvoyMeterData(
+                eid="100000032",
+                timestamp=1708006122,
+                energy_delivered=312342,
+                energy_received=323452,
+                active_power=33,
+                power_factor=0.23,
+                voltage=112,
+                current=0.3,
+                frequency=50.2,
+                state=CtState.ENABLED,
+                measurement_type=CtType.STORAGE,
+                metering_status=CtMeterStatus.NORMAL,
+                status_flags=[],
+            ),
+            PhaseNames.PHASE_3: EnvoyMeterData(
+                eid="100000033",
+                timestamp=1708006123,
+                energy_delivered=312343,
+                energy_received=323453,
+                active_power=53,
+                power_factor=0.24,
+                voltage=112,
+                current=0.3,
+                frequency=50.2,
+                state=CtState.ENABLED,
+                measurement_type=CtType.STORAGE,
                 metering_status=CtMeterStatus.NORMAL,
                 status_flags=[],
             ),

--- a/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
@@ -45,7 +45,7 @@
           'labels': list([
           ]),
           'manufacturer': 'Enphase',
-          'model': 'Envoy, phases: 3, phase mode: three, net-consumption CT, production CT',
+          'model': 'Envoy, phases: 3, phase mode: three, net-consumption CT, production CT, storage CT',
           'name': 'Envoy <<envoyserial>>',
           'name_by_user': None,
           'serial_number': '<<envoyserial>>',
@@ -3092,6 +3092,965 @@
             }),
             'state': None,
           }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': None,
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_discharged',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor': dict({
+                  'suggested_display_precision': 3,
+                }),
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy discharged',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_discharged',
+              'unique_id': '<<envoyserial>>_lifetime_battery_discharged',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': dict({
+              'attributes': dict({
+                'device_class': 'energy',
+                'friendly_name': 'Envoy <<envoyserial>> Lifetime battery energy discharged',
+                'icon': 'mdi:flash',
+                'state_class': 'total_increasing',
+                'unit_of_measurement': 'MWh',
+              }),
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_discharged',
+              'state': '0.03<<envoyserial>>',
+            }),
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': None,
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_charged',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor': dict({
+                  'suggested_display_precision': 3,
+                }),
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy charged',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_charged',
+              'unique_id': '<<envoyserial>>_lifetime_battery_charged',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': dict({
+              'attributes': dict({
+                'device_class': 'energy',
+                'friendly_name': 'Envoy <<envoyserial>> Lifetime battery energy charged',
+                'icon': 'mdi:flash',
+                'state_class': 'total_increasing',
+                'unit_of_measurement': 'MWh',
+              }),
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_charged',
+              'state': '0.032345',
+            }),
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': None,
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_current_battery_discharge',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor': dict({
+                  'suggested_display_precision': 3,
+                }),
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'kW',
+                }),
+              }),
+              'original_device_class': 'power',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Current battery discharge',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'battery_discharge',
+              'unique_id': '<<envoyserial>>_battery_discharge',
+              'unit_of_measurement': 'kW',
+            }),
+            'state': dict({
+              'attributes': dict({
+                'device_class': 'power',
+                'friendly_name': 'Envoy <<envoyserial>> Current battery discharge',
+                'icon': 'mdi:flash',
+                'state_class': 'measurement',
+                'unit_of_measurement': 'kW',
+              }),
+              'entity_id': 'sensor.envoy_<<envoyserial>>_current_battery_discharge',
+              'state': '0.103',
+            }),
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_voltage_storage_ct',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'V',
+                }),
+              }),
+              'original_device_class': 'voltage',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Voltage storage CT',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_voltage',
+              'unique_id': '<<envoyserial>>_storage_voltage',
+              'unit_of_measurement': 'V',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'options': list([
+                  'normal',
+                  'not-metering',
+                  'check-wiring',
+                ]),
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_metering_status_storage_ct',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': 'enum',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Metering status storage CT',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_metering_status',
+              'unique_id': '<<envoyserial>>_storage_ct_metering_status',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': None,
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_meter_status_flags_active_storage_ct',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': None,
+              'original_icon': 'mdi:flash',
+              'original_name': 'Meter status flags active storage CT',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_status_flags',
+              'unique_id': '<<envoyserial>>_storage_ct_status_flags',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_discharged_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy discharged l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_discharged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_discharged_l1',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_charged_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy charged l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_charged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_charged_l1',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_current_battery_discharge_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'kW',
+                }),
+              }),
+              'original_device_class': 'power',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Current battery discharge l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'battery_discharge_phase',
+              'unique_id': '<<envoyserial>>_battery_discharge_l1',
+              'unit_of_measurement': 'kW',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_voltage_storage_ct_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'V',
+                }),
+              }),
+              'original_device_class': 'voltage',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Voltage storage CT l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_voltage_phase',
+              'unique_id': '<<envoyserial>>_storage_voltage_l1',
+              'unit_of_measurement': 'V',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'options': list([
+                  'normal',
+                  'not-metering',
+                  'check-wiring',
+                ]),
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_metering_status_storage_ct_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': 'enum',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Metering status storage CT l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_metering_status_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_metering_status_l1',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': None,
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_meter_status_flags_active_storage_ct_l1',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': None,
+              'original_icon': 'mdi:flash',
+              'original_name': 'Meter status flags active storage CT l1',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_status_flags_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_status_flags_l1',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_discharged_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy discharged l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_discharged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_discharged_l2',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_charged_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy charged l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_charged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_charged_l2',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_current_battery_discharge_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'kW',
+                }),
+              }),
+              'original_device_class': 'power',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Current battery discharge l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'battery_discharge_phase',
+              'unique_id': '<<envoyserial>>_battery_discharge_l2',
+              'unit_of_measurement': 'kW',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_voltage_storage_ct_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'V',
+                }),
+              }),
+              'original_device_class': 'voltage',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Voltage storage CT l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_voltage_phase',
+              'unique_id': '<<envoyserial>>_storage_voltage_l2',
+              'unit_of_measurement': 'V',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'options': list([
+                  'normal',
+                  'not-metering',
+                  'check-wiring',
+                ]),
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_metering_status_storage_ct_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': 'enum',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Metering status storage CT l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_metering_status_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_metering_status_l2',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': None,
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_meter_status_flags_active_storage_ct_l2',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': None,
+              'original_icon': 'mdi:flash',
+              'original_name': 'Meter status flags active storage CT l2',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_status_flags_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_status_flags_l2',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_discharged_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy discharged l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_discharged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_discharged_l3',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'total_increasing',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_battery_energy_charged_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'MWh',
+                }),
+              }),
+              'original_device_class': 'energy',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Lifetime battery energy charged l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'lifetime_battery_charged_phase',
+              'unique_id': '<<envoyserial>>_lifetime_battery_charged_l3',
+              'unit_of_measurement': 'MWh',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_current_battery_discharge_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'kW',
+                }),
+              }),
+              'original_device_class': 'power',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Current battery discharge l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'battery_discharge_phase',
+              'unique_id': '<<envoyserial>>_battery_discharge_l3',
+              'unit_of_measurement': 'kW',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'state_class': 'measurement',
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_voltage_storage_ct_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+                'sensor.private': dict({
+                  'suggested_unit_of_measurement': 'V',
+                }),
+              }),
+              'original_device_class': 'voltage',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Voltage storage CT l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_voltage_phase',
+              'unique_id': '<<envoyserial>>_storage_voltage_l3',
+              'unit_of_measurement': 'V',
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': dict({
+                'options': list([
+                  'normal',
+                  'not-metering',
+                  'check-wiring',
+                ]),
+              }),
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_metering_status_storage_ct_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': 'enum',
+              'original_icon': 'mdi:flash',
+              'original_name': 'Metering status storage CT l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_metering_status_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_metering_status_l3',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
+          dict({
+            'entity': dict({
+              'aliases': list([
+              ]),
+              'area_id': None,
+              'capabilities': None,
+              'categories': dict({
+              }),
+              'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
+              'device_class': None,
+              'disabled_by': 'integration',
+              'domain': 'sensor',
+              'entity_category': None,
+              'entity_id': 'sensor.envoy_<<envoyserial>>_meter_status_flags_active_storage_ct_l3',
+              'has_entity_name': True,
+              'hidden_by': None,
+              'icon': None,
+              'labels': list([
+              ]),
+              'name': None,
+              'options': dict({
+              }),
+              'original_device_class': None,
+              'original_icon': 'mdi:flash',
+              'original_name': 'Meter status flags active storage CT l3',
+              'platform': 'enphase_envoy',
+              'previous_unique_id': None,
+              'supported_features': 0,
+              'translation_key': 'storage_ct_status_flags_phase',
+              'unique_id': '<<envoyserial>>_storage_ct_status_flags_l3',
+              'unit_of_measurement': None,
+            }),
+            'state': None,
+          }),
         ]),
       }),
       dict({
@@ -3244,6 +4203,24 @@
           'repr': "EnvoyMeterData(eid='100000013', timestamp=1708006113, energy_delivered=112343, energy_received=123453, active_power=50, power_factor=0.14, voltage=111, current=0.2, frequency=50.1, state=<CtState.ENABLED: 'enabled'>, measurement_type=<CtType.PRODUCTION: 'production'>, metering_status=<CtMeterStatus.NORMAL: 'normal'>, status_flags=[])",
         }),
       }),
+      'ctmeter_storage': dict({
+        '__type': "<class 'pyenphase.models.meters.EnvoyMeterData'>",
+        'repr': "EnvoyMeterData(eid='100000030', timestamp=1708006120, energy_delivered=31234, energy_received=32345, active_power=103, power_factor=0.23, voltage=113, current=0.4, frequency=50.3, state=<CtState.ENABLED: 'enabled'>, measurement_type=<CtType.STORAGE: 'storage'>, metering_status=<CtMeterStatus.NORMAL: 'normal'>, status_flags=[])",
+      }),
+      'ctmeter_storage_phases': dict({
+        'L1': dict({
+          '__type': "<class 'pyenphase.models.meters.EnvoyMeterData'>",
+          'repr': "EnvoyMeterData(eid='100000031', timestamp=1708006121, energy_delivered=312341, energy_received=323451, active_power=22, power_factor=0.32, voltage=113, current=0.4, frequency=50.3, state=<CtState.ENABLED: 'enabled'>, measurement_type=<CtType.STORAGE: 'storage'>, metering_status=<CtMeterStatus.NORMAL: 'normal'>, status_flags=[])",
+        }),
+        'L2': dict({
+          '__type': "<class 'pyenphase.models.meters.EnvoyMeterData'>",
+          'repr': "EnvoyMeterData(eid='100000032', timestamp=1708006122, energy_delivered=312342, energy_received=323452, active_power=33, power_factor=0.23, voltage=112, current=0.3, frequency=50.2, state=<CtState.ENABLED: 'enabled'>, measurement_type=<CtType.STORAGE: 'storage'>, metering_status=<CtMeterStatus.NORMAL: 'normal'>, status_flags=[])",
+        }),
+        'L3': dict({
+          '__type': "<class 'pyenphase.models.meters.EnvoyMeterData'>",
+          'repr': "EnvoyMeterData(eid='100000033', timestamp=1708006123, energy_delivered=312343, energy_received=323453, active_power=53, power_factor=0.24, voltage=112, current=0.3, frequency=50.2, state=<CtState.ENABLED: 'enabled'>, measurement_type=<CtType.STORAGE: 'storage'>, metering_status=<CtMeterStatus.NORMAL: 'normal'>, status_flags=[])",
+        }),
+      }),
       'dry_contact_settings': dict({
       }),
       'dry_contact_status': dict({
@@ -3299,10 +4276,11 @@
     'envoy_properties': dict({
       'active_phasecount': 3,
       'ct_consumption_meter': 'net-consumption',
-      'ct_count': 2,
+      'ct_count': 3,
       'ct_production_meter': 'production',
+      'ct_storage_meter': 'storage',
       'envoy_firmware': '7.1.2',
-      'envoy_model': 'Envoy, phases: 3, phase mode: three, net-consumption CT, production CT',
+      'envoy_model': 'Envoy, phases: 3, phase mode: three, net-consumption CT, production CT, storage CT',
       'part_number': '123456789',
       'phase_count': 3,
       'phase_mode': 'three',

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -2499,6 +2499,863 @@
       }),
       'area_id': None,
       'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_discharged',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 3,
+        }),
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy discharged',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_discharged',
+      'unique_id': '1234_lifetime_battery_discharged',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_charged',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 3,
+        }),
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy charged',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_charged',
+      'unique_id': '1234_lifetime_battery_charged',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_current_battery_discharge',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor': dict({
+          'suggested_display_precision': 3,
+        }),
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Current battery discharge',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'battery_discharge',
+      'unique_id': '1234_battery_discharge',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_voltage_storage_ct',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Voltage storage CT',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_voltage',
+      'unique_id': '1234_storage_voltage',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'options': list([
+          <CtMeterStatus.NORMAL: 'normal'>,
+          <CtMeterStatus.NOT_METERING: 'not-metering'>,
+          <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_metering_status_storage_ct',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Metering status storage CT',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_metering_status',
+      'unique_id': '1234_storage_ct_metering_status',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_meter_status_flags_active_storage_ct',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Meter status flags active storage CT',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_status_flags',
+      'unique_id': '1234_storage_ct_status_flags',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_discharged_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy discharged l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_discharged_phase',
+      'unique_id': '1234_lifetime_battery_discharged_l1',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_charged_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy charged l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_charged_phase',
+      'unique_id': '1234_lifetime_battery_charged_l1',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_current_battery_discharge_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Current battery discharge l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'battery_discharge_phase',
+      'unique_id': '1234_battery_discharge_l1',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_voltage_storage_ct_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Voltage storage CT l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_voltage_phase',
+      'unique_id': '1234_storage_voltage_l1',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'options': list([
+          <CtMeterStatus.NORMAL: 'normal'>,
+          <CtMeterStatus.NOT_METERING: 'not-metering'>,
+          <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_metering_status_storage_ct_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Metering status storage CT l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_metering_status_phase',
+      'unique_id': '1234_storage_ct_metering_status_l1',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_meter_status_flags_active_storage_ct_l1',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Meter status flags active storage CT l1',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_status_flags_phase',
+      'unique_id': '1234_storage_ct_status_flags_l1',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_discharged_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy discharged l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_discharged_phase',
+      'unique_id': '1234_lifetime_battery_discharged_l2',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_charged_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy charged l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_charged_phase',
+      'unique_id': '1234_lifetime_battery_charged_l2',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_current_battery_discharge_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Current battery discharge l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'battery_discharge_phase',
+      'unique_id': '1234_battery_discharge_l2',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_voltage_storage_ct_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Voltage storage CT l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_voltage_phase',
+      'unique_id': '1234_storage_voltage_l2',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'options': list([
+          <CtMeterStatus.NORMAL: 'normal'>,
+          <CtMeterStatus.NOT_METERING: 'not-metering'>,
+          <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_metering_status_storage_ct_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Metering status storage CT l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_metering_status_phase',
+      'unique_id': '1234_storage_ct_metering_status_l2',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_meter_status_flags_active_storage_ct_l2',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Meter status flags active storage CT l2',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_status_flags_phase',
+      'unique_id': '1234_storage_ct_status_flags_l2',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_discharged_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy discharged l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_discharged_phase',
+      'unique_id': '1234_lifetime_battery_discharged_l3',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_charged_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.ENERGY: 'energy'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Lifetime battery energy charged l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'lifetime_battery_charged_phase',
+      'unique_id': '1234_lifetime_battery_charged_l3',
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_current_battery_discharge_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.POWER: 'power'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Current battery discharge l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'battery_discharge_phase',
+      'unique_id': '1234_battery_discharge_l3',
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_voltage_storage_ct_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+        'sensor.private': dict({
+          'suggested_unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+        }),
+      }),
+      'original_device_class': <SensorDeviceClass.VOLTAGE: 'voltage'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Voltage storage CT l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_voltage_phase',
+      'unique_id': '1234_storage_voltage_l3',
+      'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
+        'options': list([
+          <CtMeterStatus.NORMAL: 'normal'>,
+          <CtMeterStatus.NOT_METERING: 'not-metering'>,
+          <CtMeterStatus.CHECK_WIRING: 'check-wiring'>,
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_metering_status_storage_ct_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Metering status storage CT l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_metering_status_phase',
+      'unique_id': '1234_storage_ct_metering_status_l3',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
+      'domain': 'sensor',
+      'entity_category': None,
+      'entity_id': 'sensor.envoy_1234_meter_status_flags_active_storage_ct_l3',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': 'mdi:flash',
+      'original_name': 'Meter status flags active storage CT l3',
+      'platform': 'enphase_envoy',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'storage_ct_status_flags_phase',
+      'unique_id': '1234_storage_ct_status_flags_l3',
+      'unit_of_measurement': None,
+    }),
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': dict({
         'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       }),
       'config_entry_id': <ANY>,
@@ -2559,6 +3416,32 @@
       'unit_of_measurement': None,
     }),
   ])
+# ---
+# name: test_sensor[sensor.envoy_1234_current_battery_discharge-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'power',
+      'friendly_name': 'Envoy 1234 Current battery discharge',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_current_battery_discharge',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.103',
+  })
+# ---
+# name: test_sensor[sensor.envoy_1234_current_battery_discharge_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_current_battery_discharge_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_current_battery_discharge_l3-state]
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_net_power_consumption-state]
   StateSnapshot({
@@ -2998,6 +3881,58 @@
 # name: test_sensor[sensor.envoy_1234_frequency_net_consumption_ct_l3-state]
   None
 # ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_charged-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime battery energy charged',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_charged',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.032345',
+  })
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_charged_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_charged_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_charged_l3-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_discharged-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'energy',
+      'friendly_name': 'Envoy 1234 Lifetime battery energy discharged',
+      'icon': 'mdi:flash',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.envoy_1234_lifetime_battery_energy_discharged',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.031234',
+  })
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_discharged_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_discharged_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_lifetime_battery_energy_discharged_l3-state]
+  None
+# ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_consumption-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
@@ -3210,6 +4145,18 @@
 # name: test_sensor[sensor.envoy_1234_meter_status_flags_active_production_ct_l3-state]
   None
 # ---
+# name: test_sensor[sensor.envoy_1234_meter_status_flags_active_storage_ct-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_meter_status_flags_active_storage_ct_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_meter_status_flags_active_storage_ct_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_meter_status_flags_active_storage_ct_l3-state]
+  None
+# ---
 # name: test_sensor[sensor.envoy_1234_metering_status_net_consumption_ct-state]
   None
 # ---
@@ -3237,6 +4184,18 @@
 # name: test_sensor[sensor.envoy_1234_metering_status_production_ct_l3-state]
   None
 # ---
+# name: test_sensor[sensor.envoy_1234_metering_status_storage_ct-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_metering_status_storage_ct_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_metering_status_storage_ct_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_metering_status_storage_ct_l3-state]
+  None
+# ---
 # name: test_sensor[sensor.envoy_1234_voltage_net_consumption_ct-state]
   None
 # ---
@@ -3247,6 +4206,18 @@
   None
 # ---
 # name: test_sensor[sensor.envoy_1234_voltage_net_consumption_ct_l3-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_voltage_storage_ct-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_voltage_storage_ct_l1-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_voltage_storage_ct_l2-state]
+  None
+# ---
+# name: test_sensor[sensor.envoy_1234_voltage_storage_ct_l3-state]
   None
 # ---
 # name: test_sensor[sensor.inverter_1-state]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enphase Envoy / IQ gateway metered supports an optional storage current transformer measuring power to and from a battery trunk (refer to appropriate vendor documentation). When implemented, it provides information on energy charged and discharged and current power flow, very much like the production and consumption CT.

This PR implements 3 new entities when a storage CT is detected:
- Lifetime battery energy discharged (MWh) (can be used with Energy dashboard)
- Lifetime battery energy charged (MWh) (can be used with Energy dashboard)
- Current battery discharge (W)

It also implements disabled by default entities:
- Voltage storage CT (V)
- Metering status storage CT
- Meter status flags active storage CT

If multi-phase CT are detected, phase entities for all these are made available as well, all disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: tbd

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
