### PR TITLE
Allow templates for enabling automation triggers

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1648,7 +1648,7 @@ TRIGGER_BASE_SCHEMA = vol.Schema(
         vol.Required(CONF_PLATFORM): str,
         vol.Optional(CONF_ID): str,
         vol.Optional(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
-        vol.Optional(CONF_ENABLED): boolean,
+        vol.Optional(CONF_ENABLED): vol.Any(boolean, template_complex),
     }
 )
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1648,7 +1648,7 @@ TRIGGER_BASE_SCHEMA = vol.Schema(
         vol.Required(CONF_PLATFORM): str,
         vol.Optional(CONF_ID): str,
         vol.Optional(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
-        vol.Optional(CONF_ENABLED): vol.Any(boolean, template_complex),
+        vol.Optional(CONF_ENABLED): vol.Any(boolean, template),
     }
 )
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -320,7 +320,7 @@ async def async_initialize_triggers(
                     enabled = enabled.async_render(variables, limited=True)
                 except TemplateError as err:
                     log_cb(logging.ERROR, f"Error rendering enabled template: {err}")
-                    return None
+                    continue
             if not enabled:
                 continue
 

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -27,11 +27,12 @@ from homeassistant.core import (
     callback,
     is_callback,
 )
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, TemplateError
 from homeassistant.loader import IntegrationNotFound, async_get_integration
 from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.hass_dict import HassKey
 
+from .template import Template
 from .typing import ConfigType, TemplateVarsType
 
 _PLATFORM_ALIASES = {
@@ -312,8 +313,16 @@ async def async_initialize_triggers(
     triggers: list[asyncio.Task[CALLBACK_TYPE]] = []
     for idx, conf in enumerate(trigger_config):
         # Skip triggers that are not enabled
-        if not conf.get(CONF_ENABLED, True):
-            continue
+        if CONF_ENABLED in conf:
+            enabled = conf[CONF_ENABLED]
+            if isinstance(enabled, Template):
+                try:
+                    enabled = enabled.async_render(variables, limited=True)
+                except TemplateError as err:
+                    log_cb(logging.ERROR, "Error rendering enabled template: %s", err)
+                    return None
+            if not enabled:
+                continue
 
         platform = await _async_get_trigger_platform(hass, conf)
         trigger_id = conf.get(CONF_ID, f"{idx}")

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -319,7 +319,7 @@ async def async_initialize_triggers(
                 try:
                     enabled = enabled.async_render(variables, limited=True)
                 except TemplateError as err:
-                    log_cb(logging.ERROR, "Error rendering enabled template: %s", err)
+                    log_cb(logging.ERROR, f"Error rendering enabled template: {err}")
                     return None
             if not enabled:
                 continue

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -110,6 +110,61 @@ async def test_if_disabled_trigger_not_firing(
     assert len(calls) == 1
 
 
+async def test_trigger_enabled_templates(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
+    """Test triggers enabled by template."""
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": [
+                    {
+                        "enabled": "{{ 'some text' }}",
+                        "platform": "event",
+                        "event_type": "truthy_template_trigger_event",
+                    },
+                    {
+                        "enabled": "{{ 3 == 4 }}",
+                        "platform": "event",
+                        "event_type": "falsy_template_trigger_event",
+                    },
+                    {
+                        "enabled": None,  # eg. from a blueprints input defaulting to null
+                        "platform": "event",
+                        "event_type": "falsy_trigger_event",
+                    },
+                    {
+                        "enabled": "some text",  # eg. from a blueprints input value
+                        "platform": "event",
+                        "event_type": "truthy_trigger_event",
+                    },
+                ],
+                "action": {
+                    "service": "test.automation",
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("falsy_template_trigger_event")
+    await hass.async_block_till_done()
+    assert not calls
+
+    hass.bus.async_fire("falsy_trigger_event")
+    await hass.async_block_till_done()
+    assert not calls
+
+    hass.bus.async_fire("truthy_template_trigger_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.bus.async_fire("truthy_trigger_event")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+
+
 async def test_trigger_alias(
     hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -131,7 +131,7 @@ async def test_trigger_enabled_templates(
                         "event_type": "falsy_template_trigger_event",
                     },
                     {
-                        "enabled": None,  # eg. from a blueprints input defaulting to null
+                        "enabled": False,  # eg. from a blueprints input defaulting to `false`
                         "platform": "event",
                         "event_type": "falsy_trigger_event",
                     },

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -165,6 +165,35 @@ async def test_trigger_enabled_templates(
     assert len(calls) == 2
 
 
+async def test_trigger_enabled_template_limited(
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test triggers enabled invalid template."""
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": [
+                    {
+                        "enabled": "{{ states('sensor.limited') }}",  # only limited template supported
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                ],
+                "action": {
+                    "service": "test.automation",
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert not calls
+    assert "Error rendering enabled template" in caplog.text
+
+
 async def test_trigger_alias(
     hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow limited templates for enabling automation triggers. This will be useful to enable / disable specific triggers based on blueprint input values.

```yaml
blueprint:
  name: Dependent disable
  domain: automation
  input:
    required_input:
      name: Required
    optional_input:
      name: Optional
      default: null

trigger_variables:
  _optional_input: !input optional_input

trigger:
  - platform: event
    event_type: !input required_input
  - platform: event
    event_type: !input optional_input
    enabled: "{{ not _optional_input == None }}"
    # or maybe even simpler without trigger_variable
    enabled: !input optional_input
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
  - https://github.com/home-assistant/architecture/discussions/1066
  - https://github.com/home-assistant/core/pull/117047
  - https://github.com/home-assistant/core/pull/117049
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32662

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
