### PR TITLE
Don't allow listening to state_reported in event triggers

### DIFF
--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -64,7 +64,7 @@ async def async_attach_trigger(
     event_types = template.render_complex(
         config[CONF_EVENT_TYPE], variables, limited=True
     )
-    if any(evt == EVENT_STATE_REPORTED for evt in event_types):
+    if EVENT_STATE_REPORTED in event_types:
         raise HomeAssistantError(
             f"Can't listen to {EVENT_STATE_REPORTED} in event trigger"
         )

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -7,8 +7,9 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_EVENT_DATA, CONF_PLATFORM
+from homeassistant.const import CONF_EVENT_DATA, CONF_PLATFORM, EVENT_STATE_REPORTED
 from homeassistant.core import CALLBACK_TYPE, Event, HassJob, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
@@ -16,10 +17,24 @@ from homeassistant.helpers.typing import ConfigType
 CONF_EVENT_TYPE = "event_type"
 CONF_EVENT_CONTEXT = "context"
 
+
+def _validate_event_types(value: Any) -> Any:
+    """Validate the event types.
+
+    If the event types are templated, we check when attaching the trigger.
+    """
+    templates: list[template.Template] = value
+    if any(tpl.is_static and tpl.template == EVENT_STATE_REPORTED for tpl in templates):
+        raise vol.Invalid(f"Can't listen to {EVENT_STATE_REPORTED} in event trigger")
+    return value
+
+
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): "event",
-        vol.Required(CONF_EVENT_TYPE): vol.All(cv.ensure_list, [cv.template]),
+        vol.Required(CONF_EVENT_TYPE): vol.All(
+            cv.ensure_list, [cv.template], _validate_event_types
+        ),
         vol.Optional(CONF_EVENT_DATA): vol.All(dict, cv.template_complex),
         vol.Optional(CONF_EVENT_CONTEXT): vol.All(dict, cv.template_complex),
     }
@@ -49,6 +64,10 @@ async def async_attach_trigger(
     event_types = template.render_complex(
         config[CONF_EVENT_TYPE], variables, limited=True
     )
+    if any(evt == EVENT_STATE_REPORTED for evt in event_types):
+        raise HomeAssistantError(
+            f"Can't listen to {EVENT_STATE_REPORTED} in event trigger"
+        )
     event_data_schema: vol.Schema | None = None
     event_data_items: ItemsView | None = None
     if CONF_EVENT_DATA in config:

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -505,3 +505,66 @@ async def test_event_data_with_list(hass: HomeAssistant, calls) -> None:
     hass.bus.async_fire("test_event", {"some_attr": [1, 2, 3]})
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+
+@pytest.mark.parametrize(
+    "event_type", ["state_reported", ["test_event", "state_reported"]]
+)
+async def test_state_reported_event(
+    hass: HomeAssistant, calls, caplog, event_type: list[str]
+) -> None:
+    """Test triggering on state reported event."""
+    context = Context()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {"platform": "event", "event_type": event_type},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event", context=context)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    assert (
+        "Unnamed automation failed to setup triggers and has been disabled: Can't "
+        "listen to state_reported in event trigger for dictionary value @ "
+        "data['event_type']. Got None" in caplog.text
+    )
+
+
+async def test_templated_state_reported_event(
+    hass: HomeAssistant, calls, caplog
+) -> None:
+    """Test triggering on state reported event."""
+    context = Context()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger_variables": {"event_type": "state_reported"},
+                "trigger": {"platform": "event", "event_type": "{{event_type}}"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event", context=context)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    assert (
+        "Got error 'Can't listen to state_reported in event trigger' "
+        "when setting up triggers for automation 0" in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't allow listening to `state_reported` in event triggers

Rationale: We want to be very restrictive initially with allowing use of the `state_reported` event since that event is fired in very large numbers. Triggering on `state_reported` should instead be done by extending the functionality of state triggers.

Background in https://github.com/home-assistant/core/pull/113511

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
