### PR TITLE
Use entity & device registry mocks instead of `hass.helpers` in airthings_ble tests

### DIFF
--- a/tests/components/airthings_ble/__init__.py
+++ b/tests/components/airthings_ble/__init__.py
@@ -12,7 +12,8 @@ from airthings_ble import (
 
 from homeassistant.components.airthings_ble.const import DOMAIN
 from homeassistant.components.bluetooth.models import BluetoothServiceInfoBleak
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceRegistry
 
 from tests.common import MockConfigEntry, MockEntity
 from tests.components.bluetooth import generate_advertisement_data, generate_ble_device
@@ -232,9 +233,8 @@ def create_entry(hass):
     return entry
 
 
-def create_device(hass, entry):
+def create_device(entry: ConfigEntry, device_registry: DeviceRegistry):
     """Create a device for the given entry."""
-    device_registry = hass.helpers.device_registry.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         connections={(CONNECTION_BLUETOOTH, WAVE_SERVICE_INFO.address)},

--- a/tests/components/airthings_ble/test_sensor.py
+++ b/tests/components/airthings_ble/test_sensor.py
@@ -5,6 +5,7 @@ import logging
 from homeassistant.components.airthings_ble.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.airthings_ble import (
     CO2_V1,
@@ -25,17 +26,19 @@ from tests.components.bluetooth import inject_bluetooth_service_info
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_migration_from_v1_to_v3_unique_id(hass: HomeAssistant):
+async def test_migration_from_v1_to_v3_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+):
     """Verify that we can migrate from v1 (pre 2023.9.0) to the latest unique id format."""
     entry = create_entry(hass)
-    device = create_device(hass, entry)
+    device = create_device(entry, device_registry)
 
     assert entry is not None
     assert device is not None
 
     new_unique_id = f"{WAVE_DEVICE_INFO.address}_temperature"
-
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
 
     sensor = entity_registry.async_get_or_create(
         domain=DOMAIN,
@@ -64,17 +67,17 @@ async def test_migration_from_v1_to_v3_unique_id(hass: HomeAssistant):
     assert entity_registry.async_get(sensor.entity_id).unique_id == new_unique_id
 
 
-async def test_migration_from_v2_to_v3_unique_id(hass: HomeAssistant):
+async def test_migration_from_v2_to_v3_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+):
     """Verify that we can migrate from v2 (introduced in 2023.9.0) to the latest unique id format."""
     entry = create_entry(hass)
-    device = create_device(hass, entry)
+    device = create_device(entry, device_registry)
 
     assert entry is not None
     assert device is not None
-
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
-
-    await hass.async_block_till_done()
 
     sensor = entity_registry.async_get_or_create(
         domain=DOMAIN,
@@ -105,17 +108,17 @@ async def test_migration_from_v2_to_v3_unique_id(hass: HomeAssistant):
     assert entity_registry.async_get(sensor.entity_id).unique_id == new_unique_id
 
 
-async def test_migration_from_v1_and_v2_to_v3_unique_id(hass: HomeAssistant):
+async def test_migration_from_v1_and_v2_to_v3_unique_id(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+):
     """Test if migration works when we have both v1 (pre 2023.9.0) and v2 (introduced in 2023.9.0) unique ids."""
     entry = create_entry(hass)
-    device = create_device(hass, entry)
+    device = create_device(entry, device_registry)
 
     assert entry is not None
     assert device is not None
-
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
-
-    await hass.async_block_till_done()
 
     v2 = entity_registry.async_get_or_create(
         domain=DOMAIN,
@@ -155,17 +158,17 @@ async def test_migration_from_v1_and_v2_to_v3_unique_id(hass: HomeAssistant):
     assert entity_registry.async_get(v2.entity_id).unique_id == CO2_V2.unique_id
 
 
-async def test_migration_with_all_unique_ids(hass: HomeAssistant):
+async def test_migration_with_all_unique_ids(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+):
     """Test if migration works when we have all unique ids."""
     entry = create_entry(hass)
-    device = create_device(hass, entry)
+    device = create_device(entry, device_registry)
 
     assert entry is not None
     assert device is not None
-
-    entity_registry = hass.helpers.entity_registry.async_get(hass)
-
-    await hass.async_block_till_done()
 
     v1 = entity_registry.async_get_or_create(
         domain=DOMAIN,


### PR DESCRIPTION
## Proposed change
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
