### PR TITLE
Rework Axis entity loader to have a better internal storage structure

### DIFF
--- a/homeassistant/components/axis/hub/entity_loader.py
+++ b/homeassistant/components/axis/hub/entity_loader.py
@@ -4,7 +4,6 @@ Central point to load entities for the different platforms.
 """
 from __future__ import annotations
 
-from functools import partial
 from typing import TYPE_CHECKING
 
 from axis.models.event import Event, EventOperation, EventTopic
@@ -22,17 +21,20 @@ class AxisEntityLoader:
     """Axis network device integration handling platforms for entity registration."""
 
     def __init__(self, hub: AxisHub) -> None:
-        """Initialize the UniFi entity loader."""
+        """Initialize the Axis entity loader."""
         self.hub = hub
 
         self.registered_events: set[tuple[str, EventTopic, str]] = set()
-        self.platforms: list[
-            tuple[
-                AddEntitiesCallback,
-                type[AxisEventEntity],
-                tuple[AxisEventDescription, ...],
-            ]
-        ] = []
+        self.topic_to_entity: dict[
+            EventTopic,
+            list[
+                tuple[
+                    AddEntitiesCallback,
+                    type[AxisEventEntity],
+                    AxisEventDescription,
+                ]
+            ],
+        ] = {}
 
     @callback
     def register_platform(
@@ -42,37 +44,39 @@ class AxisEntityLoader:
         descriptions: tuple[AxisEventDescription, ...],
     ) -> None:
         """Register Axis entity platforms."""
-        self.platforms.append((async_add_entities, entity_class, descriptions))
+        topics: tuple[EventTopic, ...]
+        for description in descriptions:
+            if isinstance(description.event_topic, EventTopic):
+                topics = (description.event_topic,)
+            else:
+                topics = description.event_topic
+            for topic in topics:
+                self.topic_to_entity.setdefault(topic, []).append(
+                    (async_add_entities, entity_class, description)
+                )
+
+    @callback
+    def _create_entities_from_event(self, event: Event) -> None:
+        """Create Axis entities from event."""
+        event_id = (event.topic, event.topic_base, event.id)
+        if event_id in self.registered_events:
+            # Device has restarted and all events are initiatlized anew
+            return
+        self.registered_events.add(event_id)
+        for (
+            async_add_entities,
+            entity_class,
+            description,
+        ) in self.topic_to_entity[event.topic_base]:
+            if not description.supported_fn(self.hub, event):
+                continue
+            async_add_entities([entity_class(self.hub, description, event)])
 
     @callback
     def initialize_platforms(self) -> None:
-        """Prepare event listeners and platforms."""
-
-        @callback
-        def load_entities(
-            platform_entity: type[AxisEventEntity],
-            descriptions: tuple[AxisEventDescription, ...],
-            async_add_entities: AddEntitiesCallback,
-        ) -> None:
-            """Set up listeners for events."""
-
-            @callback
-            def create_entity(description: AxisEventDescription, event: Event) -> None:
-                """Create Axis entity."""
-                event_id = (event.topic, event.topic_base, event.id)
-                if event_id in self.registered_events:
-                    # Device has restarted and all events are initiatlized anew
-                    return
-                self.registered_events.add(event_id)
-                if description.supported_fn(self.hub, event):
-                    async_add_entities([platform_entity(self.hub, description, event)])
-
-            for description in descriptions:
-                self.hub.api.event.subscribe(
-                    partial(create_entity, description),
-                    topic_filter=description.event_topic,
-                    operation_filter=EventOperation.INITIALIZED,
-                )
-
-        for async_add_entities, entity_class, descriptions in self.platforms:
-            load_entities(entity_class, descriptions, async_add_entities)
+        """Prepare event listener that can populate platform entities."""
+        self.hub.api.event.subscribe(
+            self._create_entities_from_event,
+            topic_filter=tuple(self.topic_to_entity.keys()),
+            operation_filter=EventOperation.INITIALIZED,
+        )

--- a/homeassistant/components/axis/hub/entity_loader.py
+++ b/homeassistant/components/axis/hub/entity_loader.py
@@ -60,7 +60,7 @@ class AxisEntityLoader:
         """Create Axis entities from event."""
         event_id = (event.topic, event.topic_base, event.id)
         if event_id in self.registered_events:
-            # Device has restarted and all events are initiatlized anew
+            # Device has restarted and all events are initialized anew
             return
         self.registered_events.add(event_id)
         for (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up from https://github.com/home-assistant/core/pull/114018
Restructure the format that works well on platform side to something that works well on loader side, leading to just one subscription and one lookup to create new entities on per event.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
