### PR TITLE
Add mute_toggle to roon volume events

### DIFF
--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -47,7 +47,7 @@ class RoonEventEntity(EventEntity):
     """Representation of a Roon Event entity."""
 
     _attr_device_class = EventDeviceClass.BUTTON
-    _attr_event_types = ["volume_up", "volume_down"]
+    _attr_event_types = ["volume_up", "volume_down", "mute_toggle"]
     _attr_translation_key = "volume"
 
     def __init__(self, server, player_data):
@@ -78,14 +78,16 @@ class RoonEventEntity(EventEntity):
     ) -> None:
         """Callbacks from the roon api with volume request."""
 
-        if event != "set_volume":
+        if event == "set_mute":
+            event = "mute_toggle"
+        elif event == "set_volume":
+            if value > 0:
+                event = "volume_up"
+            else:
+                event = "volume_down"
+        else:
             _LOGGER.debug("Received unsupported roon volume event %s", event)
             return
-
-        if value > 0:
-            event = "volume_up"
-        else:
-            event = "volume_down"
 
         self._trigger_event(event)
         self.async_write_ha_state()

--- a/homeassistant/components/roon/strings.json
+++ b/homeassistant/components/roon/strings.json
@@ -29,7 +29,8 @@
           "event_type": {
             "state": {
               "volume_up": "Volume up",
-              "volume_down": "Volume down"
+              "volume_down": "Volume down",
+              "mute_toggle": "Mute toggle"
             }
           }
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a `mute_toggle` event to the roon integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
The roon integration currently exposes two volume events. These are triggered when a user changes a volume in the roon apps - and can be used as event triggers in HA to control the volume for devices that do not communicate directly to roon.

This PR adds a third event `mute_toggle`. The event was already being sent to HA by the roon api - but was being ignored. This just exposes the additional event in HA.

It was requested by a user in the roon forum: https://community.roonlabs.com/t/roon-with-home-assistant-and-matter/256605/8?u=gregd 

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
