### PR TITLE
Drop Python 3.11 support

### DIFF
--- a/homeassistant/components/cisco_webex_teams/notify.py
+++ b/homeassistant/components/cisco_webex_teams/notify.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-import sys
 
 import voluptuous as vol
+from webexteamssdk import ApiError, WebexTeamsAPI, exceptions
 
 from homeassistant.components.notify import (
     ATTR_TITLE,
@@ -14,13 +14,8 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import CONF_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-
-if sys.version_info < (3, 12):
-    from webexteamssdk import ApiError, WebexTeamsAPI, exceptions
-
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,11 +32,6 @@ def get_service(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> CiscoWebexTeamsNotificationService | None:
     """Get the CiscoWebexTeams notification service."""
-    if sys.version_info >= (3, 12):
-        raise HomeAssistantError(
-            "Cisco Webex Teams is not supported on Python 3.12. Please use Python 3.11."
-        )
-
     client = WebexTeamsAPI(access_token=config[CONF_TOKEN])
     try:
         # Validate the token & room_id

--- a/homeassistant/components/sensor/__init__.py
+++ b/homeassistant/components/sensor/__init__.py
@@ -11,9 +11,7 @@ from decimal import Decimal, InvalidOperation as DecimalInvalidOperation
 from functools import partial
 import logging
 from math import ceil, floor, isfinite, log10
-from typing import TYPE_CHECKING, Any, Final, Self, cast, final
-
-from typing_extensions import override
+from typing import TYPE_CHECKING, Any, Final, Self, cast, final, override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (  # noqa: F401

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -20,10 +20,10 @@ MINOR_VERSION: Final = 4
 PATCH_VERSION: Final = "0.dev0"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
-REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 11, 0)
+REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)
 REQUIRED_NEXT_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)
 # Truthy date string triggers showing related deprecation warning messages.
-REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = "2024.4"
+REQUIRED_NEXT_PYTHON_HA_RELEASE: Final = ""
 
 # Format for platform files
 PLATFORM_FORMAT: Final = "{platform}.{domain}"

--- a/homeassistant/util/async_.py
+++ b/homeassistant/util/async_.py
@@ -8,7 +8,6 @@ import concurrent.futures
 from contextlib import suppress
 import functools
 import logging
-import sys
 import threading
 from typing import Any, ParamSpec, TypeVar, TypeVarTuple
 
@@ -23,35 +22,20 @@ _R = TypeVar("_R")
 _P = ParamSpec("_P")
 _Ts = TypeVarTuple("_Ts")
 
-if sys.version_info >= (3, 12, 0):
 
-    def create_eager_task(
-        coro: Coroutine[Any, Any, _T],
-        *,
-        name: str | None = None,
-        loop: AbstractEventLoop | None = None,
-    ) -> Task[_T]:
-        """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(
-            coro,
-            loop=loop or get_running_loop(),
-            name=name,
-            eager_start=True,  # type: ignore[call-arg]
-        )
-else:
-
-    def create_eager_task(
-        coro: Coroutine[Any, Any, _T],
-        *,
-        name: str | None = None,
-        loop: AbstractEventLoop | None = None,
-    ) -> Task[_T]:
-        """Create a task from a coroutine and schedule it to run immediately."""
-        return Task(
-            coro,
-            loop=loop or get_running_loop(),
-            name=name,
-        )
+def create_eager_task(
+    coro: Coroutine[Any, Any, _T],
+    *,
+    name: str | None = None,
+    loop: AbstractEventLoop | None = None,
+) -> Task[_T]:
+    """Create a task from a coroutine and schedule it to run immediately."""
+    return Task(
+        coro,
+        loop=loop or get_running_loop(),
+        name=name,
+        eager_start=True,
+    )
 
 
 def cancelling(task: Future[Any]) -> bool:

--- a/homeassistant/util/frozen_dataclass_compat.py
+++ b/homeassistant/util/frozen_dataclass_compat.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 
 import dataclasses
 import sys
-from typing import Any
-
-from typing_extensions import dataclass_transform
+from typing import Any, dataclass_transform
 
 
 def _class_fields(cls: type, kw_only: bool) -> list[tuple[str, Any, Any]]:

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@
 # To update, run python3 -m script.hassfest -p mypy_config
 
 [mypy]
-python_version = 3.11
+python_version = 3.12
 plugins = pydantic.mypy
 show_error_codes = true
 follow_imports = silent

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -705,6 +705,8 @@ ignore = [
     "UP007", # keep type annotation style as is
     # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
     "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
+    # Ignored due to incompatible with mypy: https://github.com/python/mypy/issues/15238
+    "UP040", # Checks for use of TypeAlias annotation for declaring type aliases.
 
     # May conflict with the formatter, https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
     "W191",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Home Automation",
 ]
-requires-python = ">=3.11.0"
+requires-python = ">=3.12.0"
 dependencies    = [
     "aiohttp==3.9.3",
     "aiohttp_cors==0.7.0",
@@ -90,7 +90,7 @@ include-package-data = true
 include = ["homeassistant*"]
 
 [tool.pylint.MAIN]
-py-version = "3.11"
+py-version = "3.12"
 ignore = [
     "tests",
 ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Support for Python 3.11 has been dropped. If you run Home Assistant Core, you need to make sure you run Python 3.12.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Python 3.11 was deprecated in #108160 and announced in 2024.2.0 to be dropped in the upcoming 2024.4.0 release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
