### PR TITLE
Review AndroidTV decorator exception management

### DIFF
--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -143,7 +143,7 @@ class AndroidTVEntity(Entity):
             self._attr_device_info[ATTR_CONNECTIONS] = {(CONNECTION_NETWORK_MAC, mac)}
 
         # ADB exceptions to catch
-        if not aftv.adb_server_ip:
+        if not self.aftv.adb_server_ip:
             # Using "adb_shell" (Python ADB implementation)
             self.exceptions = ADB_PYTHON_EXCEPTIONS
         else:

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -77,13 +77,15 @@ def adb_decorator(
                 )
                 return None
             except self.exceptions as err:
-                _LOGGER.error(
-                    (
-                        "Failed to execute an ADB command. ADB connection re-"
-                        "establishing attempt in the next update. Error: %s"
-                    ),
-                    err,
-                )
+                if self.available:
+                    _LOGGER.error(
+                        (
+                            "Failed to execute an ADB command. ADB connection re-"
+                            "establishing attempt in the next update. Error: %s"
+                        ),
+                        err,
+                    )
+
                 await self.aftv.adb_close()
                 # pylint: disable-next=protected-access
                 self._attr_available = False

--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -93,13 +93,15 @@ def adb_decorator(
             except Exception as err:  # pylint: disable=broad-except
                 # An unforeseen exception occurred. Close the ADB connection so that
                 # it doesn't happen over and over again.
-                _LOGGER.error(
-                    (
-                        "Unexpected exception executing an ADB command. ADB connection"
-                        " re-establishing attempt in the next update. Error: %s"
-                    ),
-                    err,
-                )
+                if self.available:
+                    _LOGGER.error(
+                        (
+                            "Unexpected exception executing an ADB command. ADB connection"
+                            " re-establishing attempt in the next update. Error: %s"
+                        ),
+                        err,
+                    )
+
                 await self.aftv.adb_close()
                 # pylint: disable-next=protected-access
                 self._attr_available = False

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -1182,7 +1182,7 @@ async def test_connection_closed_on_ha_stop(hass: HomeAssistant) -> None:
             assert adb_close.called
 
 
-async def test_exception(hass: HomeAssistant) -> None:
+async def test_exception(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
     """Test that the ADB connection gets closed when there is an unforeseen exception.
 
     HA will attempt to reconnect on the next update.
@@ -1202,6 +1202,9 @@ async def test_exception(hass: HomeAssistant) -> None:
         assert state is not None
         assert state.state == STATE_OFF
 
+        caplog.clear()
+        caplog.set_level(logging.ERROR)
+
         # When an unforeseen exception occurs, we close the ADB connection and raise the exception
         with patchers.PATCH_ANDROIDTV_UPDATE_EXCEPTION:
             await async_update_entity(hass, entity_id)
@@ -1209,6 +1212,11 @@ async def test_exception(hass: HomeAssistant) -> None:
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
+        assert len(caplog.record_tuples) == 1
+        assert caplog.record_tuples[0][1] == logging.ERROR
+        assert caplog.record_tuples[0][2].startswith(
+            "Unexpected exception executing an ADB command"
+        )
 
         # On the next update, HA will reconnect to the device
         await async_update_entity(hass, entity_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is to fix issue in AndroidTV test in PR #113957. 
Because class `entity` at line 952 catch any `Exception` on update and stop actions, the entity status is never set to unavailable and the exception is not raised as result of update.
Not sure if this is the right way, I review the decorator to manage in the same way any kind of exception. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
