### PR TITLE
Default floor level to None (and allow unsetting it)

### DIFF
--- a/homeassistant/components/config/floor_registry.py
+++ b/homeassistant/components/config/floor_registry.py
@@ -43,7 +43,7 @@ def websocket_list_floors(
         vol.Required("name"): str,
         vol.Optional("aliases"): list,
         vol.Optional("icon"): vol.Any(str, None),
-        vol.Optional("level"): int,
+        vol.Optional("level"): vol.Any(int, None),
     }
 )
 @websocket_api.require_admin
@@ -98,7 +98,7 @@ def websocket_delete_floor(
         vol.Required("floor_id"): str,
         vol.Optional("aliases"): list,
         vol.Optional("icon"): vol.Any(str, None),
-        vol.Optional("level"): int,
+        vol.Optional("level"): vol.Any(int, None),
         vol.Optional("name"): str,
     }
 )

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -42,7 +42,7 @@ class FloorEntry(NormalizedNameBaseRegistryEntry):
     aliases: set[str]
     floor_id: str
     icon: str | None = None
-    level: int = 0
+    level: int | None = None
 
 
 class FloorRegistry(BaseRegistry):
@@ -99,7 +99,7 @@ class FloorRegistry(BaseRegistry):
         *,
         aliases: set[str] | None = None,
         icon: str | None = None,
-        level: int = 0,
+        level: int | None = None,
     ) -> FloorEntry:
         """Create a new floor."""
         if floor := self.async_get_floor_by_name(name):

--- a/tests/components/config/test_floor_registry.py
+++ b/tests/components/config/test_floor_registry.py
@@ -44,7 +44,7 @@ async def test_list_floors(
         "icon": None,
         "floor_id": "first_floor",
         "name": "First floor",
-        "level": 0,
+        "level": None,
     }
     assert msg["result"][1] == {
         "aliases": unordered(["top floor", "attic"]),
@@ -72,7 +72,7 @@ async def test_create_floor(
         "icon": None,
         "floor_id": "first_floor",
         "name": "First floor",
-        "level": 0,
+        "level": None,
     }
 
     await client.send_json_auto_id(
@@ -196,7 +196,7 @@ async def test_update_floor(
             "name": "First floor",
             "aliases": [],
             "icon": None,
-            "level": 1,
+            "level": None,
             "type": "config/floor_registry/update",
         }
     )
@@ -209,7 +209,7 @@ async def test_update_floor(
         "icon": None,
         "floor_id": floor.floor_id,
         "name": "First floor",
-        "level": 1,
+        "level": None,
     }
 
 

--- a/tests/helpers/test_floor_registry.py
+++ b/tests/helpers/test_floor_registry.py
@@ -134,7 +134,7 @@ async def test_update_floor(
     assert floor.name == "First floor"
     assert floor.icon is None
     assert floor.aliases == set()
-    assert floor.level == 0
+    assert floor.level is None
 
     updated_floor = floor_registry.async_update(
         floor.floor_id,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

By request of the frontend, allow setting the level of a floor to `None` (unset), which will be the default.

The previous default was `0`, which is odd if you create multiple floors (and not all parts of the world start counting floors at `0`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
