### PR TITLE
Add force activate button to wyoming satellite

### DIFF
--- a/homeassistant/components/wyoming/__init__.py
+++ b/homeassistant/components/wyoming/__init__.py
@@ -20,6 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 SATELLITE_PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.SELECT,
     Platform.SWITCH,
     Platform.NUMBER,

--- a/homeassistant/components/wyoming/button.py
+++ b/homeassistant/components/wyoming/button.py
@@ -1,0 +1,43 @@
+"""Wyoming button entities."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .entity import WyomingSatelliteEntity
+
+if TYPE_CHECKING:
+    from .models import DomainDataItem
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up button entities."""
+    item: DomainDataItem = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Setup is only forwarded for satellites
+    assert item.satellite is not None
+
+    async_add_entities([WyomingSatelliteForceActivate(item.satellite.device)])
+
+
+class WyomingSatelliteForceActivate(WyomingSatelliteEntity, ButtonEntity):
+    """Manually activate the satellite instead of using a wake word."""
+
+    entity_description = ButtonEntityDescription(
+        key="activate",
+        translation_key="activat",
+    )
+
+    async def async_press(self, **kwargs: Any) -> None:
+        """Turn on."""
+        self._device.force_activate()

--- a/homeassistant/components/wyoming/devices.py
+++ b/homeassistant/components/wyoming/devices.py
@@ -26,6 +26,7 @@ class SatelliteDevice:
 
     _is_active_listener: Callable[[], None] | None = None
     _is_muted_listener: Callable[[], None] | None = None
+    _force_activate_listener: Callable[[], None] | None = None
     _pipeline_listener: Callable[[], None] | None = None
     _audio_settings_listener: Callable[[], None] | None = None
 
@@ -44,6 +45,12 @@ class SatelliteDevice:
             self.is_muted = muted
             if self._is_muted_listener is not None:
                 self._is_muted_listener()
+
+    @callback
+    def force_activate(self) -> None:
+        """Request to activate without a wake word."""
+        if self._force_activate_listener is not None:
+            self._force_activate_listener()
 
     @callback
     def set_pipeline_name(self, pipeline_name: str) -> None:
@@ -86,6 +93,13 @@ class SatelliteDevice:
     def set_is_muted_listener(self, is_muted_listener: Callable[[], None]) -> None:
         """Listen for updates to muted status."""
         self._is_muted_listener = is_muted_listener
+
+    @callback
+    def set_force_activate_listener(
+        self, force_activate_listener: Callable[[], None]
+    ) -> None:
+        """Listen for force activate requests."""
+        self._force_activate_listener = force_activate_listener
 
     @callback
     def set_pipeline_listener(self, pipeline_listener: Callable[[], None]) -> None:

--- a/homeassistant/components/wyoming/strings.json
+++ b/homeassistant/components/wyoming/strings.json
@@ -53,6 +53,11 @@
         "name": "Mute"
       }
     },
+    "button": {
+      "activat": {
+        "name": "Activate"
+      }
+    },
     "number": {
       "auto_gain": {
         "name": "Auto gain"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a server-side "force activate" button to wyoming satellite that causes the satellite to go directly to ASR (a sort of "push to talk" button). This allows to activate the satellite via any automation.

__Example use-case__: when my TV is on wake-word detection is very unreliable. At the same time I have a remote control in my hand. So I setup an automation that mutes the satellite when the TV is on to avoid false detections, and I configure a button of the TV remote to run another automation that lowers the TV volume, activates the satellite, and raises the volume afterwards. So I can just press the button and give whatever command I want while watching TV.

I considered various ways to implement this, here are some design considerations:
- It should work when the satellite is either muted (i.e. push-to-talk only) or unmuted (normal satellite with ability to force activate).
- The code should handle the various statellite states as uniformly as possible, without creating a dozen different event flows and with minimal changes to the satellite.
- If vad/wake is active on the satellite we might not have an active pipeline even if the satellite is unmuted.
- `run-pipeline` is normally initiated by the satellite, not the server

So I ended up with the following design (open to discussion, of course):
- The user presses the "force activate" button
- If the server has a currently running pipeline, it closes it. 
- Then `run-satellite` is sent to the satellite, with `start_stage == asr`. This event was already sent to unpause the satellite, only `start_stage` is added.
- When the satellite receives `run-satellite` with  `start_stage == asr` it unpauses as usual, but goes directly to streaming.
-  `run-pipeline` is sent from the satellite as usual, but with `start_stage == asr`.
- After the force activated pipeline is over:
  - the satellite will act as usual (going to vad / wake / ...), no change is needed.
  - if `is_muted == True`, the server will send `pause-satellite` to re-pause the satellite.

Overall this design covers the requirements with relatively small number of changes in both the server and client.

Some more notes:
- I used a button which is a bit more user-friendly, but clearly we can use a service instead.
- Concerning terminology, I used "force activate" in the code, since "active" was already used to indicate that the satellite is past the wake stage. For the user the button is simply labelled "Activate". Let me know if there are better terms to use.
- I didn't add any tests yet, I wanted to confirm the design first.
- Same for documentation, I can add it once we decide to move forward.
- The PR depends on this [wyoming PR](https://github.com/rhasspy/wyoming/pull/10) and this [wyoming-satellite PR](https://github.com/rhasspy/wyoming-satellite/pull/144) .


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
