### PR TITLE
Catch potential ValueError when getting or setting Starlink sleep values

### DIFF
--- a/homeassistant/components/starlink/time.py
+++ b/homeassistant/components/starlink/time.py
@@ -61,16 +61,15 @@ class StarlinkTimeEntity(StarlinkEntity, TimeEntity):
 
 
 def _utc_minutes_to_time(utc_minutes: int, timezone: tzinfo) -> time:
+    hour = math.floor(utc_minutes / 60)
+    minute = utc_minutes % 60
     try:
-        hour = math.floor(utc_minutes / 60)
-        minute = utc_minutes % 60
         utc = datetime.now(UTC).replace(
             hour=hour, minute=minute, second=0, microsecond=0
         )
-        return utc.astimezone(timezone).time()
     except ValueError as exc:
-        # A ValueError here means that we did not pass a valid time in to `replace` above.
         raise HomeAssistantError from exc
+    return utc.astimezone(timezone).time()
 
 
 def _time_to_utc_minutes(t: time, timezone: tzinfo) -> int:
@@ -78,11 +77,10 @@ def _time_to_utc_minutes(t: time, timezone: tzinfo) -> int:
         zoned_time = datetime.now(timezone).replace(
             hour=t.hour, minute=t.minute, second=0, microsecond=0
         )
-        utc_time = zoned_time.astimezone(UTC).time()
-        return (utc_time.hour * 60) + utc_time.minute
     except ValueError as exc:
-        # A ValueError here means that we did not pass a valid time in to `replace` above.
         raise HomeAssistantError from exc
+    utc_time = zoned_time.astimezone(UTC).time()
+    return (utc_time.hour * 60) + utc_time.minute
 
 
 TIMES = [

--- a/homeassistant/components/starlink/time.py
+++ b/homeassistant/components/starlink/time.py
@@ -10,6 +10,7 @@ import math
 from homeassistant.components.time import TimeEntity, TimeEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -60,18 +61,28 @@ class StarlinkTimeEntity(StarlinkEntity, TimeEntity):
 
 
 def _utc_minutes_to_time(utc_minutes: int, timezone: tzinfo) -> time:
-    hour = math.floor(utc_minutes / 60)
-    minute = utc_minutes % 60
-    utc = datetime.now(UTC).replace(hour=hour, minute=minute, second=0, microsecond=0)
-    return utc.astimezone(timezone).time()
+    try:
+        hour = math.floor(utc_minutes / 60)
+        minute = utc_minutes % 60
+        utc = datetime.now(UTC).replace(
+            hour=hour, minute=minute, second=0, microsecond=0
+        )
+        return utc.astimezone(timezone).time()
+    except ValueError as exc:
+        # A ValueError here means that we did not pass a valid time in to `replace` above.
+        raise HomeAssistantError from exc
 
 
 def _time_to_utc_minutes(t: time, timezone: tzinfo) -> int:
-    zoned_time = datetime.now(timezone).replace(
-        hour=t.hour, minute=t.minute, second=0, microsecond=0
-    )
-    utc_time = zoned_time.astimezone(UTC).time()
-    return (utc_time.hour * 60) + utc_time.minute
+    try:
+        zoned_time = datetime.now(timezone).replace(
+            hour=t.hour, minute=t.minute, second=0, microsecond=0
+        )
+        utc_time = zoned_time.astimezone(UTC).time()
+        return (utc_time.hour * 60) + utc_time.minute
+    except ValueError as exc:
+        # A ValueError here means that we did not pass a valid time in to `replace` above.
+        raise HomeAssistantError from exc
 
 
 TIMES = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Starlink integration has no validation for the hour and minute values it is handling, it just trusts that it's dealing with a valid time.
According to #114353, this is not always the case.
I have added a try/except to catch ValueError and raise it as a HomeAssistantError instead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #114353
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
