### PR TITLE
Make entities endpoints signature explicit instead of **kwargs

### DIFF
--- a/homeassistant/components/abode/cover.py
+++ b/homeassistant/components/abode/cover.py
@@ -1,7 +1,5 @@
 """Support for Abode Security System covers."""
 
-from typing import Any
-
 from jaraco.abode.devices.cover import Cover
 from jaraco.abode.helpers.constants import TYPE_COVER
 
@@ -37,10 +35,10 @@ class AbodeCover(AbodeDevice, CoverEntity):
         """Return true if cover is closed, else False."""
         return not self._device.is_open
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Issue close command to cover."""
         self._device.close_cover()
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Issue open command to cover."""
         self._device.open_cover()

--- a/homeassistant/components/acmeda/cover.py
+++ b/homeassistant/components/acmeda/cover.py
@@ -2,13 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -98,34 +92,34 @@ class AcmedaCover(AcmedaBase, CoverEntity):
         """Return if the cover is closed."""
         return self.roller.closed_percent == 100  # type: ignore[no-any-return]
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the roller."""
         await self.roller.move_down()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the roller."""
         await self.roller.move_up()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the roller."""
         await self.roller.move_stop()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the roller shutter to a specific position."""
-        await self.roller.move_to(100 - kwargs[ATTR_POSITION])
+        await self.roller.move_to(100 - position)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the roller."""
         await self.roller.move_down()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the roller."""
         await self.roller.move_up()
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the roller."""
         await self.roller.move_stop()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Tilt the roller shutter to a specific position."""
-        await self.roller.move_to(100 - kwargs[ATTR_POSITION])
+        await self.roller.move_to(100 - tilt_position)

--- a/homeassistant/components/ads/cover.py
+++ b/homeassistant/components/ads/cover.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pyads
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     DEVICE_CLASSES_SCHEMA,
     PLATFORM_SCHEMA,
     CoverEntity,
@@ -149,27 +146,26 @@ class AdsCover(AdsEntity, CoverEntity):
         """Return current position of cover."""
         return self._state_dict[STATE_KEY_POSITION]
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Fire the stop action."""
         if self._ads_var_stop:
             self._ads_hub.write_by_name(self._ads_var_stop, True, pyads.PLCTYPE_BOOL)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Set cover position."""
-        position = kwargs[ATTR_POSITION]
         if self._ads_var_pos_set is not None:
             self._ads_hub.write_by_name(
                 self._ads_var_pos_set, position, pyads.PLCTYPE_BYTE
             )
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Move the cover up."""
         if self._ads_var_open is not None:
             self._ads_hub.write_by_name(self._ads_var_open, True, pyads.PLCTYPE_BOOL)
         elif self._ads_var_pos_set is not None:
             self.set_cover_position(position=100)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Move the cover down."""
         if self._ads_var_close is not None:
             self._ads_hub.write_by_name(self._ads_var_close, True, pyads.PLCTYPE_BOOL)

--- a/homeassistant/components/advantage_air/cover.py
+++ b/homeassistant/components/advantage_air/cover.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -79,19 +78,19 @@ class AdvantageAirZoneVent(AdvantageAirZoneEntity, CoverEntity):
             return self._zone["value"]
         return 0
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Fully open zone vent."""
         await self.async_update_zone(
             {"state": ADVANTAGE_AIR_STATE_OPEN, "value": 100},
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Fully close zone vent."""
         await self.async_update_zone({"state": ADVANTAGE_AIR_STATE_CLOSE})
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Change vent position."""
-        position = round(kwargs[ATTR_POSITION] / 5) * 5
+        position = round(position / 5) * 5
         if position == 0:
             await self.async_update_zone({"state": ADVANTAGE_AIR_STATE_CLOSE})
         else:
@@ -123,10 +122,10 @@ class AdvantageAirThingCover(AdvantageAirThingEntity, CoverEntity):
         """Return if cover is fully closed."""
         return self._data["value"] == 0
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Fully open zone vent."""
         return await self.async_turn_on()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Fully close zone vent."""
         return await self.async_turn_off()

--- a/homeassistant/components/airzone/water_heater.py
+++ b/homeassistant/components/airzone/water_heater.py
@@ -26,7 +26,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF
+from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -93,11 +93,11 @@ class AirzoneWaterHeater(AirzoneHotWaterEntity, WaterHeaterEntity):
 
         self._async_update_attrs()
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the water heater off."""
         await self._async_update_dhw_params({API_ACS_ON: 0})
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the water heater off."""
         await self._async_update_dhw_params({API_ACS_ON: 1})
 
@@ -106,11 +106,12 @@ class AirzoneWaterHeater(AirzoneHotWaterEntity, WaterHeaterEntity):
         params = OPERATION_MODE_TO_DHW_PARAMS.get(operation_mode, {})
         await self._async_update_dhw_params(params)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        params: dict[str, Any] = {}
-        if ATTR_TEMPERATURE in kwargs:
-            params[API_ACS_SET_POINT] = kwargs[ATTR_TEMPERATURE]
+        del operation_mode  # Unused.
+        params: dict[str, Any] = {API_ACS_SET_POINT: temperature}
         await self._async_update_dhw_params(params)
 
     @callback

--- a/homeassistant/components/aladdin_connect/cover.py
+++ b/homeassistant/components/aladdin_connect/cover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any
 
 from AIOAladdinConnect import AladdinConnectClient, session_manager
 
@@ -103,12 +102,12 @@ class AladdinDevice(CoverEntity):
         self._acc.unregister_callback(self._serial, self._number)
         await self._acc.close()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Issue close command to cover."""
         if not await self._acc.close_door(self._device_id, self._number):
             raise HomeAssistantError("Aladdin Connect API failed to close the cover")
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Issue open command to cover."""
         if not await self._acc.open_door(self._device_id, self._number):
             raise HomeAssistantError("Aladdin Connect API failed to open the cover")

--- a/homeassistant/components/aosmith/water_heater.py
+++ b/homeassistant/components/aosmith/water_heater.py
@@ -1,7 +1,5 @@
 """The water heater platform for the A. O. Smith integration."""
 
-from typing import Any
-
 from py_aosmith.models import OperationMode as AOSmithOperationMode
 
 from homeassistant.components.water_heater import (
@@ -136,13 +134,12 @@ class AOSmithWaterHeaterEntity(AOSmithStatusEntity, WaterHeaterEntity):
 
             await self.coordinator.async_request_refresh()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get("temperature")
-        if temperature is not None:
-            await self.client.update_setpoint(self.junction_id, temperature)
-
-            await self.coordinator.async_request_refresh()
+        await self.client.update_setpoint(self.junction_id, int(temperature))
+        await self.coordinator.async_request_refresh()
 
     async def async_turn_away_mode_on(self) -> None:
         """Turn away mode on."""

--- a/homeassistant/components/atag/water_heater.py
+++ b/homeassistant/components/atag/water_heater.py
@@ -1,14 +1,12 @@
 """ATAG water heater component."""
 
-from typing import Any
-
 from homeassistant.components.water_heater import (
     STATE_ECO,
     STATE_PERFORMANCE,
     WaterHeaterEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, Platform, UnitOfTemperature
+from homeassistant.const import STATE_OFF, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -44,9 +42,11 @@ class AtagWaterHeater(AtagEntity, WaterHeaterEntity):
         operation = self.coordinator.data.dhw.current_operation
         return operation if operation in self.operation_list else STATE_OFF
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        if await self.coordinator.data.dhw.set_temp(kwargs.get(ATTR_TEMPERATURE)):
+        if await self.coordinator.data.dhw.set_temp(temperature):
             self.async_write_ha_state()
 
     @property

--- a/homeassistant/components/blebox/cover.py
+++ b/homeassistant/components/blebox/cover.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from blebox_uniapi.box import Box
 import blebox_uniapi.cover
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -104,29 +100,25 @@ class BleBoxCoverEntity(BleBoxEntity[blebox_uniapi.cover.Cover], CoverEntity):
         """Return whether cover is closed."""
         return self._is_state(STATE_CLOSED)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover position."""
         await self._feature.async_open()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover position."""
         await self._feature.async_close()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover position."""
-
-        position = kwargs[ATTR_POSITION]
         await self._feature.async_set_position(100 - position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._feature.async_stop()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Set the tilt position."""
-
-        position = kwargs[ATTR_TILT_POSITION]
-        await self._feature.async_set_tilt_position(100 - position)
+        await self._feature.async_set_tilt_position(100 - tilt_position)
 
     def _is_state(self, state_name) -> bool | None:
         value = BLEBOX_TO_HASS_COVER_STATES[self._feature.state]

--- a/homeassistant/components/bond/cover.py
+++ b/homeassistant/components/bond/cover.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from bond_async import Action, BPUPSubscriptions, DeviceType
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -84,33 +81,33 @@ class BondCover(BondEntity, CoverEntity):
         if (bond_position := state.get("position")) is not None:
             self._attr_current_cover_position = _bond_to_hass_position(bond_position)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover position."""
         await self._hub.bond.action(
             self._device.device_id,
-            Action.set_position(_hass_to_bond_position(kwargs[ATTR_POSITION])),
+            Action.set_position(_hass_to_bond_position(position)),
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._hub.bond.action(self._device.device_id, Action.open())
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._hub.bond.action(self._device.device_id, Action.close())
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Hold cover."""
         await self._hub.bond.action(self._device.device_id, Action.hold())
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         await self._hub.bond.action(self._device.device_id, Action.tilt_open())
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         await self._hub.bond.action(self._device.device_id, Action.tilt_close())
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover."""
         await self._hub.bond.action(self._device.device_id, Action.hold())

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -1,11 +1,8 @@
 """Platform for cover integration."""
 
-from typing import Any
-
 from boschshcpy import SHCSession, SHCShutterControl
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -54,7 +51,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         """Return the current cover position."""
         return round(self._device.level * 100.0)
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self._device.stop()
 
@@ -79,15 +76,14 @@ class ShutterControlCover(SHCEntity, CoverEntity):
             == SHCShutterControl.ShutterControlService.State.CLOSING
         )
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self._device.level = 1.0
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close cover."""
         self._device.level = 0.0
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         self._device.level = position / 100.0

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -8,7 +8,6 @@ from aiohttp.client_exceptions import ClientResponseError
 from brunt import BruntClientAsync, Thing
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -152,17 +151,17 @@ class BruntDevice(
         """Return true if cover is closed, else False."""
         return self.current_cover_position == CLOSED_POSITION
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Set the cover to the open position."""
         await self._async_update_cover(OPEN_POSITION)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Set the cover to the closed position."""
         await self._async_update_cover(CLOSED_POSITION)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover to a specific position."""
-        await self._async_update_cover(int(kwargs[ATTR_POSITION]))
+        await self._async_update_cover(position)
 
     async def _async_update_cover(self, position: int) -> None:
         """Set the cover to the new position and wait for the update to be reflected."""

--- a/homeassistant/components/comelit/cover.py
+++ b/homeassistant/components/comelit/cover.py
@@ -97,11 +97,11 @@ class ComelitCoverEntity(
         """Return if the cover is opening."""
         return self._current_action("opening")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._api.set_device_status(COVER, self._device.index, STATE_OFF)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         await self._api.set_device_status(COVER, self._device.index, STATE_ON)
 

--- a/homeassistant/components/command_line/cover.py
+++ b/homeassistant/components/command_line/cover.py
@@ -188,17 +188,17 @@ class CommandCover(ManualTriggerEntity, CoverEntity):
         """
         await self._update_entity_state(dt_util.now())
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._async_move_cover(self._command_open)
         await self._update_entity_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._async_move_cover(self._command_close)
         await self._update_entity_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._async_move_cover(self._command_stop)
         await self._update_entity_state()

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -379,23 +379,23 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return if the cover is closed or not."""
         return self._attr_is_closed
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         raise NotImplementedError
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
-        await self.hass.async_add_executor_job(ft.partial(self.open_cover, **kwargs))
+        await self.hass.async_add_executor_job(self.open_cover)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close cover."""
         raise NotImplementedError
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
-        await self.hass.async_add_executor_job(ft.partial(self.close_cover, **kwargs))
+        await self.hass.async_add_executor_job(self.close_cover)
 
-    def toggle(self, **kwargs: Any) -> None:
+    def toggle(self) -> None:
         """Toggle the entity."""
         fns = {
             "open": self.open_cover,
@@ -403,9 +403,9 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             "stop": self.stop_cover,
         }
         function = self._get_toggle_function(fns)
-        function(**kwargs)
+        function()
 
-    async def async_toggle(self, **kwargs: Any) -> None:
+    async def async_toggle(self) -> None:
         """Toggle the entity."""
         fns = {
             "open": self.async_open_cover,
@@ -413,73 +413,67 @@ class CoverEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             "stop": self.async_stop_cover,
         }
         function = self._get_toggle_function(fns)
-        await function(**kwargs)
+        await function()
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         await self.hass.async_add_executor_job(
-            ft.partial(self.set_cover_position, **kwargs)
+            ft.partial(self.set_cover_position, position=position)
         )
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
-        await self.hass.async_add_executor_job(ft.partial(self.stop_cover, **kwargs))
+        await self.hass.async_add_executor_job(self.stop_cover)
 
-    def open_cover_tilt(self, **kwargs: Any) -> None:
+    def open_cover_tilt(self) -> None:
         """Open the cover tilt."""
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
-        await self.hass.async_add_executor_job(
-            ft.partial(self.open_cover_tilt, **kwargs)
-        )
+        await self.hass.async_add_executor_job(self.open_cover_tilt)
 
-    def close_cover_tilt(self, **kwargs: Any) -> None:
+    def close_cover_tilt(self) -> None:
         """Close the cover tilt."""
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
-        await self.hass.async_add_executor_job(
-            ft.partial(self.close_cover_tilt, **kwargs)
-        )
+        await self.hass.async_add_executor_job(self.close_cover_tilt)
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    def set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         await self.hass.async_add_executor_job(
-            ft.partial(self.set_cover_tilt_position, **kwargs)
+            ft.partial(self.set_cover_tilt_position, tilt_position=tilt_position)
         )
 
-    def stop_cover_tilt(self, **kwargs: Any) -> None:
+    def stop_cover_tilt(self) -> None:
         """Stop the cover."""
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover."""
-        await self.hass.async_add_executor_job(
-            ft.partial(self.stop_cover_tilt, **kwargs)
-        )
+        await self.hass.async_add_executor_job(self.stop_cover_tilt)
 
-    def toggle_tilt(self, **kwargs: Any) -> None:
+    def toggle_tilt(self) -> None:
         """Toggle the entity."""
         if self.current_cover_tilt_position == 0:
-            self.open_cover_tilt(**kwargs)
+            self.open_cover_tilt()
         else:
-            self.close_cover_tilt(**kwargs)
+            self.close_cover_tilt()
 
-    async def async_toggle_tilt(self, **kwargs: Any) -> None:
+    async def async_toggle_tilt(self) -> None:
         """Toggle the entity."""
         if self.current_cover_tilt_position == 0:
-            await self.async_open_cover_tilt(**kwargs)
+            await self.async_open_cover_tilt()
         else:
-            await self.async_close_cover_tilt(**kwargs)
+            await self.async_close_cover_tilt()
 
     def _get_toggle_function(
         self, fns: dict[str, Callable[_P, _R]]

--- a/homeassistant/components/deconz/cover.py
+++ b/homeassistant/components/deconz/cover.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 from pydeconz.interfaces.lights import CoverAction
 from pydeconz.models import ResourceType
 from pydeconz.models.event import EventType
 from pydeconz.models.light.cover import Cover
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DOMAIN,
     CoverDeviceClass,
     CoverEntity,
@@ -89,16 +85,16 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
         """Return if the cover is closed."""
         return not self._device.is_open
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = 100 - cast(int, kwargs[ATTR_POSITION])
+        position = 100 - position
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
             lift=position,
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
@@ -106,7 +102,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
@@ -114,7 +110,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop cover."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
@@ -129,16 +125,16 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
             return 100 - self._device.tilt
         return None
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Tilt the cover to a specific position."""
-        position = 100 - cast(int, kwargs[ATTR_TILT_POSITION])
+        position = 100 - tilt_position
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
             tilt=position,
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open cover tilt."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
@@ -146,7 +142,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close cover tilt."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,
@@ -154,7 +150,7 @@ class DeconzCover(DeconzDevice[Cover], CoverEntity):
             legacy_mode=self.legacy_mode,
         )
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop cover tilt."""
         await self.hub.api.lights.covers.set_state(
             id=self._device.resource_id,

--- a/homeassistant/components/demo/cover.py
+++ b/homeassistant/components/demo/cover.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -130,7 +127,7 @@ class DemoCover(CoverEntity):
         """Return if the cover is opening."""
         return self._is_opening
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         if self._position == 0:
             return
@@ -144,7 +141,7 @@ class DemoCover(CoverEntity):
         self._requested_closing = True
         self.async_write_ha_state()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         if self._tilt_position in (0, None):
             return
@@ -152,7 +149,7 @@ class DemoCover(CoverEntity):
         self._listen_cover_tilt()
         self._requested_closing_tilt = True
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         if self._position == 100:
             return
@@ -166,7 +163,7 @@ class DemoCover(CoverEntity):
         self._requested_closing = False
         self.async_write_ha_state()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         if self._tilt_position in (100, None):
             return
@@ -174,9 +171,8 @@ class DemoCover(CoverEntity):
         self._listen_cover_tilt()
         self._requested_closing_tilt = False
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position: int = kwargs[ATTR_POSITION]
         self._set_position = round(position, -1)
         if self._position == position:
             return
@@ -186,9 +182,8 @@ class DemoCover(CoverEntity):
             self._position is not None and position < self._position
         )
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover til to a specific position."""
-        tilt_position: int = kwargs[ATTR_TILT_POSITION]
         self._set_tilt_position = round(tilt_position, -1)
         if self._tilt_position == tilt_position:
             return
@@ -198,7 +193,7 @@ class DemoCover(CoverEntity):
             self._tilt_position is not None and tilt_position < self._tilt_position
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         self._is_closing = False
         self._is_opening = False
@@ -209,7 +204,7 @@ class DemoCover(CoverEntity):
             self._unsub_listener_cover = None
             self._set_position = None
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         if self._tilt_position is None:
             return

--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -75,9 +73,11 @@ class DemoWaterHeater(WaterHeaterEntity):
             "off",
         ]
 
-    def set_temperature(self, **kwargs: Any) -> None:
+    def set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperatures."""
-        self._attr_target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        self._attr_target_temperature = temperature
         self.schedule_update_ha_state()
 
     def set_operation_mode(self, operation_mode: str) -> None:
@@ -95,10 +95,10 @@ class DemoWaterHeater(WaterHeaterEntity):
         self._attr_is_away_mode_on = False
         self.schedule_update_ha_state()
 
-    def turn_on(self, **kwargs: Any) -> None:
+    def turn_on(self) -> None:
         """Turn on water heater."""
         self.set_operation_mode("eco")
 
-    def turn_off(self, **kwargs: Any) -> None:
+    def turn_off(self) -> None:
         """Turn off water heater."""
         self.set_operation_mode("off")

--- a/homeassistant/components/devolo_home_control/cover.py
+++ b/homeassistant/components/devolo_home_control/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.cover import (
     CoverDeviceClass,
     CoverEntity,
@@ -55,14 +53,14 @@ class DevoloCoverDeviceEntity(DevoloMultiLevelSwitchDeviceEntity, CoverEntity):
         """Return if the blind is closed or not."""
         return not bool(self._value)
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the blind."""
         self._multi_level_switch_property.set(100)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the blind."""
         self._multi_level_switch_property.set(0)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Set the blind to the given position."""
-        self._multi_level_switch_property.set(kwargs["position"])
+        self._multi_level_switch_property.set(position)

--- a/homeassistant/components/duotecno/cover.py
+++ b/homeassistant/components/duotecno/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from duotecno.controller import PyDuotecno
 from duotecno.unit import DuoswitchUnit
 
@@ -52,16 +50,16 @@ class DuotecnoCover(DuotecnoEntity, CoverEntity):
         return self._unit.is_closing()
 
     @api_call
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._unit.open()
 
     @api_call
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._unit.close()
 
     @api_call
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._unit.stop()

--- a/homeassistant/components/dynalite/cover.py
+++ b/homeassistant/components/dynalite/cover.py
@@ -63,21 +63,21 @@ class DynaliteCover(DynaliteBase, CoverEntity):
         """Return true if cover is closed."""
         return self._device.is_closed
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
-        await self._device.async_open_cover(**kwargs)
+        await self._device.async_open_cover()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
-        await self._device.async_close_cover(**kwargs)
+        await self._device.async_close_cover()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover position."""
-        await self._device.async_set_cover_position(**kwargs)
+        await self._device.async_set_cover_position(position=position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
-        await self._device.async_stop_cover(**kwargs)
+        await self._device.async_stop_cover()
 
     def initialize_state(self, state):
         """Initialize the state from cache."""
@@ -94,18 +94,18 @@ class DynaliteCoverWithTilt(DynaliteCover):
         """Return the current tilt position."""
         return self._device.current_cover_tilt_position
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open cover tilt."""
-        await self._device.async_open_cover_tilt(**kwargs)
+        await self._device.async_open_cover_tilt()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close cover tilt."""
-        await self._device.async_close_cover_tilt(**kwargs)
+        await self._device.async_close_cover_tilt()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Set the cover tilt position."""
-        await self._device.async_set_cover_tilt_position(**kwargs)
+        await self._device.async_set_cover_tilt_position(tilt_position=tilt_position)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
-        await self._device.async_stop_cover_tilt(**kwargs)
+        await self._device.async_stop_cover_tilt()

--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
 
 from pyeconet.equipment import EquipmentType
 from pyeconet.equipment.water_heater import WaterHeaterOperationMode
@@ -18,7 +17,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
+from homeassistant.const import STATE_OFF, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -114,12 +113,11 @@ class EcoNetWaterHeater(EcoNetEntity, WaterHeaterEntity):
             )
         return WaterHeaterEntityFeature.TARGET_TEMPERATURE
 
-    def set_temperature(self, **kwargs: Any) -> None:
+    def set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        if (target_temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            self.water_heater.set_set_point(target_temp)
-        else:
-            _LOGGER.error("A target temperature must be provided")
+        self.water_heater.set_set_point(temperature)
 
     def set_operation_mode(self, operation_mode: str) -> None:
         """Set operation mode."""

--- a/homeassistant/components/elmax/cover.py
+++ b/homeassistant/components/elmax/cover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from elmax_api.model.command import CoverCommand
 from elmax_api.model.cover_status import CoverStatus
@@ -105,7 +104,7 @@ class ElmaxCover(ElmaxEntity, CoverEntity):
         """Return if the cover is closing or not."""
         return self.__check_cover_status(CoverStatus.DOWN)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         # To stop the cover, Elmax requires us to re-issue the same command once again.
         # To detect the current motion status, we request an immediate refresh to the coordinator

--- a/homeassistant/components/esphome/cover.py
+++ b/homeassistant/components/esphome/cover.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from aioesphomeapi import APIVersion, CoverInfo, CoverOperation, CoverState, EntityInfo
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -101,37 +97,36 @@ class EsphomeCover(EsphomeEntity[CoverInfo, CoverState], CoverEntity):
         return round(self._state.tilt * 100.0)
 
     @convert_api_error_ha_error
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._client.cover_command(key=self._key, position=1.0)
 
     @convert_api_error_ha_error
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         self._client.cover_command(key=self._key, position=0.0)
 
     @convert_api_error_ha_error
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         self._client.cover_command(key=self._key, stop=True)
 
     @convert_api_error_ha_error
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        self._client.cover_command(key=self._key, position=kwargs[ATTR_POSITION] / 100)
+        self._client.cover_command(key=self._key, position=position / 100)
 
     @convert_api_error_ha_error
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         self._client.cover_command(key=self._key, tilt=1.0)
 
     @convert_api_error_ha_error
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         self._client.cover_command(key=self._key, tilt=0.0)
 
     @convert_api_error_ha_error
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        tilt_position: int = kwargs[ATTR_TILT_POSITION]
         self._client.cover_command(key=self._key, tilt=tilt_position / 100)

--- a/homeassistant/components/evohome/water_heater.py
+++ b/homeassistant/components/evohome/water_heater.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import evohomeasync2 as evo
 from evohomeasync2.schema.const import (
@@ -146,11 +146,11 @@ class EvoDHW(EvoChild, WaterHeaterEntity):
         """Turn away mode off."""
         await self._evo_broker.call_client_api(self._evo_device.reset_mode())
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn on."""
         await self._evo_broker.call_client_api(self._evo_device.set_on())
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn off."""
         await self._evo_broker.call_client_api(self._evo_device.set_off())
 

--- a/homeassistant/components/fibaro/cover.py
+++ b/homeassistant/components/fibaro/cover.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyfibaro.fibaro_device import DeviceModel
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     ENTITY_ID_FORMAT,
     CoverEntity,
     CoverEntityFeature,
@@ -78,13 +74,13 @@ class FibaroCover(FibaroDevice, CoverEntity):
         """Return the current tilt position for venetian blinds."""
         return self.bound(self.level2)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        self.set_level(kwargs.get(ATTR_POSITION))
+        self.set_level(position)
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    def set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover to a specific position."""
-        self.set_level2(kwargs.get(ATTR_TILT_POSITION))
+        self.set_level2(tilt_position)
 
     @property
     def is_closed(self) -> bool | None:
@@ -99,22 +95,22 @@ class FibaroCover(FibaroDevice, CoverEntity):
             return None
         return self.current_cover_position == 0
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self.action("open")
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self.action("close")
 
-    def open_cover_tilt(self, **kwargs: Any) -> None:
+    def open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         self.set_level2(100)
 
-    def close_cover_tilt(self, **kwargs: Any) -> None:
+    def close_cover_tilt(self) -> None:
         """Close the cover."""
         self.set_level2(0)
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self.action("stop")

--- a/homeassistant/components/freedompro/cover.py
+++ b/homeassistant/components/freedompro/cover.py
@@ -6,7 +6,6 @@ from typing import Any
 from pyfreedompro import put_state
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -107,17 +106,17 @@ class Device(CoordinatorEntity[FreedomproDataUpdateCoordinator], CoverEntity):
         await super().async_added_to_hass()
         self._handle_coordinator_update()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.async_set_cover_position(position=100)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.async_set_cover_position(position=0)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Async function to set position to cover."""
-        payload = {"position": kwargs[ATTR_POSITION]}
+        payload = {"position": position}
         await put_state(
             self._session,
             self._api_key,

--- a/homeassistant/components/fritzbox/cover.py
+++ b/homeassistant/components/fritzbox/cover.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -68,23 +65,23 @@ class FritzboxCover(FritzBoxDeviceEntity, CoverEntity):
             return None
         return self.data.levelpercentage == 100  # type: ignore [no-any-return]
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_open)
         await self.coordinator.async_refresh()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_close)
         await self.coordinator.async_refresh()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         await self.hass.async_add_executor_job(
-            self.data.set_level_percentage, 100 - kwargs[ATTR_POSITION]
+            self.data.set_level_percentage, 100 - position
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self.hass.async_add_executor_job(self.data.set_blind_stop)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/garadget/cover.py
+++ b/homeassistant/components/garadget/cover.py
@@ -210,21 +210,21 @@ class GaradgetCover(CoverEntity):
         """Check the state of the service during an operation."""
         self.schedule_update_ha_state(True)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         if self._state not in ["close", "closing"]:
             ret = self._put_command("setState", "close")
             self._start_watcher("close")
             return ret.get("return_value") == 1
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         if self._state not in ["open", "opening"]:
             ret = self._put_command("setState", "open")
             self._start_watcher("open")
             return ret.get("return_value") == 1
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the door where it is."""
         if self._state not in ["stopped"]:
             ret = self._put_command("setState", "stop")

--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from ismartgate.common import (
     AbstractDoor,
     DoorStatus,
@@ -87,12 +85,12 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
         """Return if the cover is opening or not."""
         return self.door_status == TransitionDoorStatus.OPENING
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the door."""
         await self._api.async_open_door(self._door_id)
         await self.coordinator.async_refresh()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the door."""
         await self._api.async_close_door(self._door_id)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -177,32 +177,32 @@ class CoverGroup(GroupEntity, CoverEntity):
         else:
             self._tilts[KEY_POSITION].discard(entity_id)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Move the covers up."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_OPEN_COVER, data, blocking=True, context=self._context
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Move the covers down."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_CLOSE_COVER, data, blocking=True, context=self._context
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Fire the stop action."""
         data = {ATTR_ENTITY_ID: self._covers[KEY_STOP]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_STOP_COVER, data, blocking=True, context=self._context
         )
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set covers position."""
         data = {
             ATTR_ENTITY_ID: self._covers[KEY_POSITION],
-            ATTR_POSITION: kwargs[ATTR_POSITION],
+            ATTR_POSITION: position,
         }
         await self.hass.services.async_call(
             DOMAIN,
@@ -212,32 +212,32 @@ class CoverGroup(GroupEntity, CoverEntity):
             context=self._context,
         )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Tilt covers open."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_OPEN_COVER_TILT, data, blocking=True, context=self._context
         )
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Tilt covers closed."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_OPEN_CLOSE]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_CLOSE_COVER_TILT, data, blocking=True, context=self._context
         )
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop cover tilt."""
         data = {ATTR_ENTITY_ID: self._tilts[KEY_STOP]}
         await self.hass.services.async_call(
             DOMAIN, SERVICE_STOP_COVER_TILT, data, blocking=True, context=self._context
         )
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Set tilt position."""
         data = {
             ATTR_ENTITY_ID: self._tilts[KEY_POSITION],
-            ATTR_TILT_POSITION: kwargs[ATTR_TILT_POSITION],
+            ATTR_TILT_POSITION: tilt_position,
         }
         await self.hass.services.async_call(
             DOMAIN,

--- a/homeassistant/components/hive/water_heater.py
+++ b/homeassistant/components/hive/water_heater.py
@@ -76,12 +76,12 @@ class HiveWaterHeater(HiveEntity, WaterHeaterEntity):
     _attr_operation_list = SUPPORT_WATER_HEATER
 
     @refresh_system
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self):
         """Turn on hotwater."""
         await self.hive.hotwater.setMode(self.device, "MANUAL")
 
     @refresh_system
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self):
         """Turn on hotwater."""
         await self.hive.hotwater.setMode(self.device, "OFF")
 

--- a/homeassistant/components/homekit_controller/cover.py
+++ b/homeassistant/components/homekit_controller/cover.py
@@ -8,8 +8,6 @@ from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -109,11 +107,11 @@ class HomeKitGarageDoorCover(HomeKitEntity, CoverEntity):
         """Return if the cover is opening or not."""
         return self._state == STATE_OPENING
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Send open command."""
         await self.set_door_state(STATE_OPEN)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Send close command."""
         await self.set_door_state(STATE_CLOSED)
 
@@ -246,28 +244,26 @@ class HomeKitWindowCover(HomeKitEntity, CoverEntity):
             tilt_position = int(tilt_position / scale)
         return tilt_position
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Send hold command."""
         await self.async_put_characteristics({CharacteristicsTypes.POSITION_HOLD: 1})
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Send open command."""
         await self.async_set_cover_position(position=100)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Send close command."""
         await self.async_set_cover_position(position=0)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Send position command."""
-        position = kwargs[ATTR_POSITION]
         await self.async_put_characteristics(
             {CharacteristicsTypes.POSITION_TARGET: position}
         )
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        tilt_position = kwargs[ATTR_TILT_POSITION]
         if self.is_vertical_tilt:
             # Recalculate to convert from percentage scale to arcdegree scale.
             scale = 0.9

--- a/homeassistant/components/homematic/cover.py
+++ b/homeassistant/components/homematic/cover.py
@@ -2,14 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
-    CoverDeviceClass,
-    CoverEntity,
-)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -51,13 +44,11 @@ class HMCover(HMDevice, CoverEntity):
         """
         return int(self._hm_get_state() * 100)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        if ATTR_POSITION in kwargs:
-            position = float(kwargs[ATTR_POSITION])
-            position = min(100, max(0, position))
-            level = position / 100.0
-            self._hmdevice.set_level(level, self._channel)
+        position = min(100, max(0, position))
+        level = position / 100.0
+        self._hmdevice.set_level(level, self._channel)
 
     @property
     def is_closed(self) -> bool | None:
@@ -66,15 +57,15 @@ class HMCover(HMDevice, CoverEntity):
             return self.current_cover_position == 0
         return None
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self._hmdevice.move_up(self._channel)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self._hmdevice.move_down(self._channel)
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the device if in motion."""
         self._hmdevice.stop(self._channel)
 
@@ -95,28 +86,28 @@ class HMCover(HMDevice, CoverEntity):
             return None
         return int(position * 100)
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    def set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        if "LEVEL_2" in self._data and ATTR_TILT_POSITION in kwargs:
-            position = float(kwargs[ATTR_TILT_POSITION])
+        if "LEVEL_2" in self._data:
+            position = float(tilt_position)
             position = min(100, max(0, position))
             level = position / 100.0
             self._hmdevice.set_cover_tilt_position(level, self._channel)
 
-    def open_cover_tilt(self, **kwargs: Any) -> None:
+    def open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         if "LEVEL_2" in self._data:
             self._hmdevice.open_slats()
 
-    def close_cover_tilt(self, **kwargs: Any) -> None:
+    def close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         if "LEVEL_2" in self._data:
             self._hmdevice.close_slats()
 
-    def stop_cover_tilt(self, **kwargs: Any) -> None:
+    def stop_cover_tilt(self) -> None:
         """Stop cover tilt."""
         if "LEVEL_2" in self._data:
-            self.stop_cover(**kwargs)
+            self.stop_cover()
 
 
 class HMGarage(HMCover):

--- a/homeassistant/components/homematicip_cloud/cover.py
+++ b/homeassistant/components/homematicip_cloud/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homematicip.aio.device import (
     AsyncBlindModule,
     AsyncDinRailBlind4,
@@ -15,12 +13,7 @@ from homematicip.aio.device import (
 from homematicip.aio.group import AsyncExtendedLinkedShutterGroup
 from homematicip.base.enums import DoorCommand, DoorState
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
-    CoverDeviceClass,
-    CoverEntity,
-)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -85,18 +78,16 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
             return int((1 - self._device.secondaryShadingLevel) * 100)
         return None
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         # HmIP cover is closed:1 -> open:0
         level = 1 - position / 100.0
         await self._device.set_primary_shading_level(primaryShadingLevel=level)
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover to a specific tilt position."""
-        position = kwargs[ATTR_TILT_POSITION]
         # HmIP slats is closed:1 -> open:0
-        level = 1 - position / 100.0
+        level = 1 - tilt_position / 100.0
         await self._device.set_secondary_shading_level(
             primaryShadingLevel=self._device.primaryShadingLevel,
             secondaryShadingLevel=level,
@@ -109,37 +100,37 @@ class HomematicipBlindModule(HomematicipGenericEntity, CoverEntity):
             return self._device.primaryShadingLevel == HMIP_COVER_CLOSED
         return None
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._device.set_primary_shading_level(
             primaryShadingLevel=HMIP_COVER_OPEN
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._device.set_primary_shading_level(
             primaryShadingLevel=HMIP_COVER_CLOSED
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the device if in motion."""
         await self._device.stop()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the slats."""
         await self._device.set_secondary_shading_level(
             primaryShadingLevel=self._device.primaryShadingLevel,
             secondaryShadingLevel=HMIP_SLATS_OPEN,
         )
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the slats."""
         await self._device.set_secondary_shading_level(
             primaryShadingLevel=self._device.primaryShadingLevel,
             secondaryShadingLevel=HMIP_SLATS_CLOSED,
         )
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the device if in motion."""
         await self._device.stop()
 
@@ -170,9 +161,8 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
             )
         return None
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         # HmIP cover is closed:1 -> open:0
         level = 1 - position / 100.0
         await self._device.set_shutter_level(level, self._channel)
@@ -187,15 +177,15 @@ class HomematicipMultiCoverShutter(HomematicipGenericEntity, CoverEntity):
             )
         return None
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._device.set_shutter_level(HMIP_COVER_OPEN, self._channel)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._device.set_shutter_level(HMIP_COVER_CLOSED, self._channel)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the device if in motion."""
         await self._device.set_shutter_stop(self._channel)
 
@@ -232,26 +222,25 @@ class HomematicipMultiCoverSlats(HomematicipMultiCoverShutter, CoverEntity):
             )
         return None
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover to a specific tilt position."""
-        position = kwargs[ATTR_TILT_POSITION]
         # HmIP slats is closed:1 -> open:0
-        level = 1 - position / 100.0
+        level = 1 - tilt_position / 100.0
         await self._device.set_slats_level(slatsLevel=level, channelIndex=self._channel)
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the slats."""
         await self._device.set_slats_level(
             slatsLevel=HMIP_SLATS_OPEN, channelIndex=self._channel
         )
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the slats."""
         await self._device.set_slats_level(
             slatsLevel=HMIP_SLATS_CLOSED, channelIndex=self._channel
         )
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the device if in motion."""
         await self._device.set_shutter_stop(self._channel)
 
@@ -285,15 +274,15 @@ class HomematicipGarageDoorModule(HomematicipGenericEntity, CoverEntity):
         """Return if the cover is closed."""
         return self._device.doorState == DoorState.CLOSED
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._device.send_door_command(DoorCommand.OPEN)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._device.send_door_command(DoorCommand.CLOSE)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._device.send_door_command(DoorCommand.STOP)
 
@@ -329,40 +318,38 @@ class HomematicipCoverShutterGroup(HomematicipGenericEntity, CoverEntity):
             return self._device.shutterLevel == HMIP_COVER_CLOSED
         return None
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         # HmIP cover is closed:1 -> open:0
         level = 1 - position / 100.0
         await self._device.set_shutter_level(level)
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover to a specific tilt position."""
-        position = kwargs[ATTR_TILT_POSITION]
         # HmIP slats is closed:1 -> open:0
-        level = 1 - position / 100.0
+        level = 1 - tilt_position / 100.0
         await self._device.set_slats_level(level)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._device.set_shutter_level(HMIP_COVER_OPEN)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._device.set_shutter_level(HMIP_COVER_CLOSED)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the group if in motion."""
         await self._device.set_shutter_stop()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the slats."""
         await self._device.set_slats_level(HMIP_SLATS_OPEN)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the slats."""
         await self._device.set_slats_level(HMIP_SLATS_CLOSED)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the group if in motion."""
         await self._device.set_shutter_stop()

--- a/homeassistant/components/hunterdouglas_powerview/cover.py
+++ b/homeassistant/components/hunterdouglas_powerview/cover.py
@@ -19,8 +19,6 @@ from aiopvapi.helpers.constants import (
 from aiopvapi.resources.shade import BaseShade, ShadePosition
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -165,7 +163,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         """Return the close position and required additional positions."""
         return replace(self._shade.close_position, velocity=self.positions.velocity)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         self._async_schedule_update_for_transition(self.transition_steps)
         await self._async_execute_move(self.close_position)
@@ -173,7 +171,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self._attr_is_closing = True
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._async_schedule_update_for_transition(100 - self.transition_steps)
         await self._async_execute_move(self.open_position)
@@ -181,7 +179,7 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         self._attr_is_closing = False
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         self._async_cancel_scheduled_transition_update()
         await self._shade.stop()
@@ -193,9 +191,9 @@ class PowerViewShadeBase(ShadeEntity, CoverEntity):
         # no override required in base
         return target_hass_position
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the shade to a specific position."""
-        await self._async_set_cover_position(kwargs[ATTR_POSITION])
+        await self._async_set_cover_position(position)
 
     @callback
     def _get_shade_move(self, target_hass_position: int) -> ShadePosition:
@@ -380,21 +378,21 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
             self._shade.close_position_tilt, velocity=self.positions.velocity
         )
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         self._async_schedule_update_for_transition(self.transition_steps)
         await self._async_execute_move(self.close_tilt_position)
         self.async_write_ha_state()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         self._async_schedule_update_for_transition(100 - self.transition_steps)
         await self._async_execute_move(self.open_tilt_position)
         self.async_write_ha_state()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the tilt to a specific position."""
-        await self._async_set_cover_tilt_position(kwargs[ATTR_TILT_POSITION])
+        await self._async_set_cover_tilt_position(tilt_position)
 
     async def _async_set_cover_tilt_position(
         self, target_hass_tilt_position: int
@@ -423,7 +421,7 @@ class PowerViewShadeWithTiltBase(PowerViewShadeBase):
             velocity=self.positions.velocity,
         )
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilting."""
         await self.async_stop_cover()
 
@@ -551,9 +549,9 @@ class PowerViewShadeTopDown(PowerViewShadeBase):
         # inverted positioning
         return MAX_POSITION - self.positions.primary
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the shade to a specific position."""
-        await self._async_set_cover_position(MAX_POSITION - kwargs[ATTR_POSITION])
+        await self._async_set_cover_position(MAX_POSITION - position)
 
     @property
     def is_closed(self) -> bool:

--- a/homeassistant/components/idasen_desk/cover.py
+++ b/homeassistant/components/idasen_desk/cover.py
@@ -7,7 +7,6 @@ from typing import Any
 from bleak.exc import BleakError
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -73,31 +72,31 @@ class IdasenDeskCover(CoordinatorEntity[IdasenDeskCoordinator], CoverEntity):
         """Return if the cover is closed."""
         return self.current_cover_position == 0
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         try:
             await self._desk.move_down()
         except BleakError as err:
             raise HomeAssistantError("Failed to move down: Bluetooth error") from err
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         try:
             await self._desk.move_up()
         except BleakError as err:
             raise HomeAssistantError("Failed to move up: Bluetooth error") from err
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         try:
             await self._desk.stop()
         except BleakError as err:
             raise HomeAssistantError("Failed to stop moving: Bluetooth error") from err
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover shutter to a specific position."""
         try:
-            await self._desk.move_to(int(kwargs[ATTR_POSITION]))
+            await self._desk.move_to(position)
         except BleakError as err:
             raise HomeAssistantError(
                 "Failed to move to specified position: Bluetooth error"

--- a/homeassistant/components/insteon/cover.py
+++ b/homeassistant/components/insteon/cover.py
@@ -1,13 +1,8 @@
 """Support for Insteon covers via PowerLinc Modem."""
 
 import math
-from typing import Any
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
@@ -66,17 +61,17 @@ class InsteonCoverEntity(InsteonEntity, CoverEntity):
         """Return the boolean response if the node is on."""
         return bool(self.current_cover_position)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         await self._insteon_device.async_open()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._insteon_device.async_close()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover position."""
-        position = int(kwargs[ATTR_POSITION] * 255 / 100)
+        position = int(position * 255 / 100)
         if position == 0:
             await self._insteon_device.async_close()
         else:

--- a/homeassistant/components/isy994/cover.py
+++ b/homeassistant/components/isy994/cover.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyisy.constants import ISY_VALUE_UNKNOWN
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -66,19 +62,18 @@ class ISYCoverEntity(ISYNodeEntity, CoverEntity):
             return None
         return bool(self._node.status == 0)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Send the open cover command to the ISY cover device."""
         if not await self._node.turn_on():
             _LOGGER.error("Unable to open the cover")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Send the close cover command to the ISY cover device."""
         if not await self._node.turn_off():
             _LOGGER.error("Unable to close the cover")
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         if self._node.uom == UOM_8_BIT_RANGE:
             position = round(position * 255.0 / 100.0)
         if not await self._node.turn_on(val=position):
@@ -93,12 +88,12 @@ class ISYCoverProgramEntity(ISYProgramEntity, CoverEntity):
         """Get whether the ISY cover program is closed."""
         return bool(self._node.status)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Send the open cover command to the ISY cover program."""
         if not await self._actions.run_then():
             _LOGGER.error("Unable to open the cover")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Send the close cover command to the ISY cover program."""
         if not await self._actions.run_else():
             _LOGGER.error("Unable to close the cover")

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
 
 from xknx import XKNX
 from xknx.devices import Cover as XknxCover
 
 from homeassistant import config_entries
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -133,20 +130,20 @@ class KNXCover(KnxEntity, CoverEntity):
         """Return if the cover is closing or not."""
         return self._device.is_closing()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._device.set_down()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._device.set_up()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        knx_position = 100 - kwargs[ATTR_POSITION]
+        knx_position = 100 - position
         await self._device.set_position(knx_position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._device.stop()
 
@@ -157,25 +154,25 @@ class KNXCover(KnxEntity, CoverEntity):
             return 100 - angle
         return None
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        knx_tilt_position = 100 - kwargs[ATTR_TILT_POSITION]
+        knx_tilt_position = 100 - tilt_position
         await self._device.set_angle(knx_tilt_position)
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         if self._device.angle.writable:
             await self._device.set_angle(0)
         else:
             await self._device.set_short_up()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         if self._device.angle.writable:
             await self._device.set_angle(100)
         else:
             await self._device.set_short_down()
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         await self._device.stop()

--- a/homeassistant/components/lcn/cover.py
+++ b/homeassistant/components/lcn/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pypck
 
 from homeassistant.components.cover import DOMAIN as DOMAIN_COVER, CoverEntity
@@ -95,7 +93,7 @@ class LcnOutputsCover(LcnEntity, CoverEntity):
                 pypck.lcn_defs.OutputPort["OUTPUTDOWN"]
             )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         state = pypck.lcn_defs.MotorStateModifier.DOWN
         if not await self.device_connection.control_motors_outputs(
@@ -106,7 +104,7 @@ class LcnOutputsCover(LcnEntity, CoverEntity):
         self._attr_is_closing = True
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         state = pypck.lcn_defs.MotorStateModifier.UP
         if not await self.device_connection.control_motors_outputs(
@@ -118,7 +116,7 @@ class LcnOutputsCover(LcnEntity, CoverEntity):
         self._attr_is_closing = False
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         state = pypck.lcn_defs.MotorStateModifier.STOP
         if not await self.device_connection.control_motors_outputs(state):
@@ -186,7 +184,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
         if not self.device_connection.is_group:
             await self.device_connection.cancel_status_request_handler(self.motor)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.DOWN
@@ -196,7 +194,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
         self._attr_is_closing = True
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.UP
@@ -207,7 +205,7 @@ class LcnRelayCover(LcnEntity, CoverEntity):
         self._attr_is_closing = False
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         states = [pypck.lcn_defs.MotorStateModifier.NOCHANGE] * 4
         states[self.motor.value] = pypck.lcn_defs.MotorStateModifier.STOP

--- a/homeassistant/components/linear_garage_door/cover.py
+++ b/homeassistant/components/linear_garage_door/cover.py
@@ -1,7 +1,6 @@
 """Cover entity for Linear Garage Doors."""
 
 from datetime import timedelta
-from typing import Any
 
 from linear_garage_door import Linear
 
@@ -114,7 +113,7 @@ class LinearCoverEntity(CoordinatorEntity[LinearUpdateCoordinator], CoverEntity)
         """Return if cover is closing."""
         return bool(self._get_data("Opening_P") == "100")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the garage door."""
         if self.is_closed:
             return
@@ -131,7 +130,7 @@ class LinearCoverEntity(CoordinatorEntity[LinearUpdateCoordinator], CoverEntity)
         await linear.operate_device(self._device_id, self._subdevice, "Close")
         await linear.close()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the garage door."""
         if self.is_opened:
             return

--- a/homeassistant/components/lutron/cover.py
+++ b/homeassistant/components/lutron/cover.py
@@ -8,11 +8,7 @@ from typing import Any
 
 from pylutron import Output
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -54,19 +50,17 @@ class LutronCover(LutronDevice, CoverEntity):
     _lutron_device: Output
     _attr_name = None
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self._lutron_device.level = 0
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self._lutron_device.level = 100
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the shade to a specific position."""
-        if ATTR_POSITION in kwargs:
-            position = kwargs[ATTR_POSITION]
-            self._lutron_device.level = position
+        self._lutron_device.level = position
 
     def _request_state(self) -> None:
         """Request the state from the device."""

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -1,10 +1,6 @@
 """Support for Lutron Caseta shades."""
 
-from typing import Any
-
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DOMAIN,
     CoverDeviceClass,
     CoverEntity,
@@ -40,25 +36,25 @@ class LutronCasetaShade(LutronCasetaDeviceUpdatableEntity, CoverEntity):
         """Return the current position of cover."""
         return self._device["current_state"]
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._smartbridge.lower_cover(self.device_id)
         await self.async_update()
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._smartbridge.stop_cover(self.device_id)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._smartbridge.raise_cover(self.device_id)
         await self.async_update()
         self.async_write_ha_state()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the shade to a specific position."""
-        await self._smartbridge.set_value(self.device_id, kwargs[ATTR_POSITION])
+        await self._smartbridge.set_value(self.device_id, position)
 
 
 class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
@@ -82,21 +78,21 @@ class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
         """Return the current tilt position of blind."""
         return self._device["tilt"]
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the blind."""
         await self._smartbridge.set_tilt(self.device_id, 0)
         await self.async_update()
         self.async_write_ha_state()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the blind."""
         await self._smartbridge.set_tilt(self.device_id, 50)
         await self.async_update()
         self.async_write_ha_state()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the blind to a specific tilt."""
-        self._smartbridge.set_tilt(self.device_id, kwargs[ATTR_TILT_POSITION])
+        self._smartbridge.set_tilt(self.device_id, tilt_position)
 
 
 PYLUTRON_TYPE_TO_CLASSES = {

--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -9,8 +9,6 @@ from typing import Any
 from chip.clusters import Objects as clusters
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityDescription,
@@ -74,32 +72,32 @@ class MatterCover(MatterEntity, CoverEntity):
             else None
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover movement."""
         await self.send_device_command(clusters.WindowCovering.Commands.StopMotion())
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.send_device_command(clusters.WindowCovering.Commands.UpOrOpen())
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.send_device_command(clusters.WindowCovering.Commands.DownOrClose())
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         await self.send_device_command(
             # value needs to be inverted and is sent in 100ths
             clusters.WindowCovering.Commands.GoToLiftPercentage((100 - position) * 100)
         )
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Set the cover tilt to a specific position."""
-        position = kwargs[ATTR_TILT_POSITION]
         await self.send_device_command(
             # value needs to be inverted and is sent in 100ths
-            clusters.WindowCovering.Commands.GoToTiltPercentage((100 - position) * 100)
+            clusters.WindowCovering.Commands.GoToTiltPercentage(
+                (100 - tilt_position) * 100
+            )
         )
 
     async def send_device_command(self, command: Any) -> None:

--- a/homeassistant/components/melcloud/water_heater.py
+++ b/homeassistant/components/melcloud/water_heater.py
@@ -62,11 +62,11 @@ class AtwWaterHeater(WaterHeaterEntity):
         """Update state from MELCloud."""
         await self._api.async_update()
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the entity on."""
         await self._device.set({PROPERTY_POWER: True})
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the entity off."""
         await self._device.set({PROPERTY_POWER: False})
 
@@ -101,13 +101,13 @@ class AtwWaterHeater(WaterHeaterEntity):
         """Return the temperature we try to reach."""
         return self._device.target_tank_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
         await self._device.set(
             {
-                PROPERTY_TARGET_TANK_TEMPERATURE: kwargs.get(
-                    "temperature", self.target_temperature
-                )
+                PROPERTY_TARGET_TANK_TEMPERATURE: temperature,
             }
         )
 

--- a/homeassistant/components/microbees/cover.py
+++ b/homeassistant/components/microbees/cover.py
@@ -76,7 +76,7 @@ class MBCover(MicroBeesEntity, CoverEntity):
         self._attr_is_closing = False
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         sendCommand = await self.coordinator.microbees.sendCommand(
             self.actuator_up_id,
@@ -93,7 +93,7 @@ class MBCover(MicroBeesEntity, CoverEntity):
             self._reset_open_close,
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         sendCommand = await self.coordinator.microbees.sendCommand(
             self.actuator_down_id,
@@ -109,7 +109,7 @@ class MBCover(MicroBeesEntity, CoverEntity):
             self._reset_open_close,
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         if self.is_opening:
             await self.coordinator.microbees.sendCommand(self.actuator_up_id, 0)

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -120,7 +120,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
         self._attr_is_closing = value == self._state_closing
         self._attr_is_closed = value == self._state_closed
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         result = await self._hub.async_pb_call(
             self._slave, self._write_address, self._state_open, self._write_type
@@ -128,7 +128,7 @@ class ModbusCover(BasePlatform, CoverEntity, RestoreEntity):
         self._attr_available = result is not None
         await self.async_update()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         result = await self._hub.async_pb_call(
             self._slave, self._write_address, self._state_closed, self._write_type

--- a/homeassistant/components/motion_blinds/cover.py
+++ b/homeassistant/components/motion_blinds/cover.py
@@ -9,7 +9,6 @@ from motionblinds import DEVICE_TYPES_WIFI, BlindType
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
@@ -258,21 +257,20 @@ class MotionBaseDevice(MotionCoordinatorEntity, CoverEntity):
             self.hass, delay, self.async_scheduled_update_request
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Open)
         await self.async_request_position_till_stop()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Close)
         await self.async_request_position_till_stop()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         async with self._api_lock:
             await self.hass.async_add_executor_job(
                 self._blind.Set_position,
@@ -297,7 +295,7 @@ class MotionBaseDevice(MotionCoordinatorEntity, CoverEntity):
             )
         await self.async_request_position_till_stop()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Stop)
@@ -333,23 +331,23 @@ class MotionTiltDevice(MotionPositionDevice):
             return None
         return self._blind.position >= 95
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Set_angle, 180)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Set_angle, 0)
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        angle = kwargs[ATTR_TILT_POSITION] * 180 / 100
+        angle = tilt_position * 180 / 100
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Set_angle, angle)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Stop)
@@ -448,21 +446,20 @@ class MotionTDBUDevice(MotionBaseDevice):
             attributes[ATTR_WIDTH] = self._blind.width
         return attributes
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Open, self._motor_key)
         await self.async_request_position_till_stop()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Close, self._motor_key)
         await self.async_request_position_till_stop()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific scaled position."""
-        position = kwargs[ATTR_POSITION]
         async with self._api_lock:
             await self.hass.async_add_executor_job(
                 self._blind.Set_scaled_position, 100 - position, self._motor_key
@@ -481,7 +478,7 @@ class MotionTDBUDevice(MotionBaseDevice):
 
         await self.async_request_position_till_stop()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         async with self._api_lock:
             await self.hass.async_add_executor_job(self._blind.Stop, self._motor_key)

--- a/homeassistant/components/motionblinds_ble/cover.py
+++ b/homeassistant/components/motionblinds_ble/cover.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import logging
-from typing import Any
 
 from motionblindsble.const import MotionBlindType, MotionRunningType
 from motionblindsble.device import MotionDevice
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityDescription,
@@ -94,7 +91,7 @@ class MotionblindsBLECoverEntity(MotionblindsBLEEntity, CoverEntity):
         self.device.register_running_callback(self.async_update_running)
         self.device.register_position_callback(self.async_update_position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop moving the cover entity."""
         _LOGGER.debug("(%s) Stopping", self.entry.data[CONF_MAC_CODE])
         await self.device.stop()
@@ -145,19 +142,19 @@ class PositionCover(MotionblindsBLECoverEntity):
         | CoverEntityFeature.SET_POSITION
     )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover entity."""
         _LOGGER.debug("(%s) Opening", self.entry.data[CONF_MAC_CODE])
         await self.device.open()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover entity."""
         _LOGGER.debug("(%s) Closing", self.entry.data[CONF_MAC_CODE])
         await self.device.close()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover entity to a specific position."""
-        new_position: int = 100 - int(kwargs[ATTR_POSITION])
+        new_position: int = 100 - position
 
         _LOGGER.debug(
             "(%s) Setting position to %i",
@@ -177,23 +174,23 @@ class TiltCover(MotionblindsBLECoverEntity):
         | CoverEntityFeature.SET_TILT_POSITION
     )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Tilt the cover entity open."""
         _LOGGER.debug("(%s) Tilt opening", self.entry.data[CONF_MAC_CODE])
         await self.device.open_tilt()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Tilt the cover entity closed."""
         _LOGGER.debug("(%s) Tilt closing", self.entry.data[CONF_MAC_CODE])
         await self.device.close_tilt()
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop tilting the cover entity."""
-        await self.async_stop_cover(**kwargs)
+        await self.async_stop_cover()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Tilt the cover entity to a specific position."""
-        new_tilt: int = 100 - int(kwargs[ATTR_TILT_POSITION])
+        new_tilt: int = 100 - tilt_position
 
         _LOGGER.debug(
             "(%s) Setting tilt position to %i",

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -10,8 +10,6 @@ import voluptuous as vol
 
 from homeassistant.components import cover
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DEVICE_CLASSES_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
@@ -507,7 +505,7 @@ class MqttCover(MqttEntity, CoverEntity):
         """(Re)Subscribe to topics."""
         await subscription.async_subscribe_topics(self.hass, self._sub_state)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Move the cover up.
 
         This method is a coroutine.
@@ -526,7 +524,7 @@ class MqttCover(MqttEntity, CoverEntity):
                 self._attr_current_cover_position = 100
             self.async_write_ha_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Move the cover down.
 
         This method is a coroutine.
@@ -545,7 +543,7 @@ class MqttCover(MqttEntity, CoverEntity):
                 self._attr_current_cover_position = 0
             self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the device.
 
         This method is a coroutine.
@@ -558,7 +556,7 @@ class MqttCover(MqttEntity, CoverEntity):
             self._config[CONF_ENCODING],
         )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Tilt the cover open."""
         tilt_open_position = self._config[CONF_TILT_OPEN_POSITION]
         variables = {
@@ -581,7 +579,7 @@ class MqttCover(MqttEntity, CoverEntity):
             self._attr_current_cover_tilt_position = self._tilt_open_percentage
             self.async_write_ha_state()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Tilt the cover closed."""
         tilt_closed_position = self._config[CONF_TILT_CLOSED_POSITION]
         variables = {
@@ -606,9 +604,9 @@ class MqttCover(MqttEntity, CoverEntity):
             self._attr_current_cover_tilt_position = self._tilt_closed_percentage
             self.async_write_ha_state()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        tilt_percentage = kwargs[ATTR_TILT_POSITION]
+        tilt_percentage = tilt_position
         tilt_ranged = round(
             percentage_to_ranged_value(self._tilt_range, tilt_percentage)
         )
@@ -636,9 +634,9 @@ class MqttCover(MqttEntity, CoverEntity):
             self._attr_current_cover_tilt_position = tilt_percentage
             self.async_write_ha_state()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position_percentage = kwargs[ATTR_POSITION]
+        position_percentage = position
         position_ranged = round(
             percentage_to_ranged_value(self._pos_range, position_percentage)
         )

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing import Any
 
-from homeassistant.components.cover import ATTR_POSITION, CoverEntity
+from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
@@ -106,7 +105,7 @@ class MySensorsCover(mysensors.device.MySensorsChildEntity, CoverEntity):
         set_req = self.gateway.const.SetReq
         return self._values.get(set_req.V_DIMMER)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Move the cover up."""
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
@@ -120,7 +119,7 @@ class MySensorsCover(mysensors.device.MySensorsChildEntity, CoverEntity):
                 self._values[set_req.V_LIGHT] = STATE_ON
             self.async_write_ha_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Move the cover down."""
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
@@ -134,9 +133,8 @@ class MySensorsCover(mysensors.device.MySensorsChildEntity, CoverEntity):
                 self._values[set_req.V_LIGHT] = STATE_OFF
             self.async_write_ha_state()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs.get(ATTR_POSITION)
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(
             self.node_id, self.child_id, set_req.V_DIMMER, position, ack=1
@@ -146,7 +144,7 @@ class MySensorsCover(mysensors.device.MySensorsChildEntity, CoverEntity):
             self._values[set_req.V_DIMMER] = position
             self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the device."""
         set_req = self.gateway.const.SetReq
         self.gateway.set_child_value(

--- a/homeassistant/components/netatmo/cover.py
+++ b/homeassistant/components/netatmo/cover.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import cast
 
 from pyatmo import modules as NaModules
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -80,25 +79,25 @@ class NetatmoCover(NetatmoBaseEntity, CoverEntity):
         )
         self._attr_unique_id = f"{self._id}-{self._model}"
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._cover.async_close()
         self._attr_is_closed = True
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._cover.async_open()
         self._attr_is_closed = False
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._cover.async_stop()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover shutter to a specific position."""
-        await self._cover.async_set_target_position(kwargs[ATTR_POSITION])
+        await self._cover.async_set_target_position(position)
 
     @callback
     def async_update_callback(self) -> None:

--- a/homeassistant/components/opengarage/cover.py
+++ b/homeassistant/components/opengarage/cover.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import cast
 
 from homeassistant.components.cover import (
     CoverDeviceClass,
@@ -70,7 +70,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
             return None
         return self._state == STATE_OPENING
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         if self._state in [STATE_CLOSED, STATE_CLOSING]:
             return
@@ -78,7 +78,7 @@ class OpenGarageCover(OpenGarageEntity, CoverEntity):
         self._state = STATE_CLOSING
         await self._push_button()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         if self._state in [STATE_OPEN, STATE_OPENING]:
             return

--- a/homeassistant/components/osoenergy/water_heater.py
+++ b/homeassistant/components/osoenergy/water_heater.py
@@ -120,19 +120,19 @@ class OSOEnergyWaterHeater(
         """Return the maximum temperature."""
         return self.device.max_temperature
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self) -> None:
         """Turn on hotwater."""
         await self.osoenergy.hotwater.turn_on(self.device, True)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self) -> None:
         """Turn off hotwater."""
         await self.osoenergy.hotwater.turn_off(self.device, True)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        target_temperature = int(kwargs.get("temperature", self.target_temperature))
-        profile = [target_temperature] * 24
-
+        profile = [int(temperature)] * 24
         await self.osoenergy.hotwater.set_profile(self.device, profile)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/overkiz/cover_entities/awning.py
+++ b/homeassistant/components/overkiz/cover_entities/awning.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizState
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverDeviceClass,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 
 from .generic_cover import (
     COMMANDS_CLOSE,
@@ -56,17 +52,17 @@ class Awning(OverkizGenericCover):
 
         return None
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         await self.executor.async_execute_command(
-            OverkizCommand.SET_DEPLOYMENT, kwargs[ATTR_POSITION]
+            OverkizCommand.SET_DEPLOYMENT, position
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.executor.async_execute_command(OverkizCommand.DEPLOY)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.executor.async_execute_command(OverkizCommand.UNDEPLOY)
 

--- a/homeassistant/components/overkiz/cover_entities/generic_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/generic_cover.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
-from homeassistant.components.cover import (
-    ATTR_TILT_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 
 from ..entity import OverkizEntity
 
@@ -61,12 +57,12 @@ class OverkizGenericCover(OverkizEntity, CoverEntity):
 
         return None
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         if command := self.executor.select_command(*COMMANDS_SET_TILT_POSITION):
             await self.executor.async_execute_command(
                 command,
-                100 - kwargs[ATTR_TILT_POSITION],
+                100 - tilt_position,
             )
 
     @property
@@ -93,22 +89,22 @@ class OverkizGenericCover(OverkizEntity, CoverEntity):
 
         return None
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         if command := self.executor.select_command(*COMMANDS_OPEN_TILT):
             await self.executor.async_execute_command(command)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         if command := self.executor.select_command(*COMMANDS_CLOSE_TILT):
             await self.executor.async_execute_command(command)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         if command := self.executor.select_command(*COMMANDS_STOP):
             await self.executor.async_execute_command(command)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         if command := self.executor.select_command(*COMMANDS_STOP_TILT):
             await self.executor.async_execute_command(command)

--- a/homeassistant/components/overkiz/cover_entities/vertical_cover.py
+++ b/homeassistant/components/overkiz/cover_entities/vertical_cover.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import (
     OverkizCommand,
@@ -12,11 +12,7 @@ from pyoverkiz.enums import (
     UIWidget,
 )
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverDeviceClass,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverDeviceClass, CoverEntityFeature
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from .generic_cover import (
@@ -93,17 +89,17 @@ class VerticalCover(OverkizGenericCover):
 
         return 100 - cast(int, position)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = 100 - kwargs[ATTR_POSITION]
+        position = 100 - position
         await self.executor.async_execute_command(OverkizCommand.SET_CLOSURE, position)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         if command := self.executor.select_command(*COMMANDS_OPEN):
             await self.executor.async_execute_command(command)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         if command := self.executor.select_command(*COMMANDS_CLOSE):
             await self.executor.async_execute_command(command)
@@ -154,21 +150,21 @@ class LowSpeedCover(VerticalCover):
         self._attr_name = "Low speed"
         self._attr_unique_id = f"{self._attr_unique_id}_low_speed"
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        await self.async_set_cover_position_low_speed(**kwargs)
+        await self.async_set_cover_position_low_speed(position=position)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
-        await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 100})
+        await self.async_set_cover_position_low_speed(position=100)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
-        await self.async_set_cover_position_low_speed(**{ATTR_POSITION: 0})
+        await self.async_set_cover_position_low_speed(position=0)
 
-    async def async_set_cover_position_low_speed(self, **kwargs: Any) -> None:
+    async def async_set_cover_position_low_speed(self, position: int) -> None:
         """Move the cover to a specific position with a low speed."""
-        position = 100 - kwargs.get(ATTR_POSITION, 0)
+        position = 100 - position
 
         await self.executor.async_execute_command(
             OverkizCommand.SET_CLOSURE_AND_LINEAR_SPEED,

--- a/homeassistant/components/overkiz/water_heater_entities/atlantic_pass_apc_dhw.py
+++ b/homeassistant/components/overkiz/water_heater_entities/atlantic_pass_apc_dhw.py
@@ -1,6 +1,6 @@
 """Support for Atlantic Pass APC DHW."""
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -12,7 +12,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..entity import OverkizEntity
 
@@ -52,10 +52,10 @@ class AtlanticPassAPCDHW(OverkizEntity, WaterHeaterEntity):
             self.executor.select_state(OverkizState.CORE_TARGET_DWH_TEMPERATURE),
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         if self.is_eco_mode_on:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_ECO_TARGET_DHW_TEMPERATURE, temperature

--- a/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
+++ b/homeassistant/components/overkiz/water_heater_entities/domestic_hot_water_production.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -13,7 +13,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, STATE_ON, UnitOfTemperature
+from homeassistant.const import STATE_OFF, STATE_ON, UnitOfTemperature
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity
@@ -230,17 +230,17 @@ class DomesticHotWaterProduction(OverkizEntity, WaterHeaterEntity):
             return target_temperature_low.value_as_float
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        target_temperature = kwargs[ATTR_TEMPERATURE]
-
         if self.executor.has_command(OverkizCommand.SET_TARGET_TEMPERATURE):
             await self.executor.async_execute_command(
-                OverkizCommand.SET_TARGET_TEMPERATURE, target_temperature
+                OverkizCommand.SET_TARGET_TEMPERATURE, temperature
             )
         elif self.executor.has_command(OverkizCommand.SET_WATER_TARGET_TEMPERATURE):
             await self.executor.async_execute_command(
-                OverkizCommand.SET_WATER_TARGET_TEMPERATURE, target_temperature
+                OverkizCommand.SET_WATER_TARGET_TEMPERATURE, temperature
             )
 
         if self.executor.has_command(OverkizCommand.REFRESH_TARGET_TEMPERATURE):

--- a/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
+++ b/homeassistant/components/overkiz/water_heater_entities/hitachi_dhw.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.water_heater import (
@@ -11,13 +9,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
 )
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    PRECISION_WHOLE,
-    STATE_OFF,
-    STATE_ON,
-    UnitOfTemperature,
-)
+from homeassistant.const import PRECISION_WHOLE, STATE_OFF, STATE_ON, UnitOfTemperature
 
 from ..entity import OverkizEntity
 
@@ -62,12 +54,13 @@ class HitachiDHW(OverkizEntity, WaterHeaterEntity):
             return target_temperature.value_as_float
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-
         await self.executor.async_execute_command(
             OverkizCommand.SET_CONTROL_DHW_SETTING_TEMPERATURE,
-            int(kwargs[ATTR_TEMPERATURE]),
+            int(temperature),
         )
 
     @property

--- a/homeassistant/components/rflink/cover.py
+++ b/homeassistant/components/rflink/cover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import voluptuous as vol
 
@@ -152,15 +151,15 @@ class RflinkCover(RflinkCommand, CoverEntity, RestoreEntity):
         """Return True because covers can be stopped midway."""
         return True
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Turn the device close."""
         await self._async_handle_command("close_cover")
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Turn the device open."""
         await self._async_handle_command("open_cover")
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Turn the device stop."""
         await self._async_handle_command("stop_cover")
 

--- a/homeassistant/components/rfxtrx/cover.py
+++ b/homeassistant/components/rfxtrx/cover.py
@@ -98,7 +98,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
             if old_state is not None:
                 self._attr_is_closed = old_state.state != STATE_OPEN
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Move the cover up."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
             await self._async_send(self._device.send_up05sec)
@@ -109,7 +109,7 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         self._attr_is_closed = False
         self.async_write_ha_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Move the cover down."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
             await self._async_send(self._device.send_down05sec)
@@ -120,27 +120,27 @@ class RfxtrxCover(RfxtrxCommandEntity, CoverEntity):
         self._attr_is_closed = True
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._async_send(self._device.send_stop)
         self._attr_is_closed = False
         self.async_write_ha_state()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Tilt the cover up."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
             await self._async_send(self._device.send_up2sec)
         elif self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_EU:
             await self._async_send(self._device.send_up05sec)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Tilt the cover down."""
         if self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_US:
             await self._async_send(self._device.send_down2sec)
         elif self._venetian_blind_mode == CONST_VENETIAN_BLIND_MODE_EU:
             await self._async_send(self._device.send_down05sec)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         await self._async_send(self._device.send_stop)
         self._attr_is_closed = False

--- a/homeassistant/components/scsgate/cover.py
+++ b/homeassistant/components/scsgate/cover.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from scsgate.tasks import (
     HaltRollerShutterTask,
@@ -84,15 +83,15 @@ class SCSGateCover(CoverEntity):
         """Return if the cover is closed."""
         return None
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Move the cover."""
         self._scsgate.append_task(RaiseRollerShutterTask(target=self._scs_id))
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Move the cover down."""
         self._scsgate.append_task(LowerRollerShutterTask(target=self._scs_id))
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self._scsgate.append_task(HaltRollerShutterTask(target=self._scs_id))
 

--- a/homeassistant/components/shelly/cover.py
+++ b/homeassistant/components/shelly/cover.py
@@ -8,7 +8,6 @@ from aioshelly.block_device import Block
 from aioshelly.const import RPC_GENERATIONS
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -115,21 +114,19 @@ class BlockShellyCover(ShellyBlockEntity, CoverEntity):
 
         return self.block.roller == "open"
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         self.control_result = await self.set_state(go="close")
         self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         self.control_result = await self.set_state(go="open")
         self.async_write_ha_state()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        self.control_result = await self.set_state(
-            go="to_pos", roller_pos=kwargs[ATTR_POSITION]
-        )
+        self.control_result = await self.set_state(go="to_pos", roller_pos=position)
         self.async_write_ha_state()
 
     async def async_stop_cover(self, **_kwargs: Any) -> None:
@@ -182,19 +179,17 @@ class RpcShellyCover(ShellyRpcEntity, CoverEntity):
         """Return if the cover is opening."""
         return cast(bool, self.status["state"] == "opening")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self.call_rpc("Cover.Close", {"id": self._id})
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         await self.call_rpc("Cover.Open", {"id": self._id})
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        await self.call_rpc(
-            "Cover.GoToPosition", {"id": self._id, "pos": kwargs[ATTR_POSITION]}
-        )
+        await self.call_rpc("Cover.GoToPosition", {"id": self._id, "pos": position})
 
     async def async_stop_cover(self, **_kwargs: Any) -> None:
         """Stop the cover."""

--- a/homeassistant/components/slide/cover.py
+++ b/homeassistant/components/slide/cover.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
-from homeassistant.components.cover import ATTR_POSITION, CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.const import ATTR_ID, STATE_CLOSED, STATE_CLOSING, STATE_OPENING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -85,23 +84,23 @@ class SlideCover(CoverEntity):
             pos = int(pos * 100)
         return pos
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._slide["state"] = STATE_OPENING
         await self._api.slide_open(self._id)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         self._slide["state"] = STATE_CLOSING
         await self._api.slide_close(self._id)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._api.slide_stop(self._id)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION] / 100
+        position: float = position / 100
         if not self._invert:
             position = 1 - position
 

--- a/homeassistant/components/smartthings/cover.py
+++ b/homeassistant/components/smartthings/cover.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import Any
 
 from pysmartthings import Attribute, Capability
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     DOMAIN as COVER_DOMAIN,
     STATE_CLOSED,
     STATE_CLOSING,
@@ -97,7 +95,7 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
         elif Capability.garage_door_control in device.capabilities:
             self._attr_device_class = CoverDeviceClass.GARAGE
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         # Same command for all 3 supported capabilities
         await self._device.close(set_status=True)
@@ -105,7 +103,7 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
         # the entity state ahead of receiving the confirming push updates
         self.async_schedule_update_ha_state(True)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         # Same for all capability types
         await self._device.open(set_status=True)
@@ -113,17 +111,15 @@ class SmartThingsCover(SmartThingsEntity, CoverEntity):
         # the entity state ahead of receiving the confirming push updates
         self.async_schedule_update_ha_state(True)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         if not self.supported_features & CoverEntityFeature.SET_POSITION:
             return
         # Do not set_status=True as device will report progress.
         if Capability.window_shade_level in self._device.capabilities:
-            await self._device.set_window_shade_level(
-                kwargs[ATTR_POSITION], set_status=False
-            )
+            await self._device.set_window_shade_level(position, set_status=False)
         else:
-            await self._device.set_level(kwargs[ATTR_POSITION], set_status=False)
+            await self._device.set_level(position, set_status=False)
 
     async def async_update(self) -> None:
         """Update the attrs of the cover."""

--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
@@ -70,7 +67,7 @@ class SomaTilt(SomaEntity, CoverEntity):
             return True
         return False
 
-    def close_cover_tilt(self, **kwargs: Any) -> None:
+    def close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         response = self.api.set_shade_position(self.device["mac"], 100)
         if not is_api_response_success(response):
@@ -79,7 +76,7 @@ class SomaTilt(SomaEntity, CoverEntity):
             )
         self.set_position(0)
 
-    def open_cover_tilt(self, **kwargs: Any) -> None:
+    def open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         response = self.api.set_shade_position(self.device["mac"], -100)
         if not is_api_response_success(response):
@@ -88,7 +85,7 @@ class SomaTilt(SomaEntity, CoverEntity):
             )
         self.set_position(100)
 
-    def stop_cover_tilt(self, **kwargs: Any) -> None:
+    def stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         response = self.api.stop_shade(self.device["mac"])
         if not is_api_response_success(response):
@@ -98,19 +95,19 @@ class SomaTilt(SomaEntity, CoverEntity):
         # Set cover position to some value where up/down are both enabled
         self.set_position(50)
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    def set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         # 0 -> Closed down (api: 100)
         # 50 -> Fully open (api: 0)
         # 100 -> Closed up (api: -100)
-        target_api_position = 100 - ((kwargs[ATTR_TILT_POSITION] / 50) * 100)
+        target_api_position = 100 - ((tilt_position / 50) * 100)
         response = self.api.set_shade_position(self.device["mac"], target_api_position)
         if not is_api_response_success(response):
             raise HomeAssistantError(
                 f"Error while setting the cover position ({self.name}):"
                 f' {response["msg"]}'
             )
-        self.set_position(kwargs[ATTR_TILT_POSITION])
+        self.set_position(tilt_position)
 
     async def async_update(self) -> None:
         """Update the entity with the latest data."""
@@ -146,7 +143,7 @@ class SomaShade(SomaEntity, CoverEntity):
         """Return if the cover is closed."""
         return self.current_position == 0
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         response = self.api.set_shade_position(self.device["mac"], 100)
         if not is_api_response_success(response):
@@ -154,7 +151,7 @@ class SomaShade(SomaEntity, CoverEntity):
                 f'Error while closing the cover ({self.name}): {response["msg"]}'
             )
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         response = self.api.set_shade_position(self.device["mac"], 0)
         if not is_api_response_success(response):
@@ -162,7 +159,7 @@ class SomaShade(SomaEntity, CoverEntity):
                 f'Error while opening the cover ({self.name}): {response["msg"]}'
             )
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         response = self.api.stop_shade(self.device["mac"])
         if not is_api_response_success(response):
@@ -172,12 +169,10 @@ class SomaShade(SomaEntity, CoverEntity):
         # Set cover position to some value where up/down are both enabled
         self.set_position(50)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover shutter to a specific position."""
-        self.current_position = kwargs[ATTR_POSITION]
-        response = self.api.set_shade_position(
-            self.device["mac"], 100 - kwargs[ATTR_POSITION]
-        )
+        self.current_position = position
+        response = self.api.set_shade_position(self.device["mac"], 100 - position)
         if not is_api_response_success(response):
             raise HomeAssistantError(
                 f"Error while setting the cover position ({self.name}):"

--- a/homeassistant/components/somfy_mylink/cover.py
+++ b/homeassistant/components/somfy_mylink/cover.py
@@ -1,7 +1,6 @@
 """Cover Platform for the Somfy MyLink component."""
 
 import logging
-from typing import Any
 
 from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.config_entries import ConfigEntry
@@ -90,7 +89,7 @@ class SomfyShade(RestoreEntity, CoverEntity):
             name=name,
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         self._attr_is_closing = True
         self.async_write_ha_state()
@@ -105,7 +104,7 @@ class SomfyShade(RestoreEntity, CoverEntity):
             self._attr_is_closing = None
             self.async_write_ha_state()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         self._attr_is_opening = True
         self.async_write_ha_state()
@@ -120,7 +119,7 @@ class SomfyShade(RestoreEntity, CoverEntity):
             self._attr_is_opening = None
             self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self.somfy_mylink.move_stop(self._target_id)
 

--- a/homeassistant/components/supla/cover.py
+++ b/homeassistant/components/supla/cover.py
@@ -6,7 +6,7 @@ import logging
 from pprint import pformat
 from typing import Any
 
-from homeassistant.components.cover import ATTR_POSITION, CoverDeviceClass, CoverEntity
+from homeassistant.components.cover import CoverDeviceClass, CoverEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -69,9 +69,9 @@ class SuplaCoverEntity(SuplaEntity, CoverEntity):
             return 100 - state["shut"]
         return None
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        await self.async_action("REVEAL", percentage=kwargs.get(ATTR_POSITION))
+        await self.async_action("REVEAL", percentage=position)
 
     @property
     def is_closed(self) -> bool | None:
@@ -80,15 +80,15 @@ class SuplaCoverEntity(SuplaEntity, CoverEntity):
             return None
         return self.current_cover_position == 0
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.async_action("REVEAL")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.async_action("SHUT")
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self.async_action("STOP")
 
@@ -106,17 +106,17 @@ class SuplaDoorEntity(SuplaEntity, CoverEntity):
             return state.get("hi")
         return None
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the door."""
         if self.is_closed:
             await self.async_action("OPEN_CLOSE")
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the door."""
         if not self.is_closed:
             await self.async_action("OPEN_CLOSE")
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the door."""
         await self.async_action("OPEN_CLOSE")
 

--- a/homeassistant/components/switch_as_x/cover.py
+++ b/homeassistant/components/switch_as_x/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.cover import (
     DOMAIN as COVER_DOMAIN,
     CoverEntity,
@@ -57,7 +55,7 @@ class CoverSwitch(BaseInvertableEntity, CoverEntity):
 
     _attr_supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,
@@ -67,7 +65,7 @@ class CoverSwitch(BaseInvertableEntity, CoverEntity):
             context=self._context,
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self.hass.services.async_call(
             SWITCH_DOMAIN,

--- a/homeassistant/components/switchbee/cover.py
+++ b/homeassistant/components/switchbee/cover.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from switchbee.api.central_unit import SwitchBeeError, SwitchBeeTokenError
 from switchbee.const import SomfyCommand
 from switchbee.device import SwitchBeeShutter, SwitchBeeSomfy
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -58,15 +55,15 @@ class SwitchBeeSomfyEntity(SwitchBeeDeviceEntity[SwitchBeeSomfy], CoverEntity):
                 f"Failed to fire {command} for {self.name}, {str(exp)}"
             ) from exp
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         return await self._fire_somfy_command(SomfyCommand.UP)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         return await self._fire_somfy_command(SomfyCommand.DOWN)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop a moving cover."""
         return await self._fire_somfy_command(SomfyCommand.MY)
 
@@ -109,21 +106,21 @@ class SwitchBeeCoverEntity(SwitchBeeDeviceEntity[SwitchBeeShutter], CoverEntity)
             self._attr_is_closed = False
         super()._handle_coordinator_update()
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         if self.current_cover_position == 100:
             return
 
         await self.async_set_cover_position(position=100)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         if self.current_cover_position == 0:
             return
 
         await self.async_set_cover_position(position=0)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop a moving cover."""
         # to stop the shutter, we just interrupt it with any state during operation
         await self.async_set_cover_position(
@@ -133,21 +130,20 @@ class SwitchBeeCoverEntity(SwitchBeeDeviceEntity[SwitchBeeShutter], CoverEntity)
         # fetch data from the Central Unit to get the new position
         await self.coordinator.async_request_refresh()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(
+        self, position: int, force: bool = False
+    ) -> None:
         """Async function to set position to cover."""
-        if (
-            self.current_cover_position == kwargs[ATTR_POSITION]
-            and "force" not in kwargs
-        ):
+        if self.current_cover_position == position and not force:
             return
         try:
-            await self.coordinator.api.set_state(self._device.id, kwargs[ATTR_POSITION])
+            await self.coordinator.api.set_state(self._device.id, position)
         except (SwitchBeeError, SwitchBeeTokenError) as exp:
             raise HomeAssistantError(
-                f"Failed to set {self.name} position to {kwargs[ATTR_POSITION]}, error:"
+                f"Failed to set {self.name} position to {position}, error:"
                 f" {str(exp)}"
             ) from exp
 
-        self._get_coordinator_device().position = kwargs[ATTR_POSITION]
+        self._get_coordinator_device().position = position
         self.coordinator.async_set_updated_data(self.coordinator.data)
         self.async_write_ha_state()

--- a/homeassistant/components/switchbot/cover.py
+++ b/homeassistant/components/switchbot/cover.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import switchbot
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
     ATTR_CURRENT_TILT_POSITION,
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -74,7 +71,7 @@ class SwitchBotCurtainEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         if self._attr_current_cover_position is not None:
             self._attr_is_closed = self._attr_current_cover_position <= 20
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the curtain."""
 
         _LOGGER.debug("Switchbot to open curtain %s", self._address)
@@ -83,7 +80,7 @@ class SwitchBotCurtainEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         self._attr_is_closing = self._device.is_closing()
         self.async_write_ha_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the curtain."""
 
         _LOGGER.debug("Switchbot to close the curtain %s", self._address)
@@ -92,7 +89,7 @@ class SwitchBotCurtainEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         self._attr_is_closing = self._device.is_closing()
         self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the moving of this device."""
 
         _LOGGER.debug("Switchbot to stop %s", self._address)
@@ -101,10 +98,8 @@ class SwitchBotCurtainEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
         self._attr_is_closing = self._device.is_closing()
         self.async_write_ha_state()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover shutter to a specific position."""
-        position = kwargs.get(ATTR_POSITION)
-
         _LOGGER.debug("Switchbot to move at %d %s", position, self._address)
         self._last_run_success = bool(await self._device.set_position(position))
         self._attr_is_opening = self._device.is_opening()
@@ -159,33 +154,31 @@ class SwitchBotBlindTiltEntity(SwitchbotEntity, CoverEntity, RestoreEntity):
                 _tilt > self.CLOSED_UP_THRESHOLD
             )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the tilt."""
 
         _LOGGER.debug("Switchbot to open blind tilt %s", self._address)
         self._last_run_success = bool(await self._device.open())
         self.async_write_ha_state()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the tilt."""
 
         _LOGGER.debug("Switchbot to close the blind tilt %s", self._address)
         self._last_run_success = bool(await self._device.close())
         self.async_write_ha_state()
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the moving of this device."""
 
         _LOGGER.debug("Switchbot to stop %s", self._address)
         self._last_run_success = bool(await self._device.stop())
         self.async_write_ha_state()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        position = kwargs.get(ATTR_TILT_POSITION)
-
-        _LOGGER.debug("Switchbot to move at %d %s", position, self._address)
-        self._last_run_success = bool(await self._device.set_position(position))
+        _LOGGER.debug("Switchbot to move at %d %s", tilt_position, self._address)
+        self._last_run_success = bool(await self._device.set_position(tilt_position))
         self.async_write_ha_state()
 
     @callback

--- a/homeassistant/components/switcher_kis/cover.py
+++ b/homeassistant/components/switcher_kis/cover.py
@@ -9,7 +9,6 @@ from aioswitcher.api import SwitcherBaseResponse, SwitcherType2Api
 from aioswitcher.device import DeviceCategory, ShutterDirection, SwitcherShutter
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -114,18 +113,18 @@ class SwitcherCoverEntity(
                 f"args: {args}, response/error: {response or error}"
             )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._async_call_api(API_SET_POSITON, 0)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open cover."""
         await self._async_call_api(API_SET_POSITON, 100)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        await self._async_call_api(API_SET_POSITON, kwargs[ATTR_POSITION])
+        await self._async_call_api(API_SET_POSITON, position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._async_call_api(API_STOP)

--- a/homeassistant/components/tado/water_heater.py
+++ b/homeassistant/components/tado/water_heater.py
@@ -217,10 +217,11 @@ class TadoWaterHeater(TadoZoneEntity, WaterHeaterEntity):
             hvac_mode=CONST_MODE_HEAT, target_temp=temperature, duration=time_period
         )
 
-    def set_temperature(self, **kwargs: Any) -> None:
+    def set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if not self._supports_temperature_control or temperature is None:
+        if not self._supports_temperature_control:
             return
 
         if self._current_tado_hvac_mode not in (

--- a/homeassistant/components/tailwind/cover.py
+++ b/homeassistant/components/tailwind/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from gotailwind import (
     TailwindDoorDisabledError,
     TailwindDoorLockedOutError,
@@ -56,7 +54,7 @@ class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
             self.coordinator.data.doors[self.door_id].state == TailwindDoorState.CLOSED
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the garage door.
 
         The Tailwind operating command will await the confirmation of the
@@ -88,7 +86,7 @@ class TailwindDoorCoverEntity(TailwindDoorEntity, CoverEntity):
             self._attr_is_opening = False
         await self.coordinator.async_request_refresh()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the garage door.
 
         The Tailwind operating command will await the confirmation of the

--- a/homeassistant/components/tasmota/cover.py
+++ b/homeassistant/components/tasmota/cover.py
@@ -9,8 +9,6 @@ from hatasmota.entity import TasmotaEntity as HATasmotaEntity
 from hatasmota.models import DiscoveryHashType
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     CoverEntity,
     CoverEntityFeature,
@@ -129,36 +127,34 @@ class TasmotaCover(
             return None
         return self._position == 0
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._tasmota_entity.open()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._tasmota_entity.close()
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs[ATTR_POSITION]
         await self._tasmota_entity.set_position(position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._tasmota_entity.stop()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         await self._tasmota_entity.open_tilt()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close cover tilt."""
         await self._tasmota_entity.close_tilt()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        tilt = kwargs[ATTR_TILT_POSITION]
-        await self._tasmota_entity.set_tilt_position(tilt)
+        await self._tasmota_entity.set_tilt_position(tilt_position)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         await self._tasmota_entity.stop()

--- a/homeassistant/components/tellduslive/cover.py
+++ b/homeassistant/components/tellduslive/cover.py
@@ -1,7 +1,5 @@
 """Support for Tellstick covers using Tellstick Net."""
 
-from typing import Any
-
 from homeassistant.components import cover
 from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry
@@ -43,17 +41,17 @@ class TelldusLiveCover(TelldusLiveEntity, CoverEntity):
         """Return the current position of the cover."""
         return self.device.is_down
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self.device.down()
         self._update_callback()
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self.device.up()
         self._update_callback()
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self.device.stop()
         self._update_callback()

--- a/homeassistant/components/tellstick/cover.py
+++ b/homeassistant/components/tellstick/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.cover import CoverEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -54,15 +52,15 @@ class TellstickCover(TellstickDevice, CoverEntity):
         """Return True if unable to access real state of the entity."""
         return True
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self._tellcore_device.down()
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self._tellcore_device.up()
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self._tellcore_device.stop()
 

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DEVICE_CLASSES_SCHEMA,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
@@ -327,7 +324,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         """
         return self._tilt_value
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Move the cover up."""
         if self._open_script:
             await self.async_run_script(self._open_script, context=self._context)
@@ -341,7 +338,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             self._position = 100
             self.async_write_ha_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Move the cover down."""
         if self._close_script:
             await self.async_run_script(self._close_script, context=self._context)
@@ -355,14 +352,14 @@ class CoverTemplate(TemplateEntity, CoverEntity):
             self._position = 0
             self.async_write_ha_state()
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Fire the stop action."""
         if self._stop_script:
             await self.async_run_script(self._stop_script, context=self._context)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Set cover position."""
-        self._position = kwargs[ATTR_POSITION]
+        self._position = position
         await self.async_run_script(
             self._position_script,
             run_variables={"position": self._position},
@@ -371,7 +368,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         if self._optimistic:
             self.async_write_ha_state()
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Tilt the cover open."""
         self._tilt_value = 100
         await self.async_run_script(
@@ -382,7 +379,7 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         if self._tilt_optimistic:
             self.async_write_ha_state()
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Tilt the cover closed."""
         self._tilt_value = 0
         await self.async_run_script(
@@ -393,9 +390,9 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         if self._tilt_optimistic:
             self.async_write_ha_state()
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
-        self._tilt_value = kwargs[ATTR_TILT_POSITION]
+        self._tilt_value = tilt_position
         await self.async_run_script(
             self._tilt_script,
             run_variables={"tilt": self._tilt_value},

--- a/homeassistant/components/tessie/cover.py
+++ b/homeassistant/components/tessie/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from tessie_api import (
     close_charge_port,
     close_windows,
@@ -65,7 +63,7 @@ class TessieWindowEntity(TessieEntity, CoverEntity):
             and self.get("vehicle_state_rp_window") == TessieCoverStates.CLOSED
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open windows."""
         await self.run(vent_windows)
         self.set(
@@ -75,7 +73,7 @@ class TessieWindowEntity(TessieEntity, CoverEntity):
             ("vehicle_state_rp_window", TessieCoverStates.OPEN),
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close windows."""
         await self.run(close_windows)
         self.set(
@@ -101,12 +99,12 @@ class TessieChargePortEntity(TessieEntity, CoverEntity):
         """Return if the cover is closed or not."""
         return not self._value
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open windows."""
         await self.run(open_unlock_charge_port)
         self.set((self.key, True))
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close windows."""
         await self.run(close_charge_port)
         self.set((self.key, False))
@@ -127,7 +125,7 @@ class TessieFrontTrunkEntity(TessieEntity, CoverEntity):
         """Return if the cover is closed or not."""
         return self._value == TessieCoverStates.CLOSED
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open front trunk."""
         await self.run(open_front_trunk)
         self.set((self.key, TessieCoverStates.OPEN))
@@ -148,13 +146,13 @@ class TessieRearTrunkEntity(TessieEntity, CoverEntity):
         """Return if the cover is closed or not."""
         return self._value == TessieCoverStates.CLOSED
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open rear trunk."""
         if self._value == TessieCoverStates.CLOSED:
             await self.run(open_close_rear_trunk)
             self.set((self.key, TessieCoverStates.OPEN))
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close rear trunk."""
         if self._value == TessieCoverStates.OPEN:
             await self.run(open_close_rear_trunk)

--- a/homeassistant/components/tradfri/cover.py
+++ b/homeassistant/components/tradfri/cover.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from pytradfri.command import Command
 
-from homeassistant.components.cover import ATTR_POSITION, CoverEntity
+from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -78,25 +78,25 @@ class TradfriCover(TradfriBaseEntity, CoverEntity):
             return None
         return 100 - cast(int, self._device_data.current_cover_position)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         if not self._device_control:
             return
-        await self._api(self._device_control.set_state(100 - kwargs[ATTR_POSITION]))
+        await self._api(self._device_control.set_state(100 - position))
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         if not self._device_control:
             return
         await self._api(self._device_control.set_state(0))
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         if not self._device_control:
             return
         await self._api(self._device_control.set_state(100))
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Close cover."""
         if not self._device_control:
             return

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
 
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityDescription,
@@ -281,7 +278,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
         return None
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         value: bool | str = True
         if self.find_dpcode(
@@ -305,7 +302,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
         self._send_command(commands)
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close cover."""
         value: bool | str = False
         if self.find_dpcode(
@@ -329,7 +326,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
 
         self._send_command(commands)
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         if self._set_position is None:
             raise RuntimeError(
@@ -342,14 +339,14 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._set_position.dpcode,
                     "value": round(
                         self._set_position.remap_value_from(
-                            kwargs[ATTR_POSITION], 0, 100, reverse=True
+                            position, 0, 100, reverse=True
                         )
                     ),
                 }
             ]
         )
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self._send_command(
             [
@@ -360,7 +357,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             ]
         )
 
-    def set_cover_tilt_position(self, **kwargs: Any) -> None:
+    def set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         if self._tilt is None:
             raise RuntimeError(
@@ -372,9 +369,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                 {
                     "code": self._tilt.dpcode,
                     "value": round(
-                        self._tilt.remap_value_from(
-                            kwargs[ATTR_TILT_POSITION], 0, 100, reverse=True
-                        )
+                        self._tilt.remap_value_from(tilt_position, 0, 100, reverse=True)
                     ),
                 }
             ]

--- a/homeassistant/components/velbus/cover.py
+++ b/homeassistant/components/velbus/cover.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from velbusaio.channels import Blind as VelbusBlind
 
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -80,21 +74,21 @@ class VelbusCover(VelbusEntity, CoverEntity):
         return None
 
     @api_call
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._channel.open()
 
     @api_call
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self._channel.close()
 
     @api_call
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._channel.stop()
 
     @api_call
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        await self._channel.set_position(100 - kwargs[ATTR_POSITION])
+        await self._channel.set_position(100 - position)

--- a/homeassistant/components/velux/cover.py
+++ b/homeassistant/components/velux/cover.py
@@ -8,8 +8,6 @@ from pyvlx import OpeningDevice, Position
 from pyvlx.opening_device import Awning, Blind, GarageDoor, Gate, RollerShutter, Window
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     CoverDeviceClass,
     CoverEntity,
     CoverEntityFeature,
@@ -94,41 +92,41 @@ class VeluxCover(VeluxEntity, CoverEntity):
         """Return if the cover is closed."""
         return self.node.position.closed
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the cover."""
         await self.node.close(wait_for_completion=False)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self.node.open(wait_for_completion=False)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position_percent = 100 - kwargs[ATTR_POSITION]
+        position_percent = 100 - position
 
         await self.node.set_position(
             Position(position_percent=position_percent), wait_for_completion=False
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self.node.stop(wait_for_completion=False)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close cover tilt."""
         await cast(Blind, self.node).close_orientation(wait_for_completion=False)
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open cover tilt."""
         await cast(Blind, self.node).open_orientation(wait_for_completion=False)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop cover tilt."""
         await cast(Blind, self.node).stop_orientation(wait_for_completion=False)
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move cover tilt to a specific position."""
-        position_percent = 100 - kwargs[ATTR_TILT_POSITION]
+        position_percent = 100 - tilt_position
         orientation = Position(position_percent=position_percent)
         await cast(Blind, self.node).set_orientation(
             orientation=orientation, wait_for_completion=False

--- a/homeassistant/components/vera/cover.py
+++ b/homeassistant/components/vera/cover.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import pyvera as veraApi
 
-from homeassistant.components.cover import ATTR_POSITION, ENTITY_ID_FORMAT, CoverEntity
+from homeassistant.components.cover import ENTITY_ID_FORMAT, CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -55,9 +53,9 @@ class VeraCover(VeraDevice[veraApi.VeraCurtain], CoverEntity):
             return 100
         return position
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        self.vera_device.set_level(kwargs.get(ATTR_POSITION))
+        self.vera_device.set_level(position)
         self.schedule_update_ha_state()
 
     @property
@@ -66,17 +64,17 @@ class VeraCover(VeraDevice[veraApi.VeraCurtain], CoverEntity):
         if self.current_cover_position is not None:
             return self.current_cover_position == 0
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self.vera_device.open()
         self.schedule_update_ha_state()
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self.vera_device.close()
         self.schedule_update_ha_state()
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self.vera_device.stop()
         self.schedule_update_ha_state()

--- a/homeassistant/components/vicare/water_heater.py
+++ b/homeassistant/components/vicare/water_heater.py
@@ -21,7 +21,7 @@ from homeassistant.components.water_heater import (
     WaterHeaterEntityFeature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
+from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -144,11 +144,12 @@ class ViCareWater(ViCareEntity, WaterHeaterEntity):
         except PyViCareInvalidDataError as invalid_data_exception:
             _LOGGER.error("Invalid data from Vicare server: %s", invalid_data_exception)
 
-    def set_temperature(self, **kwargs: Any) -> None:
+    def set_temperature(
+        self, temperature: float, operation_mode: str | None = None
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            self._api.setDomesticHotWaterTemperature(temp)
-            self._attr_target_temperature = temp
+        self._api.setDomesticHotWaterTemperature(temperature)
+        self._attr_target_temperature = temperature
 
     @property
     def current_operation(self):

--- a/homeassistant/components/wilight/cover.py
+++ b/homeassistant/components/wilight/cover.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pywilight.const import (
     COVER_V1,
     ITEM_COVER,
@@ -15,7 +13,7 @@ from pywilight.const import (
     WL_STOPPED,
 )
 
-from homeassistant.components.cover import ATTR_POSITION, CoverEntity
+from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -94,19 +92,19 @@ class WiLightCover(WiLightDevice, CoverEntity):
             and wilight_to_hass_position(self._status["position_current"]) == 0
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         await self._client.cover_command(self._index, WL_OPEN)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         await self._client.cover_command(self._index, WL_CLOSE)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = hass_to_wilight_position(kwargs[ATTR_POSITION])
+        position = hass_to_wilight_position(position)
         await self._client.set_cover_position(self._index, position)
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop the cover."""
         await self._client.cover_command(self._index, WL_STOP)

--- a/homeassistant/components/xiaomi_aqara/cover.py
+++ b/homeassistant/components/xiaomi_aqara/cover.py
@@ -1,8 +1,6 @@
 """Support for Xiaomi curtain."""
 
-from typing import Any
-
-from homeassistant.components.cover import ATTR_POSITION, CoverEntity
+from homeassistant.components.cover import CoverEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -56,21 +54,20 @@ class XiaomiGenericCover(XiaomiDevice, CoverEntity):
         """Return if the cover is closed."""
         return self.current_cover_position <= 0
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close the cover."""
         self._write_to_hub(self._sid, **{self._data_key: "close"})
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open the cover."""
         self._write_to_hub(self._sid, **{self._data_key: "open"})
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop the cover."""
         self._write_to_hub(self._sid, **{self._data_key: "stop"})
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
-        position = kwargs.get(ATTR_POSITION)
         if self._data_key == DATA_KEY_PROTO_V2:
             self._write_to_hub(self._sid, **{ATTR_CURTAIN_LEVEL: position})
         else:

--- a/homeassistant/components/yolink/cover.py
+++ b/homeassistant/components/yolink/cover.py
@@ -75,10 +75,10 @@ class YoLinkCoverEntity(YoLinkEntity, CoverEntity):
         # it depends on paired device state, such as door sensor or contact sensor
         await self.call_device(ClientRequest("toggle", {}))
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Toggle garage door."""
         await self.toggle_garage_state()
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Toggle garage door."""
         await self.toggle_garage_state()

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.const import (
@@ -26,8 +26,6 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.components.cover import (
-    ATTR_POSITION,
-    ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     CoverDeviceClass,
     CoverEntity,
@@ -161,29 +159,29 @@ class CoverPositionMixin(ZWaveBaseEntity, CoverEntity):
             return None
         return self.zwave_to_percent_position(self._current_position_value.value)
 
-    async def async_set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, position: int) -> None:
         """Move the cover to a specific position."""
         assert self._target_position_value
         await self._async_set_value(
             self._target_position_value,
-            self.percent_to_zwave_position(kwargs[ATTR_POSITION]),
+            self.percent_to_zwave_position(position),
         )
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the cover."""
         assert self._target_position_value
         await self._async_set_value(
             self._target_position_value, self._fully_open_position
         )
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close cover."""
         assert self._target_position_value
         await self._async_set_value(
             self._target_position_value, self._fully_closed_position
         )
 
-    async def async_stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self) -> None:
         """Stop cover."""
         assert self._stop_position_value
         # Stop the cover, will stop regardless of the actual direction of travel.
@@ -257,25 +255,25 @@ class CoverTiltMixin(ZWaveBaseEntity, CoverEntity):
             return None
         return self.zwave_to_percent_tilt(int(value.value))
 
-    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_tilt_position(self, tilt_position: int) -> None:
         """Move the cover tilt to a specific position."""
         assert self._target_tilt_value
         await self._async_set_value(
             self._target_tilt_value,
-            self.percent_to_zwave_tilt(kwargs[ATTR_TILT_POSITION]),
+            self.percent_to_zwave_tilt(tilt_position),
         )
 
-    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_open_cover_tilt(self) -> None:
         """Open the cover tilt."""
         assert self._target_tilt_value
         await self._async_set_value(self._target_tilt_value, self._fully_open_tilt)
 
-    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_close_cover_tilt(self) -> None:
         """Close the cover tilt."""
         assert self._target_tilt_value
         await self._async_set_value(self._target_tilt_value, self._fully_closed_tilt)
 
-    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
+    async def async_stop_cover_tilt(self) -> None:
         """Stop the cover tilt."""
         assert self._stop_tilt_value
         # Stop the tilt, will stop regardless of the actual direction of travel.
@@ -451,10 +449,10 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
 
         return bool(self.info.primary_value.value == BarrierState.CLOSED)
 
-    async def async_open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self) -> None:
         """Open the garage door."""
         await self._async_set_value(self._target_state, BarrierState.OPEN)
 
-    async def async_close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self) -> None:
         """Close the garage door."""
         await self._async_set_value(self._target_state, BarrierState.CLOSED)

--- a/homeassistant/components/zwave_me/cover.py
+++ b/homeassistant/components/zwave_me/cover.py
@@ -2,13 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
-from homeassistant.components.cover import (
-    ATTR_POSITION,
-    CoverEntity,
-    CoverEntityFeature,
-)
+from homeassistant.components.cover import CoverEntity, CoverEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -55,22 +49,21 @@ class ZWaveMeCover(ZWaveMeEntity, CoverEntity):
         | CoverEntityFeature.STOP
     )
 
-    def close_cover(self, **kwargs: Any) -> None:
+    def close_cover(self) -> None:
         """Close cover."""
         self.controller.zwave_api.send_command(self.device.id, "exact?level=0")
 
-    def open_cover(self, **kwargs: Any) -> None:
+    def open_cover(self) -> None:
         """Open cover."""
         self.controller.zwave_api.send_command(self.device.id, "exact?level=99")
 
-    def set_cover_position(self, **kwargs: Any) -> None:
+    def set_cover_position(self, position: int) -> None:
         """Update the current value."""
-        value = kwargs[ATTR_POSITION]
         self.controller.zwave_api.send_command(
-            self.device.id, f"exact?level={str(min(value, 99))}"
+            self.device.id, f"exact?level={str(min(position, 99))}"
         )
 
-    def stop_cover(self, **kwargs: Any) -> None:
+    def stop_cover(self) -> None:
         """Stop cover."""
         self.controller.zwave_api.send_command(self.device.id, "stop")
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

Not a breaking change, but new implementations would need to:

1. Use the full signature of the methods they are overwriting (instead of using **kwargs)
2. For climate set_temperature, the logic has been divided between `set_target_temperature` and `set_target_temperature_range`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change proposes to make some entity methods signature explicit (with argument typing) rather than `**kwargs`. This applies for `ClimateEntity` and `WaterHeaterEntity` `set_temperature` methods, as well as most methods on `CoverEntity`.

The use of `**kwargs` required the users having to define extra logic to handle the optionality of parameters being passed and which combination of them. This change leads to specific implementations to be easier and more readable as no longer need to unpack the arguments that are passed with `**kwargs`.

For the ClimateEntity, the `set_temperature` method had 2 possible options given the parameters passed to the service. For that reason, (and in order to make components implementations easier) it has been splited into `set_target_temperature` when a single temperature value is being passed on the service, and `set_target_temperature_range` when a range of temperatures is being given.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Architecture discussion: 
  - https://github.com/home-assistant/architecture/discussions/1071
  - https://github.com/home-assistant/architecture/discussions/1072
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
