### PR TITLE
Fix workday doing blocking I/O in the event loop

### DIFF
--- a/homeassistant/components/workday/__init__.py
+++ b/homeassistant/components/workday/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 from holidays import HolidayBase, country_holidays
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,7 +15,7 @@ from homeassistant.helpers.issue_registry import IssueSeverity, async_create_iss
 from .const import CONF_PROVINCE, DOMAIN, PLATFORMS
 
 
-def _validate_country_and_province(
+async def _async_validate_country_and_province(
     hass: HomeAssistant, entry: ConfigEntry, country: str | None, province: str | None
 ) -> None:
     """Validate country and province."""
@@ -21,7 +23,7 @@ def _validate_country_and_province(
     if not country:
         return
     try:
-        country_holidays(country)
+        await hass.async_add_executor_job(country_holidays, country)
     except NotImplementedError as ex:
         async_create_issue(
             hass,
@@ -39,7 +41,9 @@ def _validate_country_and_province(
     if not province:
         return
     try:
-        country_holidays(country, subdiv=province)
+        await hass.async_add_executor_job(
+            partial(country_holidays, country, subdiv=province)
+        )
     except NotImplementedError as ex:
         async_create_issue(
             hass,
@@ -66,10 +70,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     country: str | None = entry.options.get(CONF_COUNTRY)
     province: str | None = entry.options.get(CONF_PROVINCE)
 
-    _validate_country_and_province(hass, entry, country, province)
+    await _async_validate_country_and_province(hass, entry, country, province)
 
     if country and CONF_LANGUAGE not in entry.options:
-        cls: HolidayBase = country_holidays(country, subdiv=province)
+        cls: HolidayBase = await hass.async_add_executor_job(
+            partial(country_holidays, country, subdiv=province)
+        )
         default_language = cls.default_language
         new_options = entry.options.copy()
         new_options[CONF_LANGUAGE] = default_language


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
2024-03-30 07:40:04.952 WARNING (MainThread) [homeassistant.util.async_] Detected blocking call to import_module inside the event loop by integration 'workday' at homeassistant/components/workday/__init__.py, line 24: country_holidays(country), (offender: /Users/bdraco/home-assistant/venv/lib/python3.12/site-packages/holidays/registry.py, line 222: self.entity = getattr(importlib.import_module(self.module_name), self.entity_name)) please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+workday%22

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
