### PR TITLE
Fix reolink media source data access

### DIFF
--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -46,7 +46,6 @@ class ReolinkVODMediaSource(MediaSource):
         """Initialize ReolinkVODMediaSource."""
         super().__init__(DOMAIN)
         self.hass = hass
-        self.data: dict[str, ReolinkData] = hass.data[DOMAIN]
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
         """Resolve media to a url."""
@@ -57,7 +56,8 @@ class ReolinkVODMediaSource(MediaSource):
         _, config_entry_id, channel_str, stream_res, filename = identifier
         channel = int(channel_str)
 
-        host = self.data[config_entry_id].host
+        data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
+        host = data[config_entry_id].host
 
         vod_type = VodRequestType.RTMP
         if host.api.is_nvr:
@@ -130,7 +130,8 @@ class ReolinkVODMediaSource(MediaSource):
             if config_entry.state != ConfigEntryState.LOADED:
                 continue
             channels: list[str] = []
-            host = self.data[config_entry.entry_id].host
+            data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
+            host = data[config_entry.entry_id].host
             entities = er.async_entries_for_config_entry(
                 entity_reg, config_entry.entry_id
             )
@@ -187,7 +188,8 @@ class ReolinkVODMediaSource(MediaSource):
         self, config_entry_id: str, channel: int
     ) -> BrowseMediaSource:
         """Allow the user to select the high or low playback resolution, (low loads faster)."""
-        host = self.data[config_entry_id].host
+        data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
+        host = data[config_entry_id].host
 
         main_enc = await host.api.get_encoding(channel, "main")
         if main_enc == "h265":
@@ -236,7 +238,8 @@ class ReolinkVODMediaSource(MediaSource):
         self, config_entry_id: str, channel: int, stream: str
     ) -> BrowseMediaSource:
         """Return all days on which recordings are available for a reolink camera."""
-        host = self.data[config_entry_id].host
+        data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
+        host = data[config_entry_id].host
 
         # We want today of the camera, not necessarily today of the server
         now = host.api.time() or await host.api.async_get_time()
@@ -288,7 +291,8 @@ class ReolinkVODMediaSource(MediaSource):
         day: int,
     ) -> BrowseMediaSource:
         """Return all recording files on a specific day of a Reolink camera."""
-        host = self.data[config_entry_id].host
+        data: dict[str, ReolinkData] = self.hass.data[DOMAIN]
+        host = data[config_entry_id].host
 
         start = dt.datetime(year, month, day, hour=0, minute=0, second=0)
         end = dt.datetime(year, month, day, hour=23, minute=59, second=59)

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -65,6 +65,17 @@ async def setup_component(hass: HomeAssistant) -> None:
     assert await async_setup_component(hass, MEDIA_STREAM_DOMAIN, {})
 
 
+async def test_platform_loads_before_config_entry(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test that the platform can be loaded before the config entry."""
+    # Fake that the config entry is not loaded before the media_source platform
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+    assert mock_setup_entry.call_count == 0
+
+
 async def test_resolve(
     hass: HomeAssistant,
     reolink_connect: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix access to hass.data in media source platform before config entry has been setup.
- Platforms that are setup via the integration platform helper, like diagnostics, media_source, logbook etc., need to handle being setup before their parent integration.

```
homeassistant  | 2024-04-01 16:50:35.087 ERROR (MainThread) [homeassistant.util.logging] Exception in <function _process_media_source_platform at 0x7faff441e5c0> when processing platform 'media_source': (<HomeAssistant NOT_RUNNING>, 'reolink', <module 'homeassistant.components.reolink.media_source' from '/usr/src/homeassistant/homeassistant/components/reolink/media_source.py'>)
homeassistant  | Traceback (most recent call last):
homeassistant  |   File "/usr/src/homeassistant/homeassistant/components/media_source/__init__.py", line 93, in _process_media_source_platform
homeassistant  |     hass.data[DOMAIN][domain] = await platform.async_get_media_source(hass)
homeassistant  |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant  |   File "/usr/src/homeassistant/homeassistant/components/reolink/media_source.py", line 32, in async_get_media_source
homeassistant  |     return ReolinkVODMediaSource(hass)
homeassistant  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
homeassistant  |   File "/usr/src/homeassistant/homeassistant/components/reolink/media_source.py", line 49, in __init__
homeassistant  |     self.data: dict[str, ReolinkData] = hass.data[DOMAIN]
homeassistant  |                                         ~~~~~~~~~^^^^^^^^
homeassistant  | KeyError: 'reolink'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
