### PR TITLE
Speed up checking exposed entities when setting up conversation

### DIFF
--- a/homeassistant/helpers/intent.py
+++ b/homeassistant/helpers/intent.py
@@ -14,7 +14,9 @@ from typing import Any, TypeVar
 
 import voluptuous as vol
 
-from homeassistant.components.homeassistant.exposed_entities import async_should_expose
+from homeassistant.components.homeassistant.exposed_entities import (
+    async_should_expose_entities,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -311,10 +313,13 @@ def async_match_states(
 
     if assistant is not None:
         # Filter by exposure
+        to_expose = async_should_expose_entities(
+            hass, assistant, (state.entity_id for state, _ in states_and_entities)
+        )
         states_and_entities = [
             (state, entity)
             for state, entity in states_and_entities
-            if async_should_expose(hass, assistant, state.entity_id)
+            if state.entity_id in to_expose
         ]
 
     if name is not None:

--- a/tests/components/conversation/conftest.py
+++ b/tests/components/conversation/conftest.py
@@ -7,6 +7,8 @@ import pytest
 from homeassistant.components import conversation
 from homeassistant.components.shopping_list import intent as sl_intent
 from homeassistant.const import MATCH_ALL
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 from . import MockAgent
 
@@ -52,3 +54,12 @@ async def sl_setup(hass):
     assert await hass.config_entries.async_setup(entry.entry_id)
 
     await sl_intent.async_setup_intents(hass)
+
+
+@pytest.fixture
+async def init_components(hass: HomeAssistant):
+    """Initialize relevant components with empty configs."""
+    assert await async_setup_component(hass, "homeassistant", {})
+    assert await async_setup_component(hass, "conversation", {})
+    assert await async_setup_component(hass, "intent", {})
+    await hass.async_block_till_done()

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -656,14 +656,11 @@ async def test_custom_agent(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
+    init_components,
     mock_agent,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test a custom conversation agent."""
-    assert await async_setup_component(hass, "homeassistant", {})
-    assert await async_setup_component(hass, "conversation", {})
-    assert await async_setup_component(hass, "intent", {})
-
     client = await hass_client()
 
     data = {
@@ -1059,7 +1056,9 @@ async def test_light_area_same_name(
     assert call.data == {"entity_id": [kitchen_light.entity_id]}
 
 
-async def test_agent_id_validator_invalid_agent(hass: HomeAssistant) -> None:
+async def test_agent_id_validator_invalid_agent(
+    hass: HomeAssistant, init_components
+) -> None:
     """Test validating agent id."""
     with pytest.raises(vol.Invalid):
         conversation.agent_id_validator("invalid_agent")

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -12,6 +12,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
     async_get_entity_settings,
     async_listen_entity_updates,
     async_should_expose,
+    async_should_expose_entities,
 )
 from homeassistant.const import CLOUD_NEVER_EXPOSED_ENTITIES, EntityCategory
 from homeassistant.core import HomeAssistant
@@ -351,10 +352,14 @@ async def test_listen_updates(
     # Settings not changed - listener not called
     async_expose_entity(hass, "cloud.alexa", entry.entity_id, True)
     assert len(calls) == 1
+    assert async_should_expose_entities(hass, "cloud.alexa", [entry.entity_id]) == {
+        entry.entity_id
+    }
 
     # Settings changed - listener called
     async_expose_entity(hass, "cloud.alexa", entry.entity_id, False)
     assert len(calls) == 2
+    assert async_should_expose_entities(hass, "cloud.alexa", [entry.entity_id]) == set()
 
 
 async def test_get_assistant_settings(
@@ -431,6 +436,19 @@ async def test_should_expose(
     assert (
         async_should_expose(hass, "cloud.alexa", entities["temperature_sensor"]) is True
     )
+
+    assert async_should_expose_entities(
+        hass,
+        "cloud.alexa",
+        [
+            entities["blocked"],
+            entities["lock"],
+            entities["binary_sensor"],
+            entities["door_sensor"],
+            entities["sensor"],
+            entities["temperature_sensor"],
+        ],
+    ) == {entities["lock"], entities["door_sensor"], entities["temperature_sensor"]}
 
     # Check with a different assistant
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Speed up checking exposed entities when setting up conversation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
