### PR TITLE
Add missing platforms_exist guard to check_config

### DIFF
--- a/homeassistant/helpers/check_config.py
+++ b/homeassistant/helpers/check_config.py
@@ -198,15 +198,16 @@ async def async_check_ha_config_file(  # noqa: C901
 
         # Check if the integration has a custom config validator
         config_validator = None
-        try:
-            config_validator = await integration.async_get_platform("config")
-        except ImportError as err:
-            # Filter out import error of the config platform.
-            # If the config platform contains bad imports, make sure
-            # that still fails.
-            if err.name != f"{integration.pkg_path}.config":
-                result.add_error(f"Error importing config platform {domain}: {err}")
-                continue
+        if integration.platforms_exists(("config",)):
+            try:
+                config_validator = await integration.async_get_platform("config")
+            except ImportError as err:
+                # Filter out import error of the config platform.
+                # If the config platform contains bad imports, make sure
+                # that still fails.
+                if err.name != f"{integration.pkg_path}.config":
+                    result.add_error(f"Error importing config platform {domain}: {err}")
+                    continue
 
         if config_validator is not None and hasattr(
             config_validator, "async_validate_config"

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -374,6 +374,7 @@ async def test_platform_import_error(hass: HomeAssistant) -> None:
             "homeassistant.loader.Integration.async_get_platform",
             side_effect=[None, ImportError("blablabla")],
         ),
+        patch("homeassistant.loader.Integration.platforms_exists", return_value=True),
         patch("os.path.isfile", return_value=True),
         patch_yaml_files(files),
     ):

--- a/tests/helpers/test_check_config.py
+++ b/tests/helpers/test_check_config.py
@@ -350,6 +350,7 @@ async def test_config_platform_import_error(hass: HomeAssistant) -> None:
             side_effect=ImportError("blablabla"),
         ),
         patch("os.path.isfile", return_value=True),
+        patch("homeassistant.loader.Integration.platforms_exists", return_value=True),
         patch_yaml_files(files),
     ):
         res = await async_check_ha_config_file(hass)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
related issue #112811

When the exception hits, the config will end up being saved in the traceback so the memory is never released.

This matches the check_config code to [homeassistant.config](https://github.com/home-assistant/core/blob/b1af590eed7506730464cdf40c7ead29946ebc96/homeassistant/config.py#L1512) to avoid having the exception thrown.

This does not fix the leak, but it will make it unlikely to happen.  A separate PR will fix the leak

```
2024-04-01 12:06:51.961 CRITICAL (SyncWorker_12) [homeassistant.components.profiler] Memory Growth: [('NodeStrClass', 12324, 9724), ('_NSInlineData', 11890, 3609), ('NodeDictClass', 3095, 2106), ('frame', 1404, 1404), ('traceback', 1370, 1352), ('list', 58229, 1149), ('NodeListClass', 1273, 1118), ('dict', 88954, 747), ('cell', 38400, 156), ('tuple', 97137, 129), ('function', 97321, 82), ('set', 31140, 64), ('CaseInsensitiveDict', 491, 62), ('ReadOnlyDict', 18944, 60), ('ReferenceType', 25461, 49), ('CIMultiDict', 187, 35), ('State', 471, 33), ('Event', 567, 31), ('TemplateState', 65, 30), ('URL', 49, 26), ('SplitResult', 176, 26), ('SimpleCookie', 34, 26), ('StreamWriter', 29, 26), ('HomeAssistantRequest', 27, 26), ('HomeAssistantConfig', 26, 26), ('CheckConfigError', 26, 26), ('RawRequestMessage', 28, 25), ('CIMultiDictProxy', 159, 25), ('UrlMappingMatchInfo', 27, 25), ('Response', 26, 25), ('DNSNsec', 157, 13), ('DeviceKey', 32, 7), ('NSKVONotifying_CBPeripheral', 70, 3), ('BLEDevice', 69, 3), ('__NSDictionaryM', 81, 2), ('__NSCFNumber', 94, 2), ('OC_PythonLong', 93, 2), ('builtin_function_or_method', 9216, 2), ('SessionEventsDispatch', 9, 2), ('Lock', 971, 2), ('HassJob', 873, 2), ('Session', 14, 2), ('WeakInstanceDict', 8, 2), ('WeakKeyDictionary', 140, 1), ('WSMessage', 6, 1), ('States', 2, 1), ('LogEntry', 18, 1), ('IntegrationMatchHistory', 16, 1), ('_ParserDictionaryContext', 9, 1), ('AdvertisementData', 79, 1), ('BleDiscovery', 8, 1), ('HomeKitAdvertisement', 9, 1)]
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
