### PR TITLE
Use `setup_test_component_platform` helper for sensor entity component tests instead of `hass.components`

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1461,7 +1461,10 @@ def mock_integration(
 
 
 def mock_platform(
-    hass: HomeAssistant, platform_path: str, module: Mock | MockPlatform | None = None
+    hass: HomeAssistant,
+    platform_path: str,
+    module: Mock | MockPlatform | None = None,
+    built_in=True,
 ) -> None:
     """Mock a platform.
 
@@ -1472,7 +1475,7 @@ def mock_platform(
     module_cache = hass.data[loader.DATA_COMPONENTS]
 
     if domain not in integration_cache:
-        mock_integration(hass, MockModule(domain))
+        mock_integration(hass, MockModule(domain), built_in=built_in)
 
     integration_cache[domain]._top_level_files.add(f"{platform_name}.py")
     _LOGGER.info("Adding mock integration platform: %s", platform_path)
@@ -1665,6 +1668,7 @@ def setup_test_component_platform(
     domain: str,
     entities: Sequence[Entity],
     from_config_entry: bool = False,
+    built_in: bool = True,
 ) -> MockPlatform:
     """Mock a test component platform for tests."""
 
@@ -1695,9 +1699,5 @@ def setup_test_component_platform(
         platform.async_setup_entry = _async_setup_entry
         platform.async_setup_platform = None
 
-    mock_platform(
-        hass,
-        f"test.{domain}",
-        platform,
-    )
+    mock_platform(hass, f"test.{domain}", platform, built_in=built_in)
     return platform

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -10,6 +10,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 
 if TYPE_CHECKING:
     from tests.components.light.common import MockLight
+    from tests.components.sensor.common import MockSensor
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -118,3 +119,11 @@ def mock_light_entities() -> list["MockLight"]:
         MockLight("Ceiling", STATE_OFF),
         MockLight(None, STATE_OFF),
     ]
+
+
+@pytest.fixture
+def mock_sensor_entities() -> dict[str, "MockSensor"]:
+    """Return mocked sensor entities."""
+    from tests.components.sensor.common import get_mock_sensor_entities
+
+    return get_mock_sensor_entities()

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -45,7 +45,6 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utcnow
 
-from ..sensor.common import MockSensor
 from .test_common import help_all_subscribe_calls
 
 from tests.common import (
@@ -56,6 +55,7 @@ from tests.common import (
     mock_restore_cache,
     setup_test_component_platform,
 )
+from tests.components.sensor.common import MockSensor
 from tests.typing import (
     MqttMockHAClient,
     MqttMockHAClientGenerator,

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -23,6 +23,7 @@ from homeassistant.components.mqtt.models import (
     MqttValueTemplateException,
     ReceiveMessage,
 )
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
@@ -44,6 +45,7 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 from homeassistant.util.dt import utcnow
 
+from ..sensor.common import MockSensor
 from .test_common import help_all_subscribe_calls
 
 from tests.common import (
@@ -52,9 +54,7 @@ from tests.common import (
     async_fire_mqtt_message,
     async_fire_time_changed,
     mock_restore_cache,
-)
-from tests.testing_config.custom_components.test.sensor import (  # type: ignore[attr-defined]
-    DEVICE_CLASSES,
+    setup_test_component_platform,
 )
 from tests.typing import (
     MqttMockHAClient,
@@ -3142,12 +3142,12 @@ async def test_debug_info_non_mqtt(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mqtt_mock_entry: MqttMockHAClientGenerator,
+    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get empty debug_info for a device with non MQTT entities."""
     await mqtt_mock_entry()
     domain = "sensor"
-    platform = getattr(hass.components, f"test.{domain}")
-    platform.init()
+    setup_test_component_platform(hass, domain, mock_sensor_entities)
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -3155,11 +3155,11 @@ async def test_debug_info_non_mqtt(
         config_entry_id=config_entry.entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    for device_class in DEVICE_CLASSES:
+    for device_class in SensorDeviceClass:
         entity_registry.async_get_or_create(
             domain,
             "test",
-            platform.ENTITIES[device_class].unique_id,
+            mock_sensor_entities[device_class].unique_id,
             device_id=device_entry.id,
         )
 

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -1,10 +1,6 @@
-"""Provide a mock sensor platform.
-
-Call init before using it in your tests to ensure clean test data.
-"""
+"""Common test utilities for sensor entity component tests."""
 
 from homeassistant.components.sensor import (
-    DEVICE_CLASSES,
     RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
@@ -23,8 +19,6 @@ from homeassistant.const import (
 )
 
 from tests.common import MockEntity
-
-DEVICE_CLASSES.append("none")
 
 UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.APPARENT_POWER: UnitOfApparentPower.VOLT_AMPERE,  # apparent power (VA)
@@ -55,34 +49,6 @@ UNITS_OF_MEASUREMENT = {
     SensorDeviceClass.VOLTAGE: "V",  # voltage (V)
     SensorDeviceClass.GAS: UnitOfVolume.CUBIC_METERS,  # gas (m³)
 }
-
-ENTITIES = {}
-
-
-def init(empty=False):
-    """Initialize the platform with entities."""
-    global ENTITIES
-
-    ENTITIES = (
-        {}
-        if empty
-        else {
-            device_class: MockSensor(
-                name=f"{device_class} sensor",
-                unique_id=f"unique_{device_class}",
-                device_class=device_class,
-                native_unit_of_measurement=UNITS_OF_MEASUREMENT.get(device_class),
-            )
-            for device_class in DEVICE_CLASSES
-        }
-    )
-
-
-async def async_setup_platform(
-    hass, config, async_add_entities_callback, discovery_info=None
-):
-    """Return mock entities."""
-    async_add_entities_callback(list(ENTITIES.values()))
 
 
 class MockSensor(MockEntity, SensorEntity):
@@ -141,3 +107,16 @@ class MockRestoreSensor(MockSensor, RestoreSensor):
         self._values["native_unit_of_measurement"] = (
             last_sensor_data.native_unit_of_measurement
         )
+
+
+def get_mock_sensor_entities() -> dict[str, MockSensor]:
+    """Get mock sensor entities."""
+    return {
+        device_class: MockSensor(
+            name=f"{device_class} sensor",
+            unique_id=f"unique_{device_class}",
+            device_class=device_class,
+            native_unit_of_measurement=UNITS_OF_MEASUREMENT.get(device_class),
+        )
+        for device_class in ("none", *SensorDeviceClass)
+    }

--- a/tests/components/sensor/common.py
+++ b/tests/components/sensor/common.py
@@ -118,5 +118,5 @@ def get_mock_sensor_entities() -> dict[str, MockSensor]:
             device_class=device_class,
             native_unit_of_measurement=UNITS_OF_MEASUREMENT.get(device_class),
         )
-        for device_class in ("none", *SensorDeviceClass)
+        for device_class in SensorDeviceClass
     }

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -417,10 +417,13 @@ async def test_get_condition_capabilities_legacy(
 async def test_get_condition_capabilities_none(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected capabilities from a sensor condition."""
-    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
+    entity = MockSensor(
+        name="none sensor",
+        unique_id="unique_none",
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity])
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -428,7 +431,7 @@ async def test_get_condition_capabilities_none(
     entry_none = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        mock_sensor_entities["none"].unique_id,
+        entity.unique_id,
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -26,8 +26,9 @@ from tests.common import (
     async_get_device_automation_capabilities,
     async_get_device_automations,
     async_mock_service,
+    setup_test_component_platform,
 )
-from tests.testing_config.custom_components.test.sensor import UNITS_OF_MEASUREMENT
+from tests.components.sensor.common import UNITS_OF_MEASUREMENT, MockSensor
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -85,11 +86,10 @@ async def test_get_conditions(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected conditions from a sensor."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
     sensor_entries = {}
@@ -104,7 +104,7 @@ async def test_get_conditions(
         sensor_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
-            platform.ENTITIES[device_class].unique_id,
+            mock_sensor_entities[device_class].unique_id,
             device_id=device_entry.id,
         )
 
@@ -284,6 +284,7 @@ async def test_get_condition_capabilities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    mock_sensor_entities: dict[str, MockSensor],
     set_state,
     device_class_reg,
     device_class_state,
@@ -291,8 +292,7 @@ async def test_get_condition_capabilities(
     unit_state,
 ) -> None:
     """Test we get the expected capabilities from a sensor condition."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -303,7 +303,7 @@ async def test_get_condition_capabilities(
     entity_id = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["battery"].unique_id,
+        mock_sensor_entities["battery"].unique_id,
         device_id=device_entry.id,
         original_device_class=device_class_reg,
         unit_of_measurement=unit_reg,
@@ -353,6 +353,7 @@ async def test_get_condition_capabilities_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    mock_sensor_entities: dict[str, MockSensor],
     set_state,
     device_class_reg,
     device_class_state,
@@ -360,8 +361,7 @@ async def test_get_condition_capabilities_legacy(
     unit_state,
 ) -> None:
     """Test we get the expected capabilities from a sensor condition."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -372,7 +372,7 @@ async def test_get_condition_capabilities_legacy(
     entity_id = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["battery"].unique_id,
+        mock_sensor_entities["battery"].unique_id,
         device_id=device_entry.id,
         original_device_class=device_class_reg,
         unit_of_measurement=unit_reg,
@@ -417,11 +417,10 @@ async def test_get_condition_capabilities_legacy(
 async def test_get_condition_capabilities_none(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected capabilities from a sensor condition."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -429,7 +428,7 @@ async def test_get_condition_capabilities_none(
     entry_none = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["none"].unique_id,
+        mock_sensor_entities["none"].unique_id,
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -374,10 +374,13 @@ async def test_get_trigger_capabilities_legacy(
 async def test_get_trigger_capabilities_none(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected capabilities from a sensor trigger."""
-    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities)
+    entity = MockSensor(
+        name="none sensor",
+        unique_id="unique_none",
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity])
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -385,7 +388,7 @@ async def test_get_trigger_capabilities_none(
     entry_none = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        mock_sensor_entities["none"].unique_id,
+        entity.unique_id,
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -30,8 +30,9 @@ from tests.common import (
     async_get_device_automation_capabilities,
     async_get_device_automations,
     async_mock_service,
+    setup_test_component_platform,
 )
-from tests.testing_config.custom_components.test.sensor import UNITS_OF_MEASUREMENT
+from tests.components.sensor.common import UNITS_OF_MEASUREMENT, MockSensor
 
 
 @pytest.fixture(autouse=True, name="stub_blueprint_populate")
@@ -87,11 +88,10 @@ async def test_get_triggers(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected triggers from a sensor."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities.values())
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
     sensor_entries: dict[SensorDeviceClass, er.RegistryEntry] = {}
@@ -106,7 +106,7 @@ async def test_get_triggers(
         sensor_entries[device_class] = entity_registry.async_get_or_create(
             DOMAIN,
             "test",
-            platform.ENTITIES[device_class].unique_id,
+            mock_sensor_entities[device_class].unique_id,
             device_id=device_entry.id,
         )
 
@@ -241,6 +241,7 @@ async def test_get_trigger_capabilities(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    mock_sensor_entities: dict[str, MockSensor],
     set_state,
     device_class_reg,
     device_class_state,
@@ -248,8 +249,7 @@ async def test_get_trigger_capabilities(
     unit_state,
 ) -> None:
     """Test we get the expected capabilities from a sensor trigger."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities)
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -260,7 +260,7 @@ async def test_get_trigger_capabilities(
     entity_id = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["battery"].unique_id,
+        mock_sensor_entities["battery"].unique_id,
         device_id=device_entry.id,
         original_device_class=device_class_reg,
         unit_of_measurement=unit_reg,
@@ -311,6 +311,7 @@ async def test_get_trigger_capabilities_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    mock_sensor_entities: dict[str, MockSensor],
     set_state,
     device_class_reg,
     device_class_state,
@@ -318,8 +319,7 @@ async def test_get_trigger_capabilities_legacy(
     unit_state,
 ) -> None:
     """Test we get the expected capabilities from a sensor trigger."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities)
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -330,7 +330,7 @@ async def test_get_trigger_capabilities_legacy(
     entity_id = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["battery"].unique_id,
+        mock_sensor_entities["battery"].unique_id,
         device_id=device_entry.id,
         original_device_class=device_class_reg,
         unit_of_measurement=unit_reg,
@@ -374,11 +374,10 @@ async def test_get_trigger_capabilities_legacy(
 async def test_get_trigger_capabilities_none(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    enable_custom_integrations: None,
+    mock_sensor_entities: dict[str, MockSensor],
 ) -> None:
     """Test we get the expected capabilities from a sensor trigger."""
-    platform = getattr(hass.components, f"test.{DOMAIN}")
-    platform.init()
+    setup_test_component_platform(hass, DOMAIN, mock_sensor_entities)
 
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -386,7 +385,7 @@ async def test_get_trigger_capabilities_none(
     entry_none = entity_registry.async_get_or_create(
         DOMAIN,
         "test",
-        platform.ENTITIES["none"].unique_id,
+        mock_sensor_entities["none"].unique_id,
     )
 
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -63,7 +63,9 @@ from tests.common import (
     mock_integration,
     mock_platform,
     mock_restore_cache_with_extra_data,
+    setup_test_component_platform,
 )
+from tests.components.sensor.common import MockRestoreSensor, MockSensor
 
 TEST_DOMAIN = "test"
 
@@ -103,7 +105,6 @@ TEST_DOMAIN = "test"
 )
 async def test_temperature_conversion(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     state_unit,
@@ -112,16 +113,14 @@ async def test_temperature_conversion(
 ) -> None:
     """Test temperature conversion."""
     hass.config.units = unit_system
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=str(native_value),
         native_unit_of_measurement=native_unit,
         device_class=SensorDeviceClass.TEMPERATURE,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -132,19 +131,17 @@ async def test_temperature_conversion(
 
 @pytest.mark.parametrize("device_class", [None, SensorDeviceClass.PRESSURE])
 async def test_temperature_conversion_wrong_device_class(
-    hass: HomeAssistant, device_class, enable_custom_integrations: None
+    hass: HomeAssistant, device_class
 ) -> None:
     """Test temperatures are not converted if the sensor has wrong device class."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value="0.0",
         native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
         device_class=device_class,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -158,21 +155,19 @@ async def test_temperature_conversion_wrong_device_class(
 async def test_deprecated_last_reset(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     state_class,
 ) -> None:
     """Test warning on deprecated last reset."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test", state_class=state_class, last_reset=dt_util.utc_from_timestamp(0)
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
     assert (
-        "Entity sensor.test (<class 'custom_components.test.sensor.MockSensor'>) "
+        "Entity sensor.test (<class 'tests.components.sensor.common.MockSensor'>) "
         f"with state_class {state_class} has set last_reset. Setting last_reset for "
         "entities with state_class other than 'total' is not supported. Please update "
         "your configuration if state_class is manually configured."
@@ -185,7 +180,6 @@ async def test_deprecated_last_reset(
 async def test_datetime_conversion(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test conversion of datetime."""
     test_timestamp = datetime(2017, 12, 19, 18, 29, 42, tzinfo=UTC)
@@ -193,51 +187,49 @@ async def test_datetime_conversion(
         dt_util.get_time_zone("Europe/Amsterdam")
     )
     test_date = date(2017, 12, 19)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test",
-        native_value=test_timestamp,
-        device_class=SensorDeviceClass.TIMESTAMP,
-    )
-    platform.ENTITIES["1"] = platform.MockSensor(
-        name="Test", native_value=test_date, device_class=SensorDeviceClass.DATE
-    )
-    platform.ENTITIES["2"] = platform.MockSensor(
-        name="Test", native_value=None, device_class=SensorDeviceClass.TIMESTAMP
-    )
-    platform.ENTITIES["3"] = platform.MockSensor(
-        name="Test", native_value=None, device_class=SensorDeviceClass.DATE
-    )
-    platform.ENTITIES["4"] = platform.MockSensor(
-        name="Test",
-        native_value=test_local_timestamp,
-        device_class=SensorDeviceClass.TIMESTAMP,
-    )
+    entities = [
+        MockSensor(
+            name="Test",
+            native_value=test_timestamp,
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
+        MockSensor(
+            name="Test", native_value=test_date, device_class=SensorDeviceClass.DATE
+        ),
+        MockSensor(
+            name="Test", native_value=None, device_class=SensorDeviceClass.TIMESTAMP
+        ),
+        MockSensor(name="Test", native_value=None, device_class=SensorDeviceClass.DATE),
+        MockSensor(
+            name="Test",
+            native_value=test_local_timestamp,
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
+    ]
+    setup_test_component_platform(hass, sensor.DOMAIN, entities)
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
-    state = hass.states.get(platform.ENTITIES["0"].entity_id)
+    state = hass.states.get(entities[0].entity_id)
     assert state.state == test_timestamp.isoformat()
 
-    state = hass.states.get(platform.ENTITIES["1"].entity_id)
+    state = hass.states.get(entities[1].entity_id)
     assert state.state == test_date.isoformat()
 
-    state = hass.states.get(platform.ENTITIES["2"].entity_id)
+    state = hass.states.get(entities[2].entity_id)
     assert state.state == STATE_UNKNOWN
 
-    state = hass.states.get(platform.ENTITIES["3"].entity_id)
+    state = hass.states.get(entities[3].entity_id)
     assert state.state == STATE_UNKNOWN
 
-    state = hass.states.get(platform.ENTITIES["4"].entity_id)
+    state = hass.states.get(entities[4].entity_id)
     assert state.state == test_timestamp.isoformat()
 
 
 async def test_a_sensor_with_a_non_numeric_device_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test that a sensor with a non numeric device class will be non numeric.
 
@@ -249,29 +241,29 @@ async def test_a_sensor_with_a_non_numeric_device_class(
         dt_util.get_time_zone("Europe/Amsterdam")
     )
 
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test",
-        native_value=test_local_timestamp,
-        native_unit_of_measurement="",
-        device_class=SensorDeviceClass.TIMESTAMP,
-    )
-
-    platform.ENTITIES["1"] = platform.MockSensor(
-        name="Test",
-        native_value=test_local_timestamp,
-        state_class="",
-        device_class=SensorDeviceClass.TIMESTAMP,
-    )
+    entities = [
+        MockSensor(
+            name="Test",
+            native_value=test_local_timestamp,
+            native_unit_of_measurement="",
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
+        MockSensor(
+            name="Test",
+            native_value=test_local_timestamp,
+            state_class="",
+            device_class=SensorDeviceClass.TIMESTAMP,
+        ),
+    ]
+    setup_test_component_platform(hass, sensor.DOMAIN, entities)
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
-    state = hass.states.get(platform.ENTITIES["0"].entity_id)
+    state = hass.states.get(entities[0].entity_id)
     assert state.state == test_timestamp.isoformat()
 
-    state = hass.states.get(platform.ENTITIES["1"].entity_id)
+    state = hass.states.get(entities[1].entity_id)
     assert state.state == test_timestamp.isoformat()
 
 
@@ -285,17 +277,15 @@ async def test_a_sensor_with_a_non_numeric_device_class(
 async def test_deprecated_datetime_str(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     device_class,
     state_value,
     provides,
 ) -> None:
     """Test warning on deprecated str for a date(time) value."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test", native_value=state_value, device_class=device_class
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -309,17 +299,15 @@ async def test_deprecated_datetime_str(
 async def test_reject_timezoneless_datetime_str(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test rejection of timezone-less datetime objects as timestamp."""
     test_timestamp = datetime(2017, 12, 19, 18, 29, 42, tzinfo=None)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=test_timestamp,
         device_class=SensorDeviceClass.TIMESTAMP,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -403,7 +391,6 @@ RESTORE_DATA = {
 )
 async def test_restore_sensor_save_state(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     hass_storage: dict[str, Any],
     native_value,
     native_value_type,
@@ -412,16 +399,14 @@ async def test_restore_sensor_save_state(
     uom,
 ) -> None:
     """Test RestoreSensor."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockRestoreSensor(
+    entity0 = MockRestoreSensor(
         name="Test",
         native_value=native_value,
         native_unit_of_measurement=uom,
         device_class=device_class,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -472,7 +457,6 @@ async def test_restore_sensor_save_state(
 )
 async def test_restore_sensor_restore_state(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     hass_storage: dict[str, Any],
     native_value,
     native_value_type,
@@ -483,14 +467,12 @@ async def test_restore_sensor_restore_state(
     """Test RestoreSensor."""
     mock_restore_cache_with_extra_data(hass, ((State("sensor.test", ""), extra_data),))
 
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockRestoreSensor(
+    entity0 = MockRestoreSensor(
         name="Test",
         device_class=device_class,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -621,7 +603,6 @@ async def test_restore_sensor_restore_state(
 )
 async def test_custom_unit(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     device_class,
     native_unit,
     custom_unit,
@@ -638,17 +619,15 @@ async def test_custom_unit(
     )
     await hass.async_block_till_done()
 
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=str(native_value),
         native_unit_of_measurement=native_unit,
         device_class=device_class,
         unique_id="very_unique",
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -884,7 +863,6 @@ async def test_custom_unit(
 )
 async def test_custom_unit_change(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     native_unit,
     custom_unit,
     state_unit,
@@ -895,17 +873,15 @@ async def test_custom_unit_change(
 ) -> None:
     """Test custom unit changes are picked up."""
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=str(native_value),
         native_unit_of_measurement=native_unit,
         device_class=device_class,
         unique_id="very_unique",
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
-    entity0 = platform.ENTITIES["0"]
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -972,7 +948,6 @@ async def test_custom_unit_change(
 )
 async def test_unit_conversion_priority(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     automatic_unit,
@@ -990,27 +965,21 @@ async def test_unit_conversion_priority(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
-
-    platform.ENTITIES["1"] = platform.MockSensor(
+    entity1 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
     )
-    entity1 = platform.ENTITIES["1"]
-
-    platform.ENTITIES["2"] = platform.MockSensor(
+    entity2 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1018,16 +987,23 @@ async def test_unit_conversion_priority(
         suggested_unit_of_measurement=suggested_unit,
         unique_id="very_unique_2",
     )
-    entity2 = platform.ENTITIES["2"]
-
-    platform.ENTITIES["3"] = platform.MockSensor(
+    entity3 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
         suggested_unit_of_measurement=suggested_unit,
     )
-    entity3 = platform.ENTITIES["3"]
+    setup_test_component_platform(
+        hass,
+        sensor.DOMAIN,
+        [
+            entity0,
+            entity1,
+            entity2,
+            entity3,
+        ],
+    )
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1119,7 +1095,6 @@ async def test_unit_conversion_priority(
 )
 async def test_unit_conversion_priority_precision(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     automatic_unit,
@@ -1138,10 +1113,8 @@ async def test_unit_conversion_priority_precision(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1149,18 +1122,14 @@ async def test_unit_conversion_priority_precision(
         suggested_display_precision=suggested_precision,
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
-
-    platform.ENTITIES["1"] = platform.MockSensor(
+    entity1 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
         suggested_display_precision=suggested_precision,
     )
-    entity1 = platform.ENTITIES["1"]
-
-    platform.ENTITIES["2"] = platform.MockSensor(
+    entity2 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1169,9 +1138,7 @@ async def test_unit_conversion_priority_precision(
         suggested_unit_of_measurement=suggested_unit,
         unique_id="very_unique_2",
     )
-    entity2 = platform.ENTITIES["2"]
-
-    platform.ENTITIES["3"] = platform.MockSensor(
+    entity3 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1179,7 +1146,16 @@ async def test_unit_conversion_priority_precision(
         suggested_display_precision=suggested_precision,
         suggested_unit_of_measurement=suggested_unit,
     )
-    entity3 = platform.ENTITIES["3"]
+    setup_test_component_platform(
+        hass,
+        sensor.DOMAIN,
+        [
+            entity0,
+            entity1,
+            entity2,
+            entity3,
+        ],
+    )
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1280,7 +1256,6 @@ async def test_unit_conversion_priority_precision(
 )
 async def test_unit_conversion_priority_suggested_unit_change(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     original_unit,
@@ -1294,8 +1269,6 @@ async def test_unit_conversion_priority_suggested_unit_change(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
     # Pre-register entities
     entry = entity_registry.async_get_or_create(
@@ -1315,16 +1288,14 @@ async def test_unit_conversion_priority_suggested_unit_change(
         {"suggested_unit_of_measurement": original_unit},
     )
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
-
-    platform.ENTITIES["1"] = platform.MockSensor(
+    entity1 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1332,7 +1303,7 @@ async def test_unit_conversion_priority_suggested_unit_change(
         suggested_unit_of_measurement=suggested_unit,
         unique_id="very_unique_2",
     )
-    entity1 = platform.ENTITIES["1"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0, entity1])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1392,7 +1363,6 @@ async def test_unit_conversion_priority_suggested_unit_change(
 )
 async def test_unit_conversion_priority_suggested_unit_change_2(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     native_unit_1,
     native_unit_2,
     suggested_unit,
@@ -1405,8 +1375,6 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
     hass.config.units = METRIC_SYSTEM
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
     # Pre-register entities
     entity_registry.async_get_or_create(
@@ -1416,16 +1384,14 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
         "sensor", "test", "very_unique_2", unit_of_measurement=native_unit_1
     )
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit_2,
         native_value=str(native_value),
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
-
-    platform.ENTITIES["1"] = platform.MockSensor(
+    entity1 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit_2,
@@ -1433,7 +1399,7 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
         suggested_unit_of_measurement=suggested_unit,
         unique_id="very_unique_2",
     )
-    entity1 = platform.ENTITIES["1"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0, entity1])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1496,7 +1462,6 @@ async def test_unit_conversion_priority_suggested_unit_change_2(
 )
 async def test_suggested_precision_option(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     integration_suggested_precision,
@@ -1510,10 +1475,7 @@ async def test_suggested_precision_option(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1521,7 +1483,7 @@ async def test_suggested_precision_option(
         suggested_display_precision=integration_suggested_precision,
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1574,7 +1536,6 @@ async def test_suggested_precision_option(
 )
 async def test_suggested_precision_option_update(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     suggested_unit,
@@ -1590,8 +1551,6 @@ async def test_suggested_precision_option_update(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
     # Pre-register entities
     entry = entity_registry.async_get_or_create("sensor", "test", "very_unique")
@@ -1610,7 +1569,7 @@ async def test_suggested_precision_option_update(
         },
     )
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -1618,7 +1577,7 @@ async def test_suggested_precision_option_update(
         suggested_display_precision=new_precision,
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1666,7 +1625,6 @@ async def test_suggested_precision_option_update(
 )
 async def test_unit_conversion_priority_legacy_conversion_removed(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system,
     native_unit,
     original_unit,
@@ -1679,22 +1637,20 @@ async def test_unit_conversion_priority_legacy_conversion_removed(
     hass.config.units = unit_system
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
     # Pre-register entities
     entity_registry.async_get_or_create(
         "sensor", "test", "very_unique", unit_of_measurement=original_unit
     )
 
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
         native_value=str(native_value),
         unique_id="very_unique",
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1715,17 +1671,15 @@ def test_device_classes_aligned() -> None:
 async def test_value_unknown_in_enumeration(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test warning on invalid enum value."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value="invalid_option",
         device_class=SensorDeviceClass.ENUM,
         options=["option1", "option2"],
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1739,17 +1693,15 @@ async def test_value_unknown_in_enumeration(
 async def test_invalid_enumeration_entity_with_device_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test warning on entities that provide an enum with a device class."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=21,
         device_class=SensorDeviceClass.POWER,
         options=["option1", "option2"],
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1763,16 +1715,14 @@ async def test_invalid_enumeration_entity_with_device_class(
 async def test_invalid_enumeration_entity_without_device_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test warning on entities that provide an enum without a device class."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=21,
         options=["option1", "option2"],
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1794,19 +1744,17 @@ async def test_invalid_enumeration_entity_without_device_class(
 async def test_non_numeric_device_class_with_unit_of_measurement(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     device_class: SensorDeviceClass,
 ) -> None:
     """Test error on numeric entities that provide an unit of measurement."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=None,
         device_class=device_class,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         options=["option1", "option2"],
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1869,18 +1817,16 @@ async def test_non_numeric_device_class_with_unit_of_measurement(
 async def test_device_classes_with_invalid_unit_of_measurement(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     device_class: SensorDeviceClass,
 ) -> None:
     """Test error when unit of measurement is not valid for used device class."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value="1.0",
         device_class=device_class,
         native_unit_of_measurement="INVALID!",
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
     units = [
         str(unit) if unit else "no unit of measurement"
         for unit in DEVICE_CLASS_UNITS.get(device_class, set())
@@ -1920,7 +1866,6 @@ async def test_device_classes_with_invalid_unit_of_measurement(
 async def test_non_numeric_validation_error(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     native_value: Any,
     problem: str,
     device_class: SensorDeviceClass | None,
@@ -1928,16 +1873,14 @@ async def test_non_numeric_validation_error(
     unit: str | None,
 ) -> None:
     """Test error on expected numeric entities."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=native_value,
         device_class=device_class,
         native_unit_of_measurement=unit,
         state_class=state_class,
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1966,7 +1909,6 @@ async def test_non_numeric_validation_error(
 async def test_non_numeric_validation_raise(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     native_value: Any,
     expected: str,
     device_class: SensorDeviceClass | None,
@@ -1975,9 +1917,7 @@ async def test_non_numeric_validation_raise(
     precision,
 ) -> None:
     """Test error on expected numeric entities."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         device_class=device_class,
         native_unit_of_measurement=unit,
@@ -1985,7 +1925,7 @@ async def test_non_numeric_validation_raise(
         state_class=state_class,
         suggested_display_precision=precision,
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2018,7 +1958,6 @@ async def test_non_numeric_validation_raise(
 async def test_numeric_validation(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     native_value: Any,
     expected: str,
     device_class: SensorDeviceClass | None,
@@ -2026,16 +1965,14 @@ async def test_numeric_validation(
     unit: str | None,
 ) -> None:
     """Test does not error on expected numeric entities."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=native_value,
         device_class=device_class,
         native_unit_of_measurement=unit,
         state_class=state_class,
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2052,18 +1989,15 @@ async def test_numeric_validation(
 async def test_numeric_validation_ignores_custom_device_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
 ) -> None:
     """Test does not error on expected numeric entities."""
     native_value = "Three elephants"
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=native_value,
         device_class="custom__deviceclass",
     )
-    entity0 = platform.ENTITIES["0"]
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2084,18 +2018,16 @@ async def test_numeric_validation_ignores_custom_device_class(
 async def test_device_classes_with_invalid_state_class(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     device_class: SensorDeviceClass,
 ) -> None:
     """Test error when unit of measurement is not valid for used device class."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=None,
         state_class="INVALID!",
         device_class=device_class,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2133,7 +2065,6 @@ async def test_device_classes_with_invalid_state_class(
 async def test_numeric_state_expected_helper(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
-    enable_custom_integrations: None,
     device_class: SensorDeviceClass | None,
     state_class: SensorStateClass | None,
     native_unit_of_measurement: str | None,
@@ -2141,9 +2072,7 @@ async def test_numeric_state_expected_helper(
     is_numeric: bool,
 ) -> None:
     """Test numeric_state_expected helper."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test",
         native_value=None,
         device_class=device_class,
@@ -2151,11 +2080,11 @@ async def test_numeric_state_expected_helper(
         native_unit_of_measurement=native_unit_of_measurement,
         suggested_display_precision=suggested_precision,
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
-    entity0 = platform.ENTITIES["0"]
     state = hass.states.get(entity0.entity_id)
     assert state is not None
 
@@ -2199,7 +2128,6 @@ async def test_numeric_state_expected_helper(
 )
 async def test_unit_conversion_update(
     hass: HomeAssistant,
-    enable_custom_integrations: None,
     unit_system_1,
     unit_system_2,
     native_unit,
@@ -2219,9 +2147,8 @@ async def test_unit_conversion_update(
     hass.config.units = unit_system_1
 
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
 
-    entity0 = platform.MockSensor(
+    entity0 = MockSensor(
         name="Test 0",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2229,7 +2156,7 @@ async def test_unit_conversion_update(
         unique_id="very_unique",
     )
 
-    entity1 = platform.MockSensor(
+    entity1 = MockSensor(
         name="Test 1",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2237,7 +2164,7 @@ async def test_unit_conversion_update(
         unique_id="very_unique_1",
     )
 
-    entity2 = platform.MockSensor(
+    entity2 = MockSensor(
         name="Test 2",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2246,7 +2173,7 @@ async def test_unit_conversion_update(
         unique_id="very_unique_2",
     )
 
-    entity3 = platform.MockSensor(
+    entity3 = MockSensor(
         name="Test 3",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2255,7 +2182,7 @@ async def test_unit_conversion_update(
         unique_id="very_unique_3",
     )
 
-    entity4 = platform.MockSensor(
+    entity4 = MockSensor(
         name="Test 4",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2544,11 +2471,8 @@ async def test_entity_category_config_raises_error(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test error is raised when entity category is set to config."""
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
-    platform.ENTITIES["0"] = platform.MockSensor(
-        name="Test", entity_category=EntityCategory.CONFIG
-    )
+    entity0 = MockSensor(name="Test", entity_category=EntityCategory.CONFIG)
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity0])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -2644,13 +2568,11 @@ async def test_suggested_unit_guard_invalid_unit(
     An invalid suggested unit creates a log entry and the suggested unit will be ignored.
     """
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
     state_value = 10
     invalid_suggested_unit = "invalid_unit"
 
-    entity = platform.ENTITIES["0"] = platform.MockSensor(
+    entity = MockSensor(
         name="Invalid",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2658,6 +2580,7 @@ async def test_suggested_unit_guard_invalid_unit(
         native_value=str(state_value),
         unique_id="invalid",
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity])
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()
 
@@ -2674,10 +2597,10 @@ async def test_suggested_unit_guard_invalid_unit(
         "homeassistant.components.sensor",
         logging.WARNING,
         (
-            "<class 'custom_components.test.sensor.MockSensor'> sets an"
-            " invalid suggested_unit_of_measurement. Please report it to the author"
-            " of the 'test' custom integration. This warning will become an error in"
-            " Home Assistant Core 2024.5"
+            "<class 'tests.components.sensor.common.MockSensor'> sets an"
+            " invalid suggested_unit_of_measurement. Please create a bug report at "
+            "https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+test%22."
+            " This warning will become an error in Home Assistant Core 2024.5"
         ),
     ) in caplog.record_tuples
 
@@ -2715,10 +2638,8 @@ async def test_suggested_unit_guard_valid_unit(
     in the entity registry.
     """
     entity_registry = er.async_get(hass)
-    platform = getattr(hass.components, "test.sensor")
-    platform.init(empty=True)
 
-    entity = platform.ENTITIES["0"] = platform.MockSensor(
+    entity = MockSensor(
         name="Valid",
         device_class=device_class,
         native_unit_of_measurement=native_unit,
@@ -2726,6 +2647,7 @@ async def test_suggested_unit_guard_valid_unit(
         suggested_unit_of_measurement=suggested_unit,
         unique_id="valid",
     )
+    setup_test_component_platform(hass, sensor.DOMAIN, [entity])
 
     assert await async_setup_component(hass, "sensor", {"sensor": {"platform": "test"}})
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
Make use of the `setup_test_component_platform` helper in `sensor` entity component tests and `mqtt` test instead of a custom component in `testing_config`. Main reason for this is to get rid of the deprecated `hass.components` use.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
