### PR TITLE
Fix area search for entities of devices

### DIFF
--- a/homeassistant/components/search/__init__.py
+++ b/homeassistant/components/search/__init__.py
@@ -136,6 +136,9 @@ class Searcher:
         # Scripts referencing this area
         self._add(ItemType.SCRIPT, script.scripts_with_area(self.hass, area_id))
 
+        # Entity in this area, will extend this with the entities of the devices in this area
+        entity_entries = er.async_entries_for_area(self._entity_registry, area_id)
+
         # Devices in this area
         for device in dr.async_entries_for_area(self._device_registry, area_id):
             self._add(ItemType.DEVICE, device.id)
@@ -160,10 +163,10 @@ class Searcher:
                 # Skip the entity if it's in a different area
                 if entity_entry.area_id is not None:
                     continue
-                self._add(ItemType.ENTITY, entity_entry.entity_id)
+                entity_entries.append(entity_entry)
 
-        # Entities in this area
-        for entity_entry in er.async_entries_for_area(self._entity_registry, area_id):
+        # Process entities in this area
+        for entity_entry in entity_entries:
             self._add(ItemType.ENTITY, entity_entry.entity_id)
 
             # If this entity also exists as a resource, we add it.

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -496,11 +496,14 @@ async def test_search(
         ItemType.SCRIPT: {script_scene_entity.entity_id, "script.nested"},
     }
     assert search(ItemType.AREA, living_room_area.id) == {
-        ItemType.AUTOMATION: {"automation.wled_device"},
+        ItemType.AUTOMATION: {"automation.wled_device", "automation.wled_entity"},
         ItemType.CONFIG_ENTRY: {wled_config_entry.entry_id},
         ItemType.DEVICE: {wled_device.id},
         ItemType.ENTITY: {wled_segment_1_entity.entity_id},
         ItemType.FLOOR: {first_floor.floor_id},
+        ItemType.GROUP: {"group.wled", "group.wled_hue"},
+        ItemType.SCENE: {"scene.scene_wled_seg_1", scene_wled_hue_entity.entity_id},
+        ItemType.SCRIPT: {"script.wled"},
     }
     assert search(ItemType.AREA, kitchen_area.id) == {
         ItemType.AUTOMATION: {"automation.area"},
@@ -511,7 +514,9 @@ async def test_search(
             hue_segment_2_entity.entity_id,
         },
         ItemType.FLOOR: {first_floor.floor_id},
-        ItemType.SCRIPT: {"script.area", "script.device"},
+        ItemType.GROUP: {"group.hue", "group.wled_hue"},
+        ItemType.SCENE: {"scene.scene_hue_seg_1", scene_wled_hue_entity.entity_id},
+        ItemType.SCRIPT: {"script.area", "script.device", "script.hue"},
     }
 
     assert not search(ItemType.AUTOMATION, "automation.unknown")
@@ -726,6 +731,7 @@ async def test_search(
             "automation.area",
             "automation.floor",
             "automation.wled_device",
+            "automation.wled_entity",
         },
         ItemType.CONFIG_ENTRY: {hue_config_entry.entry_id, wled_config_entry.entry_id},
         ItemType.DEVICE: {hue_device.id, wled_device.id},
@@ -734,7 +740,19 @@ async def test_search(
             hue_segment_1_entity.entity_id,
             hue_segment_2_entity.entity_id,
         },
-        ItemType.SCRIPT: {"script.device", "script.area", "script.floor"},
+        ItemType.GROUP: {"group.hue", "group.wled", "group.wled_hue"},
+        ItemType.SCENE: {
+            "scene.scene_hue_seg_1",
+            "scene.scene_wled_seg_1",
+            scene_wled_hue_entity.entity_id,
+        },
+        ItemType.SCRIPT: {
+            "script.device",
+            "script.area",
+            "script.floor",
+            "script.hue",
+            "script.wled",
+        },
     }
     assert search(ItemType.FLOOR, second_floor.floor_id) == {
         ItemType.AREA: {bedroom_area.id},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When searching an area, the search didn't take into account the entities of devices.
It only took into account devices & entities that had the area set directly. Indirect entities where missing.

Thanks to JLo for noticing 👍 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
