### PR TITLE
Use switch entities instead of toggle entities in tests

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -9,13 +9,13 @@ import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockToggleEntity
 from tests.components.conversation import MockAgent
 
 if TYPE_CHECKING:
     from tests.components.device_tracker.common import MockScanner
     from tests.components.light.common import MockLight
     from tests.components.sensor.common import MockSensor
+    from tests.components.switch.common import MockSwitch
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -145,11 +145,11 @@ def mock_sensor_entities() -> dict[str, "MockSensor"]:
 
 
 @pytest.fixture
-def mock_toggle_entities() -> list[MockToggleEntity]:
+def mock_switch_entities() -> list["MockSwitch"]:
     """Return mocked toggle entities."""
-    from tests.components.switch.common import get_mock_toggle_entities
+    from tests.components.switch.common import get_mock_switch_entities
 
-    return get_mock_toggle_entities()
+    return get_mock_switch_entities()
 
 
 @pytest.fixture

--- a/tests/components/generic_hygrostat/test_humidifier.py
+++ b/tests/components/generic_hygrostat/test_humidifier.py
@@ -37,12 +37,12 @@ from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
 from tests.common import (
-    MockToggleEntity,
     assert_setup_component,
     async_fire_time_changed,
     mock_restore_cache,
     setup_test_component_platform,
 )
+from tests.components.switch.common import MockSwitch
 
 ENTITY = "humidifier.test"
 ENT_SENSOR = "sensor.test"
@@ -129,11 +129,11 @@ async def test_humidifier_input_boolean(hass: HomeAssistant, setup_comp_1) -> No
 
 
 async def test_humidifier_switch(
-    hass: HomeAssistant, setup_comp_1, mock_toggle_entities: list[MockToggleEntity]
+    hass: HomeAssistant, setup_comp_1, mock_switch_entities: list[MockSwitch]
 ) -> None:
     """Test humidifier switching test switch."""
-    setup_test_component_platform(hass, switch.DOMAIN, mock_toggle_entities)
-    switch_1 = mock_toggle_entities[1]
+    setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
+    switch_1 = mock_switch_entities[1]
     assert await async_setup_component(
         hass, switch.DOMAIN, {"switch": {"platform": "test"}}
     )

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -50,7 +50,6 @@ from homeassistant.util import dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from tests.common import (
-    MockToggleEntity,
     assert_setup_component,
     async_fire_time_changed,
     async_mock_service,
@@ -59,6 +58,7 @@ from tests.common import (
     setup_test_component_platform,
 )
 from tests.components.climate import common
+from tests.components.switch.common import MockSwitch
 
 ENTITY = "climate.test"
 ENT_SENSOR = "sensor.test"
@@ -142,11 +142,11 @@ async def test_heater_input_boolean(hass: HomeAssistant, setup_comp_1) -> None:
 
 
 async def test_heater_switch(
-    hass: HomeAssistant, setup_comp_1, mock_toggle_entities: list[MockToggleEntity]
+    hass: HomeAssistant, setup_comp_1, mock_switch_entities: list[MockSwitch]
 ) -> None:
     """Test heater switching test switch."""
-    setup_test_component_platform(hass, switch.DOMAIN, mock_toggle_entities)
-    switch_1 = mock_toggle_entities[1]
+    setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
+    switch_1 = mock_switch_entities[1]
     assert await async_setup_component(
         hass, switch.DOMAIN, {"switch": {"platform": "test"}}
     )

--- a/tests/components/switch/common.py
+++ b/tests/components/switch/common.py
@@ -4,7 +4,9 @@ All containing methods are legacy helpers that should not be used by new
 components. Instead call the service directly.
 """
 
-from homeassistant.components.switch import DOMAIN
+from typing import Any
+
+from homeassistant.components.switch import DOMAIN, SwitchDeviceClass, SwitchEntity
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ENTITY_MATCH_ALL,
@@ -14,8 +16,6 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.loader import bind_hass
-
-from tests.common import MockToggleEntity
 
 
 @bind_hass
@@ -42,10 +42,29 @@ async def async_turn_off(hass, entity_id=ENTITY_MATCH_ALL):
     await hass.services.async_call(DOMAIN, SERVICE_TURN_OFF, data, blocking=True)
 
 
-def get_mock_toggle_entities() -> list[MockToggleEntity]:
-    """Return a list of mock toggle entities."""
+class MockSwitch(SwitchEntity):
+    """Mocked switch entity."""
+
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(self, name: str | None, state: str) -> None:
+        """Initialize the mock switch entity."""
+        self._attr_name = name
+        self._attr_is_on = state == STATE_ON
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        self._attr_is_on = True
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        self._attr_is_on = False
+
+
+def get_mock_switch_entities() -> list[MockSwitch]:
+    """Return a list of mock switch entities."""
     return [
-        MockToggleEntity("AC", STATE_ON),
-        MockToggleEntity("AC", STATE_OFF),
-        MockToggleEntity(None, STATE_OFF),
+        MockSwitch("AC", STATE_ON),
+        MockSwitch("AC", STATE_OFF),
+        MockSwitch(None, STATE_OFF),
     ]

--- a/tests/components/switch/test_init.py
+++ b/tests/components/switch/test_init.py
@@ -9,9 +9,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import common
+from .common import MockSwitch
 
 from tests.common import (
-    MockToggleEntity,
     MockUser,
     help_test_all,
     import_and_test_deprecated_constant_enum,
@@ -20,10 +20,10 @@ from tests.common import (
 
 
 @pytest.fixture(autouse=True)
-def entities(hass: HomeAssistant, mock_toggle_entities: list[MockToggleEntity]):
+def entities(hass: HomeAssistant, mock_switch_entities: list[MockSwitch]):
     """Initialize the test switch."""
-    setup_test_component_platform(hass, switch.DOMAIN, mock_toggle_entities)
-    return mock_toggle_entities
+    setup_test_component_platform(hass, switch.DOMAIN, mock_switch_entities)
+    return mock_switch_entities
 
 
 async def test_methods(


### PR DESCRIPTION
## Proposed change
As mentioned in https://github.com/home-assistant/core/pull/114305#discussion_r1542663311, we should use switch entities instead of toggle entities in switch tests.

This PR changes this.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
