### PR TITLE
Add Glances network sensors

### DIFF
--- a/homeassistant/components/glances/icons.json
+++ b/homeassistant/components/glances/icons.json
@@ -60,6 +60,12 @@
       },
       "gpu_memory_usage": {
         "default": "mdi:memory"
+      },
+      "network_rx": {
+        "default": "mdi:transmission-tower"
+      },
+      "network_tx": {
+        "default": "mdi:transmission-tower"
       }
     }
   }

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -265,6 +265,24 @@ SENSOR_TYPES = {
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    ("network", "rx"): GlancesSensorEntityDescription(
+        key="rx",
+        type="network",
+        translation_key="network_rx",
+        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    ("network", "tx"): GlancesSensorEntityDescription(
+        key="tx",
+        type="network",
+        translation_key="network_tx",
+        native_unit_of_measurement=UnitOfDataRate.BYTES_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABITS_PER_SECOND,
+        device_class=SensorDeviceClass.DATA_RATE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }
 
 
@@ -279,7 +297,7 @@ async def async_setup_entry(
     entities: list[GlancesSensor] = []
 
     for sensor_type, sensors in coordinator.data.items():
-        if sensor_type in ["fs", "diskio", "sensors", "raid", "gpu"]:
+        if sensor_type in ["fs", "diskio", "sensors", "raid", "gpu", "network"]:
             entities.extend(
                 GlancesSensor(
                     coordinator,

--- a/homeassistant/components/glances/strings.json
+++ b/homeassistant/components/glances/strings.json
@@ -115,6 +115,12 @@
       },
       "gpu_processor_usage": {
         "name": "{sensor_label} processor usage"
+      },
+      "network_rx": {
+        "name": "{sensor_label} RX"
+      },
+      "network_tx": {
+        "name": "{sensor_label} TX"
       }
     }
   },

--- a/tests/components/glances/__init__.py
+++ b/tests/components/glances/__init__.py
@@ -12,168 +12,6 @@ MOCK_USER_INPUT: dict[str, Any] = {
     "verify_ssl": True,
 }
 
-MOCK_DATA = {
-    "cpu": {
-        "total": 10.6,
-        "user": 7.6,
-        "system": 2.1,
-        "idle": 88.8,
-        "nice": 0.0,
-        "iowait": 0.6,
-    },
-    "diskio": [
-        {
-            "time_since_update": 1,
-            "disk_name": "nvme0n1",
-            "read_count": 12,
-            "write_count": 466,
-            "read_bytes": 184320,
-            "write_bytes": 23863296,
-            "key": "disk_name",
-        },
-    ],
-    "docker": {
-        "containers": [
-            {
-                "key": "name",
-                "name": "container1",
-                "Status": "running",
-                "cpu": {"total": 50.94973493230174},
-                "cpu_percent": 50.94973493230174,
-                "memory": {
-                    "usage": 1120321536,
-                    "limit": 3976318976,
-                    "rss": 480641024,
-                    "cache": 580915200,
-                    "max_usage": 1309597696,
-                },
-                "memory_usage": 539406336,
-            },
-            {
-                "key": "name",
-                "name": "container2",
-                "Status": "running",
-                "cpu": {"total": 26.23567931034483},
-                "cpu_percent": 26.23567931034483,
-                "memory": {
-                    "usage": 85139456,
-                    "limit": 3976318976,
-                    "rss": 33677312,
-                    "cache": 35012608,
-                    "max_usage": 87650304,
-                },
-                "memory_usage": 50126848,
-            },
-        ]
-    },
-    "fs": [
-        {
-            "device_name": "/dev/sda8",
-            "fs_type": "ext4",
-            "mnt_point": "/ssl",
-            "size": 511320748032,
-            "used": 32910458880,
-            "free": 457917374464,
-            "percent": 6.7,
-            "key": "mnt_point",
-        },
-        {
-            "device_name": "/dev/sda8",
-            "fs_type": "ext4",
-            "mnt_point": "/media",
-            "size": 511320748032,
-            "used": 32910458880,
-            "free": 457917374464,
-            "percent": 6.7,
-            "key": "mnt_point",
-        },
-    ],
-    "mem": {
-        "total": 3976318976,
-        "available": 2878337024,
-        "percent": 27.6,
-        "used": 1097981952,
-        "free": 2878337024,
-        "active": 567971840,
-        "inactive": 1679704064,
-        "buffers": 149807104,
-        "cached": 1334816768,
-        "shared": 1499136,
-    },
-    "sensors": [
-        {
-            "label": "cpu_thermal 1",
-            "value": 59,
-            "warning": None,
-            "critical": None,
-            "unit": "C",
-            "type": "temperature_core",
-            "key": "label",
-        },
-        {
-            "label": "err_temp",
-            "value": "ERR",
-            "warning": None,
-            "critical": None,
-            "unit": "C",
-            "type": "temperature_hdd",
-            "key": "label",
-        },
-        {
-            "label": "na_temp",
-            "value": "NA",
-            "warning": None,
-            "critical": None,
-            "unit": "C",
-            "type": "temperature_hdd",
-            "key": "label",
-        },
-    ],
-    "system": {
-        "os_name": "Linux",
-        "hostname": "fedora-35",
-        "platform": "64bit",
-        "linux_distro": "Fedora Linux 35",
-        "os_version": "5.15.6-200.fc35.x86_64",
-        "hr_name": "Fedora Linux 35 64bit",
-    },
-    "raid": {
-        "md3": {
-            "status": "active",
-            "type": "raid1",
-            "components": {"sdh1": "2", "sdi1": "0"},
-            "available": "2",
-            "used": "2",
-            "config": "UU",
-        },
-        "md1": {
-            "status": "active",
-            "type": "raid1",
-            "components": {"sdg": "0", "sde": "1"},
-            "available": "2",
-            "used": "2",
-            "config": "UU",
-        },
-        "md4": {
-            "status": "active",
-            "type": "raid1",
-            "components": {"sdf1": "1", "sdb1": "0"},
-            "available": "2",
-            "used": "2",
-            "config": "UU",
-        },
-        "md0": {
-            "status": "active",
-            "type": "raid1",
-            "components": {"sdc": "2", "sdd": "3"},
-            "available": "2",
-            "used": "2",
-            "config": "UU",
-        },
-    },
-    "uptime": "3 days, 10:25:20",
-}
-
 MOCK_REFERENCE_DATE: datetime = datetime.fromisoformat("2024-02-13T14:13:12")
 
 HA_SENSOR_DATA: dict[str, Any] = {
@@ -213,6 +51,11 @@ HA_SENSOR_DATA: dict[str, Any] = {
             "used": "2",
             "config": "UU",
         },
+    },
+    "network": {
+        "lo": {"is_up": True, "rx": 7646, "tx": 7646, "speed": 0.0},
+        "dummy0": {"is_up": False, "rx": 0.0, "tx": 0.0, "speed": 0.0},
+        "eth0": {"is_up": True, "rx": 3953, "tx": 5995, "speed": 9.8},
     },
     "uptime": "3 days, 10:25:20",
     "gpu": {

--- a/tests/components/glances/snapshots/test_sensor.ambr
+++ b/tests/components/glances/snapshots/test_sensor.ambr
@@ -200,6 +200,114 @@
     'state': '59',
   })
 # ---
+# name: test_sensor_states[sensor.0_0_0_0_dummy0_rx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_dummy0_rx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'dummy0 RX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_rx',
+    'unique_id': 'test-dummy0-rx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_dummy0_rx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 dummy0 RX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_dummy0_rx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.000000',
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_dummy0_tx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_dummy0_tx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'dummy0 TX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_tx',
+    'unique_id': 'test-dummy0-tx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_dummy0_tx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 dummy0 TX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_dummy0_tx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.000000',
+  })
+# ---
 # name: test_sensor_states[sensor.0_0_0_0_err_temp_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -249,6 +357,222 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unavailable',
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_eth0_rx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_eth0_rx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'eth0 RX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_rx',
+    'unique_id': 'test-eth0-rx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_eth0_rx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 eth0 RX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_eth0_rx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.03162',
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_eth0_tx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_eth0_tx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'eth0 TX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_tx',
+    'unique_id': 'test-eth0-tx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_eth0_tx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 eth0 TX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_eth0_tx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.04796',
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_lo_rx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_lo_rx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'lo RX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_rx',
+    'unique_id': 'test-lo-rx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_lo_rx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 lo RX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_lo_rx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.06117',
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_lo_tx-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.0_0_0_0_lo_tx',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DATA_RATE: 'data_rate'>,
+    'original_icon': None,
+    'original_name': 'lo TX',
+    'platform': 'glances',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'network_tx',
+    'unique_id': 'test-lo-tx',
+    'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+  })
+# ---
+# name: test_sensor_states[sensor.0_0_0_0_lo_tx-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'data_rate',
+      'friendly_name': '0.0.0.0 lo TX',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfDataRate.MEGABITS_PER_SECOND: 'Mbit/s'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.0_0_0_0_lo_tx',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.06117',
   })
 # ---
 # name: test_sensor_states[sensor.0_0_0_0_md1_available-entry]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
The aim of this PR is to add Glances network sensors in Home Assistant.
Each network interface has 2 sensors, RX and TX.
Native unit: Bytes/sec
Suggested unit: Megabits/sec

Note that Glances can be configured server side to provide network information, and on which devices.
If Glances doesn't provide the information, HA doesn't create the sensors.

This PR requires an upgrade to glances-api v0.6.0  to fix the computation of network sensors:
https://github.com/home-assistant-ecosystem/python-glances-api/pull/34
Bump to version 0.6.0, validated in the following PR:
https://github.com/home-assistant/core/pull/114929

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #93381
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32171

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
