### PR TITLE
Migrate more sonos tasks to use eager_start

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -230,7 +230,8 @@ class SonosDiscoveryManager:
                 return
 
             self.hass.async_create_task(
-                self.async_add_speakers(zones_to_add, subscription, soco.uid)
+                self.async_add_speakers(zones_to_add, subscription, soco.uid),
+                eager_start=True,
             )
 
         async def async_subscription_failed(now: datetime.datetime) -> None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -407,7 +407,9 @@ class SonosSpeaker:
     @callback
     def async_renew_failed(self, exception: Exception) -> None:
         """Handle a failed subscription renewal."""
-        self.hass.async_create_task(self._async_renew_failed(exception))
+        self.hass.async_create_task(
+            self._async_renew_failed(exception), eager_start=True
+        )
 
     async def _async_renew_failed(self, exception: Exception) -> None:
         """Mark the speaker as offline after a subscription renewal failure.
@@ -449,7 +451,9 @@ class SonosSpeaker:
         """Add the soco instance associated with the event to the callback."""
         if "alarm_list_version" not in event.variables:
             return
-        self.hass.async_create_task(self.alarms.async_process_event(event, self))
+        self.hass.async_create_task(
+            self.alarms.async_process_event(event, self), eager_start=True
+        )
 
     @callback
     def async_dispatch_device_properties(self, event: SonosEvent) -> None:
@@ -479,7 +483,9 @@ class SonosSpeaker:
             return
         if "container_update_i_ds" not in event.variables:
             return
-        self.hass.async_create_task(self.favorites.async_process_event(event, self))
+        self.hass.async_create_task(
+            self.favorites.async_process_event(event, self), eager_start=True
+        )
 
     @callback
     def async_dispatch_media_update(self, event: SonosEvent) -> None:
@@ -601,7 +607,7 @@ class SonosSpeaker:
         self.available = True
         if not was_available:
             self.async_write_entity_states()
-            self.hass.async_create_task(self.async_subscribe())
+            self.hass.async_create_task(self.async_subscribe(), eager_start=True)
 
     @callback
     def async_check_activity(self, now: datetime.datetime) -> None:
@@ -818,7 +824,9 @@ class SonosSpeaker:
         if "zone_player_uui_ds_in_group" not in event.variables:
             return
         self.event_stats.process(event)
-        self.hass.async_create_task(self.create_update_groups_coro(event))
+        self.hass.async_create_task(
+            self.create_update_groups_coro(event), eager_start=True
+        )
 
     def create_update_groups_coro(self, event: SonosEvent | None = None) -> Coroutine:
         """Handle callback for topology change event."""

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -494,6 +494,6 @@ def zgs_event_fixture(hass: HomeAssistant, soco: SoCo, zgs_discovery: str):
         subscription: SonosMockSubscribe = soco.zoneGroupTopology.subscribe.return_value
         sub_callback = await subscription.wait_for_callback_to_be_set()
         sub_callback(event)
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     return _wrapper

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -242,7 +242,6 @@ async def test_favorites_sensor(
 
     # Trigger subscription callback for speaker discovery
     await fire_zgs_event()
-    await hass.async_block_till_done(wait_background_tasks=True)
 
     favorites_updated_event = SonosMockEvent(
         soco, service, {"favorites_update_id": "2", "container_update_i_ds": "FV:2,2"}

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -117,7 +117,7 @@ async def test_switch_attributes(
             hass,
             dt_util.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
         )
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert m.called
 
     # Trigger subscription callback for speaker discovery

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -122,7 +122,6 @@ async def test_switch_attributes(
 
     # Trigger subscription callback for speaker discovery
     await fire_zgs_event()
-    await hass.async_block_till_done(wait_background_tasks=True)
 
     status_light_state = hass.states.get(status_light.entity_id)
     assert status_light_state.state == STATE_ON


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Now that more of the test races have been fixed, these can be migrated


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
