### PR TITLE
Deprecate `hass.helpers`

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1550,6 +1550,20 @@ class Helpers:
     def __getattr__(self, helper_name: str) -> ModuleWrapper:
         """Fetch a helper."""
         helper = importlib.import_module(f"homeassistant.helpers.{helper_name}")
+
+        # Local import to avoid circular dependencies
+        from .helpers.frame import report  # pylint: disable=import-outside-toplevel
+
+        report(
+            (
+                f"accesses hass.helpers.{helper_name}."
+                " This is deprecated and will stop working in Home Assistant 2024.10, it"
+                f" should be updated to import functions used from {helper_name} directly"
+            ),
+            error_if_core=False,
+            log_custom_component_only=True,
+        )
+
         wrapped = ModuleWrapper(self._hass, helper)
         setattr(self, helper_name, wrapped)
         return wrapped

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1557,7 +1557,7 @@ class Helpers:
         report(
             (
                 f"accesses hass.helpers.{helper_name}."
-                " This is deprecated and will stop working in Home Assistant 2024.10, it"
+                " This is deprecated and will stop working in Home Assistant 2024.11, it"
                 f" should be updated to import functions used from {helper_name} directly"
             ),
             error_if_core=False,

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1802,7 +1802,7 @@ async def test_hass_helpers_use_reported(
             return_value=integration_frame,
         ),
         patch(
-            "homeassistant.components.http.start_http_server_and_save_config",
+            "homeassistant.helpers.aiohttp_client.async_get_clientsession",
             return_value=None,
         ),
     ):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1779,3 +1779,36 @@ async def test_has_services(hass: HomeAssistant, enable_custom_integrations) -> 
     assert integration.has_services is False
     integration = await loader.async_get_integration(hass, "test_with_services")
     assert integration.has_services is True
+
+
+async def test_hass_helpers_use_reported(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
+) -> None:
+    """Test that use of hass.components is reported."""
+    mock_integration_frame.filename = (
+        "/home/paulus/homeassistant/custom_components/demo/light.py"
+    )
+    integration_frame = frame.IntegrationFrame(
+        custom_integration=True,
+        _frame=mock_integration_frame,
+        integration="test_integration_frame",
+        module="custom_components.test_integration_frame",
+        relative_filename="custom_components/test_integration_frame/__init__.py",
+    )
+
+    with (
+        patch(
+            "homeassistant.helpers.frame.get_integration_frame",
+            return_value=integration_frame,
+        ),
+        patch(
+            "homeassistant.components.http.start_http_server_and_save_config",
+            return_value=None,
+        ),
+    ):
+        hass.helpers.aiohttp_client.async_get_clientsession()
+
+        assert (
+            "Detected that custom integration 'test_integration_frame'"
+            " accesses hass.helpers.aiohttp_client. This is deprecated"
+        ) in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1785,9 +1785,6 @@ async def test_hass_helpers_use_reported(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture, mock_integration_frame: Mock
 ) -> None:
     """Test that use of hass.components is reported."""
-    mock_integration_frame.filename = (
-        "/home/paulus/homeassistant/custom_components/demo/light.py"
-    )
     integration_frame = frame.IntegrationFrame(
         custom_integration=True,
         _frame=mock_integration_frame,
@@ -1797,6 +1794,7 @@ async def test_hass_helpers_use_reported(
     )
 
     with (
+        patch.object(frame, "_REPORTED_INTEGRATIONS", new=set()),
         patch(
             "homeassistant.helpers.frame.get_integration_frame",
             return_value=integration_frame,
@@ -1809,6 +1807,6 @@ async def test_hass_helpers_use_reported(
         hass.helpers.aiohttp_client.async_get_clientsession()
 
         assert (
-            "Detected that custom integration 'test_integration_frame'"
+            "Detected that custom integration 'test_helper_frame'"
             " accesses hass.helpers.aiohttp_client. This is deprecated"
         ) in caplog.text

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1807,6 +1807,6 @@ async def test_hass_helpers_use_reported(
         hass.helpers.aiohttp_client.async_get_clientsession()
 
         assert (
-            "Detected that custom integration 'test_helper_frame'"
-            " accesses hass.helpers.aiohttp_client. This is deprecated"
+            "Detected that custom integration 'test_integration_frame' "
+            "accesses hass.helpers.aiohttp_client. This is deprecated"
         ) in caplog.text


### PR DESCRIPTION
## Proposed change
When we deprecated `hass.components` and `@bind_hass`, we completely forgot to deprecate `hass.helpers`, which is also relayed on `@bind_hass`. So we have to deprecate this too. Idk if we should add this to the 2024.04 release.

Dev blog: https://github.com/home-assistant/developers.home-assistant/pull/2130

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
