### PR TITLE
Move SignalTypes to util

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -18,7 +18,6 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResultType
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import (
-    SignalTypeFormat,
     async_dispatcher_connect,
     async_dispatcher_send,
 )
@@ -26,6 +25,7 @@ from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.helpers.typing import DiscoveryInfoType
 from homeassistant.loader import async_get_mqtt
 from homeassistant.util.json import json_loads_object
+from homeassistant.util.signal_type import SignalTypeFormat
 
 from .. import mqtt
 from .abbreviations import ABBREVIATIONS, DEVICE_ABBREVIATIONS, ORIGIN_ABBREVIATIONS

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -13,6 +13,7 @@ from .helpers.deprecation import (
     check_if_deprecated_constant,
     dir_with_deprecated_constants,
 )
+from .util.signal_type import SignalType
 
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
@@ -1609,7 +1610,9 @@ CAST_APP_ID_HOMEASSISTANT_LOVELACE: Final = "A078F6B0"
 # User used by Supervisor
 HASSIO_USER_NAME = "Supervisor"
 
-SIGNAL_BOOTSTRAP_INTEGRATIONS = "bootstrap_integrations"
+SIGNAL_BOOTSTRAP_INTEGRATIONS: SignalType[dict[str, float]] = SignalType(
+    "bootstrap_integrations"
+)
 
 
 # hass.data key for logging information.

--- a/homeassistant/helpers/discovery.py
+++ b/homeassistant/helpers/discovery.py
@@ -15,11 +15,8 @@ from homeassistant import core, setup
 from homeassistant.const import Platform
 from homeassistant.loader import bind_hass
 
-from .dispatcher import (
-    SignalTypeFormat,
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
+from ..util.signal_type import SignalTypeFormat
+from .dispatcher import async_dispatcher_connect, async_dispatcher_send
 from .typing import ConfigType, DiscoveryInfoType
 
 SIGNAL_PLATFORM_DISCOVERED: SignalTypeFormat[DiscoveryDict] = SignalTypeFormat(

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -3,55 +3,22 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from dataclasses import dataclass
 from functools import partial
 import logging
-from typing import Any, Generic, TypeVarTuple, overload
+from typing import Any, TypeVarTuple, overload
 
 from homeassistant.core import HassJob, HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util.async_ import run_callback_threadsafe
 from homeassistant.util.logging import catch_log_exception
 
+# Explicit reexport of 'SignalType' for backwards compatibility
+from homeassistant.util.signal_type import SignalType as SignalType  # noqa: PLC0414
+
 _Ts = TypeVarTuple("_Ts")
 
 _LOGGER = logging.getLogger(__name__)
 DATA_DISPATCHER = "dispatcher"
-
-
-@dataclass(frozen=True)
-class _SignalTypeBase(Generic[*_Ts]):
-    """Generic base class for SignalType."""
-
-    name: str
-
-    def __hash__(self) -> int:
-        """Return hash of name."""
-
-        return hash(self.name)
-
-    def __eq__(self, other: Any) -> bool:
-        """Check equality for dict keys to be compatible with str."""
-
-        if isinstance(other, str):
-            return self.name == other
-        if isinstance(other, SignalType):
-            return self.name == other.name
-        return False
-
-
-@dataclass(frozen=True, eq=False)
-class SignalType(_SignalTypeBase[*_Ts]):
-    """Generic string class for signal to improve typing."""
-
-
-@dataclass(frozen=True, eq=False)
-class SignalTypeFormat(_SignalTypeBase[*_Ts]):
-    """Generic string class for signal. Requires call to 'format' before use."""
-
-    def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]:
-        """Format name and return new SignalType instance."""
-        return SignalType(self.name.format(*args, **kwargs))
 
 
 _DispatcherDataType = dict[

--- a/homeassistant/util/signal_type.py
+++ b/homeassistant/util/signal_type.py
@@ -1,0 +1,43 @@
+"""Define SignalTypes for dispatcher."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Generic, TypeVarTuple
+
+_Ts = TypeVarTuple("_Ts")
+
+
+@dataclass(frozen=True)
+class _SignalTypeBase(Generic[*_Ts]):
+    """Generic base class for SignalType."""
+
+    name: str
+
+    def __hash__(self) -> int:
+        """Return hash of name."""
+
+        return hash(self.name)
+
+    def __eq__(self, other: Any) -> bool:
+        """Check equality for dict keys to be compatible with str."""
+
+        if isinstance(other, str):
+            return self.name == other
+        if isinstance(other, SignalType):
+            return self.name == other.name
+        return False
+
+
+@dataclass(frozen=True, eq=False)
+class SignalType(_SignalTypeBase[*_Ts]):
+    """Generic string class for signal to improve typing."""
+
+
+@dataclass(frozen=True, eq=False)
+class SignalTypeFormat(_SignalTypeBase[*_Ts]):
+    """Generic string class for signal. Requires call to 'format' before use."""
+
+    def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]:
+        """Format name and return new SignalType instance."""
+        return SignalType(self.name.format(*args, **kwargs))

--- a/tests/helpers/test_dispatcher.py
+++ b/tests/helpers/test_dispatcher.py
@@ -6,11 +6,10 @@ import pytest
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
-    SignalType,
-    SignalTypeFormat,
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.util.signal_type import SignalType, SignalTypeFormat
 
 
 async def test_simple_function(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
Move `SignalType` and `SignalTypeFormat` from `helpers.dispatcher` to `util.signal_type` to prevent circular imports.
`SignalTypeFormat` was only added today (#114174), so we don't need to provide the import for backwards compatibility. `SignalType` will be exported explicitly from `helpers.dispatcher`. I'll do a followup PR to update existing imports in our code base once this is merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
