### PR TITLE
Migrate nut to use aionut

### DIFF
--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             return await data.async_update()
         except NUTError as err:
-            raise UpdateFailed("Error fetching UPS state: {err}") from err
+            raise UpdateFailed(f"Error fetching UPS state: {err}") from err
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING
 
-from aionut import AIONutClient, NUTError
+from aionut import AIONUTClient, NUTError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -218,7 +218,7 @@ class PyNUTData:
         self._host = host
         self._alias = alias
 
-        self._client = AIONutClient(self._host, port, username, password, 5, persistent)
+        self._client = AIONUTClient(self._host, port, username, password, 5, persistent)
         self.ups_list: dict[str, str] | None = None
         self._status: dict[str, str] | None = None
         self._device_info: NUTDeviceInfo | None = None

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -65,8 +65,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     data = PyNUTData(host, port, alias, username, password)
 
     entry.async_on_unload(data.async_shutdown)
-    # Note that async_listen_once is not used here because the listener
-    # could be removed after the event is fired.
 
     async def async_update_data() -> dict[str, str]:
         """Fetch data from NUT."""
@@ -87,6 +85,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
 
+    # Note that async_listen_once is not used here because the listener
+    # could be removed after the event is fired.
     entry.async_on_unload(
         hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, data.async_shutdown)
     )

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -6,9 +6,9 @@ import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
-from typing import cast
+from typing import TYPE_CHECKING
 
-from pynut2.nut2 import PyNUTClient, PyNUTError
+from aionut import AIONutClient, NUTError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -67,7 +67,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def async_update_data() -> dict[str, str]:
         """Fetch data from NUT."""
         async with asyncio.timeout(10):
-            await hass.async_add_executor_job(data.update)
+            await data.async_update()
             if not data.status:
                 raise UpdateFailed("Error fetching UPS state")
             return data.status
@@ -95,7 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if username is not None and password is not None:
         user_available_commands = {
             device_supported_command
-            for device_supported_command in data.list_commands() or {}
+            for device_supported_command in await data.async_list_commands() or {}
             if device_supported_command in INTEGRATION_SUPPORTED_COMMANDS
         }
     else:
@@ -213,15 +213,14 @@ class PyNUTData:
         alias: str | None,
         username: str | None,
         password: str | None,
+        persistent: bool = True,
     ) -> None:
         """Initialize the data object."""
 
         self._host = host
         self._alias = alias
 
-        # Establish client with persistent=False to open/close connection on
-        # each update call.  This is more reliable with async.
-        self._client = PyNUTClient(self._host, port, username, password, 5, False)
+        self._client = AIONutClient(self._host, port, username, password, 5, persistent)
         self.ups_list: dict[str, str] | None = None
         self._status: dict[str, str] | None = None
         self._device_info: NUTDeviceInfo | None = None
@@ -241,11 +240,11 @@ class PyNUTData:
         """Return the device info for the ups."""
         return self._device_info or NUTDeviceInfo()
 
-    def _get_alias(self) -> str | None:
+    async def _async_get_alias(self) -> str | None:
         """Get the ups alias from NUT."""
         try:
-            ups_list: dict[str, str] = self._client.list_ups()
-        except PyNUTError as err:
+            ups_list = await self._client.list_ups()
+        except NUTError as err:
             _LOGGER.error("Failure getting NUT ups alias, %s", err)
             return None
 
@@ -268,42 +267,47 @@ class PyNUTData:
 
         return device_info
 
-    def _get_status(self) -> dict[str, str] | None:
+    async def _async_get_status(self) -> dict[str, str] | None:
         """Get the ups status from NUT."""
         if self._alias is None:
-            self._alias = self._get_alias()
+            self._alias = await self._async_get_alias()
+
+        if TYPE_CHECKING:
+            assert self._alias is not None
 
         try:
-            status: dict[str, str] = self._client.list_vars(self._alias)
-        except (PyNUTError, ConnectionResetError) as err:
+            status: dict[str, str] = await self._client.list_vars(self._alias)
+        except (NUTError, ConnectionResetError) as err:
             _LOGGER.debug("Error getting NUT vars for host %s: %s", self._host, err)
             return None
 
         return status
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Fetch the latest status from NUT."""
-        self._status = self._get_status()
+        self._status = await self._async_get_status()
         if self._device_info is None:
             self._device_info = self._get_device_info()
 
-    async def async_run_command(
-        self, hass: HomeAssistant, command_name: str | None
-    ) -> None:
+    async def async_run_command(self, command_name: str) -> None:
         """Invoke instant command in UPS."""
+        if TYPE_CHECKING:
+            assert self._alias is not None
+
         try:
-            await hass.async_add_executor_job(
-                self._client.run_command, self._alias, command_name
-            )
-        except PyNUTError as err:
+            await self._client.run_command(self._alias, command_name)
+        except NUTError as err:
             raise HomeAssistantError(
                 f"Error running command {command_name}, {err}"
             ) from err
 
-    def list_commands(self) -> dict[str, str] | None:
+    async def async_list_commands(self) -> set[str] | None:
         """Fetch the list of supported commands."""
+        if TYPE_CHECKING:
+            assert self._alias is not None
+
         try:
-            return cast(dict[str, str], self._client.list_commands(self._alias))
-        except PyNUTError as err:
+            return await self._client.list_commands(self._alias)
+        except NUTError as err:
             _LOGGER.error("Error retrieving supported commands %s", err)
             return None

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -74,6 +74,9 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     except NUTError as err:
         raise CannotConnect(str(err)) from err
 
+    if not alias and not nut_data.ups_list:
+        raise CannotConnect("No UPSes found on the NUT server")
+
     return {"ups_list": nut_data.ups_list, "available_resources": status}
 
 

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -68,7 +68,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     password = data.get(CONF_PASSWORD)
 
     nut_data = PyNUTData(host, port, alias, username, password)
-    await hass.async_add_executor_job(nut_data.update)
+    await nut_data.async_update()
     if not (status := nut_data.status):
         raise CannotConnect
 

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any
 
+from aionut import NUTError
 import voluptuous as vol
 
 from homeassistant.components import zeroconf
@@ -67,10 +68,11 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     username = data.get(CONF_USERNAME)
     password = data.get(CONF_PASSWORD)
 
-    nut_data = PyNUTData(host, port, alias, username, password)
-    await nut_data.async_update()
-    if not (status := nut_data.status):
-        raise CannotConnect
+    nut_data = PyNUTData(host, port, alias, username, password, persistent=False)
+    try:
+        status = await nut_data.async_update()
+    except NUTError as err:
+        raise CannotConnect(str(err)) from err
 
     return {"ups_list": nut_data.ups_list, "available_resources": status}
 

--- a/homeassistant/components/nut/device_action.py
+++ b/homeassistant/components/nut/device_action.py
@@ -58,7 +58,7 @@ async def async_call_action_from_config(
     device_id: str = config[CONF_DEVICE_ID]
     entry_id = _get_entry_id_from_device_id(hass, device_id)
     data: PyNUTData = hass.data[DOMAIN][entry_id][PYNUT_DATA]
-    await data.async_run_command(hass, command_name)
+    await data.async_run_command(command_name)
 
 
 def _get_device_action_name(command_name: str) -> str:

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/nut",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "loggers": ["pynut2"],
-  "requirements": ["pynut2==2.1.2"],
+  "loggers": ["aionut"],
+  "requirements": ["aionut==0.1.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==3.0.0"],
+  "requirements": ["aionut==4.0.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==1.0.0"],
+  "requirements": ["aionut==1.2.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==0.1.0"],
+  "requirements": ["aionut==1.0.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==1.2.0"],
+  "requirements": ["aionut==1.2.1"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==1.3.0"],
+  "requirements": ["aionut==3.0.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/homeassistant/components/nut/manifest.json
+++ b/homeassistant/components/nut/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["aionut"],
-  "requirements": ["aionut==1.2.1"],
+  "requirements": ["aionut==1.3.0"],
   "zeroconf": ["_nut._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.0.0
+aionut==1.2.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -314,6 +314,9 @@ aionanoleaf==0.2.1
 # homeassistant.components.notion
 aionotion==2024.03.0
 
+# homeassistant.components.nut
+aionut==0.1.0
+
 # homeassistant.components.oncue
 aiooncue==0.3.7
 
@@ -1986,9 +1989,6 @@ pynobo==1.6.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3
-
-# homeassistant.components.nut
-pynut2==2.1.2
 
 # homeassistant.components.nws
 pynws==1.6.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.2.1
+aionut==1.3.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.3.0
+aionut==3.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.2.0
+aionut==1.2.1
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==3.0.0
+aionut==4.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -315,7 +315,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==0.1.0
+aionut==1.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.2.1
+aionut==1.3.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==3.0.0
+aionut==4.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -287,6 +287,9 @@ aionanoleaf==0.2.1
 # homeassistant.components.notion
 aionotion==2024.03.0
 
+# homeassistant.components.nut
+aionut==0.1.0
+
 # homeassistant.components.oncue
 aiooncue==0.3.7
 
@@ -1540,9 +1543,6 @@ pynobo==1.6.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3
-
-# homeassistant.components.nut
-pynut2==2.1.2
 
 # homeassistant.components.nws
 pynws==1.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.2.0
+aionut==1.2.1
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.0.0
+aionut==1.2.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==0.1.0
+aionut==1.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -288,7 +288,7 @@ aionanoleaf==0.2.1
 aionotion==2024.03.0
 
 # homeassistant.components.nut
-aionut==1.3.0
+aionut==3.0.0
 
 # homeassistant.components.oncue
 aiooncue==0.3.7

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -56,7 +56,7 @@ async def test_form_zeroconf(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -94,7 +94,7 @@ async def test_form_user_one_ups(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -144,7 +144,7 @@ async def test_form_user_multiple_ups(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -161,7 +161,7 @@ async def test_form_user_multiple_ups(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -204,7 +204,7 @@ async def test_form_user_one_ups_with_ignored_entry(hass: HomeAssistant) -> None
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -241,7 +241,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     mock_pynut = _get_mock_nutclient()
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -258,10 +258,10 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
-        "homeassistant.components.nut.AIONutClient.list_ups",
+        "homeassistant.components.nut.AIONUTClient.list_ups",
         side_effect=NUTError,
     ), patch(
-        "homeassistant.components.nut.AIONutClient.list_vars",
+        "homeassistant.components.nut.AIONUTClient.list_vars",
         side_effect=NUTError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -278,10 +278,10 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
-        "homeassistant.components.nut.AIONutClient.list_ups",
+        "homeassistant.components.nut.AIONUTClient.list_ups",
         return_value={"ups1"},
     ), patch(
-        "homeassistant.components.nut.AIONutClient.list_vars",
+        "homeassistant.components.nut.AIONUTClient.list_vars",
         side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -320,7 +320,7 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -358,7 +358,7 @@ async def test_abort_if_already_setup_alias(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -373,7 +373,7 @@ async def test_abort_if_already_setup_alias(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/nut/test_config_flow.py
+++ b/tests/components/nut/test_config_flow.py
@@ -3,7 +3,7 @@
 from ipaddress import ip_address
 from unittest.mock import patch
 
-from pynut2.nut2 import PyNUTError
+from aionut import NUTError
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components import zeroconf
@@ -20,7 +20,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from .util import _get_mock_pynutclient
+from .util import _get_mock_nutclient
 
 from tests.common import MockConfigEntry
 
@@ -51,12 +51,12 @@ async def test_form_zeroconf(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
     assert result["errors"] == {}
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage", "ups.status": "OL"}, list_ups=["ups1"]
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -89,12 +89,12 @@ async def test_form_user_one_ups(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage", "ups.status": "OL"}, list_ups=["ups1"]
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -138,13 +138,13 @@ async def test_form_user_multiple_ups(hass: HomeAssistant) -> None:
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage"},
         list_ups={"ups1": "UPS 1", "ups2": "UPS2"},
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -161,7 +161,7 @@ async def test_form_user_multiple_ups(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -199,12 +199,12 @@ async def test_form_user_one_ups_with_ignored_entry(hass: HomeAssistant) -> None
     assert result["type"] == data_entry_flow.FlowResultType.FORM
     assert result["errors"] == {}
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage", "ups.status": "OL"}, list_ups=["ups1"]
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ), patch(
         "homeassistant.components.nut.async_setup_entry",
@@ -238,10 +238,10 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_pynut = _get_mock_pynutclient()
+    mock_pynut = _get_mock_nutclient()
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -258,11 +258,11 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient.list_ups",
-        side_effect=PyNUTError,
+        "homeassistant.components.nut.AIONutClient.list_ups",
+        side_effect=NUTError,
     ), patch(
-        "homeassistant.components.nut.PyNUTClient.list_vars",
-        side_effect=PyNUTError,
+        "homeassistant.components.nut.AIONutClient.list_vars",
+        side_effect=NUTError,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -278,11 +278,11 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "cannot_connect"}
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient.list_ups",
-        return_value=["ups1"],
+        "homeassistant.components.nut.AIONutClient.list_ups",
+        return_value={"ups1"},
     ), patch(
-        "homeassistant.components.nut.PyNUTClient.list_vars",
-        side_effect=TypeError,
+        "homeassistant.components.nut.AIONutClient.list_vars",
+        side_effect=Exception,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -314,13 +314,13 @@ async def test_abort_if_already_setup(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage"},
         list_ups={"ups1": "UPS 1"},
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -352,13 +352,13 @@ async def test_abort_if_already_setup_alias(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_vars={"battery.voltage": "voltage"},
         list_ups={"ups1": "UPS 1", "ups2": "UPS 2"},
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         result2 = await hass.config_entries.flow.async_configure(
@@ -373,7 +373,7 @@ async def test_abort_if_already_setup_alias(hass: HomeAssistant) -> None:
     assert result2["type"] == data_entry_flow.FlowResultType.FORM
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         result3 = await hass.config_entries.flow.async_configure(

--- a/tests/components/nut/test_device_action.py
+++ b/tests/components/nut/test_device_action.py
@@ -1,8 +1,8 @@
 """The tests for Network UPS Tools (NUT) device actions."""
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
-from pynut2.nut2 import PyNUTError
+from aionut import NUTError
 import pytest
 from pytest_unordered import unordered
 
@@ -99,7 +99,7 @@ async def test_list_commands_exception(
 ) -> None:
     """Test there are no actions if list_commands raises exception."""
     await async_init_integration(
-        hass, list_vars={"ups.status": "OL"}, list_commands_side_effect=PyNUTError
+        hass, list_vars={"ups.status": "OL"}, list_commands_side_effect=NUTError
     )
 
     device_entry = next(device for device in device_registry.devices.values())
@@ -137,7 +137,7 @@ async def test_action(hass: HomeAssistant, device_registry: dr.DeviceRegistry) -
         "beeper.enable": None,
         "beeper.disable": None,
     }
-    run_command = MagicMock()
+    run_command = AsyncMock()
     await async_init_integration(
         hass,
         list_ups={"someUps": "Some UPS"},
@@ -196,7 +196,7 @@ async def test_rund_command_exception(
 
     list_commands_return_value = {"beeper.enable": None}
     error_message = "Something wrong happened"
-    run_command = MagicMock(side_effect=PyNUTError(error_message))
+    run_command = AsyncMock(side_effect=NUTError(error_message))
     await async_init_integration(
         hass,
         list_vars={"ups.status": "OL"},

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -2,12 +2,14 @@
 
 from unittest.mock import patch
 
+from aionut import NUTError
+
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
-from .util import _get_mock_pynutclient
+from .util import _get_mock_nutclient
 
 from tests.common import MockConfigEntry
 
@@ -20,12 +22,12 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_ups={"ups1": "UPS 1"}, list_vars={"ups.status": "OL"}
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -55,11 +57,11 @@ async def test_config_not_ready(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient.list_ups",
-        return_value=["ups1"],
+        "homeassistant.components.nut.AIONutClient.list_ups",
+        return_value={"ups1"},
     ), patch(
-        "homeassistant.components.nut.PyNUTClient.list_vars",
-        side_effect=ConnectionResetError,
+        "homeassistant.components.nut.AIONutClient.list_vars",
+        side_effect=NUTError,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/nut/test_init.py
+++ b/tests/components/nut/test_init.py
@@ -27,7 +27,7 @@ async def test_async_setup_entry(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -57,10 +57,10 @@ async def test_config_not_ready(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.nut.AIONutClient.list_ups",
+        "homeassistant.components.nut.AIONUTClient.list_ups",
         return_value={"ups1"},
     ), patch(
-        "homeassistant.components.nut.AIONutClient.list_vars",
+        "homeassistant.components.nut.AIONUTClient.list_vars",
         side_effect=NUTError,
     ):
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -105,7 +105,7 @@ async def test_state_sensors(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -130,7 +130,7 @@ async def test_unknown_state_sensors(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -160,7 +160,7 @@ async def test_stale_options(hass: HomeAssistant) -> None:
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .util import _get_mock_pynutclient, async_init_integration
+from .util import _get_mock_nutclient, async_init_integration
 
 from tests.common import MockConfigEntry
 
@@ -100,12 +100,12 @@ async def test_state_sensors(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_ups={"ups1": "UPS 1"}, list_vars={"ups.status": "OL"}
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -125,12 +125,12 @@ async def test_unknown_state_sensors(hass: HomeAssistant) -> None:
     )
     entry.add_to_hass(hass)
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_ups={"ups1": "UPS 1"}, list_vars={"ups.status": "OQ"}
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -155,12 +155,12 @@ async def test_stale_options(hass: HomeAssistant) -> None:
     )
     config_entry.add_to_hass(hass)
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_ups={"ups1": "UPS 1"}, list_vars={"battery.charge": "10"}
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/nut/util.py
+++ b/tests/components/nut/util.py
@@ -1,7 +1,7 @@
 """Tests for the nut integration."""
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant.components.nut.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
@@ -10,25 +10,25 @@ from homeassistant.core import HomeAssistant
 from tests.common import MockConfigEntry, load_fixture
 
 
-def _get_mock_pynutclient(
+def _get_mock_nutclient(
     list_vars=None,
     list_ups=None,
     list_commands_return_value=None,
     list_commands_side_effect=None,
     run_command=None,
 ):
-    pynutclient = MagicMock()
-    type(pynutclient).list_ups = MagicMock(return_value=list_ups)
-    type(pynutclient).list_vars = MagicMock(return_value=list_vars)
+    nutclient = MagicMock()
+    type(nutclient).list_ups = AsyncMock(return_value=list_ups)
+    type(nutclient).list_vars = AsyncMock(return_value=list_vars)
     if list_commands_return_value is None:
         list_commands_return_value = {}
-    type(pynutclient).list_commands = MagicMock(
+    type(nutclient).list_commands = AsyncMock(
         return_value=list_commands_return_value, side_effect=list_commands_side_effect
     )
     if run_command is None:
-        run_command = MagicMock()
-    type(pynutclient).run_command = run_command
-    return pynutclient
+        run_command = AsyncMock()
+    type(nutclient).run_command = run_command
+    return nutclient
 
 
 async def async_init_integration(
@@ -52,7 +52,7 @@ async def async_init_integration(
         if list_vars is None:
             list_vars = json.loads(load_fixture(ups_fixture))
 
-    mock_pynut = _get_mock_pynutclient(
+    mock_pynut = _get_mock_nutclient(
         list_ups=list_ups,
         list_vars=list_vars,
         list_commands_return_value=list_commands_return_value,
@@ -61,7 +61,7 @@ async def async_init_integration(
     )
 
     with patch(
-        "homeassistant.components.nut.PyNUTClient",
+        "homeassistant.components.nut.AIONutClient",
         return_value=mock_pynut,
     ):
         entry = MockConfigEntry(

--- a/tests/components/nut/util.py
+++ b/tests/components/nut/util.py
@@ -61,7 +61,7 @@ async def async_init_integration(
     )
 
     with patch(
-        "homeassistant.components.nut.AIONutClient",
+        "homeassistant.components.nut.AIONUTClient",
         return_value=mock_pynut,
     ):
         entry = MockConfigEntry(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The sync lib will stop working in py3.13 because of [PEP0594](https://peps.python.org/pep-0594/#telnetlib)
https://github.com/bdraco/aionut

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr



TODO:
- [x] handle timeout in the lib and remove timeout code in HA
- [x] handle connection drop in the lib
