### PR TITLE
Address late review of 17track config flow

### DIFF
--- a/homeassistant/components/seventeentrack/config_flow.py
+++ b/homeassistant/components/seventeentrack/config_flow.py
@@ -107,13 +107,11 @@ class SeventeenTrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             login_result = await client.profile.login(
                 import_data[CONF_USERNAME], import_data[CONF_PASSWORD]
             )
-        except SeventeenTrackError as err:
-            _LOGGER.error("There was an error while logging in: %s", err)
+        except SeventeenTrackError:
             return self.async_abort(reason="cannot_connect")
 
         if not login_result:
-            _LOGGER.error("Invalid username and password provided")
-            return self.async_abort(reason="invalid_credentials")
+            return self.async_abort(reason="invalid_auth")
 
         account_id = client.profile.account_id
 
@@ -132,6 +130,7 @@ class SeventeenTrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def _get_client(self):
+    @callback
+    def _get_client(self):
         session = aiohttp_client.async_get_clientsession(self.hass)
         return SeventeenTrackClient(session=session)

--- a/homeassistant/components/seventeentrack/config_flow.py
+++ b/homeassistant/components/seventeentrack/config_flow.py
@@ -67,7 +67,7 @@ class SeventeenTrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         errors = {}
         if user_input:
-            client = await self._get_client()
+            client = self._get_client()
 
             try:
                 if not await client.profile.login(
@@ -101,7 +101,7 @@ class SeventeenTrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Import 17Track config from configuration.yaml."""
 
-        client = await self._get_client()
+        client = self._get_client()
 
         try:
             login_result = await client.profile.login(

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -94,12 +94,12 @@ async def async_setup_platform(
         async_create_issue(
             hass,
             DOMAIN,
-            f"deprecated_yaml_import_issue_${result['reason']}",
+            f"deprecated_yaml_import_issue_{result['reason']}",
             breaks_in_ha_version="2024.10.0",
             is_fixable=False,
             issue_domain=DOMAIN,
             severity=IssueSeverity.WARNING,
-            translation_key=f"deprecated_yaml_import_issue_${result['reason']}",
+            translation_key=f"deprecated_yaml_import_issue_{result['reason']}",
             translation_placeholders=ISSUE_PLACEHOLDER,
         )
 

--- a/homeassistant/components/seventeentrack/strings.json
+++ b/homeassistant/components/seventeentrack/strings.json
@@ -9,11 +9,13 @@
       }
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "error": {
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     }
   },
   "options": {
@@ -32,8 +34,8 @@
       "title": "The 17Track YAML configuration import cannot connect to server",
       "description": "Configuring 17Track using YAML is being removed but there was a connection error importing your YAML configuration.\n\nThings you can try:\nMake sure your home assistant can reach the web.\n\nThen restart Home Assistant to try importing this integration again.\n\nAlternatively, you may remove the 17Track configuration from your YAML configuration entirely, restart Home Assistant, and add the 17Track integration manually."
     },
-    "deprecated_yaml_import_issue_invalid_credentials": {
-      "title": "The 17Track YAML configuration import request failed due to invalid credentials",
+    "deprecated_yaml_import_issue_invalid_auth": {
+      "title": "The 17Track YAML configuration import request failed due to invalid authentication",
       "description": "Configuring 17Track using YAML is being removed but there were invalid credentials provided while importing your existing configuration.\nSetup will not proceed.\n\nVerify that your 17Track credentials are correct and restart Home Assistant to attempt the import again.\n\nAlternatively, you may remove the 17Track configuration from your YAML configuration entirely, restart Home Assistant, and add the 17Track integration manually."
     }
   }

--- a/tests/components/seventeentrack/test_config_flow.py
+++ b/tests/components/seventeentrack/test_config_flow.py
@@ -125,7 +125,7 @@ async def test_import_flow(hass: HomeAssistant, mock_seventeentrack: AsyncMock) 
         (
             False,
             None,
-            "invalid_credentials",
+            "invalid_auth",
         ),
         (
             True,


### PR DESCRIPTION
## Proposed change
Some small fixes for the config flow of 17Track integration


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/111196
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.


To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
