### PR TITLE
Add restrictions for listening to event_reported events

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1514,7 +1514,7 @@ class EventBus:
                 )
             if not run_immediately:
                 raise HomeAssistantError(
-                    f"Run immediately must be set for event {event_type}"
+                    f"Run immediately must be set to True for event {event_type}"
                 )
         return self._async_listen_filterable_job(
             event_type,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1507,6 +1507,15 @@ class EventBus:
         """
         if event_filter is not None and not is_callback_check_partial(event_filter):
             raise HomeAssistantError(f"Event filter {event_filter} is not a callback")
+        if event_type == EVENT_STATE_REPORTED:
+            if not event_filter:
+                raise HomeAssistantError(
+                    f"Event filter is required for event {event_type}"
+                )
+            if not run_immediately:
+                raise HomeAssistantError(
+                    f"Run immediately must be set for event {event_type}"
+                )
         return self._async_listen_filterable_job(
             event_type,
             (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3261,9 +3261,22 @@ async def test_eventbus_lazy_object_creation(hass: HomeAssistant) -> None:
 
 async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     """Test report state event."""
+
+    @ha.callback
+    def filter(event_data):
+        """Mock filter."""
+        return True
+
+    @callback
+    def listener(event: ha.Event) -> None:
+        state_reported_events.append(event)
+
     hass.states.async_set("light.bowl", "on", {})
     state_changed_events = async_capture_events(hass, EVENT_STATE_CHANGED)
-    state_reported_events = async_capture_events(hass, EVENT_STATE_REPORTED)
+    state_reported_events = []
+    hass.bus.async_listen(
+        EVENT_STATE_REPORTED, listener, event_filter=filter, run_immediately=True
+    )
 
     hass.states.async_set("light.bowl", "on")
     await hass.async_block_till_done()
@@ -3284,3 +3297,29 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(state_changed_events) == 3
     assert len(state_reported_events) == 4
+
+
+async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:
+    """Test we enforce requirements for EVENT_STATE_REPORTED listeners."""
+
+    @ha.callback
+    def listener(event):
+        """Mock listener."""
+
+    @ha.callback
+    def filter(event_data):
+        """Mock filter."""
+        return False
+
+    # run_immediately not set
+    with pytest.raises(HomeAssistantError):
+        hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=filter)
+
+    # no filter
+    with pytest.raises(HomeAssistantError):
+        hass.bus.async_listen(EVENT_STATE_REPORTED, listener, run_immediately=True)
+
+    # Both filter and run_immediately
+    hass.bus.async_listen(
+        EVENT_STATE_REPORTED, listener, event_filter=filter, run_immediately=True
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restrictions for listening to `event_reported` events:
- Require an event filter
- Require the run_immediately flag to be set

Background in https://github.com/home-assistant/core/pull/113511

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
