### PR TITLE
Use `setup_test_component_platform` func for number entity component tests instead of `hass.components`

### DIFF
--- a/tests/components/number/common.py
+++ b/tests/components/number/common.py
@@ -1,4 +1,5 @@
 """Common helper and classes for number entity tests."""
+
 from homeassistant.components.number import NumberEntity, RestoreNumber
 
 from tests.common import MockEntity

--- a/tests/components/number/common.py
+++ b/tests/components/number/common.py
@@ -1,15 +1,7 @@
-"""Provide a mock number platform.
-
-Call init before using it in your tests to ensure clean test data.
-"""
-
+"""Common helper and classes for number entity tests."""
 from homeassistant.components.number import NumberEntity, RestoreNumber
 
 from tests.common import MockEntity
-
-UNIQUE_NUMBER = "unique_number"
-
-ENTITIES = []
 
 
 class MockNumberEntity(MockEntity, NumberEntity):
@@ -60,55 +52,3 @@ class MockRestoreNumber(MockNumberEntity, RestoreNumber):
             last_number_data.native_unit_of_measurement
         )
         self._values["native_value"] = last_number_data.native_value
-
-
-class LegacyMockNumberEntity(MockEntity, NumberEntity):
-    """Mock Number class using deprecated features."""
-
-    @property
-    def max_value(self):
-        """Return the native max_value."""
-        return self._handle("max_value")
-
-    @property
-    def min_value(self):
-        """Return the native min_value."""
-        return self._handle("min_value")
-
-    @property
-    def step(self):
-        """Return the native step."""
-        return self._handle("step")
-
-    @property
-    def value(self):
-        """Return the current value."""
-        return self._handle("value")
-
-    def set_value(self, value: float) -> None:
-        """Change the selected option."""
-        self._values["value"] = value
-
-
-def init(empty=False):
-    """Initialize the platform with entities."""
-    global ENTITIES
-
-    ENTITIES = (
-        []
-        if empty
-        else [
-            MockNumberEntity(
-                name="test",
-                unique_id=UNIQUE_NUMBER,
-                native_value=50.0,
-            ),
-        ]
-    )
-
-
-async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
-    """Return mock entities."""
-    async_add_entities_callback(ENTITIES)

--- a/tests/components/number/conftest.py
+++ b/tests/components/number/conftest.py
@@ -1,0 +1,19 @@
+"""Fixtures for the number entity component tests."""
+
+import pytest
+
+from tests.components.number.common import MockNumberEntity
+
+UNIQUE_NUMBER = "unique_number"
+
+
+@pytest.fixture
+def mock_number_entities() -> list[MockNumberEntity]:
+    """Return a list of mock number entities."""
+    return [
+        MockNumberEntity(
+            name="test",
+            unique_id="unique_number",
+            native_value=50.0,
+        ),
+    ]

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -51,8 +51,8 @@ from tests.common import (
     mock_integration,
     mock_platform,
     mock_restore_cache_with_extra_data,
+    setup_test_component_platform,
 )
-from tests.components.conftest import SetupEntityPlatformCallable
 from tests.components.number import common
 
 TEST_DOMAIN = "test"
@@ -336,7 +336,6 @@ async def test_sync_set_value(hass: HomeAssistant) -> None:
 
 async def test_set_value(
     hass: HomeAssistant,
-    setup_test_component_platform: SetupEntityPlatformCallable,
     mock_number_entities: list[MockNumberEntity],
 ) -> None:
     """Test we can only set valid values."""
@@ -455,7 +454,6 @@ async def test_set_value(
 )
 async def test_temperature_conversion(
     hass: HomeAssistant,
-    setup_test_component_platform: SetupEntityPlatformCallable,
     unit_system,
     native_unit,
     state_unit,
@@ -545,7 +543,6 @@ RESTORE_DATA = {
 async def test_restore_number_save_state(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    setup_test_component_platform: SetupEntityPlatformCallable,
 ) -> None:
     """Test RestoreNumber."""
     entity0 = common.MockRestoreNumber(
@@ -613,7 +610,6 @@ async def test_restore_number_save_state(
 async def test_restore_number_restore_state(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    setup_test_component_platform: SetupEntityPlatformCallable,
     native_max_value,
     native_min_value,
     native_step,
@@ -701,7 +697,6 @@ async def test_restore_number_restore_state(
 )
 async def test_custom_unit(
     hass: HomeAssistant,
-    setup_test_component_platform: SetupEntityPlatformCallable,
     device_class,
     native_unit,
     custom_unit,
@@ -778,7 +773,6 @@ async def test_custom_unit(
 )
 async def test_custom_unit_change(
     hass: HomeAssistant,
-    setup_test_component_platform: SetupEntityPlatformCallable,
     native_unit,
     custom_unit,
     used_custom_unit,


### PR DESCRIPTION
## Proposed change
Make use of the generic `setup_test_component_platform` func to setup the number entity component in tests

~needs https://github.com/home-assistant/core/pull/114016~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
