### PR TITLE
Avoid concurrent radio operations with powerview hubs

### DIFF
--- a/homeassistant/components/hunterdouglas_powerview/button.py
+++ b/homeassistant/components/hunterdouglas_powerview/button.py
@@ -119,4 +119,5 @@ class PowerviewShadeButton(ShadeEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle the button press."""
-        await self.entity_description.press_action(self._shade)
+        async with self.coordinator.radio_operation_lock:
+            await self.entity_description.press_action(self._shade)

--- a/homeassistant/components/hunterdouglas_powerview/coordinator.py
+++ b/homeassistant/components/hunterdouglas_powerview/coordinator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 
@@ -25,6 +26,10 @@ class PowerviewShadeUpdateCoordinator(DataUpdateCoordinator[PowerviewShadeData])
         """Initialize DataUpdateCoordinator to gather data for specific Powerview Hub."""
         self.shades = shades
         self.hub = hub
+        # The hub tends to crash if there are multiple radio operations at the same time
+        # but it seems to handle all other requests that do not use RF without issue
+        # so we have a lock to prevent multiple radio operations at the same time
+        self.radio_operation_lock = asyncio.Lock()
         super().__init__(
             hass,
             _LOGGER,

--- a/homeassistant/components/hunterdouglas_powerview/entity.py
+++ b/homeassistant/components/hunterdouglas_powerview/entity.py
@@ -20,6 +20,7 @@ class HDEntity(CoordinatorEntity[PowerviewShadeUpdateCoordinator]):
     """Base class for hunter douglas entities."""
 
     _attr_has_entity_name = True
+    coordinator: PowerviewShadeUpdateCoordinator
 
     def __init__(
         self,

--- a/homeassistant/components/hunterdouglas_powerview/entity.py
+++ b/homeassistant/components/hunterdouglas_powerview/entity.py
@@ -20,7 +20,6 @@ class HDEntity(CoordinatorEntity[PowerviewShadeUpdateCoordinator]):
     """Base class for hunter douglas entities."""
 
     _attr_has_entity_name = True
-    coordinator: PowerviewShadeUpdateCoordinator
 
     def __init__(
         self,

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -114,5 +114,6 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
         """Change the selected option."""
         await self.entity_description.select_fn(self._shade, option)
         # force update data to ensure new info is in coordinator
-        await self._shade.refresh()
+        async with self.coordinator.radio_operation_lock:
+            await self._shade.refresh()
         self.async_write_ha_state()

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -115,5 +115,5 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
         await self.entity_description.select_fn(self._shade, option)
         # force update data to ensure new info is in coordinator
         async with self.coordinator.radio_operation_lock:
-            await self._shade.refresh()
+            await self._shade.refresh(suppress_timeout=true)
         self.async_write_ha_state()

--- a/homeassistant/components/hunterdouglas_powerview/select.py
+++ b/homeassistant/components/hunterdouglas_powerview/select.py
@@ -115,5 +115,5 @@ class PowerViewSelect(ShadeEntity, SelectEntity):
         await self.entity_description.select_fn(self._shade, option)
         # force update data to ensure new info is in coordinator
         async with self.coordinator.radio_operation_lock:
-            await self._shade.refresh(suppress_timeout=true)
+            await self._shade.refresh(suppress_timeout=True)
         self.async_write_ha_state()

--- a/homeassistant/components/hunterdouglas_powerview/sensor.py
+++ b/homeassistant/components/hunterdouglas_powerview/sensor.py
@@ -153,5 +153,6 @@ class PowerViewSensor(ShadeEntity, SensorEntity):
 
     async def async_update(self) -> None:
         """Refresh sensor entity."""
-        await self.entity_description.update_fn(self._shade)
+        async with self.coordinator.radio_operation_lock:
+            await self.entity_description.update_fn(self._shade)
         self.async_write_ha_state()


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These devices tend to crash if there are concurrent radio operations. PARALLEL_UPDATES was set to 1 to try to avoid this problem, but it turned out not to be enough


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #73900
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
