### PR TITLE
Update `person` to use `_attr_*` and thus cached properties

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -411,8 +411,6 @@ class Person(
     _entity_component_unrecorded_attributes = frozenset({ATTR_DEVICE_TRACKERS})
 
     _attr_should_poll = False
-    _attr_state: str | None = None
-    device_trackers: list[str] = []
     editable: bool
 
     def __init__(self, config: dict[str, Any]) -> None:
@@ -423,6 +421,8 @@ class Person(
         self._gps_accuracy: float | None = None
         self._source: str | None = None
         self._unsub_track_device: Callable[[], None] | None = None
+        self._attr_state: str | None = None
+        self.device_trackers: list[str] = []
 
         self._attr_unique_id = config[CONF_ID]
         self._set_attrs_from_config()

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from functools import cached_property
 import logging
 from typing import Any, Self
 
@@ -403,15 +402,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-CACHED_PROPERTIES_WITH_ATTR_ = {
-    "device_trackers",
-}
-
-
 class Person(
     collection.CollectionEntity,
     RestoreEntity,
-    cached_properties=CACHED_PROPERTIES_WITH_ATTR_,
 ):
     """Represent a tracked person."""
 
@@ -419,7 +412,7 @@ class Person(
 
     _attr_should_poll = False
     _attr_state: str | None = None
-    _attr_device_trackers: list[str] = []
+    device_trackers: list[str] = []
     editable: bool
 
     def __init__(self, config: dict[str, Any]) -> None:
@@ -438,7 +431,7 @@ class Person(
         """Set attributes from config."""
         self._attr_name = self._config[CONF_NAME]
         self._attr_entity_picture = self._config.get(CONF_PICTURE)
-        self._attr_device_trackers = self._config[CONF_DEVICE_TRACKERS]
+        self.device_trackers = self._config[CONF_DEVICE_TRACKERS]
 
     @classmethod
     def from_storage(cls, config: ConfigType) -> Self:
@@ -453,11 +446,6 @@ class Person(
         person = cls(config)
         person.editable = False
         return person
-
-    @cached_property
-    def device_trackers(self) -> list[str]:
-        """Return the device trackers for the person."""
-        return self._attr_device_trackers
 
     async def async_added_to_hass(self) -> None:
         """Register device trackers."""

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -432,9 +432,13 @@ class Person(
         self._unsub_track_device: Callable[[], None] | None = None
 
         self._attr_unique_id = config[CONF_ID]
-        self._attr_name = config[CONF_NAME]
-        self._attr_entity_picture = config.get(CONF_PICTURE)
-        self._attr_device_trackers = config[CONF_DEVICE_TRACKERS]
+        self._set_attrs_from_config()
+
+    def _set_attrs_from_config(self) -> None:
+        """Set attributes from config."""
+        self._attr_name = self._config[CONF_NAME]
+        self._attr_entity_picture = self._config.get(CONF_PICTURE)
+        self._attr_device_trackers = self._config[CONF_DEVICE_TRACKERS]
 
     @classmethod
     def from_storage(cls, config: ConfigType) -> Self:
@@ -486,10 +490,7 @@ class Person(
     def _async_update_config(self, config: ConfigType) -> None:
         """Handle when the config is updated."""
         self._config = config
-
-        self._attr_name = config[CONF_NAME]
-        self._attr_entity_picture = config.get(CONF_PICTURE)
-        self._attr_device_trackers = config[CONF_DEVICE_TRACKERS]
+        self._set_attrs_from_config()
 
         if self._unsub_track_device is not None:
             self._unsub_track_device()


### PR DESCRIPTION
## Proposed change
`person` does not currently make use of cached properties. Therefore, this PR moves some properties to their `_attr_*` equivalent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
