### PR TITLE
Update mypy-dev to 1.10.0a3

### DIFF
--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -194,7 +194,7 @@ def _map_error_to_schema_errors(
 class FlowManager(abc.ABC, Generic[_FlowResultT, _HandlerT]):
     """Manage all the flows that are in progress."""
 
-    _flow_result: Callable[..., _FlowResultT] = FlowResult  # type: ignore[assignment]
+    _flow_result: type[_FlowResultT] = FlowResult  # type: ignore[assignment]
 
     def __init__(
         self,
@@ -615,7 +615,7 @@ class FlowManager(abc.ABC, Generic[_FlowResultT, _HandlerT]):
 class FlowHandler(Generic[_FlowResultT, _HandlerT]):
     """Handle a data entry flow."""
 
-    _flow_result: Callable[..., _FlowResultT] = FlowResult  # type: ignore[assignment]
+    _flow_result: type[_FlowResultT] = FlowResult  # type: ignore[assignment]
 
     # Set by flow manager
     cur_step: _FlowResultT | None = None

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,7 +11,7 @@ astroid==3.1.0
 coverage==7.4.4
 freezegun==1.4.0
 mock-open==1.4.0
-mypy-dev==1.9.0b1
+mypy-dev==1.10.0a3
 pre-commit==3.7.0
 pydantic==1.10.12
 pylint==3.1.0


### PR DESCRIPTION
## Proposed change
https://github.com/cdce8p/mypy-dev/releases/tag/1.10.0a3
Mypy base commit: https://github.com/python/mypy/commit/4310586460e0af07fa8994a0b4f03cb323e352f0
Diff: https://github.com/python/mypy/compare/996544fe21aa21ee29d1ed5a178e2026edbe6bce...4310586460e0af07fa8994a0b4f03cb323e352f0

## Changes since Mypy `1.9.0` (incomplete)
- Improvements to generic inference with empty dict types `{}`.
Required for: https://github.com/home-assistant/core/pull/103844
- Support for `TypeIs` [PEP-742](https://peps.python.org/pep-0742/). A stricter version of `TypeGuard`.
- Bugfix to allow TypedDict initialization from `type[DataTD]` annotation instead of `Callable[..., DataTD]`. This adds an extra level of type checking as now the arguments are checked as well.
Followup from: https://github.com/home-assistant/core/pull/111814#discussion_r1507454712
- Typeshed updates


--
I didn't bump mypy to `1.9.0` the last time as the mypy-dev version was functionally equivalent.
Blog post for the last release `1.9`: https://mypy-lang.blogspot.com/2024/03/mypy-19-released.html
The relevant change summary can also be found in the last PR
- #111258

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
