### PR TITLE
Use new `setup_test_component_platform` helper instead of test fixture for light platform

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 
 if TYPE_CHECKING:
-    from tests.components.light.common import MockLight, SetupLightPlatformCallable
+    from tests.components.light.common import MockLight
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -118,11 +118,3 @@ def mock_light_entities() -> list["MockLight"]:
         MockLight("Ceiling", STATE_OFF),
         MockLight(None, STATE_OFF),
     ]
-
-
-@pytest.fixture
-def setup_light_platform() -> "SetupLightPlatformCallable":
-    """Return a callable to set up the mock light entity component."""
-    from tests.components.light.common import setup_light_platform
-
-    return setup_light_platform

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -24,8 +24,13 @@ from homeassistant.setup import async_setup_component
 
 from . import expose_entity, expose_new
 
-from tests.common import MockConfigEntry, MockUser, async_mock_service
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.common import (
+    MockConfigEntry,
+    MockUser,
+    async_mock_service,
+    setup_test_component_platform,
+)
+from tests.components.light.common import MockLight
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 AGENT_ID_OPTIONS = [None, conversation.HOME_ASSISTANT_AGENT]
@@ -257,7 +262,6 @@ async def test_http_processing_intent_entity_renamed(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API with entities renamed later.
@@ -268,7 +272,7 @@ async def test_http_processing_intent_entity_renamed(
     entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    setup_light_platform(hass, [entity])
+    setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
 
     assert await async_setup_component(
         hass,
@@ -346,7 +350,6 @@ async def test_http_processing_intent_entity_exposed(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API with manual expose.
@@ -357,7 +360,7 @@ async def test_http_processing_intent_entity_exposed(
     entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    setup_light_platform(hass, [entity])
+    setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
 
     assert await async_setup_component(
         hass,
@@ -449,7 +452,6 @@ async def test_http_processing_intent_conversion_not_expose_new(
     hass_client: ClientSessionGenerator,
     hass_admin_user: MockUser,
     entity_registry: er.EntityRegistry,
-    setup_light_platform: SetupLightPlatformCallable,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test processing intent via HTTP API when not exposing new entities."""
@@ -459,7 +461,7 @@ async def test_http_processing_intent_conversion_not_expose_new(
     entity = MockLight("kitchen light", "on")
     entity._attr_unique_id = "1234"
     entity.entity_id = "light.kitchen"
-    setup_light_platform(hass, [entity])
+    setup_test_component_platform(hass, LIGHT_DOMAIN, [entity])
 
     assert await async_setup_component(
         hass,

--- a/tests/components/group/test_light.py
+++ b/tests/components/group/test_light.py
@@ -44,8 +44,12 @@ from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_capture_events, get_fixture_path
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.common import (
+    async_capture_events,
+    get_fixture_path,
+    setup_test_component_platform,
+)
+from tests.components.light.common import MockLight
 
 
 async def test_default_state(
@@ -261,15 +265,13 @@ async def test_state_reporting_all(hass: HomeAssistant) -> None:
     assert hass.states.get("light.light_group").state == STATE_UNAVAILABLE
 
 
-async def test_brightness(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_brightness(hass: HomeAssistant) -> None:
     """Test brightness reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.BRIGHTNESS}
@@ -334,15 +336,13 @@ async def test_brightness(
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["brightness"]
 
 
-async def test_color_hs(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_hs(hass: HomeAssistant) -> None:
     """Test hs color reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.HS}
@@ -406,15 +406,13 @@ async def test_color_hs(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgb(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_rgb(hass: HomeAssistant) -> None:
     """Test rgbw color reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGB}
@@ -480,15 +478,13 @@ async def test_color_rgb(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgbw(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_rgbw(hass: HomeAssistant) -> None:
     """Test rgbw color reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGBW}
@@ -554,15 +550,13 @@ async def test_color_rgbw(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_color_rgbww(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_rgbww(hass: HomeAssistant) -> None:
     """Test rgbww color reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.RGBWW}
@@ -628,15 +622,13 @@ async def test_color_rgbww(
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
 
-async def test_white(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_white(hass: HomeAssistant) -> None:
     """Test white reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.HS, ColorMode.WHITE}
@@ -687,15 +679,13 @@ async def test_white(
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["hs", "white"]
 
 
-async def test_color_temp(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_temp(hass: HomeAssistant) -> None:
     """Test color temp reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
@@ -758,16 +748,14 @@ async def test_color_temp(
     assert state.attributes[ATTR_SUPPORTED_COLOR_MODES] == ["color_temp"]
 
 
-async def test_emulated_color_temp_group(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_emulated_color_temp_group(hass: HomeAssistant) -> None:
     """Test emulated color temperature in a group."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
         MockLight("test3", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
@@ -824,9 +812,7 @@ async def test_emulated_color_temp_group(
     assert state.attributes[ATTR_HS_COLOR] == (27.001, 19.243)
 
 
-async def test_min_max_mireds(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_min_max_mireds(hass: HomeAssistant) -> None:
     """Test min/max mireds reporting.
 
     min/max mireds is reported both when light is on and off
@@ -835,7 +821,7 @@ async def test_min_max_mireds(
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP}
@@ -1005,16 +991,14 @@ async def test_effect(hass: HomeAssistant) -> None:
     assert state.attributes[ATTR_EFFECT] == "Random"
 
 
-async def test_supported_color_modes(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_supported_color_modes(hass: HomeAssistant) -> None:
     """Test supported_color_modes reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
         MockLight("test3", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
@@ -1055,16 +1039,14 @@ async def test_supported_color_modes(
     }
 
 
-async def test_color_mode(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_mode(hass: HomeAssistant) -> None:
     """Test color_mode reporting."""
     entities = [
         MockLight("test1", STATE_ON),
         MockLight("test2", STATE_OFF),
         MockLight("test3", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {ColorMode.COLOR_TEMP, ColorMode.HS}
@@ -1130,9 +1112,7 @@ async def test_color_mode(
     assert state.attributes[ATTR_COLOR_MODE] == ColorMode.HS
 
 
-async def test_color_mode2(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_color_mode2(hass: HomeAssistant) -> None:
     """Test onoff color_mode and brightness are given lowest priority."""
     entities = [
         MockLight("test1", STATE_ON),
@@ -1142,7 +1122,7 @@ async def test_color_mode2(
         MockLight("test5", STATE_ON),
         MockLight("test6", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity = entities[0]
     entity.supported_color_modes = {ColorMode.COLOR_TEMP}
@@ -1256,7 +1236,6 @@ async def test_supported_features(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize("supported_color_modes", [ColorMode.HS, ColorMode.RGB])
 async def test_service_calls(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     supported_color_modes,
 ) -> None:
     """Test service calls."""
@@ -1265,7 +1244,7 @@ async def test_service_calls(
         MockLight("ceiling_lights", STATE_OFF),
         MockLight("kitchen_lights", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, LIGHT_DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {supported_color_modes}

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -4,7 +4,6 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 
-from collections.abc import Callable
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -33,12 +32,9 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.loader import bind_hass
 
-from tests.common import MockPlatform, MockToggleEntity, mock_platform
+from tests.common import MockToggleEntity
 
 
 @bind_hass
@@ -288,25 +284,3 @@ class MockLight(MockToggleEntity, LightEntity):
                 setattr(self, "brightness", value)
             if key in TURN_ON_ARG_TO_COLOR_MODE:
                 self._attr_color_mode = TURN_ON_ARG_TO_COLOR_MODE[key]
-
-
-SetupLightPlatformCallable = Callable[[HomeAssistant, list[MockLight]], None]
-
-
-def setup_light_platform(hass: HomeAssistant, entities: list[MockLight]) -> None:
-    """Set up the mock light entity platform."""
-
-    async def async_setup_platform(
-        hass: HomeAssistant,
-        config: ConfigType,
-        async_add_entities: AddEntitiesCallback,
-        discovery_info: DiscoveryInfoType | None = None,
-    ) -> None:
-        """Set up test light platform."""
-        async_add_entities(entities)
-
-    mock_platform(
-        hass,
-        f"test.{DOMAIN}",
-        MockPlatform(async_setup_platform=async_setup_platform),
-    )

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -21,8 +21,9 @@ from tests.common import (
     async_get_device_automation_capabilities,
     async_get_device_automations,
     async_mock_service,
+    setup_test_component_platform,
 )
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.components.light.common import MockLight
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -324,7 +325,6 @@ async def test_if_fires_on_for_condition(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     calls,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test for firing if condition is on with delay."""
@@ -344,7 +344,7 @@ async def test_if_fires_on_for_condition(
     point2 = point1 + timedelta(seconds=10)
     point3 = point2 + timedelta(seconds=10)
 
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, DOMAIN, mock_light_entities)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -22,8 +22,13 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.setup import async_setup_component
 import homeassistant.util.color as color_util
 
-from tests.common import MockEntityPlatform, MockUser, async_mock_service
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.common import (
+    MockEntityPlatform,
+    MockUser,
+    async_mock_service,
+    setup_test_component_platform,
+)
+from tests.components.light.common import MockLight
 
 orig_Profiles = light.Profiles
 
@@ -111,11 +116,10 @@ async def test_methods(hass: HomeAssistant) -> None:
 async def test_services(
     hass: HomeAssistant,
     mock_light_profiles,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test the provided services."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -512,11 +516,10 @@ async def test_light_profiles(
     profile_name,
     expected_data,
     last_call,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test light profiles."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     profile_mock_data = {
         "test": (0.4, 0.6, 100, 0),
@@ -561,11 +564,10 @@ async def test_light_profiles(
 async def test_default_profiles_group(
     hass: HomeAssistant,
     mock_light_profiles,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test default turn-on light profile for all lights."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -787,11 +789,10 @@ async def test_default_profiles_light(
     extra_call_params,
     expected_params_state_was_off,
     expected_params_state_was_on,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test default turn-on light profile for a specific light."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}
@@ -857,11 +858,10 @@ async def test_default_profiles_light(
 async def test_light_context(
     hass: HomeAssistant,
     hass_admin_user: MockUser,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test that light context works."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -886,11 +886,10 @@ async def test_light_context(
 async def test_light_turn_on_auth(
     hass: HomeAssistant,
     hass_read_only_user: MockUser,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test that light context works."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -910,16 +909,14 @@ async def test_light_turn_on_auth(
         )
 
 
-async def test_light_brightness_step(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_brightness_step(hass: HomeAssistant) -> None:
     """Test that light context works."""
     entities = [
         MockLight("Test_0", STATE_ON),
         MockLight("Test_1", STATE_ON),
     ]
 
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_features = light.SUPPORT_BRIGHTNESS
@@ -986,11 +983,10 @@ async def test_light_brightness_step(
 async def test_light_brightness_pct_conversion(
     hass: HomeAssistant,
     enable_custom_integrations: None,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test that light brightness percent conversion."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     entity = mock_light_entities[0]
     entity.supported_features = light.SUPPORT_BRIGHTNESS
@@ -1147,7 +1143,7 @@ invalid_no_brightness_no_color_no_transition,,,
 
 @pytest.mark.parametrize("light_state", [STATE_ON, STATE_OFF])
 async def test_light_backwards_compatibility_supported_color_modes(
-    hass: HomeAssistant, light_state, setup_light_platform: SetupLightPlatformCallable
+    hass: HomeAssistant, light_state
 ) -> None:
     """Test supported_color_modes if not implemented by the entity."""
     entities = [
@@ -1186,7 +1182,7 @@ async def test_light_backwards_compatibility_supported_color_modes(
     entity4.supported_color_modes = None
     entity4.color_mode = None
 
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1230,9 +1226,7 @@ async def test_light_backwards_compatibility_supported_color_modes(
         assert state.attributes["color_mode"] == light.ColorMode.UNKNOWN
 
 
-async def test_light_backwards_compatibility_color_mode(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_backwards_compatibility_color_mode(hass: HomeAssistant) -> None:
     """Test color_mode if not implemented by the entity."""
     entities = [
         MockLight("Test_0", STATE_ON),
@@ -1275,7 +1269,7 @@ async def test_light_backwards_compatibility_color_mode(
     entity4.hs_color = (240, 100)
     entity4.color_temp_kelvin = 10000
 
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1308,14 +1302,12 @@ async def test_light_backwards_compatibility_color_mode(
     assert state.attributes["color_mode"] == light.ColorMode.HS
 
 
-async def test_light_service_call_rgbw(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_service_call_rgbw(hass: HomeAssistant) -> None:
     """Test rgbw functionality in service calls."""
     entity0 = MockLight("Test_rgbw", STATE_ON)
     entity0.supported_color_modes = {light.ColorMode.RGBW}
 
-    setup_light_platform(hass, [entity0])
+    setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1338,9 +1330,7 @@ async def test_light_service_call_rgbw(
     assert data == {"brightness": 255, "rgbw_color": (10, 20, 30, 40)}
 
 
-async def test_light_state_off(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_state_off(hass: HomeAssistant) -> None:
     """Test rgbw color conversion in state updates."""
     entities = [
         MockLight("Test_onoff", STATE_OFF),
@@ -1348,7 +1338,7 @@ async def test_light_state_off(
         MockLight("Test_ct", STATE_OFF),
         MockLight("Test_rgbw", STATE_OFF),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.ONOFF}
@@ -1411,12 +1401,10 @@ async def test_light_state_off(
     }
 
 
-async def test_light_state_rgbw(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_state_rgbw(hass: HomeAssistant) -> None:
     """Test rgbw color conversion in state updates."""
     entity0 = MockLight("Test_rgbw", STATE_ON)
-    setup_light_platform(hass, [entity0])
+    setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
     entity0.brightness = 255
     entity0.supported_color_modes = {light.ColorMode.RGBW}
@@ -1444,12 +1432,10 @@ async def test_light_state_rgbw(
     }
 
 
-async def test_light_state_rgbww(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_state_rgbww(hass: HomeAssistant) -> None:
     """Test rgbww color conversion in state updates."""
     entity0 = MockLight("Test_rgbww", STATE_ON)
-    setup_light_platform(hass, [entity0])
+    setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
     entity0.supported_color_modes = {light.ColorMode.RGBWW}
     entity0.color_mode = light.ColorMode.RGBWW
@@ -1477,9 +1463,7 @@ async def test_light_state_rgbww(
     }
 
 
-async def test_light_service_call_color_conversion(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_service_call_color_conversion(hass: HomeAssistant) -> None:
     """Test color conversion in service calls."""
     entities = [
         MockLight("Test_hs", STATE_ON),
@@ -1491,7 +1475,7 @@ async def test_light_service_call_color_conversion(
         MockLight("Test_rgbww", STATE_ON),
         MockLight("Test_temperature", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
@@ -1923,7 +1907,7 @@ async def test_light_service_call_color_conversion(
 
 
 async def test_light_service_call_color_conversion_named_tuple(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
+    hass: HomeAssistant,
 ) -> None:
     """Test a named tuple (RGBColor) is handled correctly."""
     entities = [
@@ -1935,7 +1919,7 @@ async def test_light_service_call_color_conversion_named_tuple(
         MockLight("Test_rgbw", STATE_ON),
         MockLight("Test_rgbww", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
@@ -2002,16 +1986,14 @@ async def test_light_service_call_color_conversion_named_tuple(
     assert data == {"brightness": 64, "rgbww_color": (128, 0, 0, 0, 0)}
 
 
-async def test_light_service_call_color_temp_emulation(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_service_call_color_temp_emulation(hass: HomeAssistant) -> None:
     """Test color conversion in service calls."""
     entities = [
         MockLight("Test_hs_ct", STATE_ON),
         MockLight("Test_hs", STATE_ON),
         MockLight("Test_hs_white", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.COLOR_TEMP, light.ColorMode.HS}
@@ -2062,15 +2044,13 @@ async def test_light_service_call_color_temp_emulation(
     assert data == {"brightness": 255, "hs_color": (27.001, 19.243)}
 
 
-async def test_light_service_call_color_temp_conversion(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_service_call_color_temp_conversion(hass: HomeAssistant) -> None:
     """Test color temp conversion in service calls."""
     entities = [
         MockLight("Test_rgbww_ct", STATE_ON),
         MockLight("Test_rgbww", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {
@@ -2195,15 +2175,13 @@ async def test_light_service_call_color_temp_conversion(
     assert data == {"brightness": 255, "rgbww_color": (0, 0, 0, 66, 189)}
 
 
-async def test_light_mired_color_temp_conversion(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_mired_color_temp_conversion(hass: HomeAssistant) -> None:
     """Test color temp conversion from K to legacy mired."""
     entities = [
         MockLight("Test_rgbww_ct", STATE_ON),
         MockLight("Test_rgbww", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {
@@ -2243,13 +2221,11 @@ async def test_light_mired_color_temp_conversion(
     assert state.attributes["color_temp_kelvin"] == 3500
 
 
-async def test_light_service_call_white_mode(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_service_call_white_mode(hass: HomeAssistant) -> None:
     """Test color_mode white in service calls."""
     entity0 = MockLight("Test_white", STATE_ON)
     entity0.supported_color_modes = {light.ColorMode.HS, light.ColorMode.WHITE}
-    setup_light_platform(hass, [entity0])
+    setup_test_component_platform(hass, light.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2344,9 +2320,7 @@ async def test_light_service_call_white_mode(
     assert data == {"white": 128}
 
 
-async def test_light_state_color_conversion(
-    hass: HomeAssistant, setup_light_platform: SetupLightPlatformCallable
-) -> None:
+async def test_light_state_color_conversion(hass: HomeAssistant) -> None:
     """Test color conversion in state updates."""
     entities = [
         MockLight("Test_hs", STATE_ON),
@@ -2354,7 +2328,7 @@ async def test_light_state_color_conversion(
         MockLight("Test_xy", STATE_ON),
         MockLight("Test_legacy", STATE_ON),
     ]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
 
     entity0 = entities[0]
     entity0.supported_color_modes = {light.ColorMode.HS}
@@ -2415,11 +2389,10 @@ async def test_light_state_color_conversion(
 async def test_services_filter_parameters(
     hass: HomeAssistant,
     mock_light_profiles,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test turn_on and turn_off filters unsupported parameters."""
-    setup_light_platform(hass, mock_light_entities)
+    setup_test_component_platform(hass, light.DOMAIN, mock_light_entities)
 
     assert await async_setup_component(
         hass, light.DOMAIN, {light.DOMAIN: {CONF_PLATFORM: "test"}}

--- a/tests/components/scene/test_init.py
+++ b/tests/components/scene/test_init.py
@@ -18,19 +18,22 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.yaml import loader as yaml_loader
 
-from tests.common import async_mock_service, mock_restore_cache
-from tests.components.light.common import MockLight, SetupLightPlatformCallable
+from tests.common import (
+    async_mock_service,
+    mock_restore_cache,
+    setup_test_component_platform,
+)
+from tests.components.light.common import MockLight
 
 
 @pytest.fixture(autouse=True)
 def entities(
     hass: HomeAssistant,
-    setup_light_platform: SetupLightPlatformCallable,
     mock_light_entities: list[MockLight],
 ) -> list[MockLight]:
     """Initialize the test light."""
     entities = mock_light_entities[0:2]
-    setup_light_platform(hass, entities)
+    setup_test_component_platform(hass, light.DOMAIN, entities)
     return entities
 
 


### PR DESCRIPTION
## Proposed change
Use the new `setup_test_component_platform` helper function instead of test fixture for light platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
