### PR TITLE
Avoid changing local time on Nobø Ecohub

### DIFF
--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -7,6 +7,7 @@ from pynobo import nobo
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
+import homeassistant.util.dt as dt_util
 
 from .const import CONF_AUTO_DISCOVERED, CONF_SERIAL, DOMAIN
 
@@ -19,7 +20,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     serial = entry.data[CONF_SERIAL]
     discover = entry.data[CONF_AUTO_DISCOVERED]
     ip_address = None if discover else entry.data[CONF_IP_ADDRESS]
-    hub = nobo(serial=serial, ip=ip_address, discover=discover, synchronous=False)
+    hub = nobo(
+        serial=serial,
+        ip=ip_address,
+        discover=discover,
+        synchronous=False,
+        timezone=dt_util.DEFAULT_TIME_ZONE,
+    )
     await hub.connect()
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/nobo_hub/manifest.json
+++ b/homeassistant/components/nobo_hub/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/nobo_hub",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "requirements": ["pynobo==1.6.0"]
+  "requirements": ["pynobo==1.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1985,7 +1985,7 @@ pynetgear==0.10.10
 pynetio==0.1.9.1
 
 # homeassistant.components.nobo_hub
-pynobo==1.6.0
+pynobo==1.8.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1539,7 +1539,7 @@ pymysensors==0.24.0
 pynetgear==0.10.10
 
 # homeassistant.components.nobo_hub
-pynobo==1.6.0
+pynobo==1.8.0
 
 # homeassistant.components.nuki
 pynuki==1.6.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes an issue where the time of the Nobø Ecohub is set wrong during the handshake in the case where `localtime` uses a different time zone than the hub is configured with (when using the mobile app).

For detail, see https://github.com/echoromeo/pynobo/issues/35

The fix required a change in the upstream library: [pynobo 1.8.0](https://github.com/echoromeo/pynobo/releases/tag/v1.8.0)
Note that this PR also includes changes in [1.6.1](https://github.com/echoromeo/pynobo/releases/tag/v1.6.1) and [1.7.0](https://github.com/echoromeo/pynobo/releases/tag/v1.7.0)

Full library diff: https://github.com/echoromeo/pynobo/compare/v1.6.0...v1.8.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
