### PR TITLE
Add adax on/off functionality for local heaters

### DIFF
--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -189,4 +189,4 @@ class LocalAdaxDevice(ClimateEntity):
             self._attr_hvac_mode = HVACMode.HEAT
             self._attr_icon = "mdi:radiator"
             self._attr_target_temperature = data["target_temperature"]
-            
+

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -159,9 +159,7 @@ class LocalAdaxDevice(ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
         if hvac_mode == HVACMode.HEAT:
-            temperature = max(
-                self.min_temp, self._attr_target_temperature or self.min_temp
-            )
+            temperature = self.target_temperature or self.min_temp
             await self._adax_data_handler.set_target_temperature(temperature)
         elif hvac_mode == HVACMode.OFF:
             await self._adax_data_handler.set_target_temperature(0)

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -165,8 +165,6 @@ class LocalAdaxDevice(ClimateEntity):
             await self._adax_data_handler.set_target_temperature(temperature)
         elif hvac_mode == HVACMode.OFF:
             await self._adax_data_handler.set_target_temperature(0)
-        else:
-            return
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -175,12 +175,12 @@ class LocalAdaxDevice(ClimateEntity):
         data = await self._adax_data_handler.get_status()
         self._attr_current_temperature = data["current_temperature"]
         self._attr_available = self._attr_current_temperature is not None
-        if data["target_temperature"] == 0:
+        if (target_temp := data["target_temperature"]) == 0:
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_icon = "mdi:radiator-off"
-            if self._attr_target_temperature == 0:
+            if target_temp == 0:
                 self._attr_target_temperature = self._attr_min_temp
         else:
             self._attr_hvac_mode = HVACMode.HEAT
             self._attr_icon = "mdi:radiator"
-            self._attr_target_temperature = data["target_temperature"]
+            self._attr_target_temperature = target_temp

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -178,7 +178,7 @@ class LocalAdaxDevice(ClimateEntity):
         self._attr_target_temperature = data["target_temperature"]
         self._attr_current_temperature = data["current_temperature"]
         self._attr_available = self._attr_current_temperature is not None
-        if data["target_temperature"] == 0:
+        if self._attr_target_temperature == 0:
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_icon = "mdi:radiator-off"
             if self._attr_target_temperature == 0:

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -189,4 +189,3 @@ class LocalAdaxDevice(ClimateEntity):
             self._attr_hvac_mode = HVACMode.HEAT
             self._attr_icon = "mdi:radiator"
             self._attr_target_temperature = data["target_temperature"]
-

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -159,7 +159,7 @@ class LocalAdaxDevice(ClimateEntity):
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""
         if hvac_mode == HVACMode.HEAT:
-            temperature = self.target_temperature or self.min_temp
+            temperature = self._attr_target_temperature or self._attr_min_temp
             await self._adax_data_handler.set_target_temperature(temperature)
         elif hvac_mode == HVACMode.OFF:
             await self._adax_data_handler.set_target_temperature(0)
@@ -173,14 +173,13 @@ class LocalAdaxDevice(ClimateEntity):
     async def async_update(self) -> None:
         """Get the latest data."""
         data = await self._adax_data_handler.get_status()
-        self._attr_target_temperature = data["target_temperature"]
         self._attr_current_temperature = data["current_temperature"]
         self._attr_available = self._attr_current_temperature is not None
-        if self._attr_target_temperature == 0:
+        if data["target_temperature"] == 0:
             self._attr_hvac_mode = HVACMode.OFF
             self._attr_icon = "mdi:radiator-off"
             if self._attr_target_temperature == 0:
-                self._attr_target_temperature = self.min_temp
+                self._attr_target_temperature = self._attr_min_temp
         else:
             self._attr_hvac_mode = HVACMode.HEAT
             self._attr_icon = "mdi:radiator"

--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -135,11 +135,15 @@ class AdaxDevice(ClimateEntity):
 class LocalAdaxDevice(ClimateEntity):
     """Representation of a heater."""
 
-    _attr_hvac_modes = [HVACMode.HEAT]
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
     _attr_hvac_mode = HVACMode.HEAT
     _attr_max_temp = 35
     _attr_min_temp = 5
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
     _attr_target_temperature_step = PRECISION_WHOLE
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
 
@@ -151,6 +155,18 @@ class LocalAdaxDevice(ClimateEntity):
             identifiers={(DOMAIN, unique_id)},
             manufacturer="Adax",
         )
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set hvac mode."""
+        if hvac_mode == HVACMode.HEAT:
+            temperature = max(
+                self.min_temp, self._attr_target_temperature or self.min_temp
+            )
+            await self._adax_data_handler.set_target_temperature(temperature)
+        elif hvac_mode == HVACMode.OFF:
+            await self._adax_data_handler.set_target_temperature(0)
+        else:
+            return
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -164,3 +180,13 @@ class LocalAdaxDevice(ClimateEntity):
         self._attr_target_temperature = data["target_temperature"]
         self._attr_current_temperature = data["current_temperature"]
         self._attr_available = self._attr_current_temperature is not None
+        if data["target_temperature"] == 0:
+            self._attr_hvac_mode = HVACMode.OFF
+            self._attr_icon = "mdi:radiator-off"
+            if self._attr_target_temperature == 0:
+                self._attr_target_temperature = self.min_temp
+        else:
+            self._attr_hvac_mode = HVACMode.HEAT
+            self._attr_icon = "mdi:radiator"
+            self._attr_target_temperature = data["target_temperature"]
+            


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
I have discovered that the local heater reports temperature "0" if it is off, and it can be turned off by calling set temperature = 0.
 -->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
