### PR TITLE
Fix memory leak when importing a platform fails

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -750,9 +750,7 @@ class Integration:
         self._import_futures: dict[str, asyncio.Future[ModuleType]] = {}
         cache: dict[str, ModuleType | ComponentProtocol] = hass.data[DATA_COMPONENTS]
         self._cache = cache
-        missing_platforms_cache: dict[str, ImportError] = hass.data[
-            DATA_MISSING_PLATFORMS
-        ]
+        missing_platforms_cache: dict[str, bool] = hass.data[DATA_MISSING_PLATFORMS]
         self._missing_platforms_cache = missing_platforms_cache
         self._top_level_files = top_level_files or set()
         _LOGGER.info("Loaded %s from %s", self.domain, pkg_path)
@@ -1085,8 +1083,7 @@ class Integration:
         import_futures: list[tuple[str, asyncio.Future[ModuleType]]] = []
 
         for platform_name in platform_names:
-            full_name = f"{domain}.{platform_name}"
-            if platform := self._get_platform_cached_or_raise(full_name):
+            if platform := self._get_platform_cached_or_raise(platform_name):
                 platforms[platform_name] = platform
                 continue
 
@@ -1095,6 +1092,7 @@ class Integration:
                 in_progress_imports[platform_name] = future
                 continue
 
+            full_name = f"{domain}.{platform_name}"
             if (
                 self.import_executor
                 and full_name not in self.hass.config.components
@@ -1166,14 +1164,18 @@ class Integration:
 
         return platforms
 
-    def _get_platform_cached_or_raise(self, full_name: str) -> ModuleType | None:
+    def _get_platform_cached_or_raise(self, platform_name: str) -> ModuleType | None:
         """Return a platform for an integration from cache."""
+        full_name = f"{self.domain}.{platform_name}"
         if full_name in self._cache:
             # the cache is either a ModuleType or a ComponentProtocol
             # but we only care about the ModuleType here
             return self._cache[full_name]  # type: ignore[return-value]
         if full_name in self._missing_platforms_cache:
-            raise self._missing_platforms_cache[full_name]
+            raise ModuleNotFoundError(
+                f"Platform {full_name} not found",
+                name=f"{self.pkg_path}.{platform_name}",
+            )
         return None
 
     def platforms_are_loaded(self, platform_names: Iterable[str]) -> bool:
@@ -1189,9 +1191,7 @@ class Integration:
 
     def get_platform(self, platform_name: str) -> ModuleType:
         """Return a platform for an integration."""
-        if platform := self._get_platform_cached_or_raise(
-            f"{self.domain}.{platform_name}"
-        ):
+        if platform := self._get_platform_cached_or_raise(platform_name):
             return platform
         return self._load_platform(platform_name)
 
@@ -1212,10 +1212,7 @@ class Integration:
             ):
                 existing_platforms.append(platform_name)
                 continue
-            missing_platforms[full_name] = ModuleNotFoundError(
-                f"Platform {full_name} not found",
-                name=f"{self.pkg_path}.{platform_name}",
-            )
+            missing_platforms[full_name] = True
 
         return existing_platforms
 
@@ -1233,11 +1230,12 @@ class Integration:
         cache: dict[str, ModuleType] = self.hass.data[DATA_COMPONENTS]
         try:
             cache[full_name] = self._import_platform(platform_name)
-        except ImportError as ex:
+        except ModuleNotFoundError:
             if self.domain in cache:
                 # If the domain is loaded, cache that the platform
                 # does not exist so we do not try to load it again
-                self._missing_platforms_cache[full_name] = ex
+                self._missing_platforms_cache[full_name] = True
+        except ImportError:
             raise
         except RuntimeError as err:
             # _DeadlockError inherits from RuntimeError

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1235,6 +1235,7 @@ class Integration:
                 # If the domain is loaded, cache that the platform
                 # does not exist so we do not try to load it again
                 self._missing_platforms_cache[full_name] = True
+            raise
         except ImportError:
             raise
         except RuntimeError as err:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -274,7 +274,7 @@ async def test_get_integration_exceptions(hass: HomeAssistant) -> None:
 async def test_get_platform_caches_failures_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test get_platform cache failures only when the component is loaded.
+    """Test get_platform caches failures only when the component is loaded.
 
     Only ModuleNotFoundError is cached, ImportError is not cached.
     """
@@ -378,7 +378,7 @@ async def test_get_platform_only_cached_module_not_found_when_component_loaded(
 async def test_async_get_platform_caches_failures_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_get_platform cache failures only when the component is loaded.
+    """Test async_get_platform caches failures only when the component is loaded.
 
     Only ModuleNotFoundError is cached, ImportError is not cached.
     """

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -274,7 +274,61 @@ async def test_get_integration_exceptions(hass: HomeAssistant) -> None:
 async def test_get_platform_caches_failures_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test get_platform cache failures only when the component is loaded."""
+    """Test get_platform cache failures only when the component is loaded.
+
+    Only ModuleNotFoundError is cached, ImportError is not cached.
+    """
+    integration = await loader.async_get_integration(hass, "hue")
+
+    with (
+        pytest.raises(ModuleNotFoundError),
+        patch(
+            "homeassistant.loader.importlib.import_module",
+            side_effect=ModuleNotFoundError("Boom"),
+        ),
+    ):
+        assert integration.get_component() == hue
+
+    with (
+        pytest.raises(ModuleNotFoundError),
+        patch(
+            "homeassistant.loader.importlib.import_module",
+            side_effect=ModuleNotFoundError("Boom"),
+        ),
+    ):
+        assert integration.get_platform("light") == hue_light
+
+    # Hue is not loaded so we should still hit the import_module path
+    with (
+        pytest.raises(ModuleNotFoundError),
+        patch(
+            "homeassistant.loader.importlib.import_module",
+            side_effect=ModuleNotFoundError("Boom"),
+        ),
+    ):
+        assert integration.get_platform("light") == hue_light
+
+    assert integration.get_component() == hue
+
+    # Hue is loaded so we should cache the import_module failure now
+    with (
+        pytest.raises(ModuleNotFoundError),
+        patch(
+            "homeassistant.loader.importlib.import_module",
+            side_effect=ModuleNotFoundError("Boom"),
+        ),
+    ):
+        assert integration.get_platform("light") == hue_light
+
+    # Hue is loaded and the last call should have cached the import_module failure
+    with pytest.raises(ModuleNotFoundError):
+        assert integration.get_platform("light") == hue_light
+
+
+async def test_get_platform_only_cached_module_not_found_when_component_loaded(
+    hass: HomeAssistant,
+) -> None:
+    """Test get_platform cache only cache module not found when the component is loaded."""
     integration = await loader.async_get_integration(hass, "hue")
 
     with (
@@ -317,41 +371,43 @@ async def test_get_platform_caches_failures_when_component_loaded(
     ):
         assert integration.get_platform("light") == hue_light
 
-    # Hue is loaded and the last call should have cached the import_module failure
-    with pytest.raises(ImportError):
-        assert integration.get_platform("light") == hue_light
+    # ImportError is not cached because we only cache ModuleNotFoundError
+    assert integration.get_platform("light") == hue_light
 
 
 async def test_async_get_platform_caches_failures_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_get_platform cache failures only when the component is loaded."""
+    """Test async_get_platform cache failures only when the component is loaded.
+
+    Only ModuleNotFoundError is cached, ImportError is not cached.
+    """
     integration = await loader.async_get_integration(hass, "hue")
 
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert integration.get_component() == hue
 
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platform("light") == hue_light
 
     # Hue is not loaded so we should still hit the import_module path
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platform("light") == hue_light
@@ -360,16 +416,16 @@ async def test_async_get_platform_caches_failures_when_component_loaded(
 
     # Hue is loaded so we should cache the import_module failure now
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platform("light") == hue_light
 
     # Hue is loaded and the last call should have cached the import_module failure
-    with pytest.raises(ImportError):
+    with pytest.raises(ModuleNotFoundError):
         assert await integration.async_get_platform("light") == hue_light
 
     # The cache should never be filled because the import error is remembered
@@ -379,33 +435,36 @@ async def test_async_get_platform_caches_failures_when_component_loaded(
 async def test_async_get_platforms_caches_failures_when_component_loaded(
     hass: HomeAssistant,
 ) -> None:
-    """Test async_get_platforms cache failures only when the component is loaded."""
+    """Test async_get_platforms cache failures only when the component is loaded.
+
+    Only ModuleNotFoundError is cached, ImportError is not cached.
+    """
     integration = await loader.async_get_integration(hass, "hue")
 
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert integration.get_component() == hue
 
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platforms(["light"]) == {"light": hue_light}
 
     # Hue is not loaded so we should still hit the import_module path
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platforms(["light"]) == {"light": hue_light}
@@ -414,16 +473,16 @@ async def test_async_get_platforms_caches_failures_when_component_loaded(
 
     # Hue is loaded so we should cache the import_module failure now
     with (
-        pytest.raises(ImportError),
+        pytest.raises(ModuleNotFoundError),
         patch(
             "homeassistant.loader.importlib.import_module",
-            side_effect=ImportError("Boom"),
+            side_effect=ModuleNotFoundError("Boom"),
         ),
     ):
         assert await integration.async_get_platforms(["light"]) == {"light": hue_light}
 
     # Hue is loaded and the last call should have cached the import_module failure
-    with pytest.raises(ImportError):
+    with pytest.raises(ModuleNotFoundError):
         assert await integration.async_get_platforms(["light"]) == {"light": hue_light}
 
     # The cache should never be filled because the import error is remembered


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Re-raising ImportError would trigger a memory leak.

I was expecting that storing `ImportError` was the problem but that seems fine. It was the re-raise here that triggered the leak. By making a new exception it doesn't leak.

If we can't re-raise it there is no reason to store it so I changed to store a bool.  That seems much safer as it ensures we don't refactor it later and re-introduce the leak.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #112811
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
