### PR TITLE
Improve sonos test synchronization

### DIFF
--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -1,16 +1,20 @@
 """Configuration for Sonos tests."""
 
+import asyncio
+from collections.abc import Callable
 from copy import copy
 from ipaddress import ip_address
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from soco import SoCo
+from soco.events_base import Event as SonosEvent
 
 from homeassistant.components import ssdp, zeroconf
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.sonos import DOMAIN
 from homeassistant.const import CONF_HOSTS
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -30,6 +34,31 @@ class SonosMockSubscribe:
         """Initialize the mock subscriber."""
         self.event_listener = SonosMockEventListener(ip_address)
         self.service = Mock()
+        self.callback_future: asyncio.Future[Callable[[SonosEvent], None]] = None
+        self._callback: Callable[[SonosEvent], None] | None = None
+
+    @property
+    def callback(self) -> Callable[[SonosEvent], None] | None:
+        """Return the callback."""
+        return self._callback
+
+    @callback.setter
+    def callback(self, callback: Callable[[SonosEvent], None]) -> None:
+        """Set the callback."""
+        self._callback = callback
+        future = self._get_callback_future()
+        if not future.done():
+            future.set_result(callback)
+
+    def _get_callback_future(self) -> asyncio.Future[Callable[[SonosEvent], None]]:
+        """Get the callback future."""
+        if not self.callback_future:
+            self.callback_future = asyncio.get_running_loop().create_future()
+        return self.callback_future
+
+    async def wait_for_callback_to_be_set(self) -> Callable[[SonosEvent], None]:
+        """Wait for the callback to be set."""
+        return await self._get_callback_future()
 
     async def unsubscribe(self) -> None:
         """Unsubscribe mock."""
@@ -456,14 +485,14 @@ def zgs_discovery_fixture():
 
 
 @pytest.fixture(name="fire_zgs_event")
-def zgs_event_fixture(hass, soco, zgs_discovery):
+def zgs_event_fixture(hass: HomeAssistant, soco: SoCo, zgs_discovery: str):
     """Create alarm_event fixture."""
     variables = {"ZoneGroupState": zgs_discovery}
 
     async def _wrapper():
         event = SonosMockEvent(soco, soco.zoneGroupTopology, variables)
-        subscription = soco.zoneGroupTopology.subscribe.return_value
-        sub_callback = subscription.callback
+        subscription: SonosMockSubscribe = soco.zoneGroupTopology.subscribe.return_value
+        sub_callback = await subscription.wait_for_callback_to_be_set()
         sub_callback(event)
         await hass.async_block_till_done()
 

--- a/tests/components/sonos/test_repairs.py
+++ b/tests/components/sonos/test_repairs.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+from soco import SoCo
+
 from homeassistant.components.sonos.const import (
     DOMAIN,
     SCAN_INTERVAL,
@@ -11,27 +13,25 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.issue_registry import async_get as async_get_issue_registry
 from homeassistant.util import dt as dt_util
 
-from .conftest import SonosMockEvent
+from .conftest import SonosMockEvent, SonosMockSubscribe
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_subscription_repair_issues(
-    hass: HomeAssistant, config_entry: MockConfigEntry, soco, zgs_discovery
+    hass: HomeAssistant, config_entry: MockConfigEntry, soco: SoCo, zgs_discovery
 ) -> None:
     """Test repair issues handling for failed subscriptions."""
     issue_registry = async_get_issue_registry(hass)
 
-    subscription = soco.zoneGroupTopology.subscribe.return_value
+    subscription: SonosMockSubscribe = soco.zoneGroupTopology.subscribe.return_value
     subscription.event_listener = Mock(address=("192.168.4.2", 1400))
 
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-    await hass.async_block_till_done()
 
     # Ensure an issue is registered on subscription failure
-    sub_callback = subscription.callback
+    sub_callback = await subscription.wait_for_callback_to_be_set()
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done(wait_background_tasks=True)
     assert issue_registry.async_get_issue(DOMAIN, SUB_FAIL_ISSUE_ID)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve sonos test synchronization

This should prevent some of the sonos tests from flapping

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
