### PR TITLE
Speed up logger setup

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -223,6 +223,7 @@ SETUP_ORDER = (
 # If they do not exist they will not be loaded
 #
 PRELOAD_STORAGE = [
+    "core.logger",
     "core.network",
     "http.auth",
     "image",

--- a/homeassistant/components/logger/helpers.py
+++ b/homeassistant/components/logger/helpers.py
@@ -28,6 +28,9 @@ from .const import (
     STORAGE_VERSION,
 )
 
+SAVE_DELAY = 15.0
+SAVE_DELAY_LONG = 180.0
+
 
 @callback
 def async_get_domain_config(hass: HomeAssistant) -> LoggerDomainConfig:
@@ -148,7 +151,7 @@ class LoggerSettings:
                 for domain, settings in stored_log_config.items()
             }
         }
-        await self._store.async_save(self._async_data_to_save())
+        self.async_save(SAVE_DELAY_LONG)
 
     @callback
     def _async_data_to_save(self) -> dict[str, dict[str, dict[str, str]]]:
@@ -164,9 +167,9 @@ class LoggerSettings:
         }
 
     @callback
-    def async_save(self) -> None:
+    def async_save(self, delay: float = SAVE_DELAY) -> None:
         """Save settings."""
-        self._store.async_delay_save(self._async_data_to_save, 15)
+        self._store.async_delay_save(self._async_data_to_save, delay)
 
     @callback
     def _async_get_logger_logs(self) -> dict[str, int]:

--- a/homeassistant/components/logger/helpers.py
+++ b/homeassistant/components/logger/helpers.py
@@ -29,6 +29,13 @@ from .const import (
 )
 
 SAVE_DELAY = 15.0
+# At startup, we want to save after a long delay to avoid
+# saving while the system is still starting up. If the system
+# for some reason restarts quickly, it will still be written
+# at the final write event. In most cases we expect startup
+# to happen in less than 180 seconds, but if it takes longer
+# its likely delayed because of remote I/O and not local
+# I/O so its fine to save at that point.
 SAVE_DELAY_LONG = 180.0
 
 

--- a/homeassistant/components/logger/helpers.py
+++ b/homeassistant/components/logger/helpers.py
@@ -34,8 +34,8 @@ SAVE_DELAY = 15.0
 # for some reason restarts quickly, it will still be written
 # at the final write event. In most cases we expect startup
 # to happen in less than 180 seconds, but if it takes longer
-# its likely delayed because of remote I/O and not local
-# I/O so its fine to save at that point.
+# it's likely delayed because of remote I/O and not local
+# I/O so it's fine to save at that point.
 SAVE_DELAY_LONG = 180.0
 
 

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -1,6 +1,7 @@
 """The tests for the Logger component."""
 
 from collections import defaultdict
+import datetime
 import logging
 from typing import Any
 from unittest.mock import Mock, patch
@@ -9,8 +10,12 @@ import pytest
 
 from homeassistant.components import logger
 from homeassistant.components.logger import LOGSEVERITY
+from homeassistant.components.logger.helpers import SAVE_DELAY_LONG
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 HASS_NS = "unused.homeassistant"
 COMPONENTS_NS = f"{HASS_NS}.components"
@@ -403,7 +408,7 @@ async def test_log_once_removed_from_store(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test logs with persistence "once" are removed from the store at startup."""
-    hass_storage["core.logger"] = {
+    store_contents = {
         "data": {
             "logs": {
                 ZONE_NS: {"type": "module", "level": "DEBUG", "persistence": "once"}
@@ -412,7 +417,15 @@ async def test_log_once_removed_from_store(
         "key": "core.logger",
         "version": 1,
     }
+    hass_storage["core.logger"] = store_contents
 
     assert await async_setup_component(hass, "logger", {})
+
+    assert hass_storage["core.logger"]["data"] == store_contents["data"]
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + datetime.timedelta(seconds=SAVE_DELAY_LONG)
+    )
+    await hass.async_block_till_done()
 
     assert hass_storage["core.logger"]["data"] == {"logs": {}}


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Preload core.logger and avoid saving it until after startup


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
