### PR TITLE
Avoid Exception on Glances missing key

### DIFF
--- a/homeassistant/components/glances/coordinator.py
+++ b/homeassistant/components/glances/coordinator.py
@@ -45,15 +45,16 @@ class GlancesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except exceptions.GlancesApiError as err:
             raise UpdateFailed from err
         # Update computed values
-        uptime: datetime | None = self.data["computed"]["uptime"] if self.data else None
-        up_duration: timedelta | None = None
-        if up_duration := parse_duration(data.get("uptime")):
+        up_duration: timedelta | None = (
+            parse_duration(data["uptime"]) if "uptime" in data else None
+        )
+        uptime: datetime | None = (
+            self.data["computed"]["uptime"] if up_duration and self.data else None
+        )
+        if up_duration:
             # Update uptime if previous value is None or previous uptime is bigger than
             # new uptime (i.e. server restarted)
-            if (
-                self.data is None
-                or self.data["computed"]["uptime_duration"] > up_duration
-            ):
+            if uptime is None or self.data["computed"]["uptime_duration"] > up_duration:
                 uptime = utcnow() - up_duration
         data["computed"] = {"uptime_duration": up_duration, "uptime": uptime}
         return data or {}

--- a/homeassistant/components/glances/coordinator.py
+++ b/homeassistant/components/glances/coordinator.py
@@ -45,13 +45,10 @@ class GlancesDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except exceptions.GlancesApiError as err:
             raise UpdateFailed from err
         # Update computed values
-        up_duration: timedelta | None = (
-            parse_duration(data["uptime"]) if "uptime" in data else None
-        )
-        uptime: datetime | None = (
-            self.data["computed"]["uptime"] if up_duration and self.data else None
-        )
-        if up_duration:
+        uptime: datetime | None = None
+        up_duration: timedelta | None = None
+        if "uptime" in data and (up_duration := parse_duration(data["uptime"])):
+            uptime = self.data["computed"]["uptime"] if self.data else None
             # Update uptime if previous value is None or previous uptime is bigger than
             # new uptime (i.e. server restarted)
             if uptime is None or self.data["computed"]["uptime_duration"] > up_duration:

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -351,14 +351,7 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
     @property
     def available(self) -> bool:
         """Set sensor unavailable when native value is invalid."""
-        if super().available and self._attr_available:
-            return (
-                not self._numeric_state_expected
-                or isinstance(value := self.native_value, (int, float))
-                or isinstance(value, str)
-                and value.isnumeric()
-            )
-        return False
+        return super().available and self._attr_available
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -375,4 +368,12 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
             self._attr_native_value = data.get(self.entity_description.key)
         else:
             self._attr_native_value = None
-        self._attr_available = self._attr_native_value is not None
+        self._update_available()
+
+    def _update_available(self) -> None:
+        self._attr_available = self._attr_native_value is not None and (
+            not self._numeric_state_expected
+            or isinstance(self._attr_native_value, (int, float))
+            or isinstance(self._attr_native_value, str)
+            and self._attr_native_value.isnumeric()
+        )

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -325,6 +325,7 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
 
     entity_description: GlancesSensorEntityDescription
     _attr_has_entity_name = True
+    _data_valid: bool = False
 
     def __init__(
         self,
@@ -351,7 +352,7 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
     @property
     def available(self) -> bool:
         """Set sensor unavailable when native value is invalid."""
-        return super().available and self._attr_available
+        return super().available and self._data_valid
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -368,10 +369,10 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
             self._attr_native_value = data.get(self.entity_description.key)
         else:
             self._attr_native_value = None
-        self._update_available()
+        self._update_data_valid()
 
-    def _update_available(self) -> None:
-        self._attr_available = self._attr_native_value is not None and (
+    def _update_data_valid(self) -> None:
+        self._data_valid = self._attr_native_value is not None and (
             not self._numeric_state_expected
             or isinstance(self._attr_native_value, (int, float))
             or isinstance(self._attr_native_value, str)

--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -351,7 +351,7 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
     @property
     def available(self) -> bool:
         """Set sensor unavailable when native value is invalid."""
-        if super().available:
+        if super().available and self._attr_available:
             return (
                 not self._numeric_state_expected
                 or isinstance(value := self.native_value, (int, float))
@@ -368,10 +368,11 @@ class GlancesSensor(CoordinatorEntity[GlancesDataUpdateCoordinator], SensorEntit
 
     def _update_native_value(self) -> None:
         """Update sensor native value from coordinator data."""
-        data = self.coordinator.data[self.entity_description.type]
-        if dict_val := data.get(self._sensor_label):
+        data = self.coordinator.data.get(self.entity_description.type)
+        if data and (dict_val := data.get(self._sensor_label)):
             self._attr_native_value = dict_val.get(self.entity_description.key)
-        elif self.entity_description.key in data:
+        elif data and (self.entity_description.key in data):
             self._attr_native_value = data.get(self.entity_description.key)
         else:
             self._attr_native_value = None
+        self._attr_available = self._attr_native_value is not None

--- a/tests/components/glances/test_sensor.py
+++ b/tests/components/glances/test_sensor.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.glances.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -71,3 +72,40 @@ async def test_uptime_variation(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert hass.states.get("sensor.0_0_0_0_uptime").state == "2024-02-15T12:49:52+00:00"
+
+
+async def test_sensor_removed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_api: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test sensor removed server side."""
+
+    # Init with reference time
+    freezer.move_to(MOCK_REFERENCE_DATE)
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT, entry_id="test")
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.0_0_0_0_ssl_disk_used").state != STATE_UNAVAILABLE
+    assert hass.states.get("sensor.0_0_0_0_memory_use").state != STATE_UNAVAILABLE
+    assert hass.states.get("sensor.0_0_0_0_uptime").state != STATE_UNAVAILABLE
+
+    # Remove some sensors from Glances API data
+    mock_data = HA_SENSOR_DATA.copy()
+    mock_data.pop("fs")
+    mock_data.pop("mem")
+    mock_data.pop("uptime")
+    mock_api.return_value.get_ha_sensor_data = AsyncMock(return_value=mock_data)
+
+    # Server stops providing some sensors, so state should switch to Unavailable
+    freezer.move_to(MOCK_REFERENCE_DATE + timedelta(minutes=2))
+    freezer.tick(delta=timedelta(seconds=120))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.0_0_0_0_ssl_disk_used").state == STATE_UNAVAILABLE
+    assert hass.states.get("sensor.0_0_0_0_memory_use").state == STATE_UNAVAILABLE
+    assert hass.states.get("sensor.0_0_0_0_uptime").state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The aim of this PR is to handle gracefully the case where a Glances sensor is removed server side.
In that case, HA should stop updating this sensor and mark it as Unavailable.
Today, the code breaks (exception in logs).

In more detail, there are three cases where Glances data can become unavailable after the inital setup completes correctly:

1. Request to the server fails, no data available at all => already handled by existing code
2. Configuration changes server side to remove a whole module (eg: fs, network) => currently provokes a missing key error, now handled by this PR to mark sensors as Unavailable
3. Configuration changes server side to remove an item in a module (eg: hide a filesystem in fs module, or hide a network adapter in network module) => currently provokes a missing key error, now handled by this PR to mark sensors as Unavailable

The PR adds systematic checks that the keys used are present in the data provided by `python-glances-api`. If not, the value is set to `None`.
It also updates the logic of `available()` to check for `None` values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: possibly fixes #108945
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
