### PR TITLE
Remove deprecated `hass.components` from system_health tests

### DIFF
--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from aiohttp.client_exceptions import ClientError
 
 from homeassistant.components import system_health
+from homeassistant.components.system_health import async_register_info
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -74,7 +75,7 @@ async def test_info_endpoint_register_callback(
     async def mock_info(hass):
         return {"storage": "YAML"}
 
-    hass.components.system_health.async_register_info("lovelace", mock_info)
+    async_register_info(hass, "lovelace", mock_info)
     assert await async_setup_component(hass, "system_health", {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
@@ -94,7 +95,7 @@ async def test_info_endpoint_register_callback_timeout(
     async def mock_info(hass):
         raise TimeoutError
 
-    hass.components.system_health.async_register_info("lovelace", mock_info)
+    async_register_info(hass, "lovelace", mock_info)
     assert await async_setup_component(hass, "system_health", {})
     data = await gather_system_health_info(hass, hass_ws_client)
 
@@ -111,7 +112,7 @@ async def test_info_endpoint_register_callback_exc(
     async def mock_info(hass):
         raise Exception("TEST ERROR")
 
-    hass.components.system_health.async_register_info("lovelace", mock_info)
+    async_register_info(hass, "lovelace", mock_info)
     assert await async_setup_component(hass, "system_health", {})
     data = await gather_system_health_info(hass, hass_ws_client)
 


### PR DESCRIPTION
## Proposed change
Remove the deprecated use of `hass.components` from system_health tests and import function from component directly.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
