### PR TITLE
Use TypeVarTuple for add_job and run_job methods

### DIFF
--- a/homeassistant/components/http/ban.py
+++ b/homeassistant/components/http/ban.py
@@ -116,7 +116,8 @@ async def process_wrong_login(request: Request) -> None:
     """
     hass = request.app[KEY_HASS]
 
-    remote_addr = ip_address(request.remote)  # type: ignore[arg-type]
+    assert request.remote
+    remote_addr = ip_address(request.remote)
     remote_host = request.remote
     with suppress(herror):
         remote_host, _, _ = await hass.async_add_executor_job(

--- a/homeassistant/components/meteo_france/__init__.py
+++ b/homeassistant/components/meteo_france/__init__.py
@@ -54,6 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def _async_update_data_alert() -> CurrentPhenomenons:
         """Fetch data from API endpoint."""
+        assert isinstance(department, str)
         return await hass.async_add_executor_job(
             client.get_warning_current_phenomenoms, department, 0, True
         )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -40,6 +40,7 @@ from typing import (
     ParamSpec,
     Self,
     TypedDict,
+    TypeVarTuple,
     cast,
     overload,
 )
@@ -135,6 +136,7 @@ _T = TypeVar("_T")
 _R = TypeVar("_R")
 _R_co = TypeVar("_R_co", covariant=True)
 _P = ParamSpec("_P")
+_Ts = TypeVarTuple("_Ts")
 # Internal; not helpers.typing.UNDEFINED due to circular dependency
 _UNDEF: dict[Any, Any] = {}
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
@@ -529,7 +531,7 @@ class HomeAssistant:
         self.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
 
     def add_job(
-        self, target: Callable[..., Any] | Coroutine[Any, Any, Any], *args: Any
+        self, target: Callable[[*_Ts], Any] | Coroutine[Any, Any, Any], *args: *_Ts
     ) -> None:
         """Add a job to be executed by the event loop or by an executor.
 
@@ -547,7 +549,7 @@ class HomeAssistant:
             )
             return
         if TYPE_CHECKING:
-            target = cast(Callable[..., Any], target)
+            target = cast(Callable[[*_Ts], Any], target)
         self.loop.call_soon_threadsafe(
             functools.partial(
                 self.async_add_hass_job, HassJob(target), *args, eager_start=True
@@ -558,8 +560,8 @@ class HomeAssistant:
     @callback
     def async_add_job(
         self,
-        target: Callable[..., Coroutine[Any, Any, _R]],
-        *args: Any,
+        target: Callable[[*_Ts], Coroutine[Any, Any, _R]],
+        *args: *_Ts,
         eager_start: bool = False,
     ) -> asyncio.Future[_R] | None:
         ...
@@ -568,8 +570,8 @@ class HomeAssistant:
     @callback
     def async_add_job(
         self,
-        target: Callable[..., Coroutine[Any, Any, _R] | _R],
-        *args: Any,
+        target: Callable[[*_Ts], Coroutine[Any, Any, _R] | _R],
+        *args: *_Ts,
         eager_start: bool = False,
     ) -> asyncio.Future[_R] | None:
         ...
@@ -587,8 +589,9 @@ class HomeAssistant:
     @callback
     def async_add_job(
         self,
-        target: Callable[..., Coroutine[Any, Any, _R] | _R] | Coroutine[Any, Any, _R],
-        *args: Any,
+        target: Callable[[*_Ts], Coroutine[Any, Any, _R] | _R]
+        | Coroutine[Any, Any, _R],
+        *args: *_Ts,
         eager_start: bool = False,
     ) -> asyncio.Future[_R] | None:
         """Add a job to be executed by the event loop or by an executor.
@@ -623,7 +626,7 @@ class HomeAssistant:
         # the type used for the cast. For history see:
         # https://github.com/home-assistant/core/pull/71960
         if TYPE_CHECKING:
-            target = cast(Callable[..., Coroutine[Any, Any, _R] | _R], target)
+            target = cast(Callable[[*_Ts], Coroutine[Any, Any, _R] | _R], target)
         return self.async_add_hass_job(HassJob(target), *args, eager_start=eager_start)
 
     @overload
@@ -772,7 +775,7 @@ class HomeAssistant:
 
     @callback
     def async_add_executor_job(
-        self, target: Callable[..., _T], *args: Any
+        self, target: Callable[[*_Ts], _T], *args: *_Ts
     ) -> asyncio.Future[_T]:
         """Add an executor job from within the event loop."""
         task = self.loop.run_in_executor(None, target, *args)
@@ -783,7 +786,7 @@ class HomeAssistant:
 
     @callback
     def async_add_import_executor_job(
-        self, target: Callable[..., _T], *args: Any
+        self, target: Callable[[*_Ts], _T], *args: *_Ts
     ) -> asyncio.Future[_T]:
         """Add an import executor job from within the event loop."""
         task = self.loop.run_in_executor(self.import_executor, target, *args)
@@ -844,14 +847,14 @@ class HomeAssistant:
     @overload
     @callback
     def async_run_job(
-        self, target: Callable[..., Coroutine[Any, Any, _R]], *args: Any
+        self, target: Callable[[*_Ts], Coroutine[Any, Any, _R]], *args: *_Ts
     ) -> asyncio.Future[_R] | None:
         ...
 
     @overload
     @callback
     def async_run_job(
-        self, target: Callable[..., Coroutine[Any, Any, _R] | _R], *args: Any
+        self, target: Callable[[*_Ts], Coroutine[Any, Any, _R] | _R], *args: *_Ts
     ) -> asyncio.Future[_R] | None:
         ...
 
@@ -865,8 +868,9 @@ class HomeAssistant:
     @callback
     def async_run_job(
         self,
-        target: Callable[..., Coroutine[Any, Any, _R] | _R] | Coroutine[Any, Any, _R],
-        *args: Any,
+        target: Callable[[*_Ts], Coroutine[Any, Any, _R] | _R]
+        | Coroutine[Any, Any, _R],
+        *args: *_Ts,
     ) -> asyncio.Future[_R] | None:
         """Run a job from within the event loop.
 
@@ -894,7 +898,7 @@ class HomeAssistant:
         # the type used for the cast. For history see:
         # https://github.com/home-assistant/core/pull/71960
         if TYPE_CHECKING:
-            target = cast(Callable[..., Coroutine[Any, Any, _R] | _R], target)
+            target = cast(Callable[[*_Ts], Coroutine[Any, Any, _R] | _R], target)
         return self.async_run_hass_job(HassJob(target), *args)
 
     def block_till_done(self) -> None:


### PR DESCRIPTION
## Proposed change
Use TypeVarTuple and callback typing to better annotate the `add_job` and `run_job` methods.
This PR only updates methods which accept `Callable`. To do the same for the remaining once (with `HassJob`) a mypy bug needs to be fixed first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
