### PR TITLE
Fix Rpi_power test race condition

### DIFF
--- a/tests/components/rpi_power/test_binary_sensor.py
+++ b/tests/components/rpi_power/test_binary_sensor.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from homeassistant.components.rpi_power import binary_sensor
 from homeassistant.components.rpi_power.binary_sensor import (
     DESCRIPTION_NORMALIZED,
     DESCRIPTION_UNDER_VOLTAGE,
@@ -48,32 +49,25 @@ async def test_new_detected(
     """Test new entry with under voltage detected."""
     mocked_under_voltage = await _async_setup_component(hass, True)
     state = hass.states.get(ENTITY_ID)
+    assert state
     assert state.state == STATE_ON
     assert (
-        len(
-            [
-                x
-                for x in caplog.records
-                if x.levelno == logging.WARNING
-                and x.message == DESCRIPTION_UNDER_VOLTAGE
-            ]
-        )
-        == 1
-    )
+        binary_sensor.__name__,
+        logging.WARNING,
+        DESCRIPTION_UNDER_VOLTAGE,
+    ) in caplog.record_tuples
 
     # back to normal
     type(mocked_under_voltage).get = MagicMock(return_value=False)
     future = dt_util.utcnow() + timedelta(minutes=1)
     async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
     state = hass.states.get(ENTITY_ID)
+    assert state
+    assert state.state == STATE_OFF
     assert (
-        len(
-            [
-                x
-                for x in caplog.records
-                if x.levelno == logging.INFO and x.message == DESCRIPTION_NORMALIZED
-            ]
-        )
-        == 1
-    )
+        binary_sensor.__name__,
+        logging.INFO,
+        DESCRIPTION_NORMALIZED,
+    ) in caplog.record_tuples


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fixes the following error in https://github.com/home-assistant/core/actions/runs/8526535253/job/23356357462:
```
FAILED tests/components/rpi_power/test_binary_sensor.py::test_new_detected - assert 0 == 1
 +  where 0 = len([])
```
- Compare record tuples instead list length
- assert forgotten state


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
