### PR TITLE
Add gree water tank binary sensor

### DIFF
--- a/homeassistant/components/gree/__init__.py
+++ b/homeassistant/components/gree/__init__.py
@@ -20,7 +20,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = [Platform.CLIMATE, Platform.SWITCH]
+PLATFORMS = [Platform.CLIMATE, Platform.SWITCH, Platform.BINARY_SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/gree/binary_sensor.py
+++ b/homeassistant/components/gree/binary_sensor.py
@@ -1,0 +1,83 @@
+"""Support for interface with a Gree climate systems."""
+
+from __future__ import annotations
+
+import logging
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from greeclimate.device import Device
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import COORDINATORS, DISPATCH_DEVICE_DISCOVERED, DOMAIN
+from .entity import GreeEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True, frozen=True)
+class GreeBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Gree binary sensor entity."""
+
+    get_value_fn: Callable[[Device], bool]
+
+
+GREE_BINARY_SENSORS: tuple[GreeBinarySensorEntityDescription, ...] = (
+    GreeBinarySensorEntityDescription(
+        key="Water Tank Full",
+        translation_key="water_full",
+        get_value_fn=lambda d: d.water_full,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Gree HVAC device from a config entry."""
+
+    @callback
+    def init_device(coordinator):
+        """Register the device."""
+
+        async_add_entities(
+            GreeBinarySensor(coordinator=coordinator, description=description)
+            for description in GREE_BINARY_SENSORS
+        )
+
+    for coordinator in hass.data[DOMAIN][COORDINATORS]:
+        init_device(coordinator)
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, DISPATCH_DEVICE_DISCOVERED, init_device)
+    )
+
+
+class GreeBinarySensor(GreeEntity, BinarySensorEntity):
+    """Generic Gree binary sensor entity."""
+
+    entity_description: GreeBinarySensorEntityDescription
+
+    def __init__(
+        self, coordinator, description: GreeBinarySensorEntityDescription
+    ) -> None:
+        """Initialize the Gree device."""
+        self.entity_description = description
+
+        super().__init__(coordinator, description.key)
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the state is turned on."""
+        return self.entity_description.get_value_fn(self.coordinator.device)

--- a/homeassistant/components/gree/strings.json
+++ b/homeassistant/components/gree/strings.json
@@ -27,6 +27,11 @@
       "health_mode": {
         "name": "Health mode"
       }
+    },
+    "binary_sensor": {
+      "water_full": {
+        "name": "Water Tank Full"
+      }
     }
   }
 }

--- a/tests/components/gree/snapshots/test_binary_sensor.ambr
+++ b/tests/components/gree/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_entity_state
+  list([
+    StateSnapshot({
+      'attributes': ReadOnlyDict({
+        'device_class': 'binary_sensor',
+        'friendly_name': 'fake-device-1 Water Tank Full',
+      }),
+      'context': <ANY>,
+      'entity_id': 'binary_sensor.fake_device_1_water_full',
+      'last_changed': <ANY>,
+      'last_reported': <ANY>,
+      'last_updated': <ANY>,
+      'state': 'on',
+    })
+  ])
+# ---
+# name: test_registry_settings
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': set({
+      }),
+      'area_id': None,
+      'capabilities': None,
+      'config_entry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'binary_sensor',
+      'entity_category': None,
+      'entity_id': 'binary_sensor.fake_device_1_water_full',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': 'Water Tank Full',
+      'platform': 'gree',
+      'previous_unique_id': None,
+      'supported_features': 0,
+      'translation_key': 'water_full',
+      'unique_id': 'aabbcc112233_Water Tank Full',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---

--- a/tests/components/gree/test_binary_sensor.py
+++ b/tests/components/gree/test_binary_sensor.py
@@ -1,0 +1,51 @@
+"""Tests for gree component."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.gree.const import DOMAIN as GREE_DOMAIN
+from homeassistant.components.binary_sensor import DOMAIN
+from homeassistant.const import STATE_OFF
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID_WATER_FULL = f"{DOMAIN}.fake_device_1_water_full"
+
+
+async def async_setup_gree(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up the gree binary_sensor platform."""
+    entry = MockConfigEntry(domain=GREE_DOMAIN)
+    entry.add_to_hass(hass)
+    await async_setup_component(hass, GREE_DOMAIN, {GREE_DOMAIN: {DOMAIN: {}}})
+    await hass.async_block_till_done()
+    return entry
+
+
+@patch("homeassistant.components.gree.PLATFORMS", [DOMAIN])
+async def test_registry_settings(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test for entity registry settings (disabled_by, unique_id)."""
+    entry = await async_setup_gree(hass)
+
+    state = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
+    assert state == snapshot
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_entity_state(
+    hass: HomeAssistant,
+) -> None:
+    """Test for reading state of entity."""
+    await async_setup_gree(hass)
+
+    state = hass.states.get(ENTITY_ID_WATER_FULL)
+    assert state is not None
+    assert state.state == STATE_OFF


### PR DESCRIPTION
## Proposed change
Add water tank binary sensor for dehumidifiers

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
Tried to add tests but existing tests in test_switch.py have been failing. Help?

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
