### PR TITLE
Add generic test component platform setup function

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1649,13 +1649,10 @@ def extract_stack_to_frame(extract_stack: list[Mock]) -> FrameType:
     return top_frame
 
 
-_EntityT = TypeVar("_EntityT", bound=MockEntity | MockToggleEntity)
-
-
 def setup_test_component_platform(
     hass: HomeAssistant,
     domain: str,
-    entities: list[_EntityT],
+    entities: Sequence[MockEntity | MockToggleEntity],
     from_config_entry: bool = False,
 ) -> MockPlatform:
     """Mock a test component platform for tests."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -79,8 +79,9 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.json import JSONEncoder, _orjson_default_encoder, json_dumps
-from homeassistant.helpers.typing import ConfigType, StateType
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 from homeassistant.setup import setup_component
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as dt_util
@@ -1646,3 +1647,47 @@ def extract_stack_to_frame(extract_stack: list[Mock]) -> FrameType:
         current_frame = next_frame
 
     return top_frame
+
+
+def setup_test_component_platform(
+    hass: HomeAssistant,
+    domain: str,
+    entities: list[MockEntity],
+    from_config_entry: bool = False,
+) -> MockPlatform:
+    """Mock a test component platform for tests."""
+
+    async def _async_setup_platform(
+        hass: HomeAssistant,
+        config: ConfigType,
+        async_add_entities: AddEntitiesCallback,
+        discovery_info: DiscoveryInfoType | None = None,
+    ) -> None:
+        """Set up a test component platform."""
+        async_add_entities(entities)
+
+    platform = MockPlatform(
+        async_setup_platform=_async_setup_platform,
+    )
+
+    # avoid loading config_entry if not needed
+    if from_config_entry:
+        from homeassistant.config_entries import ConfigEntry
+
+        async def _async_setup_entry(
+            hass: HomeAssistant,
+            entry: ConfigEntry,
+            async_add_entities: AddEntitiesCallback,
+        ) -> None:
+            """Set up a test component platform."""
+            async_add_entities(entities)
+
+        platform.async_setup_entry = _async_setup_entry
+        platform.async_setup_platform = None
+
+    mock_platform(
+        hass,
+        f"test.{domain}",
+        platform,
+    )
+    return platform

--- a/tests/common.py
+++ b/tests/common.py
@@ -1649,10 +1649,13 @@ def extract_stack_to_frame(extract_stack: list[Mock]) -> FrameType:
     return top_frame
 
 
+_EntityT = TypeVar("_EntityT", bound=MockEntity | MockToggleEntity)
+
+
 def setup_test_component_platform(
     hass: HomeAssistant,
     domain: str,
-    entities: list[MockEntity],
+    entities: list[_EntityT],
     from_config_entry: bool = False,
 ) -> MockPlatform:
     """Mock a test component platform for tests."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -1653,7 +1653,7 @@ def extract_stack_to_frame(extract_stack: list[Mock]) -> FrameType:
 def setup_test_component_platform(
     hass: HomeAssistant,
     domain: str,
-    entities: list[Entity],
+    entities: Sequence[Entity],
     from_config_entry: bool = False,
 ) -> MockPlatform:
     """Mock a test component platform for tests."""

--- a/tests/common.py
+++ b/tests/common.py
@@ -79,6 +79,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.json import JSONEncoder, _orjson_default_encoder, json_dumps
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
@@ -1652,7 +1653,7 @@ def extract_stack_to_frame(extract_stack: list[Mock]) -> FrameType:
 def setup_test_component_platform(
     hass: HomeAssistant,
     domain: str,
-    entities: Sequence[MockEntity | MockToggleEntity],
+    entities: list[Entity],
     from_config_entry: bool = False,
 ) -> MockPlatform:
     """Mock a test component platform for tests."""

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -139,8 +139,8 @@ SetupEntityPlatformCallable = Callable[
 
 
 @pytest.fixture
-async def setup_entity_platform() -> SetupEntityPlatformCallable:
-    """Mock the entity platform for tests."""
+async def setup_test_component_platform() -> SetupEntityPlatformCallable:
+    """Mock a test component platform for tests."""
 
     def _setup(
         hass: HomeAssistant,
@@ -148,7 +148,7 @@ async def setup_entity_platform() -> SetupEntityPlatformCallable:
         entities: list[MockEntity],
         from_config_entry: bool | None = None,
     ) -> MockPlatform:
-        """Set up entity test platform."""
+        """Set up a test component platform."""
 
         async def _async_setup_platform(
             hass: HomeAssistant,
@@ -156,7 +156,7 @@ async def setup_entity_platform() -> SetupEntityPlatformCallable:
             async_add_entities: AddEntitiesCallback,
             discovery_info: DiscoveryInfoType | None = None,
         ) -> None:
-            """Set up entity test platform."""
+            """Set up a test component platform."""
             async_add_entities(entities)
 
         platform = MockPlatform(
@@ -172,7 +172,7 @@ async def setup_entity_platform() -> SetupEntityPlatformCallable:
                 entry: ConfigEntry,
                 async_add_entities: AddEntitiesCallback,
             ) -> None:
-                """Set up entity test platform."""
+                """Set up a test component platform."""
                 async_add_entities(entities)
 
             platform.async_setup_entry = _async_setup_entry

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -134,16 +134,17 @@ def setup_light_platform() -> "SetupLightPlatformCallable":
 
 
 SetupEntityPlatformCallable = Callable[
-    [HomeAssistant, str, list[MockEntity], bool | None], MockPlatform
+    [str, list[MockEntity], bool | None], MockPlatform
 ]
 
 
 @pytest.fixture
-async def setup_test_component_platform() -> SetupEntityPlatformCallable:
+async def setup_test_component_platform(
+    hass: HomeAssistant,
+) -> SetupEntityPlatformCallable:
     """Mock a test component platform for tests."""
 
     def _setup(
-        hass: HomeAssistant,
         domain: str,
         entities: list[MockEntity],
         from_config_entry: bool | None = None,

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,12 +1,17 @@
 """Fixtures for component testing."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from tests.common import MockEntity, MockPlatform, mock_platform
 
 if TYPE_CHECKING:
     from tests.components.light.common import MockLight, SetupLightPlatformCallable
@@ -126,3 +131,58 @@ def setup_light_platform() -> "SetupLightPlatformCallable":
     from tests.components.light.common import setup_light_platform
 
     return setup_light_platform
+
+
+SetupEntityPlatformCallable = Callable[
+    [HomeAssistant, str, list[MockEntity], bool | None], MockPlatform
+]
+
+
+@pytest.fixture
+async def setup_entity_platform() -> SetupEntityPlatformCallable:
+    """Mock the entity platform for tests."""
+
+    def _setup(
+        hass: HomeAssistant,
+        domain: str,
+        entities: list[MockEntity],
+        from_config_entry: bool | None = None,
+    ) -> MockPlatform:
+        """Set up entity test platform."""
+
+        async def _async_setup_platform(
+            hass: HomeAssistant,
+            config: ConfigType,
+            async_add_entities: AddEntitiesCallback,
+            discovery_info: DiscoveryInfoType | None = None,
+        ) -> None:
+            """Set up entity test platform."""
+            async_add_entities(entities)
+
+        platform = MockPlatform(
+            async_setup_platform=_async_setup_platform,
+        )
+
+        # avoid loading config_entry if not needed
+        if from_config_entry:
+            from homeassistant.config_entries import ConfigEntry
+
+            async def _async_setup_entry(
+                hass: HomeAssistant,
+                entry: ConfigEntry,
+                async_add_entities: AddEntitiesCallback,
+            ) -> None:
+                """Set up entity test platform."""
+                async_add_entities(entities)
+
+            platform.async_setup_entry = _async_setup_entry
+            platform.async_setup_platform = None
+
+        mock_platform(
+            hass,
+            f"test.{domain}",
+            platform,
+        )
+        return platform
+
+    return _setup

--- a/tests/components/flux/test_switch.py
+++ b/tests/components/flux/test_switch.py
@@ -22,8 +22,9 @@ from tests.common import (
     async_fire_time_changed,
     async_mock_service,
     mock_restore_cache,
+    setup_test_component_platform,
 )
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.components.light.common import MockLight
 
 
 @pytest.fixture(autouse=True)
@@ -138,11 +139,10 @@ async def test_invalid_config_no_lights(hass: HomeAssistant) -> None:
 
 async def test_flux_when_switch_is_off(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch when it is off."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -191,11 +191,10 @@ async def test_flux_when_switch_is_off(
 
 async def test_flux_before_sunrise(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -252,11 +251,10 @@ async def test_flux_before_sunrise(
 
 async def test_flux_before_sunrise_known_location(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -312,11 +310,10 @@ async def test_flux_before_sunrise_known_location(
 
 async def test_flux_after_sunrise_before_sunset(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunrise and before sunset."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -372,11 +369,10 @@ async def test_flux_after_sunrise_before_sunset(
 
 async def test_flux_after_sunset_before_stop(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -433,11 +429,10 @@ async def test_flux_after_sunset_before_stop(
 
 async def test_flux_after_stop_before_sunrise(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after stop and before sunrise."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -493,11 +488,10 @@ async def test_flux_after_stop_before_sunrise(
 
 async def test_flux_with_custom_start_stop_times(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop times."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -555,14 +549,13 @@ async def test_flux_with_custom_start_stop_times(
 
 async def test_flux_before_sunrise_stop_next_day(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch before sunrise.
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -619,14 +612,13 @@ async def test_flux_before_sunrise_stop_next_day(
 
 async def test_flux_after_sunrise_before_sunset_stop_next_day(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunrise and before sunset.
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -685,14 +677,13 @@ async def test_flux_after_sunrise_before_sunset_stop_next_day(
 async def test_flux_after_sunset_before_midnight_stop_next_day(
     hass: HomeAssistant,
     x,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -749,14 +740,13 @@ async def test_flux_after_sunset_before_midnight_stop_next_day(
 
 async def test_flux_after_sunset_after_midnight_stop_next_day(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after sunset and before stop.
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -813,14 +803,13 @@ async def test_flux_after_sunset_after_midnight_stop_next_day(
 
 async def test_flux_after_stop_before_sunrise_stop_next_day(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch after stop and before sunrise.
 
     This test has the stop_time on the next day (after midnight).
     """
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -877,11 +866,10 @@ async def test_flux_after_stop_before_sunrise_stop_next_day(
 
 async def test_flux_with_custom_colortemps(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -940,11 +928,10 @@ async def test_flux_with_custom_colortemps(
 
 async def test_flux_with_custom_brightness(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux with custom start and stop colortemps."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1002,11 +989,10 @@ async def test_flux_with_custom_brightness(
 
 async def test_flux_with_multiple_lights(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch with multiple light entities."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1085,11 +1071,10 @@ async def test_flux_with_multiple_lights(
 
 async def test_flux_with_mired(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode mired."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -1144,11 +1129,10 @@ async def test_flux_with_mired(
 
 async def test_flux_with_rgb(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the flux switch´s mode rgb."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}


### PR DESCRIPTION
## Proposed change
Add a generic test component platform setup function instead of creating for each entity component a new fixture.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
