### PR TITLE
Improve Shelly RPC device update progress

### DIFF
--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -296,7 +296,7 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
             await self.coordinator.async_shutdown_device_and_start_reauth()
         else:
             self._ota_in_progress = True
-            LOGGER.info("OTA update call successful")
+            LOGGER.info("OTA update call for %s successful", self.coordinator.name)
 
 
 class RpcSleepingUpdateEntity(

--- a/homeassistant/components/shelly/update.py
+++ b/homeassistant/components/shelly/update.py
@@ -222,7 +222,7 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
     ) -> None:
         """Initialize update entity."""
         super().__init__(coordinator, key, attribute, description)
-        self._ota_in_progress: bool = False
+        self._ota_in_progress: bool | int = False
         self._attr_release_url = get_release_url(
             coordinator.device.gen, coordinator.model, description.beta
         )
@@ -237,14 +237,13 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
     @callback
     def _ota_progress_callback(self, event: dict[str, Any]) -> None:
         """Handle device OTA progress."""
-        if self._ota_in_progress:
+        if self.in_progress is not False:
             event_type = event["event"]
             if event_type == OTA_BEGIN:
-                self._attr_in_progress = 0
+                self._ota_in_progress = 0
             elif event_type == OTA_PROGRESS:
-                self._attr_in_progress = event["progress_percent"]
+                self._ota_in_progress = event["progress_percent"]
             elif event_type in (OTA_ERROR, OTA_SUCCESS):
-                self._attr_in_progress = False
                 self._ota_in_progress = False
             self.async_write_ha_state()
 
@@ -261,6 +260,11 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
             return cast(str, new_version)
 
         return self.installed_version
+
+    @property
+    def in_progress(self) -> bool | int:
+        """Update installation in progress."""
+        return self._ota_in_progress
 
     async def async_install(
         self, version: str | None, backup: bool, **kwargs: Any
@@ -292,7 +296,7 @@ class RpcUpdateEntity(ShellyRpcAttributeEntity, UpdateEntity):
             await self.coordinator.async_shutdown_device_and_start_reauth()
         else:
             self._ota_in_progress = True
-            LOGGER.debug("OTA update call successful")
+            LOGGER.info("OTA update call successful")
 
 
 class RpcSleepingUpdateEntity(

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -255,6 +255,16 @@ async def test_rpc_update(
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
+
+    assert mock_rpc_device.trigger_ota_update.call_count == 1
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
+    assert state.attributes[ATTR_LATEST_VERSION] == "2"
+    assert state.attributes[ATTR_IN_PROGRESS] is True
+    assert state.attributes[ATTR_RELEASE_URL] == GEN2_RELEASE_URL
+
     inject_rpc_device_event(
         monkeypatch,
         mock_rpc_device,
@@ -270,14 +280,7 @@ async def test_rpc_update(
         },
     )
 
-    assert mock_rpc_device.trigger_ota_update.call_count == 1
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_INSTALLED_VERSION] == "1"
-    assert state.attributes[ATTR_LATEST_VERSION] == "2"
-    assert state.attributes[ATTR_IN_PROGRESS] == 0
-    assert state.attributes[ATTR_RELEASE_URL] == GEN2_RELEASE_URL
+    assert hass.states.get(entity_id).attributes[ATTR_IN_PROGRESS] == 0
 
     inject_rpc_device_event(
         monkeypatch,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the delay between clicking `Install` button and the visual start of the update installation. Previously, the user did not know for a few seconds whether the installation had started or not.

![shelly-update](https://github.com/home-assistant/core/assets/478555/c2f76f53-915c-440a-b8d4-7c7617636be9)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
