### PR TITLE
Bump axis to v60

### DIFF
--- a/homeassistant/components/axis/hub/hub.py
+++ b/homeassistant/components/axis/hub/hub.py
@@ -116,7 +116,7 @@ class AxisHub:
         if status.status.state == ClientState.ACTIVE:
             self.config.entry.async_on_unload(
                 await mqtt.async_subscribe(
-                    hass, f"{self.api.vapix.serial_number}/#", self.mqtt_message
+                    hass, f"{status.config.device_topic_prefix}/#", self.mqtt_message
                 )
             )
 
@@ -124,7 +124,8 @@ class AxisHub:
     def mqtt_message(self, message: ReceiveMessage) -> None:
         """Receive Axis MQTT message."""
         self.disconnect_from_stream()
-
+        if message.topic.endswith("event/connection"):
+            return
         event = mqtt_json_to_event(message.payload)
         self.api.event.handler(event)
 

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -26,7 +26,7 @@
   "iot_class": "local_push",
   "loggers": ["axis"],
   "quality_scale": "platinum",
-  "requirements": ["axis==59"],
+  "requirements": ["axis==60"],
   "ssdp": [
     {
       "manufacturer": "AXIS"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -514,7 +514,7 @@ aurorapy==0.2.7
 # avion==0.10
 
 # homeassistant.components.axis
-axis==59
+axis==60
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.11.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -454,7 +454,7 @@ auroranoaa==0.0.3
 aurorapy==0.2.7
 
 # homeassistant.components.axis
-axis==59
+axis==60
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.11.1

--- a/tests/components/axis/const.py
+++ b/tests/components/axis/const.py
@@ -74,6 +74,7 @@ MQTT_CLIENT_RESPONSE = {
         "status": {"state": "active", "connectionStatus": "Connected"},
         "config": {
             "server": {"protocol": "tcp", "host": "192.168.0.90", "port": 1883},
+            "deviceTopicPrefix": f"axis/{MAC}",
         },
     },
 }

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -91,9 +91,9 @@ async def test_device_support_mqtt(
     hass: HomeAssistant, mqtt_mock: MqttMockHAClient, setup_config_entry
 ) -> None:
     """Successful setup."""
-    mqtt_mock.async_subscribe.assert_called_with(f"{MAC}/#", mock.ANY, 0, "utf-8")
+    mqtt_mock.async_subscribe.assert_called_with(f"axis/{MAC}/#", mock.ANY, 0, "utf-8")
 
-    topic = f"{MAC}/event/tns:onvif/Device/tns:axis/Sensor/PIR/$source/sensor/0"
+    topic = f"axis/{MAC}/event/tns:onvif/Device/tns:axis/Sensor/PIR/$source/sensor/0"
     message = (
         b'{"timestamp": 1590258472044, "topic": "onvif:Device/axis:Sensor/PIR",'
         b' "message": {"source": {"sensor": "0"}, "key": {}, "data": {"state": "1"}}}'


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/Kane610/axis/compare/v59...v60
Fix adding M7001 https://github.com/Kane610/axis/pull/428
Fix cameras not being adding https://github.com/Kane610/axis/pull/430
Reported through unofficial channels is MQTT breaks on some firmwares https://github.com/Kane610/axis/pull/426
Fix MQTT topic subscription and last will and testament message in integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114033, fixes #114504
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
