### PR TITLE
Fix nibe_heatpump climate for models without cooling support

### DIFF
--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -112,7 +112,12 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
 
         self._coil_current = _get(climate.current)
         self._coil_setpoint_heat = _get(climate.setpoint_heat)
-        self._coil_setpoint_cool = _get(climate.setpoint_cool)
+        try:
+            self._coil_setpoint_cool = _get(climate.setpoint_cool)
+            self._support_cooling = True
+        except CoilNotFoundException:
+            self._attr_hvac_modes = [HVACMode.AUTO, HVACMode.HEAT]
+            self._support_cooling = False
         self._coil_prio = _get(unit.prio)
         self._coil_mixing_valve_state = _get(climate.mixing_valve_state)
         if climate.active_accessory is None:
@@ -147,8 +152,10 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
         self._attr_hvac_mode = mode
 
         setpoint_heat = _get_float(self._coil_setpoint_heat)
-        setpoint_cool = _get_float(self._coil_setpoint_cool)
-
+        if self._support_cooling:
+            setpoint_cool = _get_float(self._coil_setpoint_cool)
+        else:
+            setpoint_cool = None
         if mode == HVACMode.HEAT_COOL:
             self._attr_target_temperature = None
             self._attr_target_temperature_low = setpoint_heat
@@ -207,9 +214,12 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
                     self._coil_setpoint_heat, temperature
                 )
             elif hvac_mode == HVACMode.COOL:
-                await coordinator.async_write_coil(
-                    self._coil_setpoint_cool, temperature
-                )
+                if self._support_cooling:
+                    await coordinator.async_write_coil(
+                        self._coil_setpoint_cool, temperature
+                    )
+                else:
+                    raise ValueError(f"{hvac_mode} mode not supported for {self.name}")
             else:
                 raise ValueError(
                     "'set_temperature' requires 'hvac_mode' when passing"
@@ -220,7 +230,10 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
         if (temperature := kwargs.get(ATTR_TARGET_TEMP_LOW)) is not None:
             await coordinator.async_write_coil(self._coil_setpoint_heat, temperature)
 
-        if (temperature := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None:
+        if (
+            self._support_cooling
+            and (temperature := kwargs.get(ATTR_TARGET_TEMP_HIGH)) is not None
+        ):
             await coordinator.async_write_coil(self._coil_setpoint_cool, temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/tests/components/nibe_heatpump/snapshots/test_climate.ambr
+++ b/tests/components/nibe_heatpump/snapshots/test_climate.ambr
@@ -319,6 +319,214 @@
     'state': 'auto',
   })
 # ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][cooling]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.COOLING: 'cooling'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': 21.0,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][heating (auto)]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.HEATING: 'heating'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': None,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][heating (only)]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.HEATING: 'heating'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': None,
+      'target_temp_step': 0.5,
+      'temperature': 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][heating]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.HEATING: 'heating'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': 21.0,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][idle (mixing valve)]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': 21.0,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][initial]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.IDLE: 'idle'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': 21.0,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat_cool',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][off (auto)]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.OFF: 'off'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': None,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
+  })
+# ---
+# name: test_basic[Model.F730-s1-climate.climate_system_s1][unavailable]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'current_temperature': 20.5,
+      'friendly_name': 'Climate System S1',
+      'hvac_action': <HVACAction.OFF: 'off'>,
+      'hvac_modes': list([
+        <HVACMode.AUTO: 'auto'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      'max_temp': 35.0,
+      'min_temp': 5.0,
+      'supported_features': <ClimateEntityFeature: 3>,
+      'target_temp_high': None,
+      'target_temp_low': None,
+      'target_temp_step': 0.5,
+      'temperature': None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.climate_system_s1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'auto',
+  })
+# ---
 # name: test_basic[Model.S320-s1-climate.climate_system_s1][cooling]
   StateSnapshot({
     'attributes': ReadOnlyDict({

--- a/tests/components/nibe_heatpump/test_climate.py
+++ b/tests/components/nibe_heatpump/test_climate.py
@@ -197,6 +197,19 @@ async def test_set_temperature(
         assert mock_connection.write_coil.mock_calls == [
             call(CoilData(coil_setpoint_cool, 22))
         ]
+    else:
+        with pytest.raises(ValueError):
+            await hass.services.async_call(
+                PLATFORM_DOMAIN,
+                SERVICE_SET_TEMPERATURE,
+                {
+                    ATTR_ENTITY_ID: entity_id,
+                    ATTR_TEMPERATURE: 22,
+                    ATTR_HVAC_MODE: HVACMode.COOL,
+                },
+                blocking=True,
+            )
+
     mock_connection.write_coil.reset_mock()
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes #114548 to show the Climate Sensor also for  Nibe heat pumps that do not support cooling


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #114548
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
