### PR TITLE
Add reconfigure step to holiday

### DIFF
--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -8,7 +8,7 @@ from babel import Locale, UnknownLocaleError
 from holidays import list_supported_countries
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_COUNTRY
 from homeassistant.helpers.selector import (
     CountrySelector,
@@ -27,6 +27,7 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Holiday."""
 
     VERSION = 1
+    config_entry: ConfigEntry | None
 
     def __init__(self) -> None:
         """Initialize the config flow."""
@@ -109,3 +110,54 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
         return self.async_show_form(step_id="province", data_schema=province_schema)
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the re-configuration of a province."""
+        self.config_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_reconfigure_confirm()
+
+    async def async_step_reconfigure_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the re-configuration of a province."""
+        assert self.config_entry
+
+        if user_input is not None:
+            combined_input: dict[str, Any] = {**self.config_entry.data, **user_input}
+
+            country = combined_input[CONF_COUNTRY]
+            province = combined_input.get(CONF_PROVINCE)
+
+            self._async_abort_entries_match(
+                {
+                    CONF_COUNTRY: country,
+                    CONF_PROVINCE: province,
+                }
+            )
+
+            return self.async_update_reload_and_abort(
+                self.config_entry,
+                data=combined_input,
+                reason="reconfigure_successful",
+            )
+
+        province_schema = vol.Schema(
+            {
+                vol.Optional(CONF_PROVINCE): SelectSelector(
+                    SelectSelectorConfig(
+                        options=SUPPORTED_COUNTRIES[
+                            self.config_entry.data[CONF_COUNTRY]
+                        ],
+                        mode=SelectSelectorMode.DROPDOWN,
+                    )
+                )
+            }
+        )
+
+        return self.async_show_form(
+            step_id="reconfigure_confirm", data_schema=province_schema
+        )

--- a/homeassistant/components/holiday/config_flow.py
+++ b/homeassistant/components/holiday/config_flow.py
@@ -139,8 +139,18 @@ class HolidayConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             )
 
+            try:
+                locale = Locale.parse(self.hass.config.language, sep="-")
+            except UnknownLocaleError:
+                # Default to (US) English if language not recognized by babel
+                # Mainly an issue with English flavors such as "en-GB"
+                locale = Locale("en")
+            province_str = f", {province}" if province else ""
+            name = f"{locale.territories[country]}{province_str}"
+
             return self.async_update_reload_and_abort(
                 self.config_entry,
+                title=name,
                 data=combined_input,
                 reason="reconfigure_successful",
             )

--- a/homeassistant/components/holiday/strings.json
+++ b/homeassistant/components/holiday/strings.json
@@ -2,7 +2,8 @@
   "title": "Holiday",
   "config": {
     "abort": {
-      "already_configured": "Already configured. Only a single configuration for country/province combination possible."
+      "already_configured": "Already configured. Only a single configuration for country/province combination possible.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "step": {
       "user": {
@@ -13,6 +14,11 @@
       "province": {
         "data": {
           "province": "Province"
+        }
+      },
+      "reconfigure_confirm": {
+        "data": {
+          "province": "[%key:component::holiday::config::step::province::data::province%]"
         }
       }
     }

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -219,3 +219,36 @@ async def test_form_babel_replace_dash_with_underscore(hass: HomeAssistant) -> N
         "country": "DE",
         "province": "BW",
     }
+
+
+async def test_reconfigure(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
+    """Test reconfigure flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Germany, BW",
+        data={"country": "DE", "province": "BW"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_PROVINCE: "NW",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert entry.title == "Germany, NW"
+    assert entry.data == {"country": "DE", "province": "NW"}

--- a/tests/components/holiday/test_config_flow.py
+++ b/tests/components/holiday/test_config_flow.py
@@ -252,3 +252,44 @@ async def test_reconfigure(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> 
     entry = hass.config_entries.async_get_entry(entry.entry_id)
     assert entry.title == "Germany, NW"
     assert entry.data == {"country": "DE", "province": "NW"}
+
+
+async def test_reconfigure_entry_exists(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock
+) -> None:
+    """Test reconfigure flow stops if other entry already exist."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Germany, BW",
+        data={"country": "DE", "province": "BW"},
+    )
+    entry.add_to_hass(hass)
+    entry2 = MockConfigEntry(
+        domain=DOMAIN,
+        title="Germany, NW",
+        data={"country": "DE", "province": "NW"},
+    )
+    entry2.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": entry.entry_id,
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_PROVINCE: "NW",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    entry = hass.config_entries.async_get_entry(entry.entry_id)
+    assert entry.title == "Germany, BW"
+    assert entry.data == {"country": "DE", "province": "BW"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a reconfigure step to holiday to modify province after setup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
