### PR TITLE
Use fallback voice for selected language in cloud

### DIFF
--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -179,6 +179,15 @@ class CloudTTSEntity(TextToSpeechEntity):
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
         voice = handle_deprecated_voice(self.hass, original_voice)
+        if voice not in TTS_VOICES[language]:
+            default_voice = TTS_VOICES[language][0]
+            _LOGGER.debug(
+                "Unsupported voice %s detected, falling back to default %s for %s",
+                voice,
+                default_voice,
+                language,
+            )
+            voice = default_voice
         # Process TTS
         try:
             data = await self.cloud.voice.process_tts(
@@ -249,6 +258,15 @@ class CloudProvider(Provider):
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
         voice = handle_deprecated_voice(self.hass, original_voice)
+        if voice not in TTS_VOICES[language]:
+            default_voice = TTS_VOICES[language][0]
+            _LOGGER.debug(
+                "Unsupported voice %s detected, falling back to default %s for %s",
+                voice,
+                default_voice,
+                language,
+            )
+            voice = default_voice
         # Process TTS
         try:
             data = await self.cloud.voice.process_tts(

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -177,7 +177,7 @@ class CloudTTSEntity(TextToSpeechEntity):
         gender: Gender | str | None = options.get(ATTR_GENDER)
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
-        if original_voice is None:
+        if original_voice is None and language == self._language:
             original_voice = self._voice
         voice = handle_deprecated_voice(self.hass, original_voice)
         if voice not in TTS_VOICES[language]:
@@ -257,7 +257,7 @@ class CloudProvider(Provider):
         gender: Gender | str | None = options.get(ATTR_GENDER)
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
-        if original_voice is None:
+        if original_voice is None and language == self._language:
             original_voice = self._voice
         voice = handle_deprecated_voice(self.hass, original_voice)
         if voice not in TTS_VOICES[language]:

--- a/homeassistant/components/cloud/tts.py
+++ b/homeassistant/components/cloud/tts.py
@@ -140,7 +140,6 @@ class CloudTTSEntity(TextToSpeechEntity):
         """Return a dict include default options."""
         return {
             ATTR_AUDIO_OUTPUT: AudioOutput.MP3,
-            ATTR_VOICE: self._voice,
         }
 
     @property
@@ -178,6 +177,8 @@ class CloudTTSEntity(TextToSpeechEntity):
         gender: Gender | str | None = options.get(ATTR_GENDER)
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
+        if original_voice is None:
+            original_voice = self._voice
         voice = handle_deprecated_voice(self.hass, original_voice)
         if voice not in TTS_VOICES[language]:
             default_voice = TTS_VOICES[language][0]
@@ -246,7 +247,6 @@ class CloudProvider(Provider):
         """Return a dict include default options."""
         return {
             ATTR_AUDIO_OUTPUT: AudioOutput.MP3,
-            ATTR_VOICE: self._voice,
         }
 
     async def async_get_tts_audio(
@@ -257,6 +257,8 @@ class CloudProvider(Provider):
         gender: Gender | str | None = options.get(ATTR_GENDER)
         gender = handle_deprecated_gender(self.hass, gender)
         original_voice: str | None = options.get(ATTR_VOICE)
+        if original_voice is None:
+            original_voice = self._voice
         voice = handle_deprecated_voice(self.hass, original_voice)
         if voice not in TTS_VOICES[language]:
             default_voice = TTS_VOICES[language][0]

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -657,7 +657,7 @@ async def test_deprecated_gender(
     assert mock_process_tts.call_args is not None
     assert mock_process_tts.call_args.kwargs["text"] == "There is someone at the door."
     assert mock_process_tts.call_args.kwargs["language"] == language
-    assert mock_process_tts.call_args.kwargs["voice"] == "JennyNeural"
+    assert mock_process_tts.call_args.kwargs["voice"] == "XiaoxiaoNeural"
     assert mock_process_tts.call_args.kwargs["output"] == "mp3"
     issue = issue_registry.async_get_issue("cloud", "deprecated_gender")
     assert issue is None
@@ -690,7 +690,7 @@ async def test_deprecated_gender(
     assert mock_process_tts.call_args.kwargs["text"] == "There is someone at the door."
     assert mock_process_tts.call_args.kwargs["language"] == language
     assert mock_process_tts.call_args.kwargs["gender"] == gender_option
-    assert mock_process_tts.call_args.kwargs["voice"] == "JennyNeural"
+    assert mock_process_tts.call_args.kwargs["voice"] == "XiaoxiaoNeural"
     assert mock_process_tts.call_args.kwargs["output"] == "mp3"
     issue = issue_registry.async_get_issue("cloud", issue_id)
     assert issue is not None

--- a/tests/components/cloud/test_tts.py
+++ b/tests/components/cloud/test_tts.py
@@ -132,13 +132,13 @@ async def test_prefs_default_voice(
     assert engine is not None
     # The platform config provider will be overridden by the discovery info provider.
     assert engine.default_language == "en-US"
-    assert engine.default_options == {"audio_output": "mp3", "voice": "JennyNeural"}
+    assert engine.default_options == {"audio_output": "mp3"}
 
     await set_cloud_prefs({"tts_default_voice": ("nl-NL", "MaartenNeural")})
     await hass.async_block_till_done()
 
     assert engine.default_language == "nl-NL"
-    assert engine.default_options == {"audio_output": "mp3", "voice": "MaartenNeural"}
+    assert engine.default_options == {"audio_output": "mp3"}
 
 
 async def test_deprecated_platform_config(
@@ -240,11 +240,11 @@ async def test_get_tts_audio(
         "url": (
             "http://example.local:8123/api/tts_proxy/"
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_en-us_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
         "path": (
             "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_en-us_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
     }
     await hass.async_block_till_done()
@@ -254,6 +254,7 @@ async def test_get_tts_audio(
     assert mock_process_tts.call_args.kwargs["text"] == "There is someone at the door."
     assert mock_process_tts.call_args.kwargs["language"] == "en-US"
     assert mock_process_tts.call_args.kwargs["gender"] is None
+    assert mock_process_tts.call_args.kwargs["voice"] == "JennyNeural"
     assert mock_process_tts.call_args.kwargs["output"] == "mp3"
 
 
@@ -292,11 +293,11 @@ async def test_get_tts_audio_logged_out(
         "url": (
             "http://example.local:8123/api/tts_proxy/"
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_en-us_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
         "path": (
             "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_en-us_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
     }
     await hass.async_block_till_done()
@@ -306,6 +307,7 @@ async def test_get_tts_audio_logged_out(
     assert mock_process_tts.call_args.kwargs["text"] == "There is someone at the door."
     assert mock_process_tts.call_args.kwargs["language"] == "en-US"
     assert mock_process_tts.call_args.kwargs["gender"] is None
+    assert mock_process_tts.call_args.kwargs["voice"] == "JennyNeural"
     assert mock_process_tts.call_args.kwargs["output"] == "mp3"
 
 
@@ -356,11 +358,11 @@ async def test_tts_entity(
         "url": (
             "http://example.local:8123/api/tts_proxy/"
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{entity_id}.mp3"
+            f"_en-us_6e8b81ac47_{entity_id}.mp3"
         ),
         "path": (
             "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_en-us_5c97d21c48_{entity_id}.mp3"
+            f"_en-us_6e8b81ac47_{entity_id}.mp3"
         ),
     }
     await hass.async_block_till_done()
@@ -370,6 +372,7 @@ async def test_tts_entity(
     assert mock_process_tts.call_args.kwargs["text"] == "There is someone at the door."
     assert mock_process_tts.call_args.kwargs["language"] == "en-US"
     assert mock_process_tts.call_args.kwargs["gender"] is None
+    assert mock_process_tts.call_args.kwargs["voice"] == "JennyNeural"
     assert mock_process_tts.call_args.kwargs["output"] == "mp3"
 
     state = hass.states.get(entity_id)
@@ -644,11 +647,11 @@ async def test_deprecated_gender(
         "url": (
             "http://example.local:8123/api/tts_proxy/"
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_{language.lower()}_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_{language.lower()}_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
         "path": (
             "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_{language.lower()}_5c97d21c48_{expected_url_suffix}.mp3"
+            f"_{language.lower()}_6e8b81ac47_{expected_url_suffix}.mp3"
         ),
     }
     await hass.async_block_till_done()
@@ -674,11 +677,11 @@ async def test_deprecated_gender(
         "url": (
             "http://example.local:8123/api/tts_proxy/"
             "42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_{language.lower()}_5dded72256_{expected_url_suffix}.mp3"
+            f"_{language.lower()}_dd0e95eb04_{expected_url_suffix}.mp3"
         ),
         "path": (
             "/api/tts_proxy/42f18378fd4393d18c8dd11d03fa9563c1e54491"
-            f"_{language.lower()}_5dded72256_{expected_url_suffix}.mp3"
+            f"_{language.lower()}_dd0e95eb04_{expected_url_suffix}.mp3"
         ),
     }
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- When a non default language is selected in a `tts.say` or `tts.speak` service call without selecting a valid voice, the default potentially invalid voice will still be selected. To keep the voice optional in the service call we will now fall back to the first valid voice for the selected language instead of failing the text-to-speech call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #113931
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
