### PR TITLE
Add script to compare alexa locales with upstream

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -303,7 +303,7 @@ class Alexa(AlexaCapability):
 
     To compare current supported locales in Home Assistant
     with Alexa supported locales, run the following script:
-    script/alexa_locales.py
+    python -m script.alexa_locales
     """
 
     supported_locales = {

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -300,6 +300,10 @@ class Alexa(AlexaCapability):
     The API suggests you should explicitly include this interface.
 
     https://developer.amazon.com/docs/device-apis/alexa-interface.html
+
+    To compare current supported locales in Home Assistant
+    with Alexa supported locales, run the following script:
+    script/alexa_locales.py
     """
 
     supported_locales = {

--- a/script/alexa_locales.py
+++ b/script/alexa_locales.py
@@ -13,50 +13,55 @@ SITE = (
 )
 
 
-response = requests.get(SITE, timeout=10)
-soup = BeautifulSoup(response.text, "html.parser")
+def run_script():
+    """Run the script."""
+    response = requests.get(SITE, timeout=10)
+    soup = BeautifulSoup(response.text, "html.parser")
 
-table = soup.find("table")
-table_body = table.find_all("tbody")[-1]
-rows = table_body.find_all("tr")
-data = [[ele.text.strip() for ele in row.find_all("td") if ele] for row in rows]
-upstream_locales_raw = {row[0]: row[3] for row in data}
-language_pattern = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
-upstream_locales = {
-    upstream_interface: {
-        name
-        for word in upstream_locale.split(" ")
-        if (name := word.strip(",")) and language_pattern.match(name) is not None
+    table = soup.find("table")
+    table_body = table.find_all("tbody")[-1]
+    rows = table_body.find_all("tr")
+    data = [[ele.text.strip() for ele in row.find_all("td") if ele] for row in rows]
+    upstream_locales_raw = {row[0]: row[3] for row in data}
+    language_pattern = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
+    upstream_locales = {
+        upstream_interface: {
+            name
+            for word in upstream_locale.split(" ")
+            if (name := word.strip(",")) and language_pattern.match(name) is not None
+        }
+        for upstream_interface, upstream_locale in upstream_locales_raw.items()
+        if upstream_interface.count(".") == 1  # Skip sub-interfaces
     }
-    for upstream_interface, upstream_locale in upstream_locales_raw.items()
-    if upstream_interface.count(".") == 1  # Skip sub-interfaces
-}
 
-interfaces_missing = {}
-interfaces_nok = {}
-interfaces_ok = {}
+    interfaces_missing = {}
+    interfaces_nok = {}
+    interfaces_ok = {}
 
-for upstream_interface, upstream_locale in upstream_locales.items():
-    core_interface_name = upstream_interface.replace(".", "")
-    core_interface = getattr(capabilities, core_interface_name, None)
+    for upstream_interface, upstream_locale in upstream_locales.items():
+        core_interface_name = upstream_interface.replace(".", "")
+        core_interface = getattr(capabilities, core_interface_name, None)
 
-    if core_interface is None:
-        interfaces_missing[upstream_interface] = upstream_locale
-        continue
+        if core_interface is None:
+            interfaces_missing[upstream_interface] = upstream_locale
+            continue
 
-    core_locale = core_interface.supported_locales
+        core_locale = core_interface.supported_locales
 
-    if not upstream_locale.issubset(core_locale):
-        interfaces_nok[core_interface_name] = core_locale
-    else:
-        interfaces_ok[core_interface_name] = core_locale
+        if not upstream_locale.issubset(core_locale):
+            interfaces_nok[core_interface_name] = core_locale
+        else:
+            interfaces_ok[core_interface_name] = core_locale
+
+    print("Missing interfaces:")
+    pprint(list(interfaces_missing))
+    print("\n")
+    print("Interfaces where upstream locales are not subsets of the core locales:")
+    pprint(list(interfaces_nok))
+    print("\n")
+    print("Interfaces checked ok:")
+    pprint(list(interfaces_ok))
 
 
-print("Missing interfaces:")
-pprint(list(interfaces_missing))
-print("\n")
-print("Interfaces where upstream locales are not subsets of the core locales:")
-pprint(list(interfaces_nok))
-print("\n")
-print("Interfaces checked ok:")
-pprint(list(interfaces_ok))
+if __name__ == "__main__":
+    run_script()

--- a/script/alexa_locales.py
+++ b/script/alexa_locales.py
@@ -13,7 +13,7 @@ SITE = (
 )
 
 
-def run_script():
+def run_script() -> None:
     """Run the script."""
     response = requests.get(SITE, timeout=10)
     soup = BeautifulSoup(response.text, "html.parser")

--- a/script/alexa_locales.py
+++ b/script/alexa_locales.py
@@ -1,0 +1,62 @@
+"""Check if upstream Alexa locales are subset of the core Alexa supported locales."""
+
+from pprint import pprint
+import re
+
+from bs4 import BeautifulSoup
+import requests
+
+from homeassistant.components.alexa import capabilities
+
+SITE = (
+    "https://developer.amazon.com/en-GB/docs/alexa/device-apis/list-of-interfaces.html"
+)
+
+
+response = requests.get(SITE, timeout=10)
+soup = BeautifulSoup(response.text, "html.parser")
+
+table = soup.find("table")
+table_body = table.find_all("tbody")[-1]
+rows = table_body.find_all("tr")
+data = [[ele.text.strip() for ele in row.find_all("td") if ele] for row in rows]
+upstream_locales_raw = {row[0]: row[3] for row in data}
+language_pattern = re.compile(r"^[a-z]{2}-[A-Z]{2}$")
+upstream_locales = {
+    upstream_interface: {
+        name
+        for word in upstream_locale.split(" ")
+        if (name := word.strip(",")) and language_pattern.match(name) is not None
+    }
+    for upstream_interface, upstream_locale in upstream_locales_raw.items()
+    if upstream_interface.count(".") == 1  # Skip sub-interfaces
+}
+
+interfaces_missing = {}
+interfaces_nok = {}
+interfaces_ok = {}
+
+for upstream_interface, upstream_locale in upstream_locales.items():
+    core_interface_name = upstream_interface.replace(".", "")
+    core_interface = getattr(capabilities, core_interface_name, None)
+
+    if core_interface is None:
+        interfaces_missing[upstream_interface] = upstream_locale
+        continue
+
+    core_locale = core_interface.supported_locales
+
+    if not upstream_locale.issubset(core_locale):
+        interfaces_nok[core_interface_name] = core_locale
+    else:
+        interfaces_ok[core_interface_name] = core_locale
+
+
+print("Missing interfaces:")
+pprint(list(interfaces_missing))
+print("\n")
+print("Interfaces where upstream locales are not subsets of the core locales:")
+pprint(list(interfaces_nok))
+print("\n")
+print("Interfaces checked ok:")
+pprint(list(interfaces_ok))

--- a/tests/fixtures/non_packaged_scripts/alexa_locales.txt
+++ b/tests/fixtures/non_packaged_scripts/alexa_locales.txt
@@ -1,0 +1,650 @@
+                  <h1>List of Alexa Interfaces and Supported Languages</h1>
+
+
+<div markdown="span" class="alert alert-info" role="alert"><i class="fa fa-info-circle"></i> <b>Note:</b> Sign in to the <a href="https://developer.amazon.com/alexa/console/ask" target="_blank" rel="noopener noreferrer">developer console</a> to build or publish your skill.</div><hr />
+
+
+
+
+
+                  <p>Implement the Alexa interfaces to build automotive skills, music, radio, and podcast skills, smart home skills, and video skills.  Alexa interfaces use the <a href="../ask-overviews/voice-interaction-models.html#prebuilt-models">pre-built voice interaction model</a>.</p>
+
+<p>You can use these interfaces with Alexa Voice Service (AVS) Built-in and Alexa Connect Kit (ACK) enabled devices, also. For more details, see <a href="../smarthome/development-options.html">Smart Home Development Options</a>.</p>
+
+<h2 id="alexa-interfaces">Alexa interfaces</h2>
+
+<p>The following table shows the interfaces that you can implement in your Alexa skills. Follow the link to each interface for full details, including the supported capabilities and example customer utterances.</p>
+
+<table><thead><tr><th> Interface
+</th>
+<th> Version
+</th>
+<th> Primary skill type
+</th>
+<th> Supported languages
+
+</th></tr></thead><tbody></tbody><colgroup><col width=" 40%" /><col width="10%" /><col width="20%" /><col width="30%" /></colgroup><tbody><tr><td>
+        <p><a href="../alexa-voice-service/alexa-applicationstatereporter.html"><code>Alexa.ApplicationStateReporter</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>AVS</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-audio-playqueue.html"><code>Alexa.Audio.PlayQueue</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Music, Radio, Podcast</p>
+      </td><td>
+        <p><code>en-US</code>, <code>es-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../automotive/alexa-authorizationcontroller.html"><code>Alexa.AuthorizationController</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Automotive</p>
+      </td><td>
+        <p><code>en-CA</code>, <code>en-US</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-automationmanagement.html"><code>Alexa.AutomationManagement</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home Energy</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../automotive/alexa-automotive-vehicledata.html"><code>Alexa.Automotive.VehicleData</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Automotive</p>
+      </td><td>
+        <p><code>en-CA</code>, <code>en-US</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-brightnesscontroller.html"><code>Alexa.BrightnessController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>,<code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../alexa-voice-service/alexa-liveviewcontroller.html"><code>Alexa.Camera.LiveViewController</code></a></p>
+      </td><td>
+        <p>1.7</p>
+      </td><td>
+        <p>AVS</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-camerastreamcontroller.html"><code>Alexa.CameraStreamController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-channelcontroller.html"><code>Alexa.ChannelController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment, <br />
+Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-colorcontroller.html"><code>Alexa.ColorController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-colortemperaturecontroller.html"><code>Alexa.ColorTemperatureController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-commissionable.html"><code>Alexa.Commissionable</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-consentrequiredreporter.html"><code>Alexa.ConsentManagement.ConsentRequiredReporter</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-contactsensor.html"><code>Alexa.ContactSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking.html"><code>Alexa.Cooking</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-foodtemperaturecontroller.html"><code>Alexa.Cooking.FoodTemperatureController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-foodtemperaturesensor.html"><code>Alexa.Cooking.FoodTemperatureSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-presetcontroller.html"><code>Alexa.Cooking.PresetController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-temperaturecontroller.html"><code>Alexa.Cooking.TemperatureController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-temperaturesensor.html"><code>Alexa.Cooking.TemperatureSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-cooking-timecontroller.html"><code>Alexa.Cooking.TimeController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-datacontroller.html"><code>Alexa.DataController</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-deviceusage-estimation.html"><code>Alexa.DeviceUsage.Estimation</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home Energy</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-deviceusage-meter.html"><code>Alexa.DeviceUsage.Meter</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home Energy</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-doorbelleventsource.html"><code>Alexa.DoorbellEventSource</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-endpointhealth.html"><code>Alexa.EndpointHealth</code></a></p>
+      </td><td>
+        <p>3.1</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-equalizercontroller.html"><code>Alexa.EqualizerController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-inputcontroller.html"><code>Alexa.InputController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment, <br />
+Video, AVS</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-inventorylevelsensor.html"><code>Alexa.InventoryLevelSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>,  <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-inventorylevelusagesensor.html"><code>Alexa.InventoryLevelUsageSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>,  <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-inventoryusagesensor.html"><code>Alexa.InventoryUsageSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>,  <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-keypadcontroller.html"><code>Alexa.KeypadController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-launcher.html"><code>Alexa.Launcher</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-lockcontroller.html"><code>Alexa.LockController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-media-playback.html"><code>Alexa.Media.Playback</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Music, Radio, Podcast</p>
+      </td><td>
+        <p><code>en-US</code>, <code>es-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-media-playqueue.html"><code>Alexa.Media.PlayQueue</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Music, Radio, Podcast</p>
+      </td><td>
+        <p><code>en-US</code>, <code>es-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-media-search.html"><code>Alexa.Media.Search</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Music, Radio, Podcast</p>
+      </td><td>
+        <p><code>en-US</code>, <code>es-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-modecontroller.html"><code>Alexa.ModeController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home, AVS</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-motionsensor.html"><code>Alexa.MotionSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-percentagecontroller.html"><code>Alexa.PercentageController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>,  <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-playbackcontroller.html"><code>Alexa.PlaybackController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment, <br />
+Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-playbackcontroller.html"><code>Alexa.PlaybackStateReporter</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment, <br />
+Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-powercontroller.html"><code>Alexa.PowerController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home,  <br />
+Video, AVS</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-powerlevelcontroller.html"><code>Alexa.PowerLevelController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-proactivenotificationsource.html"><code>Alexa.ProactiveNotificationSource</code></a></p>
+      </td><td>
+        <p>3.0</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p>Notifications for device state: <code>de-DE</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>it-IT</code> <br />
+Notifications for cooking: <code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-rangecontroller.html"><code>Alexa.RangeController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home, AVS</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-recordcontroller.html"><code>Alexa.RecordController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-remotevideoplayer.html"><code>Alexa.RemoteVideoPlayer</code></a></p>
+      </td><td>
+        <p>3.1</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-rtcsessioncontroller.html"><code>Alexa.RTCSessionController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-ES</code>,  <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-scenecontroller.html"><code>Alexa.SceneController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-securitypanelcontroller.html"><code>Alexa.SecurityPanelController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-securitypanelcontroller-alert.html"><code>Alexa.SecurityPanelController.Alert</code></a></p>
+      </td><td>
+        <p>1.1</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-US</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-seekcontroller.html"><code>Alexa.SeekController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-simpleeventsource.html"><code>Alexa.SimpleEventSource</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-smartvision-objectdetectionsensor.html"><code>Alexa.SmartVision.ObjectDetectionSensor</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home Security</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-speaker.html"><code>Alexa.Speaker</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment,  <br />
+Video</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-stepspeaker.html"><code>Alexa.StepSpeaker</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment,  <br />
+Video</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>it-IT</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-temperaturesensor.html"><code>Alexa.TemperatureSensor</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-thermostatcontroller.html"><code>Alexa.ThermostatController</code></a></p>
+      </td><td>
+        <p>3.1</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-thermostatcontroller-configuration.html"><code>Alexa.ThermostatController.Configuration</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-thermostatcontroller-hvac-components.html"><code>Alexa.ThermostatController.HVAC.Components</code></a></p>
+      </td><td>
+        <p>1.0</p>
+      </td><td>
+        <p>Smart Home Energy</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-thermostatcontroller-schedule.html"><code>Alexa.ThermostatController.Schedule</code></a></p>
+      </td><td>
+        <p>3.2</p>
+      </td><td>
+        <p>Smart Home</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-timeholdcontroller.html"><code>Alexa.TimeHoldController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Cooking</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-togglecontroller.html"><code>Alexa.ToggleController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home, AVS</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>,  <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-uicontroller.html"><code>Alexa.UIController</code></a></p>
+      </td><td>
+        <p>3.0</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>en-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-userpreference.html"><code>Alexa.UserPreference</code></a></p>
+      </td><td>
+        <p>2.0</p>
+      </td><td>
+        <p>Music, Radio, Podcast</p>
+      </td><td>
+        <p><code>en-US</code>, <code>es-US</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-videorecorder.html"><code>Alexa.VideoRecorder</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Video</p>
+      </td><td>
+        <p><code>ar-SA</code>, <code>de-DE</code>, <code>en-AU</code>, <code>en-CA</code>, <code>en-GB</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>es-MX</code>, <code>es-US</code>, <code>fr-CA</code>, <code>fr-FR</code>, <code>hi-IN</code>, <code>it-IT</code>, <code>ja-JP</code>, <code>pt-BR</code></p>
+
+      </td></tr><tr><td>
+        <p><a href="../device-apis/alexa-wakeonlancontroller.html"><code>Alexa.WakeOnLANController</code></a></p>
+      </td><td>
+        <p>3</p>
+      </td><td>
+        <p>Smart Home Entertainment</p>
+      </td><td>
+        <p><code>de-DE</code>, <code>en-AU</code>, <code>en-IN</code>, <code>en-US</code>, <code>es-ES</code>, <code>it-IT</code>, <code>ja-JP</code></p>
+
+      </td></tr></tbody></table>
+
+
+
+

--- a/tests/non_packaged_scripts/__init__.py
+++ b/tests/non_packaged_scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the non-packaged scripts in the script directory."""

--- a/tests/non_packaged_scripts/snapshots/test_alexa_locales.ambr
+++ b/tests/non_packaged_scripts/snapshots/test_alexa_locales.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_alexa_locales
+  '''
+  Missing interfaces:
+  ['Alexa.ApplicationStateReporter',
+   'Alexa.AuthorizationController',
+   'Alexa.AutomationManagement',
+   'Alexa.Commissionable',
+   'Alexa.Cooking',
+   'Alexa.DataController',
+   'Alexa.InventoryLevelSensor',
+   'Alexa.InventoryLevelUsageSensor',
+   'Alexa.InventoryUsageSensor',
+   'Alexa.KeypadController',
+   'Alexa.Launcher',
+   'Alexa.PercentageController',
+   'Alexa.ProactiveNotificationSource',
+   'Alexa.RecordController',
+   'Alexa.RemoteVideoPlayer',
+   'Alexa.RTCSessionController',
+   'Alexa.SimpleEventSource',
+   'Alexa.UIController',
+   'Alexa.UserPreference',
+   'Alexa.VideoRecorder',
+   'Alexa.WakeOnLANController']
+  
+  
+  Interfaces where upstream locales are not subsets of the core locales:
+  []
+  
+  
+  Interfaces checked ok:
+  ['AlexaBrightnessController',
+   'AlexaCameraStreamController',
+   'AlexaChannelController',
+   'AlexaColorController',
+   'AlexaColorTemperatureController',
+   'AlexaContactSensor',
+   'AlexaDoorbellEventSource',
+   'AlexaEndpointHealth',
+   'AlexaEqualizerController',
+   'AlexaInputController',
+   'AlexaLockController',
+   'AlexaModeController',
+   'AlexaMotionSensor',
+   'AlexaPlaybackController',
+   'AlexaPlaybackStateReporter',
+   'AlexaPowerController',
+   'AlexaPowerLevelController',
+   'AlexaRangeController',
+   'AlexaSceneController',
+   'AlexaSecurityPanelController',
+   'AlexaSeekController',
+   'AlexaSpeaker',
+   'AlexaStepSpeaker',
+   'AlexaTemperatureSensor',
+   'AlexaThermostatController',
+   'AlexaTimeHoldController',
+   'AlexaToggleController']
+  
+  '''
+# ---

--- a/tests/non_packaged_scripts/test_alexa_locales.py
+++ b/tests/non_packaged_scripts/test_alexa_locales.py
@@ -1,0 +1,26 @@
+"""Test the alexa_locales script."""
+
+from pathlib import Path
+
+import pytest
+import requests_mock
+
+from script.alexa_locales import SITE, run_script
+
+
+def test_alexa_locales(
+    capsys: pytest.CaptureFixture[str], requests_mock: requests_mock.Mocker
+) -> None:
+    """Test alexa_locales script."""
+    fixture_file = (
+        Path(__file__).parent.parent / "fixtures/non_packaged_scripts/alexa_locales.txt"
+    )
+    requests_mock.get(
+        SITE,
+        text=fixture_file.read_text(encoding="utf-8"),
+    )
+
+    run_script()
+
+    captured = capsys.readouterr()
+    assert "Missing interfaces:" in captured.out

--- a/tests/non_packaged_scripts/test_alexa_locales.py
+++ b/tests/non_packaged_scripts/test_alexa_locales.py
@@ -4,12 +4,15 @@ from pathlib import Path
 
 import pytest
 import requests_mock
+from syrupy import SnapshotAssertion
 
 from script.alexa_locales import SITE, run_script
 
 
 def test_alexa_locales(
-    capsys: pytest.CaptureFixture[str], requests_mock: requests_mock.Mocker
+    capsys: pytest.CaptureFixture[str],
+    requests_mock: requests_mock.Mocker,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test alexa_locales script."""
     fixture_file = (
@@ -23,4 +26,4 @@ def test_alexa_locales(
     run_script()
 
     captured = capsys.readouterr()
-    assert "Missing interfaces:" in captured.out
+    assert captured.out == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add a script that fetches the Alexa docs page for Alexa interfaces and compares the documented supported languages against our currently supported languages in core in the Alexa integration.
- Alexa docs page: https://developer.amazon.com/en-GB/docs/alexa/device-apis/list-of-interfaces.html

```
(home-assistant) x:~/dev/home-assistant/core$ python -m script.alexa_locales
Missing interfaces:
['Alexa.ApplicationStateReporter',
 'Alexa.AuthorizationController',
 'Alexa.AutomationManagement',
 'Alexa.Commissionable',
 'Alexa.Cooking',
 'Alexa.DataController',
 'Alexa.InventoryLevelSensor',
 'Alexa.InventoryLevelUsageSensor',
 'Alexa.InventoryUsageSensor',
 'Alexa.KeypadController',
 'Alexa.Launcher',
 'Alexa.PercentageController',
 'Alexa.ProactiveNotificationSource',
 'Alexa.RecordController',
 'Alexa.RemoteVideoPlayer',
 'Alexa.RTCSessionController',
 'Alexa.SimpleEventSource',
 'Alexa.UIController',
 'Alexa.UserPreference',
 'Alexa.VideoRecorder',
 'Alexa.WakeOnLANController']


Interfaces where upstream locales are not subsets of the core locales:
[]


Interfaces checked ok:
['AlexaBrightnessController',
 'AlexaCameraStreamController',
 'AlexaChannelController',
 'AlexaColorController',
 'AlexaColorTemperatureController',
 'AlexaContactSensor',
 'AlexaDoorbellEventSource',
 'AlexaEndpointHealth',
 'AlexaEqualizerController',
 'AlexaInputController',
 'AlexaLockController',
 'AlexaModeController',
 'AlexaMotionSensor',
 'AlexaPlaybackController',
 'AlexaPlaybackStateReporter',
 'AlexaPowerController',
 'AlexaPowerLevelController',
 'AlexaRangeController',
 'AlexaSceneController',
 'AlexaSecurityPanelController',
 'AlexaSeekController',
 'AlexaSpeaker',
 'AlexaStepSpeaker',
 'AlexaTemperatureSensor',
 'AlexaThermostatController',
 'AlexaTimeHoldController',
 'AlexaToggleController']
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
