### PR TITLE
Optimize loading of translations

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -734,7 +734,7 @@ async def _async_resolve_domains_to_setup(
         *chain.from_iterable(platform_integrations.values()),
     }
 
-    translations_to_load = {*domains_to_setup, *additional_manifests_to_load}
+    translations_to_load = additional_manifests_to_load.copy()
 
     # Resolve all dependencies so we know all integrations
     # that will have to be loaded and start right-away
@@ -818,6 +818,12 @@ async def _async_resolve_domains_to_setup(
         "check installed requirements",
         eager_start=True,
     )
+
+    #
+    # Only add the domains_to_setup after we finish resolving
+    # as new domains are likely to added in the process
+    #
+    translations_to_load.update(domains_to_setup)
     # Start loading translations for all integrations we are going to set up
     # in the background so they are ready when we need them. This avoids a
     # lot of waiting for the translation load lock and a thundering herd of

--- a/homeassistant/components/flux_led/discovery.py
+++ b/homeassistant/components/flux_led/discovery.py
@@ -29,6 +29,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_MODEL, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, discovery_flow
+from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.network import is_ip_address
 
 from .const import (
@@ -185,7 +186,7 @@ async def async_discover_devices(
     for idx, discovered in enumerate(
         await asyncio.gather(
             *[
-                scanner.async_scan(timeout=timeout, address=address)
+                create_eager_task(scanner.async_scan(timeout=timeout, address=address))
                 for address in targets
             ],
             return_exceptions=True,

--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -10,7 +10,7 @@ from discovery30303 import Device30303, normalize_mac
 import voluptuous as vol
 
 from homeassistant.components import dhcp
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigEntryState, ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_MODEL, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -72,7 +72,10 @@ class SteamistConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id == mac or entry.data[CONF_HOST] == host:
-                if async_update_entry_from_discovery(self.hass, entry, device):
+                if (
+                    async_update_entry_from_discovery(self.hass, entry, device)
+                    and entry.state is ConfigEntryState.LOADED
+                ):
                     self.hass.async_create_task(
                         self.hass.config_entries.async_reload(entry.entry_id)
                     )

--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -72,9 +72,12 @@ class SteamistConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id == mac or entry.data[CONF_HOST] == host:
-                if (
-                    async_update_entry_from_discovery(self.hass, entry, device)
-                    and entry.state is ConfigEntryState.LOADED
+                if async_update_entry_from_discovery(
+                    self.hass, entry, device
+                ) and entry.state in (
+                    ConfigEntryState.LOADED,
+                    ConfigEntryState.SETUP_RETRY,
+                    ConfigEntryState.NOT_LOADED,
                 ):
                     self.hass.async_create_task(
                         self.hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/steamist/config_flow.py
+++ b/homeassistant/components/steamist/config_flow.py
@@ -72,16 +72,11 @@ class SteamistConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(mac)
         for entry in self._async_current_entries(include_ignore=False):
             if entry.unique_id == mac or entry.data[CONF_HOST] == host:
-                if async_update_entry_from_discovery(
-                    self.hass, entry, device
-                ) and entry.state in (
-                    ConfigEntryState.LOADED,
-                    ConfigEntryState.SETUP_RETRY,
-                    ConfigEntryState.NOT_LOADED,
+                if (
+                    async_update_entry_from_discovery(self.hass, entry, device)
+                    and entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
                 ):
-                    self.hass.async_create_task(
-                        self.hass.config_entries.async_reload(entry.entry_id)
-                    )
+                    self.hass.config_entries.async_schedule_reload(entry.entry_id)
                 return self.async_abort(reason="already_configured")
         self.context[CONF_HOST] = host
         for progress in self._async_in_progress():

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -298,8 +298,6 @@ async def _async_setup_component(  # noqa: C901
         load_translations_task = create_eager_task(
             translation.async_load_integrations(hass, integration_set)
         )
-
-    _LOGGER.debug("Resolve deps %s", domain)
     # Validate all dependencies exist and there are no circular dependencies
     if not await integration.resolve_dependencies():
         return False

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -285,6 +285,21 @@ async def _async_setup_component(  # noqa: C901
         log_error(f"Dependency is disabled - {integration.disabled}")
         return False
 
+    integration_set = {domain}
+
+    load_translations_task: asyncio.Task[None] | None = None
+    if integration.has_translations and not translation.async_translations_loaded(
+        hass, integration_set
+    ):
+        # For most cases we expect the translations are already
+        # loaded since we try to load them in bootstrap ahead of time.
+        # If for some reason the background task in bootstrap was too slow
+        # or the integration was added after bootstrap, we will load them here.
+        load_translations_task = create_eager_task(
+            translation.async_load_integrations(hass, integration_set)
+        )
+
+    _LOGGER.debug("Resolve deps %s", domain)
     # Validate all dependencies exist and there are no circular dependencies
     if not await integration.resolve_dependencies():
         return False
@@ -351,17 +366,6 @@ async def _async_setup_component(  # noqa: C901
         )
 
     _LOGGER.info("Setting up %s", domain)
-    integration_set = {domain}
-
-    load_translations_task: asyncio.Task[None] | None = None
-    if not translation.async_translations_loaded(hass, integration_set):
-        # For most cases we expect the translations are already
-        # loaded since we try to load them in bootstrap ahead of time.
-        # If for some reason the background task in bootstrap was too slow
-        # or the integration was added after bootstrap, we will load them here.
-        load_translations_task = create_eager_task(
-            translation.async_load_integrations(hass, integration_set)
-        )
 
     with async_start_setup(hass, integration=domain, phase=SetupPhases.SETUP):
         if hasattr(component, "PLATFORM_SCHEMA"):

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -234,6 +234,8 @@ async def test_discover_platform(
 ) -> None:
     """Test discovery of device_tracker demo platform."""
     await async_setup_component(hass, "homeassistant", {})
+    await async_setup_component(hass, device_tracker.DOMAIN, {})
+    await hass.async_block_till_done()
     with patch("homeassistant.components.device_tracker.legacy.update_config"):
         await discovery.async_load_platform(
             hass, device_tracker.DOMAIN, "demo", {"test_key": "test_val"}, {"bla": {}}
@@ -337,6 +339,7 @@ async def test_see_service(
     """Test the see service with a unicode dev_id and NO MAC."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
     params = {
         "dev_id": "some_device",
         "host_name": "example.com",
@@ -372,6 +375,7 @@ async def test_see_service_guard_config_entry(
     mock_registry(hass, {entity_id: mock_entry})
     devices = mock_device_tracker_conf
     assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+    await hass.async_block_till_done()
     params = {"dev_id": dev_id, "gps": [0.3, 0.8]}
 
     common.async_see(hass, **params)
@@ -388,6 +392,7 @@ async def test_new_device_event_fired(
     """Test that the device tracker will fire an event."""
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
     test_events = []
 
     @callback
@@ -423,6 +428,7 @@ async def test_duplicate_yaml_keys(
     devices = mock_device_tracker_conf
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
 
     common.async_see(hass, "mac_1", host_name="hello")
     common.async_see(hass, "mac_2", host_name="hello")
@@ -442,6 +448,7 @@ async def test_invalid_dev_id(
     devices = mock_device_tracker_conf
     with assert_setup_component(1, device_tracker.DOMAIN):
         assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
 
     common.async_see(hass, dev_id="hello-world")
     await hass.async_block_till_done()
@@ -454,6 +461,7 @@ async def test_see_state(
 ) -> None:
     """Test device tracker see records state correctly."""
     assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+    await hass.async_block_till_done()
 
     params = {
         "mac": "AA:BB:CC:DD:EE:FF",
@@ -508,6 +516,7 @@ async def test_see_passive_zone_state(
         }
 
         await async_setup_component(hass, zone.DOMAIN, {"zone": zone_info})
+        await hass.async_block_till_done()
 
     scanner = getattr(hass.components, "test.device_tracker").SCANNER
     scanner.reset()
@@ -603,6 +612,7 @@ async def test_async_added_to_hass(hass: HomeAssistant) -> None:
     files = {path: "jk:\n  name: JK Phone\n  track: True"}
     with patch_yaml_files(files):
         assert await async_setup_component(hass, device_tracker.DOMAIN, {})
+        await hass.async_block_till_done()
 
     state = hass.states.get("device_tracker.jk")
     assert state

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -70,7 +70,7 @@ async def test_configuring_tplink_causes_discovery(
 async def test_config_entry_reload(hass: HomeAssistant) -> None:
     """Test that a config entry can be reloaded."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     with _patch_discovery(), _patch_single_discovery(), _patch_connect():
@@ -266,7 +266,9 @@ async def test_config_entry_errors(
 
 async def test_plug_auth_fails(hass: HomeAssistant) -> None:
     """Test a smart plug auth failure."""
-    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=MAC_ADDRESS)
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
     config_entry.add_to_hass(hass)
     plug = _mocked_plug()
     with _patch_discovery(device=plug), _patch_connect(device=plug):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -24,7 +24,7 @@ from homeassistant.components.light import (
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -45,7 +45,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_light_unique_id(hass: HomeAssistant) -> None:
     """Test a light unique id."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -67,7 +67,7 @@ async def test_color_light(
 ) -> None:
     """Test a color light and that all transitions are correctly passed."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb.color_temp = None
@@ -147,7 +147,7 @@ async def test_color_light(
 async def test_color_light_no_temp(hass: HomeAssistant) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -207,7 +207,7 @@ async def test_color_temp_light(
 ) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb.is_color = is_color
@@ -286,7 +286,7 @@ async def test_color_temp_light(
 async def test_brightness_only_light(hass: HomeAssistant) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -330,7 +330,7 @@ async def test_brightness_only_light(hass: HomeAssistant) -> None:
 async def test_on_off_light(hass: HomeAssistant) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -364,7 +364,7 @@ async def test_on_off_light(hass: HomeAssistant) -> None:
 async def test_off_at_start_light(hass: HomeAssistant) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -388,7 +388,7 @@ async def test_off_at_start_light(hass: HomeAssistant) -> None:
 async def test_dimmer_turn_on_fix(hass: HomeAssistant) -> None:
     """Test a light."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -414,7 +414,7 @@ async def test_dimmer_turn_on_fix(hass: HomeAssistant) -> None:
 async def test_smart_strip_effects(hass: HomeAssistant) -> None:
     """Test smart strip effects."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_smart_light_strip()
@@ -496,7 +496,7 @@ async def test_smart_strip_effects(hass: HomeAssistant) -> None:
 async def test_smart_strip_custom_random_effect(hass: HomeAssistant) -> None:
     """Test smart strip custom random effects."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_smart_light_strip()
@@ -653,7 +653,7 @@ async def test_smart_strip_custom_random_effect(hass: HomeAssistant) -> None:
 async def test_smart_strip_custom_random_effect_at_start(hass: HomeAssistant) -> None:
     """Test smart strip custom random effects at startup."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_smart_light_strip()
@@ -686,7 +686,7 @@ async def test_smart_strip_custom_random_effect_at_start(hass: HomeAssistant) ->
 async def test_smart_strip_custom_sequence_effect(hass: HomeAssistant) -> None:
     """Test smart strip custom sequence effects."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_smart_light_strip()

--- a/tests/components/tplink/test_sensor.py
+++ b/tests/components/tplink/test_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from homeassistant.components import tplink
 from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -16,7 +17,7 @@ from tests.common import MockConfigEntry
 async def test_color_light_with_an_emeter(hass: HomeAssistant) -> None:
     """Test a light with an emeter."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -56,7 +57,7 @@ async def test_color_light_with_an_emeter(hass: HomeAssistant) -> None:
 async def test_plug_with_an_emeter(hass: HomeAssistant) -> None:
     """Test a plug with an emeter."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     plug = _mocked_plug()
@@ -91,7 +92,7 @@ async def test_plug_with_an_emeter(hass: HomeAssistant) -> None:
 async def test_color_light_no_emeter(hass: HomeAssistant) -> None:
     """Test a light without an emeter."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     bulb = _mocked_bulb()
@@ -120,7 +121,7 @@ async def test_color_light_no_emeter(hass: HomeAssistant) -> None:
 async def test_sensor_unique_id(hass: HomeAssistant) -> None:
     """Test a sensor unique ids."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     plug = _mocked_plug()

--- a/tests/components/tplink/test_switch.py
+++ b/tests/components/tplink/test_switch.py
@@ -9,7 +9,13 @@ import pytest
 from homeassistant.components import tplink
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.tplink.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -30,7 +36,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 async def test_plug(hass: HomeAssistant) -> None:
     """Test a smart plug."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     plug = _mocked_plug()
@@ -66,7 +72,7 @@ async def test_plug(hass: HomeAssistant) -> None:
 async def test_led_switch(hass: HomeAssistant, dev, domain: str) -> None:
     """Test LED setting for plugs, strips and dimmers."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     with _patch_discovery(device=dev), _patch_connect(device=dev):
@@ -96,7 +102,7 @@ async def test_led_switch(hass: HomeAssistant, dev, domain: str) -> None:
 async def test_plug_unique_id(hass: HomeAssistant) -> None:
     """Test a plug unique id."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     plug = _mocked_plug()
@@ -112,7 +118,7 @@ async def test_plug_unique_id(hass: HomeAssistant) -> None:
 async def test_plug_update_fails(hass: HomeAssistant) -> None:
     """Test a smart plug update failure."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     plug = _mocked_plug()
@@ -134,7 +140,7 @@ async def test_plug_update_fails(hass: HomeAssistant) -> None:
 async def test_strip(hass: HomeAssistant) -> None:
     """Test a smart strip."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_strip()
@@ -182,7 +188,7 @@ async def test_strip(hass: HomeAssistant) -> None:
 async def test_strip_unique_ids(hass: HomeAssistant) -> None:
     """Test a strip unique id."""
     already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={}, unique_id=MAC_ADDRESS
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
     strip = _mocked_strip()

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1167,8 +1167,9 @@ async def test_loading_component_loads_translations(hass: HomeAssistant) -> None
     mock_setup = Mock(return_value=True)
 
     mock_integration(hass, MockModule("comp", setup=mock_setup))
-
-    assert await setup.async_setup_component(hass, "comp", {})
+    integration = await loader.async_get_integration(hass, "comp")
+    with patch.object(integration, "has_translations", True):
+        assert await setup.async_setup_component(hass, "comp", {})
     assert mock_setup.called
     assert translation.async_translations_loaded(hass, {"comp"}) is True
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Ensure deps are added to the translations preload in bootstrap (we were missing a lot of them which caused them to h ave to load at setup and slow down startup)
- Start the load process as soon as we know we are going to need the translations in async_setup_component
- Avoid trying to load translations if we know in advance that the integration does not have any

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
