### PR TITLE
Add Climate groups

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -64,6 +64,7 @@ SERVICE_REMOVE = "remove"
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
     Platform.COVER,
     Platform.FAN,
     Platform.LIGHT,

--- a/homeassistant/components/group/climate.py
+++ b/homeassistant/components/group/climate.py
@@ -1,0 +1,342 @@
+"""Platform for allowing several climate devices to be grouped into one climate device."""
+from __future__ import annotations
+
+import logging
+from statistics import mean
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
+    ATTR_FAN_MODE,
+    ATTR_FAN_MODES,
+    ATTR_HVAC_ACTION,
+    ATTR_HVAC_MODE,
+    ATTR_HVAC_MODES,
+    ATTR_MAX_TEMP,
+    ATTR_MIN_TEMP,
+    ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
+    ATTR_SWING_MODE,
+    ATTR_SWING_MODES,
+    ATTR_TARGET_TEMP_HIGH,
+    ATTR_TARGET_TEMP_LOW,
+    ATTR_TARGET_TEMP_STEP,
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    SERVICE_SET_FAN_MODE,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_PRESET_MODE,
+    SERVICE_SET_SWING_MODE,
+    SERVICE_SET_TEMPERATURE,
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_TEMPERATURE,
+    CONF_ENTITIES,
+    CONF_NAME,
+    CONF_TEMPERATURE_UNIT,
+    CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .entity import GroupEntity
+from .util import (
+    find_state_attributes,
+    most_frequent_attribute,
+    reduce_attribute,
+    states_equal,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_NAME = "Climate Group"
+
+# No limit on parallel updates to enable a group calling another group
+PARALLEL_UPDATES = 0
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
+    }
+)
+# edit the supported_flags
+SUPPORT_FLAGS = (
+    ClimateEntityFeature.TARGET_TEMPERATURE
+    | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+    | ClimateEntityFeature.PRESET_MODE
+    | ClimateEntityFeature.SWING_MODE
+    | ClimateEntityFeature.FAN_MODE
+)
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Initialize climate.group platform."""
+    async_add_entities(
+        [
+            ClimateGroup(
+                config.get(CONF_UNIQUE_ID),
+                config[CONF_NAME],
+                config[CONF_ENTITIES],
+                config.get(CONF_TEMPERATURE_UNIT, hass.config.units.temperature_unit),
+            )
+        ]
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Climate Group config entry."""
+    registry = er.async_get(hass)
+    entities = er.async_validate_entity_ids(
+        registry, config_entry.options[CONF_ENTITIES]
+    )
+
+    async_add_entities(
+        [
+            ClimateGroup(
+                config_entry.entry_id,
+                config_entry.title,
+                entities,
+                config_entry.options.get(
+                    CONF_TEMPERATURE_UNIT, hass.config.units.temperature_unit
+                ),
+            )
+        ]
+    )
+
+
+class ClimateGroup(GroupEntity, ClimateEntity):
+    """Representation of a climate group."""
+
+    _attr_available: bool = False
+    _attr_assumed_state: bool = True
+
+    def __init__(
+        self,
+        unique_id: str | None,
+        name: str,
+        entity_ids: list[str],
+        temperature_unit: str,
+    ) -> None:
+        """Initialize a climate group."""
+        self._entity_ids = entity_ids
+
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_ids}
+
+        self._attr_temperature_unit = temperature_unit
+
+        # Set some defaults (will be overwritten on update)
+        self._attr_supported_features = ClimateEntityFeature(0)
+        self._attr_hvac_modes = [HVACMode.OFF]
+        self._attr_hvac_mode = None
+        self._attr_hvac_action = None
+
+        self._attr_swing_modes = None
+        self._attr_swing_mode = None
+
+        self._attr_fan_modes = None
+        self._attr_fan_mode = None
+
+        self._attr_preset_modes = None
+        self._attr_preset_mode = None
+
+    @callback
+    def async_update_group_state(self) -> None:
+        """Query all members and determine the climate group state."""
+        self._attr_assumed_state = False
+
+        states = [
+            state
+            for entity_id in self._entity_ids
+            if (state := self.hass.states.get(entity_id)) is not None
+        ]
+        self._attr_assumed_state |= not states_equal(states)
+
+        # Set group as unavailable if all members are unavailable or missing
+        self._attr_available = any(state.state != STATE_UNAVAILABLE for state in states)
+
+        # Temperature settings
+        self._attr_target_temperature = reduce_attribute(
+            states, ATTR_TEMPERATURE, reduce=lambda *data: mean(data)
+        )
+
+        self._attr_target_temperature_step = reduce_attribute(
+            states, ATTR_TARGET_TEMP_STEP, reduce=max
+        )
+
+        self._attr_target_temperature_low = reduce_attribute(
+            states, ATTR_TARGET_TEMP_LOW, reduce=lambda *data: mean(data)
+        )
+        self._attr_target_temperature_high = reduce_attribute(
+            states, ATTR_TARGET_TEMP_HIGH, reduce=lambda *data: mean(data)
+        )
+
+        self._attr_current_temperature = reduce_attribute(
+            states, ATTR_CURRENT_TEMPERATURE, reduce=lambda *data: mean(data)
+        )
+
+        self._attr_min_temp = reduce_attribute(states, ATTR_MIN_TEMP, reduce=max)
+        self._attr_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
+        # End temperature settings
+
+        # available HVAC modes
+        all_hvac_modes = list(find_state_attributes(states, ATTR_HVAC_MODES))
+        if all_hvac_modes:
+            # Merge all effects from all effect_lists with a union merge.
+            self._attr_hvac_modes = list(set().union(*all_hvac_modes))
+
+        current_hvac_modes = [
+            x.state
+            for x in states
+            if x.state not in [HVACMode.OFF, STATE_UNAVAILABLE, STATE_UNKNOWN]
+        ]
+        # return the most common hvac mode (what the thermostat is set to do) except OFF, UNKNOWN and UNAVAILABE
+        if current_hvac_modes:
+            self._attr_hvac_mode = HVACMode(
+                max(sorted(set(current_hvac_modes)), key=current_hvac_modes.count)
+            )
+        # return off if any is off
+        elif any(x.state == HVACMode.OFF for x in states):
+            self._attr_hvac_mode = HVACMode.OFF
+        # else it's none
+        else:
+            self._attr_hvac_mode = None
+        # return the most common action if it is not off
+        hvac_actions = list(find_state_attributes(states, ATTR_HVAC_ACTION))
+        current_hvac_actions = [a for a in hvac_actions if a != HVACAction.OFF]
+        # return the most common action if it is not off
+        if current_hvac_actions:
+            self._attr_hvac_action = max(
+                sorted(set(current_hvac_actions)), key=current_hvac_actions.count
+            )
+        # return action off if all are off
+        elif all(a == HVACAction.OFF for a in hvac_actions):
+            self._attr_hvac_action = HVACAction.OFF
+        # else it's none
+        else:
+            self._attr_hvac_action = None
+
+        # available swing modes
+        all_swing_modes = list(find_state_attributes(states, ATTR_SWING_MODES))
+        if all_swing_modes:
+            self._attr_swing_modes = list(set().union(*all_swing_modes))
+
+        # Report the most common swing_mode.
+        self._attr_swing_mode = most_frequent_attribute(states, ATTR_SWING_MODE)
+
+        # available fan modes
+        all_fan_modes = list(find_state_attributes(states, ATTR_FAN_MODES))
+        if all_fan_modes:
+            # Merge all effects from all effect_lists with a union merge.
+            self._attr_fan_modes = list(set().union(*all_fan_modes))
+
+        # Report the most common fan_mode.
+        self._attr_fan_mode = most_frequent_attribute(states, ATTR_FAN_MODE)
+
+        # available preset modes
+        all_preset_modes = list(find_state_attributes(states, ATTR_PRESET_MODES))
+        if all_preset_modes:
+            # Merge all effects from all effect_lists with a union merge.
+            self._attr_preset_modes = list(set().union(*all_preset_modes))
+
+        # Report the most common fan_mode.
+        self._attr_preset_mode = most_frequent_attribute(states, ATTR_PRESET_MODE)
+
+        # Supported flags
+        for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
+            # Merge supported features by emulating support for every feature
+            # we find.
+            self._attr_supported_features |= support
+
+        # Bitwise-and the supported features with the Grouped climate's features
+        # so that we don't break in the future when a new feature is added.
+        self._attr_supported_features &= SUPPORT_FLAGS
+
+        _LOGGER.debug("State update complete")
+
+    async def async_set_temperature(self, **kwargs: Any) -> None:
+        """Forward the turn_on command to all climate in the climate group."""
+        data = {ATTR_ENTITY_ID: self._entity_ids}
+
+        if ATTR_HVAC_MODE in kwargs:
+            _LOGGER.debug("Set temperature with HVAC MODE")
+            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
+
+        if ATTR_TEMPERATURE in kwargs:
+            data[ATTR_TEMPERATURE] = kwargs[ATTR_TEMPERATURE]
+        if ATTR_TARGET_TEMP_LOW in kwargs:
+            data[ATTR_TARGET_TEMP_LOW] = kwargs[ATTR_TARGET_TEMP_LOW]
+        if ATTR_TARGET_TEMP_HIGH in kwargs:
+            data[ATTR_TARGET_TEMP_HIGH] = kwargs[ATTR_TARGET_TEMP_HIGH]
+
+        _LOGGER.debug("Setting temperature: %s", data)
+
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_SET_TEMPERATURE, data, blocking=True, context=self._context
+        )
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Forward the turn_on command to all climate in the climate group."""
+        data = {ATTR_ENTITY_ID: self._entity_ids, ATTR_HVAC_MODE: hvac_mode}
+        _LOGGER.debug("Setting hvac mode: %s", data)
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_SET_HVAC_MODE, data, blocking=True, context=self._context
+        )
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Forward the fan_mode to all climate in the climate group."""
+        data = {ATTR_ENTITY_ID: self._entity_ids, ATTR_FAN_MODE: fan_mode}
+        _LOGGER.debug("Setting fan mode: %s", data)
+        await self.hass.services.async_call(
+            DOMAIN, SERVICE_SET_FAN_MODE, data, blocking=True, context=self._context
+        )
+
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Forward the swing_mode to all climate in the climate group."""
+        data = {ATTR_ENTITY_ID: self._entity_ids, ATTR_SWING_MODE: swing_mode}
+        _LOGGER.debug("Setting swing mode: %s", data)
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_SWING_MODE,
+            data,
+            blocking=True,
+            context=self._context,
+        )
+
+    async def async_set_preset_mode(self, preset_mode: str) -> None:
+        """Forward the preset_mode to all climate in the climate group."""
+        data = {ATTR_ENTITY_ID: self._entity_ids, ATTR_PRESET_MODE: preset_mode}
+        _LOGGER.debug("Setting preset mode: %s", data)
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            data,
+            blocking=True,
+            context=self._context,
+        )

--- a/homeassistant/components/group/climate.py
+++ b/homeassistant/components/group/climate.py
@@ -239,15 +239,15 @@ class ClimateGroup(GroupEntity, ClimateEntity):
         self._attr_max_temp = reduce_attribute(states, ATTR_MAX_TEMP, reduce=min)
         # End temperature settings
 
-        # Build util that will help with the computation of intersection of modes
+        # Build util that will help with the computation of union of modes
         # across all the entity states.
-        def intersect_modes(modes: list[list[Any]]) -> list[Any]:
-            return list(set().union(*modes).intersection(*modes))
+        def merge_modes(modes: list[list[Any]]) -> list[Any]:
+            return list(set().union(*modes))
 
         # available HVAC modes
         all_hvac_modes = list(find_state_attributes(states, ATTR_HVAC_MODES))
         if all_hvac_modes:
-            self._attr_hvac_modes = intersect_modes(all_hvac_modes)
+            self._attr_hvac_modes = merge_modes(all_hvac_modes)
 
         current_hvac_modes = [
             x.state
@@ -283,7 +283,7 @@ class ClimateGroup(GroupEntity, ClimateEntity):
         # available swing modes
         all_swing_modes = list(find_state_attributes(states, ATTR_SWING_MODES))
         if all_swing_modes:
-            self._attr_swing_modes = intersect_modes(all_swing_modes)
+            self._attr_swing_modes = merge_modes(all_swing_modes)
 
         # Report the most common swing_mode.
         self._attr_swing_mode = most_frequent_attribute(states, ATTR_SWING_MODE)
@@ -291,7 +291,7 @@ class ClimateGroup(GroupEntity, ClimateEntity):
         # available fan modes
         all_fan_modes = list(find_state_attributes(states, ATTR_FAN_MODES))
         if all_fan_modes:
-            self._attr_fan_modes = intersect_modes(all_fan_modes)
+            self._attr_fan_modes = merge_modes(all_fan_modes)
 
         # Report the most common fan_mode.
         self._attr_fan_mode = most_frequent_attribute(states, ATTR_FAN_MODE)
@@ -299,7 +299,7 @@ class ClimateGroup(GroupEntity, ClimateEntity):
         # available preset modes
         all_preset_modes = list(find_state_attributes(states, ATTR_PRESET_MODES))
         if all_preset_modes:
-            self._attr_preset_modes = intersect_modes(all_preset_modes)
+            self._attr_preset_modes = merge_modes(all_preset_modes)
 
         # Report the most common fan_mode.
         self._attr_preset_mode = most_frequent_attribute(states, ATTR_PRESET_MODE)

--- a/homeassistant/components/group/climate.py
+++ b/homeassistant/components/group/climate.py
@@ -44,7 +44,6 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ENTITIES,
     CONF_NAME,
-    CONF_TEMPERATURE_UNIT,
     CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -72,16 +71,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_ENTITIES): cv.entities_domain(DOMAIN),
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Optional(CONF_TEMPERATURE_UNIT): cv.temperature_unit,
     }
-)
-# edit the supported_flags
-SUPPORT_FLAGS = (
-    ClimateEntityFeature.TARGET_TEMPERATURE
-    | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-    | ClimateEntityFeature.PRESET_MODE
-    | ClimateEntityFeature.SWING_MODE
-    | ClimateEntityFeature.FAN_MODE
 )
 
 
@@ -98,7 +88,7 @@ async def async_setup_platform(
                 config.get(CONF_UNIQUE_ID),
                 config[CONF_NAME],
                 config[CONF_ENTITIES],
-                config.get(CONF_TEMPERATURE_UNIT, hass.config.units.temperature_unit),
+                hass.config.units.temperature_unit,
             )
         ]
     )
@@ -121,11 +111,22 @@ async def async_setup_entry(
                 config_entry.entry_id,
                 config_entry.title,
                 entities,
-                config_entry.options.get(
-                    CONF_TEMPERATURE_UNIT, hass.config.units.temperature_unit
-                ),
+                hass.config.units.temperature_unit,
             )
         ]
+    )
+
+
+@callback
+def async_create_preview_climate(
+    hass: HomeAssistant, name: str, validated_config: dict[str, Any]
+) -> ClimateGroup:
+    """Create a preview sensor."""
+    return ClimateGroup(
+        None,
+        name,
+        validated_config[CONF_ENTITIES],
+        hass.config.units.temperature_unit,
     )
 
 

--- a/homeassistant/components/group/climate.py
+++ b/homeassistant/components/group/climate.py
@@ -315,20 +315,24 @@ class ClimateGroup(GroupEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Forward the temperature command to all climate in the climate group."""
-        if kwargs.get(ATTR_TEMPERATURE):
+        if temp := kwargs.get(ATTR_TEMPERATURE):
             data = {
                 ATTR_ENTITY_ID: self._features[ClimateEntityFeature.TARGET_TEMPERATURE],
-                ATTR_TEMPERATURE: kwargs[ATTR_TEMPERATURE],
+                ATTR_TEMPERATURE: temp,
             }
-        elif kwargs.get(ATTR_TARGET_TEMP_HIGH):
+        elif (temp_high := kwargs.get(ATTR_TARGET_TEMP_HIGH)) and (
+            temp_low := kwargs.get(ATTR_TARGET_TEMP_LOW)
+        ):
             data = {
-                ATTR_ENTITY_ID: self._features[ClimateEntityFeature.TARGET_TEMPERATURE],
-                ATTR_TARGET_TEMP_HIGH: kwargs[ATTR_TARGET_TEMP_HIGH],
-                ATTR_TARGET_TEMP_LOW: kwargs[ATTR_TARGET_TEMP_LOW],
+                ATTR_ENTITY_ID: self._features[
+                    ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+                ],
+                ATTR_TARGET_TEMP_HIGH: temp_high,
+                ATTR_TARGET_TEMP_LOW: temp_low,
             }
-        if ATTR_HVAC_MODE in kwargs:
+        if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
             data |= {
-                ATTR_HVAC_MODE: kwargs[ATTR_HVAC_MODE],
+                ATTR_HVAC_MODE: hvac_mode,
             }
 
         await self.hass.services.async_call(

--- a/homeassistant/components/group/climate.py
+++ b/homeassistant/components/group/climate.py
@@ -299,19 +299,13 @@ class ClimateGroup(GroupEntity, ClimateEntity):
         # Report the most common fan_mode.
         self._attr_preset_mode = most_frequent_attribute(states, ATTR_PRESET_MODE)
 
-        # Supported flags
-        self._attr_supported_features = ClimateEntityFeature(0)
-        for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
-            # Merge supported features by emulating support for every feature
-            # we find.
-            self._attr_supported_features |= support
-
         # Bitwise-and the supported features with the Grouped climate's features
         # so that we don't break in the future when a new feature is added.
-        all_supported_features = ClimateEntityFeature(0)
-        for feature_flags in self._features:
-            all_supported_features |= feature_flags
-        self._attr_supported_features &= all_supported_features
+        self._attr_supported_features = ClimateEntityFeature(0)
+        for feature_flags, entities in self._features.items():
+            if not entities:
+                continue
+            self._attr_supported_features |= feature_flags
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Forward the temperature command to all climate in the climate group."""

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -149,6 +149,7 @@ async def light_switch_options_schema(
 GROUP_TYPES = [
     "binary_sensor",
     "button",
+    "climate",
     "cover",
     "event",
     "fan",
@@ -193,6 +194,11 @@ CONFIG_FLOW = {
         basic_group_config_schema("button"),
         preview="group",
         validate_user_input=set_group_type("button"),
+    ),
+    "climate": SchemaFlowFormStep(
+        basic_group_config_schema("climate"),
+        preview="climate",
+        validate_user_input=set_group_type("climate"),
     ),
     "cover": SchemaFlowFormStep(
         basic_group_config_schema("cover"),
@@ -251,6 +257,10 @@ OPTIONS_FLOW = {
     "button": SchemaFlowFormStep(
         partial(basic_group_options_schema, "button"),
         preview="group",
+    ),
+    "climate": SchemaFlowFormStep(
+        partial(basic_group_options_schema, "climate"),
+        preview="climate",
     ),
     "cover": SchemaFlowFormStep(
         partial(basic_group_options_schema, "cover"),

--- a/homeassistant/components/group/config_flow.py
+++ b/homeassistant/components/group/config_flow.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
 
 from .binary_sensor import CONF_ALL, async_create_preview_binary_sensor
 from .button import async_create_preview_button
+from .climate import async_create_preview_climate
 from .const import CONF_HIDE_MEMBERS, CONF_IGNORE_NON_NUMERIC, DOMAIN
 from .cover import async_create_preview_cover
 from .entity import GroupEntity
@@ -197,7 +198,7 @@ CONFIG_FLOW = {
     ),
     "climate": SchemaFlowFormStep(
         basic_group_config_schema("climate"),
-        preview="climate",
+        preview="group",
         validate_user_input=set_group_type("climate"),
     ),
     "cover": SchemaFlowFormStep(
@@ -260,7 +261,7 @@ OPTIONS_FLOW = {
     ),
     "climate": SchemaFlowFormStep(
         partial(basic_group_options_schema, "climate"),
-        preview="climate",
+        preview="group",
     ),
     "cover": SchemaFlowFormStep(
         partial(basic_group_options_schema, "cover"),
@@ -308,6 +309,7 @@ CREATE_PREVIEW_ENTITY: dict[
 ] = {
     "binary_sensor": async_create_preview_binary_sensor,
     "button": async_create_preview_button,
+    "climate": async_create_preview_climate,
     "cover": async_create_preview_cover,
     "event": async_create_preview_event,
     "fan": async_create_preview_fan,

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -8,6 +8,7 @@
         "menu_options": {
           "binary_sensor": "Binary sensor group",
           "button": "Button group",
+          "climate": "Climate group",
           "cover": "Cover group",
           "event": "Event group",
           "fan": "Fan group",

--- a/homeassistant/components/group/strings.json
+++ b/homeassistant/components/group/strings.json
@@ -37,6 +37,14 @@
           "name": "[%key:common::config_flow::data::name%]"
         }
       },
+      "climate": {
+        "title": "[%key:component::group::config::step::user::title%]",
+        "data": {
+          "entities": "[%key:component::group::config::step::binary_sensor::data::entities%]",
+          "hide_members": "[%key:component::group::config::step::binary_sensor::data::hide_members%]",
+          "name": "[%key:common::config_flow::data::name%]"
+        }
+      },
       "cover": {
         "title": "[%key:component::group::config::step::user::title%]",
         "data": {

--- a/tests/components/group/fixtures/configuration.yaml
+++ b/tests/components/group/fixtures/configuration.yaml
@@ -1,3 +1,15 @@
+climate:
+  - platform: group
+    name: Downstairs G
+    entities:
+      - climate.downstairs
+      - climate.downstairs_2
+  - platform: group
+    name: Upstairs G
+    entities:
+      - climate.upstairs
+      - climate.upstairs_2
+
 light:
   - platform: group
     name: Master Hall Lights G

--- a/tests/components/group/test_climate.py
+++ b/tests/components/group/test_climate.py
@@ -60,7 +60,7 @@ async def test_default_state(hass: HomeAssistant) -> None:
     ]
     assert state.attributes.get(ATTR_SWING_MODES) is None
     assert state.attributes.get(ATTR_FAN_MODES) is None
-    assert state.attributes.get(ATTR_HVAC_MODES) == [HVACMode.OFF]
+    assert state.attributes.get(ATTR_HVAC_MODES) == []
 
     entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("climate.bedroom_group")
@@ -182,9 +182,7 @@ async def test_supported_features(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     state = hass.states.get("climate.climate_group")
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == (
-        ClimateEntityFeature.TARGET_TEMPERATURE
-        | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
-        | ClimateEntityFeature.FAN_MODE
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
     )
 
     hass.states.async_set(
@@ -197,7 +195,6 @@ async def test_supported_features(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     state = hass.states.get("climate.climate_group")
-    # test1: 0, test2: SWING_MODE
     assert (
         state.attributes[ATTR_SUPPORTED_FEATURES]
         == ClimateEntityFeature.TARGET_TEMPERATURE
@@ -216,12 +213,10 @@ async def test_supported_features(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
     state = hass.states.get("climate.climate_group")
-    # test1: PRESET_MODE | SWING_MODE, test2: SWING_MODE
     assert (
         state.attributes[ATTR_SUPPORTED_FEATURES]
         == ClimateEntityFeature.PRESET_MODE
         | ClimateEntityFeature.SWING_MODE
-        | ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
     )
 

--- a/tests/components/group/test_climate.py
+++ b/tests/components/group/test_climate.py
@@ -1,0 +1,381 @@
+"""The tests for the Group Climate platform."""
+import asyncio
+from unittest.mock import patch
+
+from homeassistant import config as hass_config
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate.const import (
+    ATTR_FAN_MODES,
+    ATTR_HVAC_MODES,
+    ATTR_SWING_MODES,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.components.group import DOMAIN, SERVICE_RELOAD
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import get_fixture_path
+
+
+async def test_default_state(hass):
+    """Test component group default state."""
+    hass.states.async_set("climate.kitchen", HVACMode.AUTO)
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["climate.kitchen", "climate.bedroom"],
+                "name": "Bedroom Group",
+                "unique_id": "unique_identifier",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("climate.bedroom_group")
+    assert state is not None
+    assert state.state == HVACMode.AUTO
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+    assert state.attributes.get(ATTR_ENTITY_ID) == [
+        "climate.kitchen",
+        "climate.bedroom",
+    ]
+    assert state.attributes.get(ATTR_SWING_MODES) is None
+    assert state.attributes.get(ATTR_FAN_MODES) is None
+    assert state.attributes.get(ATTR_HVAC_MODES) == [HVACMode.OFF]
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get("climate.bedroom_group")
+    assert entry
+    assert entry.unique_id == "unique_identifier"
+
+
+async def test_state_reporting(hass):
+    """Test the state reporting.
+
+    The group state is unavailable if all group members are unavailable.
+    Otherwise, the group state is unknown if all group members are unknown.
+    Otherwise, the group state is on if at least one group member is on.
+    Otherwise, the group state is off.
+    """
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["climate.test1", "climate.test2"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # Initial state with no group member in the state machine -> unavailable
+    assert hass.states.get("climate.climate_group").state == STATE_UNAVAILABLE
+
+    # All group members unavailable -> unavailable
+    hass.states.async_set("climate.test1", STATE_UNAVAILABLE)
+    hass.states.async_set("climate.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == STATE_UNAVAILABLE
+
+    # All group members unknown -> unknown
+    hass.states.async_set("climate.test1", STATE_UNKNOWN)
+    hass.states.async_set("climate.test2", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == STATE_UNKNOWN
+
+    # Group members unknown or unavailable -> unknown
+    hass.states.async_set("climate.test1", STATE_UNKNOWN)
+    hass.states.async_set("climate.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == STATE_UNKNOWN
+
+    # At least one member on -> group on
+    hass.states.async_set("climate.test1", HVACMode.AUTO)
+    hass.states.async_set("climate.test2", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.AUTO
+
+    hass.states.async_set("climate.test1", HVACMode.AUTO)
+    hass.states.async_set("climate.test2", HVACMode.OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.AUTO
+
+    hass.states.async_set("climate.test1", HVACMode.AUTO)
+    hass.states.async_set("climate.test2", HVACMode.AUTO)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.AUTO
+
+    hass.states.async_set("climate.test1", HVACMode.AUTO)
+    hass.states.async_set("climate.test2", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.AUTO
+
+    # Otherwise -> off
+    hass.states.async_set("climate.test1", HVACMode.OFF)
+    hass.states.async_set("climate.test2", HVACMode.OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.OFF
+
+    hass.states.async_set("climate.test1", STATE_UNKNOWN)
+    hass.states.async_set("climate.test2", HVACMode.OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.OFF
+
+    hass.states.async_set("climate.test1", STATE_UNAVAILABLE)
+    hass.states.async_set("climate.test2", HVACMode.OFF)
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.OFF
+
+    # All group members removed from the state machine -> unavailable
+    hass.states.async_remove("climate.test1")
+    hass.states.async_remove("climate.test2")
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == STATE_UNAVAILABLE
+
+
+async def test_supported_features(hass):
+    """Test supported features reporting."""
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: {
+                "platform": DOMAIN,
+                "entities": ["climate.test1", "climate.test2"],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    hass.states.async_set("climate.test1", HVACMode.AUTO, {ATTR_SUPPORTED_FEATURES: 0})
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.climate_group")
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == 0
+
+    hass.states.async_set(
+        "climate.test2",
+        HVACMode.AUTO,
+        {ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.SWING_MODE},
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.climate_group")
+    # test1: 0, test2: SWING_MODE
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == ClimateEntityFeature.SWING_MODE
+
+    hass.states.async_set(
+        "climate.test1",
+        HVACMode.AUTO,
+        {
+            ATTR_SUPPORTED_FEATURES: ClimateEntityFeature.PRESET_MODE
+            | ClimateEntityFeature.SWING_MODE
+        },
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.climate_group")
+    # test1: PRESET_MODE | SWING_MODE, test2: SWING_MODE
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.SWING_MODE
+    )
+
+    # Test that unknown feature 256 is blocked
+    hass.states.async_set(
+        "climate.test2", HVACMode.AUTO, {ATTR_SUPPORTED_FEATURES: 256}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("climate.climate_group")
+
+    # test1: PRESET_MODE | SWING_MODE, test2: 256
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.SWING_MODE
+    )
+
+
+async def test_reload(hass):
+    """Test the ability to reload lights."""
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: [
+                {"platform": "demo"},
+                {
+                    "platform": DOMAIN,
+                    "entities": [
+                        "climate.hvac",
+                        "climate.ecobee",
+                    ],
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+    await hass.async_block_till_done()
+    assert hass.states.get("climate.climate_group").state == HVACMode.COOL
+
+    yaml_path = get_fixture_path("configuration.yaml", "group")
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get("climate.climate_group") is None
+    assert hass.states.get("climate.upstairs_g") is not None
+    assert hass.states.get("climate.downstairs_g") is not None
+
+
+async def test_reload_with_platform_not_setup(hass):
+    """Test the ability to reload climate."""
+    hass.states.async_set("climate.bowl", HVACMode.AUTO)
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: [
+                {"platform": "demo"},
+            ]
+        },
+    )
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "climate.Bowl", "icon": "mdi:work"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    yaml_path = get_fixture_path("configuration.yaml", "group")
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get("climate.climate_group") is None
+    assert hass.states.get("climate.upstairs_g") is not None
+    assert hass.states.get("climate.downstairs_g") is not None
+
+
+async def test_reload_with_base_integration_platform_not_setup(hass):
+    """Test the ability to reload climate."""
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "group_zero": {"entities": "climate.Bowl", "icon": "mdi:work"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("climate.upstairs", HVACMode.AUTO)
+    hass.states.async_set("climate.upstairs_2", HVACMode.AUTO)
+
+    hass.states.async_set("climate.downstairs", HVACMode.OFF)
+    hass.states.async_set("climate.downstairs_2", HVACMode.OFF)
+
+    yaml_path = get_fixture_path("configuration.yaml", "group")
+    with patch.object(hass_config, "YAML_CONFIG_FILE", yaml_path):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            {},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get("climate.climate_group") is None
+    assert hass.states.get("climate.upstairs_g") is not None
+    assert hass.states.get("climate.downstairs_g") is not None
+    assert hass.states.get("climate.upstairs_g").state == HVACMode.AUTO
+    assert hass.states.get("climate.downstairs_g").state == HVACMode.OFF
+
+
+async def test_nested_group(hass):
+    """Test nested light group."""
+    await async_setup_component(
+        hass,
+        CLIMATE_DOMAIN,
+        {
+            CLIMATE_DOMAIN: [
+                {"platform": "demo"},
+                {
+                    "platform": DOMAIN,
+                    "entities": ["climate.bedroom_group"],
+                    "name": "Nested Group",
+                },
+                {
+                    "platform": DOMAIN,
+                    "entities": ["climate.hvac", "climate.ecobee"],
+                    "name": "Bedroom Group",
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state_hvav = hass.states.get("climate.hvac")
+    assert state_hvav.state == HVACMode.COOL
+    state_ecobee = hass.states.get("climate.ecobee")
+    assert state_ecobee.state == HVACMode.HEAT_COOL
+    state_group = hass.states.get("climate.bedroom_group")
+
+    assert state_group is not None
+    assert state_group.state == HVACMode.COOL
+    assert state_group.attributes.get(ATTR_ENTITY_ID) == [
+        "climate.hvac",
+        "climate.ecobee",
+    ]
+
+    state_nested = hass.states.get("climate.nested_group")
+    assert state_nested is not None
+    assert state_nested.state == HVACMode.COOL
+    assert state_nested.attributes.get(ATTR_ENTITY_ID) == ["climate.bedroom_group"]
+
+    # Test controlling the nested group
+    async with asyncio.timeout(0.5):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "climate.nested_group"},
+            blocking=True,
+        )
+    assert hass.states.get("climate.ecobee").state == HVACMode.OFF
+    assert hass.states.get("climate.hvac").state == HVACMode.OFF
+    assert hass.states.get("climate.bedroom_group").state == HVACMode.OFF
+    assert hass.states.get("climate.nested_group").state == HVACMode.OFF

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -30,6 +30,7 @@ from tests.typing import WebSocketGenerator
         ("binary_sensor", "on", "on", {}, {}, {"all": False}, {}),
         ("binary_sensor", "on", "on", {}, {"all": True}, {"all": True}, {}),
         ("button", STATE_UNKNOWN, "2021-01-01T23:59:59.123+00:00", {}, {}, {}, {}),
+        ("climate", "off", "off", {}, {}, {}, {}),
         ("cover", "open", "open", {}, {}, {}, {}),
         (
             "event",
@@ -138,6 +139,7 @@ async def test_config_flow(
     [
         ("binary_sensor", {"all": False}),
         ("button", {}),
+        ("climate", {}),
         ("cover", {}),
         ("event", {}),
         ("fan", {}),
@@ -217,6 +219,7 @@ def get_suggested(schema, key):
     [
         ("binary_sensor", "on", {"all": False}, {}),
         ("button", "2021-01-01T23:59:59.123+00:00", {}, {}),
+        ("climate", "off", {}, {}),
         ("cover", "open", {}, {}),
         ("event", "2021-01-01T23:59:59.123+00:00", {}, {}),
         ("fan", "on", {}, {}),
@@ -403,6 +406,7 @@ async def test_all_options(
     [
         ("binary_sensor", {"all": False}),
         ("button", {}),
+        ("climate", {}),
         ("cover", {}),
         ("event", {}),
         ("fan", {}),

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -483,6 +483,19 @@ async def test_options_flow_hides_members(
     assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by
 
 
+CLIMATE_ATTRS = [
+    {
+        "supported_features": 0,
+        "hvac_modes": ["off"],
+        "max_temp": None,
+        "min_temp": None,
+    },
+    {
+        "assumed_state": True,
+        "current_temperature": None,
+        "hvac_action": "off",
+    },
+]
 COVER_ATTRS = [{"supported_features": 0}, {}]
 EVENT_ATTRS = [{"event_types": []}, {"event_type": None}]
 FAN_ATTRS = [{"supported_features": 0}, {}]
@@ -505,6 +518,7 @@ SENSOR_ATTRS = [{"icon": "mdi:calculator"}, {"max_entity_id": "sensor.input_two"
     [
         ("binary_sensor", {"all": True}, ["on", "off"], "off", [{}, {}]),
         ("button", {}, ["", ""], "unknown", [{}, {}]),
+        ("climate", {}, ["heat", "off"], "heat", CLIMATE_ATTRS),
         ("cover", {}, ["open", "closed"], "open", COVER_ATTRS),
         ("event", {}, ["", ""], "unknown", EVENT_ATTRS),
         ("fan", {}, ["on", "off"], "on", FAN_ATTRS),
@@ -616,6 +630,7 @@ async def test_config_flow_preview(
     [
         ("binary_sensor", {"all": True}, {"all": False}, ["on", "off"], "on", [{}, {}]),
         ("button", {}, {}, ["", ""], "unknown", [{}, {}]),
+        ("climate", {}, {}, ["heat", "off"], "heat", CLIMATE_ATTRS),
         ("cover", {}, {}, ["open", "closed"], "open", COVER_ATTRS),
         ("event", {}, {}, ["", ""], "unknown", EVENT_ATTRS),
         ("fan", {}, {}, ["on", "off"], "on", FAN_ATTRS),

--- a/tests/components/group/test_config_flow.py
+++ b/tests/components/group/test_config_flow.py
@@ -486,7 +486,7 @@ async def test_options_flow_hides_members(
 CLIMATE_ATTRS = [
     {
         "supported_features": 0,
-        "hvac_modes": ["off"],
+        "hvac_modes": [],
         "max_temp": None,
         "min_temp": None,
     },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Note**: This PR is a continuation of the existing work: https://github.com/home-assistant/core/pull/77737

Adds a climate group component. Based initially on https://github.com/daenny/climate_group, but updated to be similar to the existing light/fan implementations.

Description of the grouping behaviour (taken from the docs PR):

In short, when any group member is active (not `off` state), the most common state is shown.

- The group state is `unavailable` if all group members are `unavailable`.
- Otherwise, the group state is `unknown` if all group members are `unknown` or `unavailable`.
- Otherwise, the group state is `off` if all group members are `off`.
- Otherwise, the group state is the most common state of the group members which are not `off`.

For other modes, the most common mode is reported (e.g. for `PRESET_MODES`, `FAN_MODE` and `SWING_MODE`). The reported temperatures are the averages from the given entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #111482
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32091

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
