### PR TITLE
Add IMAP seen, move and delete service

### DIFF
--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -141,7 +141,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise_on_error(response, "seen_failed")
         await client.close()
 
-    hass.services.async_register(DOMAIN, "seen", async_seen, SERVICE_SEEN_SCHEMA)
+    if not hass.services.has_service(DOMAIN, "seen"):
+        hass.services.async_register(DOMAIN, "seen", async_seen, SERVICE_SEEN_SCHEMA)
 
     async def async_move(call: ServiceCall) -> None:
         """Process move email service call."""
@@ -177,7 +178,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ) from exc
         await client.close()
 
-    hass.services.async_register(DOMAIN, "move", async_move, SERVICE_MOVE_SCHEMA)
+    if not hass.services.has_service(DOMAIN, "move"):
+        hass.services.async_register(DOMAIN, "move", async_move, SERVICE_MOVE_SCHEMA)
 
     async def async_delete(call: ServiceCall) -> None:
         """Process deleting email service call."""
@@ -204,7 +206,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ) from exc
         await client.close()
 
-    hass.services.async_register(DOMAIN, "delete", async_delete, SERVICE_DELETE_SCHEMA)
+    if not hass.services.has_service(DOMAIN, "delete"):
+        hass.services.async_register(
+            DOMAIN, "delete", async_delete, SERVICE_DELETE_SCHEMA
+        )
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     ServiceValidationError,
 )
+import homeassistant.helpers.config_validation as cv
 
 from .const import CONF_ENABLE_PUSH, DOMAIN
 from .coordinator import (
@@ -35,16 +36,16 @@ CONF_TARGET_FOLDER = "target_folder"
 
 _SERVICE_UID_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ENTRY): str,
-        vol.Required(CONF_UID): str,
+        vol.Required(CONF_ENTRY): cv.string,
+        vol.Required(CONF_UID): cv.string,
     }
 )
 
 SERVICE_SEEN_SCHEMA = _SERVICE_UID_SCHEMA
 SERVICE_MOVE_SCHEMA = _SERVICE_UID_SCHEMA.extend(
     {
-        vol.Optional(CONF_SEEN): bool,
-        vol.Required(CONF_TARGET_FOLDER): str,
+        vol.Optional(CONF_SEEN): cv.boolean,
+        vol.Required(CONF_TARGET_FOLDER): cv.string,
     }
 )
 SERVICE_DELETE_SCHEMA = _SERVICE_UID_SCHEMA

--- a/homeassistant/components/imap/__init__.py
+++ b/homeassistant/components/imap/__init__.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from aioimaplib import IMAP4_SSL, AioImapException
+import asyncio
+from typing import TYPE_CHECKING
+
+from aioimaplib import IMAP4_SSL, AioImapException, Response
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryError,
     ConfigEntryNotReady,
+    ServiceValidationError,
 )
 
 from .const import CONF_ENABLE_PUSH, DOMAIN
@@ -22,6 +27,68 @@ from .coordinator import (
 from .errors import InvalidAuth, InvalidFolder
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
+
+CONF_ENTRY = "entry"
+CONF_SEEN = "seen"
+CONF_UID = "uid"
+CONF_TARGET_FOLDER = "target_folder"
+
+_SERVICE_UID_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_ENTRY): str,
+        vol.Required(CONF_UID): str,
+    }
+)
+
+SERVICE_SEEN_SCHEMA = _SERVICE_UID_SCHEMA
+SERVICE_MOVE_SCHEMA = _SERVICE_UID_SCHEMA.extend(
+    {
+        vol.Optional(CONF_SEEN): bool,
+        vol.Required(CONF_TARGET_FOLDER): str,
+    }
+)
+SERVICE_DELETE_SCHEMA = _SERVICE_UID_SCHEMA
+
+
+async def async_get_imap_client(hass: HomeAssistant, entry_id: str) -> IMAP4_SSL:
+    """Get IMAP client and connect."""
+    if hass.data[DOMAIN].get(entry_id) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_entry",
+        )
+    entry = hass.config_entries.async_get_entry(entry_id)
+    if TYPE_CHECKING:
+        assert entry is not None
+    try:
+        client = await connect_to_server(entry.data)
+    except InvalidAuth as exc:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN, translation_key="invalid_auth"
+        ) from exc
+    except InvalidFolder as exc:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN, translation_key="invalid_folder"
+        ) from exc
+    except (TimeoutError, AioImapException) as exc:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="imap_server_fail",
+            translation_placeholders={"error": str(exc)},
+        ) from exc
+    return client
+
+
+@callback
+def raise_on_error(response: Response, translation_key: str) -> None:
+    """Get error message from response."""
+    if response.result != "OK":
+        error: str = response.lines[0].decode("utf-8")
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key=translation_key,
+            translation_placeholders={"error": error},
+        )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -49,6 +116,69 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     await coordinator.async_config_entry_first_refresh()
 
+    async def async_seen(call: ServiceCall) -> None:
+        """Process mark as seen service call."""
+        client = await async_get_imap_client(hass, call.data[CONF_ENTRY])
+        try:
+            response = await client.store(call.data[CONF_UID], "+FLAGS (\\Seen)")
+        except (TimeoutError, AioImapException) as exc:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="imap_server_fail",
+                translation_placeholders={"error": str(exc)},
+            ) from exc
+        raise_on_error(response, "seen_failed")
+        await client.close()
+
+    hass.services.async_register(DOMAIN, "seen", async_seen, SERVICE_SEEN_SCHEMA)
+
+    async def async_move(call: ServiceCall) -> None:
+        """Process move email service call."""
+        client = await async_get_imap_client(hass, call.data[CONF_ENTRY])
+        uid: str = call.data[CONF_UID]
+        try:
+            if call.data.get(CONF_SEEN):
+                response = await client.store(uid, "+FLAGS (\\Seen)")
+                raise_on_error(response, "seen_failed")
+            response = await client.copy(uid, call.data[CONF_TARGET_FOLDER])
+            raise_on_error(response, "copy_failed")
+            response = await client.store(uid, "+FLAGS (\\Deleted)")
+            raise_on_error(response, "delete_failed")
+            response = await asyncio.wait_for(
+                client.protocol.expunge(uid, by_uid=True), client.timeout
+            )
+            raise_on_error(response, "expunge_failed")
+        except (TimeoutError, AioImapException) as exc:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="imap_server_fail",
+                translation_placeholders={"error": str(exc)},
+            ) from exc
+        await client.close()
+
+    hass.services.async_register(DOMAIN, "move", async_move, SERVICE_MOVE_SCHEMA)
+
+    async def async_delete(call: ServiceCall) -> None:
+        """Process deleting email service call."""
+        client = await async_get_imap_client(hass, call.data[CONF_ENTRY])
+        uid: str = call.data[CONF_UID]
+        try:
+            response = await client.store(uid, "+FLAGS (\\Deleted)")
+            raise_on_error(response, "delete_failed")
+            response = await asyncio.wait_for(
+                client.protocol.expunge(uid, by_uid=True), client.timeout
+            )
+            raise_on_error(response, "expunge_failed")
+        except (TimeoutError, AioImapException) as exc:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="imap_server_fail",
+                translation_placeholders={"error": str(exc)},
+            ) from exc
+        await client.close()
+
+    hass.services.async_register(DOMAIN, "delete", async_delete, SERVICE_DELETE_SCHEMA)
+
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     entry.async_on_unload(
@@ -67,4 +197,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ImapPushDataUpdateCoordinator | ImapPollingDataUpdateCoordinator
         ) = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.shutdown()
+    if not hass.data[DOMAIN]:
+        hass.services.async_remove(DOMAIN, "seen")
+        hass.services.async_remove(DOMAIN, "move")
+        hass.services.async_remove(DOMAIN, "delete")
     return unload_ok

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -254,6 +254,7 @@ class ImapDataUpdateCoordinator(DataUpdateCoordinator[int | None]):
                 initial = False
             self._last_message_id = message_id
             data = {
+                "entry_id": self.config_entry.entry_id,
                 "server": self.config_entry.data[CONF_SERVER],
                 "username": self.config_entry.data[CONF_USERNAME],
                 "search": self.config_entry.data[CONF_SEARCH],

--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -1,4 +1,4 @@
-"""Coordinator for imag integration."""
+"""Coordinator for imap integration."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/imap/icons.json
+++ b/homeassistant/components/imap/icons.json
@@ -8,5 +8,10 @@
         }
       }
     }
+  },
+  "services": {
+    "seen": "mdi:email-open-outline",
+    "move": "mdi:email-arrow-right-outline",
+    "delete": "mdi:trash-can-outline"
   }
 }

--- a/homeassistant/components/imap/services.yaml
+++ b/homeassistant/components/imap/services.yaml
@@ -1,0 +1,45 @@
+seen:
+  fields:
+    entry:
+      required: true
+      selector:
+        config_entry:
+          integration: "imap"
+    uid:
+      required: true
+      example: "12"
+      selector:
+        text:
+move:
+  fields:
+    entry:
+      required: true
+      selector:
+        config_entry:
+          integration: "imap"
+    uid:
+      required: true
+      example: "12"
+      selector:
+        text:
+    seen:
+      selector:
+        boolean:
+    target_folder:
+      required: true
+      example: "INBOX.Trash"
+      selector:
+        text:
+
+delete:
+  fields:
+    entry:
+      required: true
+      selector:
+        config_entry:
+          integration: "imap"
+    uid:
+      example: "12"
+      required: true
+      selector:
+        text:

--- a/homeassistant/components/imap/strings.json
+++ b/homeassistant/components/imap/strings.json
@@ -35,6 +35,32 @@
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
+  "exceptions": {
+    "copy_failed": {
+      "message": "Copying the message failed with '{error}'."
+    },
+    "delete_failed": {
+      "message": "Marking the the message for deletion failed with '{error}'."
+    },
+    "expunge_failed": {
+      "message": "Expungling the the message failed with '{error}'."
+    },
+    "invalid_entry": {
+      "message": "No valid IMAP entry was found."
+    },
+    "invalid_auth": {
+      "message": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "invalid_folder": {
+      "message": "[%key:component::imap::config::error::invalid_folder%]"
+    },
+    "imap_server_fail": {
+      "message": "The IMAP server failed to connect: {error}."
+    },
+    "seen_failed": {
+      "message": "Marking message as seen failed with '{error}'."
+    }
+  },
   "options": {
     "step": {
       "init": {
@@ -62,6 +88,58 @@
         "python_default": "Default settings",
         "modern": "Modern ciphers",
         "intermediate": "Intermediate ciphers"
+      }
+    }
+  },
+  "services": {
+    "seen": {
+      "name": "Mark message as seen",
+      "description": "Mark an email as seen.",
+      "fields": {
+        "entry": {
+          "name": "Entry",
+          "description": "The IMAP config entry."
+        },
+        "uid": {
+          "name": "UID",
+          "description": "The email identifier (UID)."
+        }
+      }
+    },
+    "move": {
+      "name": "Move message",
+      "description": "Move an email to a target folder.",
+      "fields": {
+        "entry": {
+          "name": "[%key:component::imap::services::seen::fields::entry::name%]",
+          "description": "[%key:component::imap::services::seen::fields::entry::description%]"
+        },
+        "seen": {
+          "name": "Seen",
+          "description": "Mark the email as seen."
+        },
+        "uid": {
+          "name": "[%key:component::imap::services::seen::fields::uid::name%]",
+          "description": "[%key:component::imap::services::seen::fields::uid::description%]"
+        },
+        "target_folder": {
+          "name": "Target folder",
+          "description": "The target folder the email should be moved to."
+        }
+      }
+    },
+    "delete": {
+      "name": "Delete message",
+      "description": "Delete an email.",
+      "fields": {
+        "entry": {
+          "name": "[%key:component::imap::services::seen::fields::entry::name%]",
+          "description": "[%key:component::imap::services::seen::fields::entry::description%]"
+        },
+        "uid": {
+          "name": "[%key:component::imap::services::seen::fields::uid::name%]",
+          "description": "[%key:component::imap::services::seen::fields::uid::description%]"
+        }
       }
     }
   }

--- a/tests/components/imap/test_init.py
+++ b/tests/components/imap/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.components.imap.errors import InvalidAuth, InvalidFolder
 from homeassistant.components.sensor.const import SensorStateClass
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util.dt import utcnow
 
 from .const import (
@@ -780,3 +781,139 @@ async def test_enforce_polling(
         mock_imap_protocol.wait_server_push.assert_not_called()
     else:
         mock_imap_protocol.assert_has_calls([call.wait_server_push])
+
+
+@pytest.mark.parametrize(
+    ("imap_search", "imap_fetch"),
+    [(TEST_SEARCH_RESPONSE, TEST_FETCH_RESPONSE_TEXT_PLAIN)],
+)
+@pytest.mark.parametrize("imap_has_capability", [True, False], ids=["push", "poll"])
+async def test_services(hass: HomeAssistant, mock_imap_protocol: MagicMock) -> None:
+    """Test receiving a message successfully."""
+    event_called = async_capture_events(hass, "imap_content")
+
+    config = MOCK_CONFIG.copy()
+    config_entry = MockConfigEntry(domain=DOMAIN, data=config)
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    # Make sure we have had one update (when polling)
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=5))
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.imap_email_email_com")
+    # we should have received one message
+    assert state is not None
+    assert state.state == "1"
+    assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+    # we should have received one event
+    assert len(event_called) == 1
+    data: dict[str, Any] = event_called[0].data
+    assert data["server"] == "imap.server.com"
+    assert data["username"] == "email@email.com"
+    assert data["search"] == "UnSeen UnDeleted"
+    assert data["folder"] == "INBOX"
+    assert data["sender"] == "john.doe@example.com"
+    assert data["subject"] == "Test subject"
+    assert data["uid"] == "1"
+    assert data["entry_id"] == config_entry.entry_id
+
+    # Test seen service
+    data = {"entry": config_entry.entry_id, "uid": "1"}
+    await hass.services.async_call(DOMAIN, "seen", data, blocking=True)
+    mock_imap_protocol.store.assert_called_with("1", "+FLAGS (\\Seen)")
+    mock_imap_protocol.store.reset_mock()
+
+    # Test move service
+    data = {
+        "entry": config_entry.entry_id,
+        "uid": "1",
+        "seen": True,
+        "target_folder": "Trash",
+    }
+    await hass.services.async_call(DOMAIN, "move", data, blocking=True)
+    mock_imap_protocol.store.assert_has_calls(
+        [call("1", "+FLAGS (\\Seen)"), call("1", "+FLAGS (\\Deleted)")]
+    )
+    mock_imap_protocol.copy.assert_called_with("1", "Trash")
+    mock_imap_protocol.protocol.expunge.assert_called_once()
+    mock_imap_protocol.store.reset_mock()
+    mock_imap_protocol.copy.reset_mock()
+    mock_imap_protocol.protocol.expunge.reset_mock()
+
+    # Test delete service
+    data = {"entry": config_entry.entry_id, "uid": "1"}
+    await hass.services.async_call(DOMAIN, "delete", data, blocking=True)
+    mock_imap_protocol.store.assert_called_with("1", "+FLAGS (\\Deleted)")
+    mock_imap_protocol.protocol.expunge.assert_called_once()
+
+    # Test with invalid entry_id
+    data = {"entry": "invalid", "uid": "1"}
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(DOMAIN, "seen", data, blocking=True)
+    assert exc.value.translation_domain == DOMAIN
+    assert exc.value.translation_key == "invalid_entry"
+
+    # Test processing imap client failures
+    exceptions = {
+        "invalid_auth": {"exc": InvalidAuth(), "translation_placeholders": None},
+        "invalid_folder": {"exc": InvalidFolder(), "translation_placeholders": None},
+        "imap_server_fail": {
+            "exc": AioImapException("Bla"),
+            "translation_placeholders": {"error": "Bla"},
+        },
+    }
+    for translation_key, attrs in exceptions.items():
+        with patch(
+            "homeassistant.components.imap.connect_to_server", side_effect=attrs["exc"]
+        ):
+            data = {"entry": config_entry.entry_id, "uid": "1"}
+            with pytest.raises(ServiceValidationError) as exc:
+                await hass.services.async_call(DOMAIN, "seen", data, blocking=True)
+            assert exc.value.translation_domain == DOMAIN
+            assert exc.value.translation_key == translation_key
+            assert (
+                exc.value.translation_placeholders == attrs["translation_placeholders"]
+            )
+
+    # Test unexpected errors with storing a flag during a service call
+    service_calls = {
+        "seen": {"entry": config_entry.entry_id, "uid": "1"},
+        "move": {
+            "entry": config_entry.entry_id,
+            "uid": "1",
+            "seen": False,
+            "target_folder": "Trash",
+        },
+        "delete": {"entry": config_entry.entry_id, "uid": "1"},
+    }
+    store_error_translation_key = {
+        "seen": "seen_failed",
+        "move": "copy_failed",
+        "delete": "delete_failed",
+    }
+    for service, data in service_calls.items():
+        with (
+            pytest.raises(ServiceValidationError) as exc,
+            patch.object(
+                mock_imap_protocol, "store", side_effect=AioImapException("Bla")
+            ),
+        ):
+            await hass.services.async_call(DOMAIN, service, data, blocking=True)
+        assert exc.value.translation_domain == DOMAIN
+        assert exc.value.translation_key == "imap_server_fail"
+        assert exc.value.translation_placeholders == {"error": "Bla"}
+        # Test with bad responses on store command
+        with (
+            pytest.raises(ServiceValidationError) as exc,
+            patch.object(
+                mock_imap_protocol, "store", return_value=Response("BAD", [b"Bla"])
+            ),
+            patch.object(
+                mock_imap_protocol, "copy", return_value=Response("BAD", [b"Bla"])
+            ),
+        ):
+            await hass.services.async_call(DOMAIN, service, data, blocking=True)
+        assert exc.value.translation_domain == DOMAIN
+        assert exc.value.translation_key == store_error_translation_key[service]
+        assert exc.value.translation_placeholders == {"error": "Bla"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds services that allow post processing based on the uid of the message.

The `uid` and `entry_id` will be added together with the IMAP event data.

Users can use the services in automation actions where they can use UI to select the `entry` parameter. The `uid` field can be extracted from the event data and be passed using a template.

With #114432 the `uid` was already added to the event data by @luca-angemi with the aim of post processing messages. This PR allows to do this directly from an automation.

Possible operations are:
- `seen`: Mark a message as seen/read.
- `move`: Move a message to a different folder and optionally mark it as seen.
- `delete`: Permanently delete a message.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32107

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
