### PR TITLE
Automatic cleanup of entity and device registry in Tankerkoenig

### DIFF
--- a/homeassistant/components/tankerkoenig/__init__.py
+++ b/homeassistant/components/tankerkoenig/__init__.py
@@ -21,7 +21,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     coordinator = TankerkoenigDataUpdateCoordinator(
         hass,
-        entry,
         name=entry.unique_id or DOMAIN,
         update_interval=DEFAULT_SCAN_INTERVAL,
     )

--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -37,7 +37,6 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator):
     def __init__(
         self,
         hass: HomeAssistant,
-        entry: ConfigEntry,
         name: str,
         update_interval: int,
     ) -> None:
@@ -50,13 +49,14 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(minutes=update_interval),
         )
 
-        self._selected_stations: list[str] = entry.data[CONF_STATIONS]
+        self._selected_stations: list[str] = self.config_entry.data[CONF_STATIONS]
         self.stations: dict[str, Station] = {}
-        self.fuel_types: list[str] = entry.data[CONF_FUEL_TYPES]
-        self.show_on_map: bool = entry.options[CONF_SHOW_ON_MAP]
+        self.fuel_types: list[str] = self.config_entry.data[CONF_FUEL_TYPES]
+        self.show_on_map: bool = self.config_entry.options[CONF_SHOW_ON_MAP]
 
         self._tankerkoenig = Tankerkoenig(
-            api_key=entry.data[CONF_API_KEY], session=async_get_clientsession(hass)
+            api_key=self.config_entry.data[CONF_API_KEY],
+            session=async_get_clientsession(hass),
         )
 
     async def async_setup(self) -> None:

--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -89,7 +89,7 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator):
             entity_reg, self.config_entry.entry_id
         ):
             if entity.unique_id.split("_")[0] not in self._selected_stations:
-                _LOGGER.debug("remove obsolet entity entry %s", entity.entity_id)
+                _LOGGER.debug("Removing obsolete entity entry %s", entity.entity_id)
                 entity_reg.async_remove(entity.entity_id)
 
         device_reg = dr.async_get(self.hass)
@@ -100,7 +100,7 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator):
                 (ATTR_ID, station_id) in device.identifiers
                 for station_id in self._selected_stations
             ):
-                _LOGGER.debug("remove obsolet device entry %s", device.name)
+                _LOGGER.debug("Removing obsolete device entry %s", device.name)
                 device_reg.async_remove_device(device.id)
 
         if len(self.stations) > 10:

--- a/tests/components/tankerkoenig/test_coordinator.py
+++ b/tests/components/tankerkoenig/test_coordinator.py
@@ -133,7 +133,7 @@ async def test_automatic_registry_cleanup(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test automatic registry cleanup for obsolet entity and devices entries."""
+    """Test automatic registry cleanup for obsolete entity and devices entries."""
     # setup normal
     config_entry.add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
@@ -148,25 +148,25 @@ async def test_automatic_registry_cleanup(
         == 1
     )
 
-    # add obsolet entity and device entries
-    obsolet_station_id = "aabbccddee-xxxx-xxxx-xxxx-ff11223344"
+    # add obsolete entity and device entries
+    obsolete_station_id = "aabbccddee-xxxx-xxxx-xxxx-ff11223344"
 
     entity_registry.async_get_or_create(
         DOMAIN,
         BINARY_SENSOR_DOMAIN,
-        f"{obsolet_station_id}_status",
+        f"{obsolete_station_id}_status",
         config_entry=config_entry,
     )
     entity_registry.async_get_or_create(
         DOMAIN,
         SENSOR_DOMAIN,
-        f"{obsolet_station_id}_e10",
+        f"{obsolete_station_id}_e10",
         config_entry=config_entry,
     )
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={(ATTR_ID, obsolet_station_id)},
-        name="Obsolet Station",
+        identifiers={(ATTR_ID, obsolete_station_id)},
+        name="Obsolete Station",
     )
 
     assert (

--- a/tests/components/tankerkoenig/test_coordinator.py
+++ b/tests/components/tankerkoenig/test_coordinator.py
@@ -130,6 +130,8 @@ async def test_automatic_registry_cleanup(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     tankerkoenig: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
 ) -> None:
     """Test automatic registry cleanup for obsolet entity and devices entries."""
     # setup normal
@@ -137,42 +139,43 @@ async def test_automatic_registry_cleanup(
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    entity_reg = er.async_get(hass)
-    device_reg = dr.async_get(hass)
-
     assert (
-        len(er.async_entries_for_config_entry(entity_reg, config_entry.entry_id)) == 4
+        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        == 4
     )
     assert (
-        len(dr.async_entries_for_config_entry(device_reg, config_entry.entry_id)) == 1
+        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        == 1
     )
 
     # add obsolet entity and device entries
     obsolet_station_id = "aabbccddee-xxxx-xxxx-xxxx-ff11223344"
 
-    entity_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         DOMAIN,
         BINARY_SENSOR_DOMAIN,
         f"{obsolet_station_id}_status",
         config_entry=config_entry,
     )
-    entity_reg.async_get_or_create(
+    entity_registry.async_get_or_create(
         DOMAIN,
         SENSOR_DOMAIN,
         f"{obsolet_station_id}_e10",
         config_entry=config_entry,
     )
-    device_reg.async_get_or_create(
+    device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(ATTR_ID, obsolet_station_id)},
         name="Obsolet Station",
     )
 
     assert (
-        len(er.async_entries_for_config_entry(entity_reg, config_entry.entry_id)) == 6
+        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        == 6
     )
     assert (
-        len(dr.async_entries_for_config_entry(device_reg, config_entry.entry_id)) == 2
+        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        == 2
     )
 
     # reload config entry to trigger automatic cleanup
@@ -180,8 +183,10 @@ async def test_automatic_registry_cleanup(
     await hass.async_block_till_done()
 
     assert (
-        len(er.async_entries_for_config_entry(entity_reg, config_entry.entry_id)) == 4
+        len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))
+        == 4
     )
     assert (
-        len(dr.async_entries_for_config_entry(device_reg, config_entry.entry_id)) == 1
+        len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
+        == 1
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will add an automatic cleanup of entity and device registry entries. In case the user de-select a station via the options flow, the config entry will reload and entries related to no longer selected stations will be removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114099
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
