### PR TITLE
Climate split set temperature logic

### DIFF
--- a/homeassistant/components/adax/climate.py
+++ b/homeassistant/components/adax/climate.py
@@ -14,7 +14,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_IP_ADDRESS,
     CONF_PASSWORD,
     CONF_TOKEN,
@@ -107,10 +106,12 @@ class AdaxDevice(ClimateEntity):
             return
         await self._adax_data_handler.update()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self._adax_data_handler.set_room_target_temperature(
             self._device_id, temperature, True
         )
@@ -152,10 +153,12 @@ class LocalAdaxDevice(ClimateEntity):
             manufacturer="Adax",
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self._adax_data_handler.set_target_temperature(temperature)
 
     async def async_update(self) -> None:

--- a/homeassistant/components/advantage_air/climate.py
+++ b/homeassistant/components/advantage_air/climate.py
@@ -3,11 +3,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.climate import (
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -17,7 +14,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -225,17 +222,27 @@ class AdvantageAirAC(AdvantageAirAcEntity, ClimateEntity):
             mode = fan_mode
         await self.async_update_ac({"fan": mode})
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the Temperature."""
-        if ATTR_TEMPERATURE in kwargs:
-            await self.async_update_ac({"setTemp": kwargs[ATTR_TEMPERATURE]})
-        if ATTR_TARGET_TEMP_LOW in kwargs and ATTR_TARGET_TEMP_HIGH in kwargs:
-            await self.async_update_ac(
-                {
-                    ADVANTAGE_AIR_COOL_TARGET: kwargs[ATTR_TARGET_TEMP_HIGH],
-                    ADVANTAGE_AIR_HEAT_TARGET: kwargs[ATTR_TARGET_TEMP_LOW],
-                }
-            )
+        await self.async_update_ac({"setTemp": temperature})
+
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature range."""
+        await self.async_update_ac(
+            {
+                ADVANTAGE_AIR_COOL_TARGET: temperature_high,
+                ADVANTAGE_AIR_HEAT_TARGET: temperature_low,
+            }
+        )
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
@@ -300,7 +307,10 @@ class AdvantageAirZone(AdvantageAirZoneEntity, ClimateEntity):
         else:
             await self.async_turn_on()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the Temperature."""
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        await self.async_update_zone({"setTemp": temp})
+        await self.async_update_zone({"setTemp": temperature})

--- a/homeassistant/components/airtouch4/climate.py
+++ b/homeassistant/components/airtouch4/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.climate import (
     FAN_AUTO,
@@ -17,7 +16,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -284,15 +283,16 @@ class AirtouchGroup(CoordinatorEntity, ClimateEntity):
         )
         return [AT_TO_HA_FAN_SPEED[speed] for speed in airtouch_fan_speeds]
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
-            _LOGGER.debug("Argument `temperature` is missing in set_temperature")
-            return
 
-        _LOGGER.debug("Setting temp of %s to %s", self._group_number, str(temp))
+        _LOGGER.debug("Setting temp of %s to %s", self._group_number, str(temperature))
         self._unit = await self._airtouch.SetGroupToTemperature(
-            self._group_number, int(temp)
+            self._group_number, int(temperature)
         )
         self.async_write_ha_state()
 

--- a/homeassistant/components/airtouch5/climate.py
+++ b/homeassistant/components/airtouch5/climate.py
@@ -1,7 +1,6 @@
 """AirTouch 5 component to control AirTouch 5 Climate Devices."""
 
 import logging
-from typing import Any
 
 from airtouch5py.airtouch5_simple_client import Airtouch5SimpleClient
 from airtouch5py.packets.ac_ability import AcAbility
@@ -35,7 +34,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -255,13 +254,13 @@ class Airtouch5AC(Airtouch5ClimateEntity):
         fan_speed = FAN_MODE_TO_SET_AC_FAN_SPEED[fan_mode]
         await self._control(fan=fan_speed)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
-            _LOGGER.debug("Argument `temperature` is missing in set_temperature")
-            return
-
-        await self._control(temp=temp)
+        await self._control(temp=int(temperature))
 
 
 class Airtouch5Zone(Airtouch5ClimateEntity):
@@ -361,16 +360,15 @@ class Airtouch5Zone(Airtouch5ClimateEntity):
 
         await self._control(power=power)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
-            _LOGGER.debug("Argument `temperature` is missing in set_temperature")
-            return
-
         await self._control(
             zsv=ZoneSettingValue.SET_TARGET_SETPOINT,
-            value=float(temp),
+            value=temperature,
         )
 
     async def async_turn_on(self) -> None:

--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -36,7 +36,6 @@ from aioairzone_cloud.const import (
 )
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -47,7 +46,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -223,20 +222,24 @@ class AirzoneDeviceClimate(AirzoneClimate):
         }
         await self._async_update_params(params)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        params: dict[str, Any] = {}
-        if ATTR_TEMPERATURE in kwargs:
-            params[API_SETPOINT] = {
-                API_VALUE: kwargs[ATTR_TEMPERATURE],
+        params: dict[str, Any] = {
+            API_SETPOINT: {
+                API_VALUE: temperature,
                 API_OPTS: {
                     API_UNITS: TemperatureUnit.CELSIUS.value,
                 },
             }
+        }
         await self._async_update_params(params)
 
-        if ATTR_HVAC_MODE in kwargs:
-            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
+        if hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
 
 
 class AirzoneDeviceGroupClimate(AirzoneClimate):
@@ -266,20 +269,24 @@ class AirzoneDeviceGroupClimate(AirzoneClimate):
         }
         await self._async_update_params(params)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        params: dict[str, Any] = {}
-        if ATTR_TEMPERATURE in kwargs:
-            params[API_PARAMS] = {
-                API_SETPOINT: kwargs[ATTR_TEMPERATURE],
-            }
-            params[API_OPTS] = {
+        params: dict[str, Any] = {
+            API_PARAMS: {
+                API_SETPOINT: temperature,
+            },
+            API_OPTS: {
                 API_UNITS: TemperatureUnit.CELSIUS.value,
-            }
+            },
+        }
         await self._async_update_params(params)
 
-        if ATTR_HVAC_MODE in kwargs:
-            await self.async_set_hvac_mode(kwargs[ATTR_HVAC_MODE])
+        if hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set hvac mode."""

--- a/homeassistant/components/ambiclimate/climate.py
+++ b/homeassistant/components/ambiclimate/climate.py
@@ -18,7 +18,6 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_NAME,
-    ATTR_TEMPERATURE,
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     UnitOfTemperature,
@@ -175,10 +174,12 @@ class AmbiclimateEntity(ClimateEntity):
             name=heater.name,
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self._heater.set_target_temperature(temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/aprilaire/climate.py
+++ b/homeassistant/components/aprilaire/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyaprilaire.const import Attribute
 
 from homeassistant.components.climate import (
@@ -230,28 +228,23 @@ class AprilaireClimate(BaseAprilaireEntity, ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
+        await self.coordinator.client.update_setpoint(temperature, temperature)
+        await self.coordinator.client.read_control()
 
-        cool_setpoint = 0
-        heat_setpoint = 0
-
-        if temperature := kwargs.get("temperature"):
-            if self.coordinator.data.get(Attribute.MODE) == 3:
-                cool_setpoint = temperature
-            else:
-                heat_setpoint = temperature
-        else:
-            if target_temp_low := kwargs.get("target_temp_low"):
-                heat_setpoint = target_temp_low
-            if target_temp_high := kwargs.get("target_temp_high"):
-                cool_setpoint = target_temp_high
-
-        if cool_setpoint == 0 and heat_setpoint == 0:
-            return
-
-        await self.coordinator.client.update_setpoint(cool_setpoint, heat_setpoint)
-
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature range."""
+        await self.coordinator.client.update_setpoint(temperature_low, temperature_high)
         await self.coordinator.client.read_control()
 
     async def async_set_humidity(self, humidity: int) -> None:

--- a/homeassistant/components/atag/climate.py
+++ b/homeassistant/components/atag/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.climate import (
     PRESET_AWAY,
     PRESET_BOOST,
@@ -13,7 +11,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.enum import try_parse_enum
@@ -81,9 +79,13 @@ class AtagThermostat(AtagEntity, ClimateEntity):
         preset = self.coordinator.data.climate.preset_mode
         return PRESET_INVERTED.get(preset)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await self.coordinator.data.climate.set_temp(kwargs.get(ATTR_TEMPERATURE))
+        await self.coordinator.data.climate.set_temp(temperature)
         self.async_write_ha_state()
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/baf/climate.py
+++ b/homeassistant/components/baf/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant import config_entries
 from homeassistant.components.climate import (
     ClimateEntity,
@@ -11,7 +9,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -58,8 +56,12 @@ class BAFAutoComfort(BAFEntity, ClimateEntity):
         """Set the HVAC mode."""
         self._device.auto_comfort_enable = hvac_mode == HVACMode.FAN_ONLY
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the target temperature."""
         if not self._device.auto_comfort_enable:
             self._device.auto_comfort_enable = True
-        self._device.comfort_ideal_temperature = kwargs[ATTR_TEMPERATURE]
+        self._device.comfort_ideal_temperature = temperature

--- a/homeassistant/components/balboa/climate.py
+++ b/homeassistant/components/balboa/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from enum import IntEnum
-from typing import Any
 
 from pybalboa import SpaClient, SpaControl
 from pybalboa.enums import HeatMode, HeatState, TemperatureUnit
@@ -15,12 +14,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    PRECISION_HALVES,
-    PRECISION_WHOLE,
-    UnitOfTemperature,
-)
+from homeassistant.const import PRECISION_HALVES, PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -132,9 +126,13 @@ class BalboaClimateEntity(BalboaEntity, ClimateEntity):
         """Return current preset mode."""
         return self._client.heat_mode.state.name.lower()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set a new target temperature."""
-        await self._client.set_temperature(kwargs[ATTR_TEMPERATURE])
+        await self._client.set_temperature(temperature)
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set new preset mode."""

--- a/homeassistant/components/blebox/climate.py
+++ b/homeassistant/components/blebox/climate.py
@@ -1,7 +1,6 @@
 """BleBox climate entity."""
 
 from datetime import timedelta
-from typing import Any
 
 from blebox_uniapi.box import Box
 import blebox_uniapi.climate
@@ -13,7 +12,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -119,7 +118,10 @@ class BleBoxClimateEntity(BleBoxEntity[blebox_uniapi.climate.Climate], ClimateEn
 
         await self._feature.async_off()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the thermostat temperature."""
-        value = kwargs[ATTR_TEMPERATURE]
-        await self._feature.async_set_temperature(value)
+        await self._feature.async_set_temperature(temperature)

--- a/homeassistant/components/broadlink/climate.py
+++ b/homeassistant/components/broadlink/climate.py
@@ -3,7 +3,6 @@
 from typing import Any
 
 from homeassistant.components.climate import (
-    ATTR_TEMPERATURE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -51,9 +50,12 @@ class BroadlinkThermostat(BroadlinkEntity, ClimateEntity):
         self._attr_unique_id = device.unique_id
         self._attr_hvac_mode = None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
         await self._device.async_request(self._device.api.set_temp, temperature)
         self._attr_target_temperature = temperature
         self.async_write_ha_state()

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -155,9 +155,13 @@ class BSBLANClimate(
                 translation_placeholders={"preset_mode": preset_mode},
             )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        await self.async_set_data(**kwargs)
+        await self.async_set_data(temperature=temperature, hvac_mode=hvac_mode)
 
     async def async_set_data(self, **kwargs: Any) -> None:
         """Set device settings using BSBLAN."""

--- a/homeassistant/components/ccm15/climate.py
+++ b/homeassistant/components/ccm15/climate.py
@@ -18,7 +18,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -142,10 +142,13 @@ class CCM15Climate(CoordinatorEntity[CCM15Coordinator], ClimateEntity):
             return {"error_code": data.error_code}
         return {}
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self.coordinator.async_set_temperature(self._ac_index, temperature)
+        await self.coordinator.async_set_temperature(self._ac_index, temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the hvac mode."""

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -718,6 +718,53 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
             ft.partial(self.set_temperature, **kwargs)
         )
 
+    def set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+        raise NotImplementedError
+
+    async def async_set_target_temperature(
+        self,
+        temperature: float | None = None,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+        await self.hass.async_add_executor_job(
+            ft.partial(
+                self.set_temperature,
+                temperature=temperature,
+                hvac_mode=hvac_mode,
+            )
+        )
+
+    def set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+        raise NotImplementedError
+
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature."""
+        await self.hass.async_add_executor_job(
+            ft.partial(
+                self.set_temperature,
+                temperature_high=temperature_high,
+                temperature_low=temperature_low,
+                hvac_mode=hvac_mode,
+            )
+        )
+
     def set_humidity(self, humidity: int) -> None:
         """Set new target humidity."""
         raise NotImplementedError

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -130,8 +130,6 @@ DEFAULT_MAX_HUMIDITY = 99
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SCAN_INTERVAL = timedelta(seconds=60)
 
-CONVERTIBLE_ATTRIBUTE = [ATTR_TEMPERATURE, ATTR_TARGET_TEMP_LOW, ATTR_TARGET_TEMP_HIGH]
-
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -728,7 +726,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
 
     async def async_set_target_temperature(
         self,
-        temperature: float | None = None,
+        temperature: float,
         hvac_mode: HVACMode | None = None,
     ) -> None:
         """Set new target temperature."""
@@ -746,7 +744,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         temperature_low: float,
         hvac_mode: HVACMode | None = None,
     ) -> None:
-        """Set new target temperature."""
+        """Set new target temperature range."""
         raise NotImplementedError
 
     async def async_set_target_temperature_range(
@@ -755,7 +753,7 @@ class ClimateEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         temperature_low: float,
         hvac_mode: HVACMode | None = None,
     ) -> None:
-        """Set new target temperature."""
+        """Set new target temperature range."""
         await self.hass.async_add_executor_job(
             ft.partial(
                 self.set_temperature,
@@ -951,17 +949,57 @@ async def async_service_temperature_set(
 ) -> None:
     """Handle set temperature service."""
     hass = entity.hass
-    kwargs = {}
 
-    for value, temp in service_call.data.items():
-        if value in CONVERTIBLE_ATTRIBUTE:
-            kwargs[value] = TemperatureConverter.convert(
-                temp, hass.config.units.temperature_unit, entity.temperature_unit
+    temp_convert = ft.partial(
+        TemperatureConverter.convert,
+        from_unit=hass.config.units.temperature_unit,
+        to_unit=entity.temperature_unit,
+    )
+    hvac_mode: HVACMode | None = service_call.data.get(ATTR_HVAC_MODE)
+
+    if (
+        ATTR_TEMPERATURE in service_call.data
+        and ClimateEntityFeature.TARGET_TEMPERATURE in entity.supported_features
+    ):
+        temperature = temp_convert(service_call.data[ATTR_TEMPERATURE])
+        if (
+            type(entity).async_set_target_temperature
+            is not ClimateEntity.async_set_target_temperature
+        ):
+            await entity.async_set_target_temperature(
+                temperature=temperature, hvac_mode=hvac_mode
             )
         else:
-            kwargs[value] = temp
-
-    await entity.async_set_temperature(**kwargs)
+            await entity.async_set_temperature(
+                **{
+                    ATTR_TEMPERATURE: temperature,
+                    ATTR_HVAC_MODE: hvac_mode,
+                }
+            )
+    elif (
+        ATTR_TARGET_TEMP_HIGH in service_call.data
+        and ATTR_TARGET_TEMP_LOW in service_call.data
+        and ClimateEntityFeature.TARGET_TEMPERATURE_RANGE in entity.supported_features
+    ):
+        temperature_high = temp_convert(service_call.data[ATTR_TARGET_TEMP_HIGH])
+        temperature_low = temp_convert(service_call.data[ATTR_TARGET_TEMP_LOW])
+        if (
+            type(entity).async_set_target_temperature_range
+            is not ClimateEntity.async_set_target_temperature_range
+        ):
+            await entity.async_set_target_temperature_range(
+                temperature_high=temperature_high,
+                temperature_low=temperature_low,
+                hvac_mode=hvac_mode,
+            )
+        else:
+            await entity.async_set_temperature(
+                **{
+                    ATTR_TARGET_TEMP_HIGH: temperature_high,
+                    ATTR_TARGET_TEMP_LOW: temperature_low,
+                    ATTR_HVAC_MODE: hvac_mode,
+                }
+            )
 
 
 # As we import deprecated constants from the const module, we need to add these two functions

--- a/homeassistant/components/comelit/climate.py
+++ b/homeassistant/components/comelit/climate.py
@@ -16,7 +16,7 @@ from homeassistant.components.climate import (
     UnitOfTemperature,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS
+from homeassistant.const import PRECISION_TENTHS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -181,18 +181,20 @@ class ComelitClimateEntity(CoordinatorEntity[ComelitSerialBridge], ClimateEntity
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (
-            target_temp := kwargs.get(ATTR_TEMPERATURE)
-        ) is None or self.hvac_mode == HVACMode.OFF:
+        if self.hvac_mode == HVACMode.OFF:
             return
 
         await self.coordinator.api.set_clima_status(
             self._device.index, ClimaComelitCommand.MANUAL
         )
         await self.coordinator.api.set_clima_status(
-            self._device.index, ClimaComelitCommand.SET, target_temp
+            self._device.index, ClimaComelitCommand.SET, temperature
         )
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/coolmaster/climate.py
+++ b/homeassistant/components/coolmaster/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from pycoolmasternet_async import SWING_MODES
 
@@ -13,7 +12,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -123,12 +122,15 @@ class CoolmasterClimate(CoolmasterEntity, ClimateEntity):
         """Return swing modes if supported."""
         return SWING_MODES if self.swing_mode is not None else None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            _LOGGER.debug("Setting temp of %s to %s", self.unique_id, str(temp))
-            self._unit = await self._unit.set_thermostat(temp)
-            self.async_write_ha_state()
+        _LOGGER.debug("Setting temp of %s to %s", self.unique_id, str(temperature))
+        self._unit = await self._unit.set_thermostat(temperature)
+        self.async_write_ha_state()
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -202,9 +202,22 @@ class DaikinClimate(ClimateEntity):
         """Return the temperature we try to reach."""
         return self._api.device.target_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await self._set(kwargs)
+        params = {
+            HA_ATTR_TO_DAIKIN[ATTR_TARGET_TEMPERATURE]: format_target_temperature(
+                temperature
+            ),
+        }
+        if hvac_mode is not None:
+            params |= {
+                HA_ATTR_TO_DAIKIN[ATTR_HVAC_MODE]: HA_STATE_TO_DAIKIN[hvac_mode],
+            }
+        await self._api.device.set(params)
 
     @property
     def hvac_action(self) -> HVACAction | None:

--- a/homeassistant/components/deconz/climate.py
+++ b/homeassistant/components/deconz/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydeconz.models.event import EventType
 from pydeconz.models.sensor.thermostat import (
     Thermostat,
@@ -29,7 +27,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -231,20 +229,22 @@ class DeconzThermostat(DeconzDevice[Thermostat], ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if ATTR_TEMPERATURE not in kwargs:
-            raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")
 
         if self._device.mode == ThermostatMode.COOL:
             await self.hub.api.sensors.thermostat.set_config(
                 id=self._device.resource_id,
-                cooling_setpoint=kwargs[ATTR_TEMPERATURE] * 100,
+                cooling_setpoint=int(temperature * 100),
             )
         else:
             await self.hub.api.sensors.thermostat.set_config(
                 id=self._device.resource_id,
-                heating_setpoint=kwargs[ATTR_TEMPERATURE] * 100,
+                heating_setpoint=int(temperature * 100),
             )
 
     @property

--- a/homeassistant/components/demo/climate.py
+++ b/homeassistant/components/demo/climate.py
@@ -2,19 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -242,17 +237,27 @@ class DemoClimate(ClimateEntity):
         """List of available swing modes."""
         return self._swing_modes
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if kwargs.get(ATTR_TEMPERATURE) is not None:
-            self._target_temperature = kwargs.get(ATTR_TEMPERATURE)
-        if (
-            kwargs.get(ATTR_TARGET_TEMP_HIGH) is not None
-            and kwargs.get(ATTR_TARGET_TEMP_LOW) is not None
-        ):
-            self._target_temperature_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-            self._target_temperature_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        if (hvac_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
+        self._target_temperature = temperature
+        if hvac_mode is not None:
+            self._hvac_mode = hvac_mode
+        self.async_write_ha_state()
+
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature range."""
+        self._target_temperature_high = temperature_high
+        self._target_temperature_low = temperature_low
+        if hvac_mode is not None:
             self._hvac_mode = hvac_mode
         self.async_write_ha_state()
 

--- a/homeassistant/components/duotecno/climate.py
+++ b/homeassistant/components/duotecno/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Final
+from typing import Final
 
 from duotecno.controller import PyDuotecno
 from duotecno.unit import SensUnit
@@ -13,7 +13,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -80,11 +80,13 @@ class DuotecnoClimate(DuotecnoEntity, ClimateEntity):
         return PRESETMODES_REVERSE[self._unit.get_preset()]
 
     @api_call
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-        await self._unit.set_temp(temp)
+        await self._unit.set_temp(temperature)
 
     @api_call
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/electrasmart/climate.py
+++ b/homeassistant/components/electrasmart/climate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import time
-from typing import Any
 
 from electrasmart.api import STATUS_SUCCESS, Attributes, ElectraAPI, ElectraApiError
 from electrasmart.device import ElectraAirConditioner, OperationMode
@@ -25,7 +24,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -250,12 +249,12 @@ class ElectraClimateEntity(ClimateEntity):
 
         await self._async_operate_electra_ac()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            raise ValueError("No target temperature provided")
-
         self._electra_ac_device.set_temperature(int(temperature))
         await self._async_operate_electra_ac()
 

--- a/homeassistant/components/elkm1/climate.py
+++ b/homeassistant/components/elkm1/climate.py
@@ -9,8 +9,6 @@ from elkm1_lib.elements import Element
 from elkm1_lib.thermostats import Thermostat
 
 from homeassistant.components.climate import (
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_ON,
     ClimateEntity,
@@ -165,14 +163,15 @@ class ElkThermostat(ElkEntity, ClimateEntity):
         thermostat_mode, elk_fan_mode = HASS_TO_ELK_FAN_MODES[fan_mode]
         self._elk_set(thermostat_mode, elk_fan_mode)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        low_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        high_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if low_temp is not None:
-            self._element.set(ThermostatSetting.HEAT_SETPOINT, round(low_temp))
-        if high_temp is not None:
-            self._element.set(ThermostatSetting.COOL_SETPOINT, round(high_temp))
+        self._element.set(ThermostatSetting.HEAT_SETPOINT, round(temperature_low))
+        self._element.set(ThermostatSetting.COOL_SETPOINT, round(temperature_high))
 
     def _element_changed(self, element: Element, changeset: Any) -> None:
         if self._element.mode is None:

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -1,14 +1,12 @@
 """Platform for eQ-3 climate entities."""
 
 import logging
-from typing import Any
 
 from eq3btsmart import Thermostat
 from eq3btsmart.const import EQ3BT_MAX_TEMP, EQ3BT_OFF_TEMP, Eq3Preset, OperationMode
 from eq3btsmart.exceptions import Eq3Exception
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     PRESET_NONE,
     ClimateEntity,
     ClimateEntityFeature,
@@ -16,7 +14,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.device_registry import (
@@ -244,24 +242,20 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
             return HVACAction.IDLE
         return HVACAction.HEATING
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
 
-        if ATTR_HVAC_MODE in kwargs:
-            mode: HVACMode | None
-            if (mode := kwargs.get(ATTR_HVAC_MODE)) is None:
-                return
-
-            if mode is not HVACMode.OFF:
-                await self.async_set_hvac_mode(mode)
+        if hvac_mode is not None:
+            if hvac_mode is not HVACMode.OFF:
+                await self.async_set_hvac_mode(hvac_mode)
             else:
                 raise ServiceValidationError(
                     f"[{self._eq3_config.mac_address}] Can't change HVAC mode to off while changing temperature",
                 )
-
-        temperature: float | None
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
 
         previous_temperature = self._target_temperature
         self._target_temperature = temperature

--- a/homeassistant/components/escea/climate.py
+++ b/homeassistant/components/escea/climate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from collections.abc import Coroutine
 import logging
-from typing import Any
 
 from pescea import Controller
 
@@ -17,7 +16,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -203,11 +202,13 @@ class ControllerEntity(ClimateEntity):
         else:
             self.set_available(True)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        if temp is not None:
-            await self.wrap_and_catch(self._controller.set_desired_temp(temp))
+        await self.wrap_and_catch(self._controller.set_desired_temp(temperature))
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""

--- a/homeassistant/components/flexit/climate.py
+++ b/homeassistant/components/flexit/climate.py
@@ -22,7 +22,6 @@ from homeassistant.components.modbus import (
     get_hub,
 )
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_NAME,
     CONF_SLAVE,
     DEVICE_DEFAULT_NAME,
@@ -155,14 +154,14 @@ class Flexit(ClimateEntity):
             "outdoor_air_temp": self._outdoor_air_temp,
         }
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            _LOGGER.error("Received invalid temperature")
-            return
-
-        if await self._async_write_int16_to_register(8, int(target_temperature * 10)):
-            self._attr_target_temperature = target_temperature
+        if await self._async_write_int16_to_register(8, int(temperature * 10)):
+            self._attr_target_temperature = temperature
         else:
             _LOGGER.error("Modbus error setting target temperature to Flexit")
 

--- a/homeassistant/components/flexit_bacnet/climate.py
+++ b/homeassistant/components/flexit_bacnet/climate.py
@@ -1,7 +1,6 @@
 """The Flexit Nordic (BACnet) integration."""
 
 import asyncio.exceptions
-from typing import Any
 
 from flexit_bacnet import (
     VENTILATION_MODE_AWAY,
@@ -20,7 +19,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -105,11 +104,12 @@ class FlexitClimateEntity(FlexitEntity, ClimateEntity):
 
         return self.device.air_temp_setpoint_home
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-
         try:
             if self.device.ventilation_mode == VENTILATION_MODE_AWAY:
                 await self.device.set_air_temp_setpoint_away(temperature)

--- a/homeassistant/components/fritzbox/climate.py
+++ b/homeassistant/components/fritzbox/climate.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     PRESET_COMFORT,
     PRESET_ECO,
     ClimateEntity,
@@ -13,12 +10,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_BATTERY_LEVEL,
-    ATTR_TEMPERATURE,
-    PRECISION_HALVES,
-    UnitOfTemperature,
-)
+from homeassistant.const import ATTR_BATTERY_LEVEL, PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -99,16 +91,17 @@ class FritzboxThermostat(FritzBoxDeviceEntity, ClimateEntity):
             return OFF_REPORT_SET_TEMPERATURE
         return self.data.target_temperature  # type: ignore [no-any-return]
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if kwargs.get(ATTR_HVAC_MODE) is not None:
-            hvac_mode = kwargs[ATTR_HVAC_MODE]
+        if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)
-        elif kwargs.get(ATTR_TEMPERATURE) is not None:
-            temperature = kwargs[ATTR_TEMPERATURE]
-            await self.hass.async_add_executor_job(
-                self.data.set_target_temperature, temperature
-            )
+        await self.hass.async_add_executor_job(
+            self.data.set_target_temperature, temperature
+        )
         await self.coordinator.async_refresh()
 
     @property

--- a/homeassistant/components/generic_thermostat/climate.py
+++ b/homeassistant/components/generic_thermostat/climate.py
@@ -6,7 +6,6 @@ import asyncio
 from datetime import datetime, timedelta
 import logging
 import math
-from typing import Any
 
 import voluptuous as vol
 
@@ -389,10 +388,12 @@ class GenericThermostat(ClimateEntity, RestoreEntity):
         # Ensure we update the current operation after changing the mode
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         self._target_temp = temperature
         await self._async_control_heating(force=True)
         self.async_write_ha_state()

--- a/homeassistant/components/gree/climate.py
+++ b/homeassistant/components/gree/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from greeclimate.device import (
     TEMP_MAX,
@@ -18,7 +17,6 @@ from greeclimate.device import (
 )
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -37,7 +35,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -149,15 +147,15 @@ class GreeClimateEntity(GreeEntity, ClimateEntity):
         """Return the target temperature for the device."""
         return self.coordinator.device.target_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if ATTR_TEMPERATURE not in kwargs:
-            raise ValueError(f"Missing parameter {ATTR_TEMPERATURE}")
-
-        if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
+        if hvac_mode is not None:
             await self.async_set_hvac_mode(hvac_mode)
 
-        temperature = kwargs[ATTR_TEMPERATURE]
         _LOGGER.debug(
             "Setting temperature to %d for %s",
             temperature,

--- a/homeassistant/components/hisense_aehw4a1/climate.py
+++ b/homeassistant/components/hisense_aehw4a1/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from pyaehw4a1.aehw4a1 import AehW4a1
 import pyaehw4a1.exceptions
@@ -26,7 +25,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -227,21 +226,24 @@ class ClimateAehW4a1(ClimateEntity):
             self._attr_target_temperature = None
             self._attr_preset_mode = None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
         if self._on != "1":
             _LOGGER.warning(
                 "AC at %s is off, could not set temperature", self._attr_unique_id
             )
             return
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            _LOGGER.debug("Setting temp of %s to %s", self._attr_unique_id, temp)
-            if self._attr_preset_mode != PRESET_NONE:
-                await self.async_set_preset_mode(PRESET_NONE)
-            if self._attr_temperature_unit == UnitOfTemperature.CELSIUS:
-                await self._device.command(f"temp_{int(temp)}_C")
-            else:
-                await self._device.command(f"temp_{int(temp)}_F")
+        _LOGGER.debug("Setting temp of %s to %s", self._attr_unique_id, temperature)
+        if self._attr_preset_mode != PRESET_NONE:
+            await self.async_set_preset_mode(PRESET_NONE)
+        if self._attr_temperature_unit == UnitOfTemperature.CELSIUS:
+            await self._device.command(f"temp_{int(temperature)}_C")
+        else:
+            await self._device.command(f"temp_{int(temperature)}_F")
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new fan mode."""

--- a/homeassistant/components/hive/climate.py
+++ b/homeassistant/components/hive/climate.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 import logging
-from typing import Any
 
 import voluptuous as vol
 
@@ -110,11 +109,13 @@ class HiveClimateEntity(HiveEntity, ClimateEntity):
         await self.hive.heating.setMode(self.device, new_mode)
 
     @refresh_system
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        new_temperature = kwargs.get(ATTR_TEMPERATURE)
-        if new_temperature is not None:
-            await self.hive.heating.setTargetTemperature(self.device, new_temperature)
+        await self.hive.heating.setTargetTemperature(self.device, temperature)
 
     @refresh_system
     async def async_set_preset_mode(self, preset_mode: str) -> None:

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -25,7 +25,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -198,11 +198,12 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
         """Return the maximum temperature."""
         return self._device.maxTemperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-
         if self.min_temp <= temperature <= self.max_temp:
             await self._device.set_point_temperature(temperature)
 

--- a/homeassistant/components/huum/climate.py
+++ b/homeassistant/components/huum/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from huum.const import SaunaStatus
 from huum.exceptions import SafetyException
@@ -16,7 +15,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -102,15 +101,16 @@ class HuumDevice(ClimateEntity):
         elif hvac_mode == HVACMode.OFF:
             await self._huum_handler.turn_off()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is None:
-            return
-        self._target_temperature = temperature
+        self._target_temperature = int(temperature)
 
         if self.hvac_mode == HVACMode.HEAT:
-            await self._turn_on(temperature)
+            await self._turn_on(self._target_temperature)
 
     async def async_update(self) -> None:
         """Get the latest status data.

--- a/homeassistant/components/iaqualink/climate.py
+++ b/homeassistant/components/iaqualink/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from iaqualink.device import AqualinkThermostat
 
@@ -14,7 +13,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -88,9 +87,13 @@ class HassAqualinkThermostat(AqualinkEntity, ClimateEntity):
         return float(self.dev.state)
 
     @refresh_system
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await await_or_reraise(self.dev.set_temperature(int(kwargs[ATTR_TEMPERATURE])))
+        await await_or_reraise(self.dev.set_temperature(int(temperature)))
 
     @property
     def current_temperature(self) -> float | None:

--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -10,7 +10,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -81,9 +81,12 @@ class InComfortClimate(IncomfortChild, ClimateEntity):
         """Return max valid temperature that can be set."""
         return 30.0
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set a new target temperature for this zone."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
         await self._room.set_override(temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/insteon/climate.py
+++ b/homeassistant/components/insteon/climate.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyinsteon.config import CELSIUS
 from pyinsteon.constants import ThermostatMode
 
 from homeassistant.components.climate import (
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     ClimateEntity,
     ClimateEntityFeature,
@@ -17,7 +13,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, Platform, UnitOfTemperature
+from homeassistant.const import Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -180,19 +176,26 @@ class InsteonClimateEntity(InsteonEntity, ClimateEntity):
         attr["humidifier"] = humidifier
         return attr
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        target_temp = kwargs.get(ATTR_TEMPERATURE)
-        target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if target_temp is not None:
-            if self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.HEAT:
-                await self._insteon_device.async_set_heat_set_point(target_temp)
-            elif self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.COOL:
-                await self._insteon_device.async_set_cool_set_point(target_temp)
-        else:
-            await self._insteon_device.async_set_heat_set_point(target_temp_low)
-            await self._insteon_device.async_set_cool_set_point(target_temp_high)
+        if self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.HEAT:
+            await self._insteon_device.async_set_heat_set_point(temperature)
+        elif self._insteon_device.groups[SYSTEM_MODE].value == ThermostatMode.COOL:
+            await self._insteon_device.async_set_cool_set_point(temperature)
+
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature range."""
+        await self._insteon_device.async_set_heat_set_point(temperature_low)
+        await self._insteon_device.async_set_cool_set_point(temperature_high)
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""

--- a/homeassistant/components/intellifire/climate.py
+++ b/homeassistant/components/intellifire/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityDescription,
@@ -11,7 +9,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -78,14 +76,17 @@ class IntellifireClimate(IntellifireEntity, ClimateEntity):
             return HVACMode.HEAT
         return HVACMode.OFF
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Turn on thermostat by setting a target temperature."""
-        raw_target_temp = kwargs[ATTR_TEMPERATURE]
-        self.last_temp = int(raw_target_temp)
+        self.last_temp = int(temperature)
         LOGGER.debug(
             "Setting target temp to %sc %sf",
-            int(raw_target_temp),
-            (raw_target_temp * 9 / 5) + 32,
+            int(temperature),
+            (temperature * 9 / 5) + 32,
         )
         await self.coordinator.control_api.set_thermostat_c(
             temp_c=self.last_temp,

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -23,7 +23,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_EXCLUDE,
     PRECISION_HALVES,
     PRECISION_TENTHS,
@@ -400,13 +399,13 @@ class ControllerDevice(ClimateEntity):
         else:
             self.set_available(True)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if not self.supported_features & ClimateEntityFeature.TARGET_TEMPERATURE:
-            self.async_schedule_update_ha_state(True)
-            return
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self.wrap_and_catch(self._controller.set_temp_setpoint(temp))
+        await self.wrap_and_catch(self._controller.set_temp_setpoint(temperature))
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
@@ -579,12 +578,15 @@ class ZoneDevice(ClimateEntity):
         )
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
         if self._zone.mode != Zone.Mode.AUTO:
             return
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self._controller.wrap_and_catch(self._zone.set_temp_setpoint(temp))
+        await self._controller.wrap_and_catch(self._zone.set_temp_setpoint(temperature))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -17,7 +17,6 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_ENTITY_CATEGORY,
     CONF_NAME,
     Platform,
@@ -181,12 +180,14 @@ class KNXClimate(KnxEntity, ClimateEntity):
         temp = self._device.target_temperature_max
         return temp if temp is not None else super().max_temp
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is not None:
-            await self._device.set_target_temperature(temperature)
-            self.async_write_ha_state()
+        await self._device.set_target_temperature(temperature)
+        self.async_write_ha_state()
 
     @property
     def hvac_mode(self) -> HVACMode:

--- a/homeassistant/components/lcn/climate.py
+++ b/homeassistant/components/lcn/climate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 import pypck
 
@@ -14,7 +14,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_ADDRESS,
     CONF_DOMAIN,
     CONF_ENTITIES,
@@ -87,7 +86,7 @@ class LcnClimate(LcnEntity, ClimateEntity):
         self._min_temp = config[CONF_DOMAIN_DATA][CONF_MIN_TEMP]
 
         self._current_temperature = None
-        self._target_temperature = None
+        self._target_temperature: float | None = None
         self._is_on = True
 
         self._attr_hvac_modes = [HVACMode.HEAT]
@@ -167,11 +166,12 @@ class LcnClimate(LcnEntity, ClimateEntity):
             self._target_temperature = None
             self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-
         if not await self.device_connection.var_abs(
             self.setpoint, temperature, self.unit
         ):

--- a/homeassistant/components/livisi/climate.py
+++ b/homeassistant/components/livisi/climate.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -89,11 +89,15 @@ class LivisiClimate(LivisiEntity, ClimateEntity):
         self._attr_max_temp = config.get("maxTemperature", MAX_TEMPERATURE)
         self._attr_min_temp = config.get("minTemperature", MIN_TEMPERATURE)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
         response = await self.aio_livisi.async_vrcc_set_temperature(
             self._target_temperature_capability,
-            kwargs.get(ATTR_TEMPERATURE),
+            temperature,
             self.coordinator.is_avatar,
         )
         if response is None:

--- a/homeassistant/components/lookin/climate.py
+++ b/homeassistant/components/lookin/climate.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Final, cast
+from typing import Final, cast
 
 from aiolookin import Climate, MeteoSensor, Remote
 from aiolookin.models import UDPCommandType, UDPEvent
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     FAN_AUTO,
     FAN_HIGH,
     FAN_LOW,
@@ -21,12 +20,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    ATTR_TEMPERATURE,
-    PRECISION_WHOLE,
-    Platform,
-    UnitOfTemperature,
-)
+from homeassistant.const import PRECISION_WHOLE, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -131,13 +125,15 @@ class ConditionerEntity(LookinCoordinatorEntity, ClimateEntity):
         self._climate.hvac_mode = mode
         await self._async_update_conditioner()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the temperature of the device."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         self._climate.temp_celsius = int(temperature)
         lookin_index = LOOKIN_HVAC_MODE_IDX_TO_HASS
-        if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
+        if hvac_mode is not None:
             self._climate.hvac_mode = HASS_TO_LOOKIN_HVAC_MODE[hvac_mode]
         elif self._climate.hvac_mode == lookin_index.index(HVACMode.OFF):
             #

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -16,7 +16,6 @@ from pymelcloud.atw_device import (
 import voluptuous as vol
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     DEFAULT_MAX_TEMP,
     DEFAULT_MIN_TEMP,
     ClimateEntity,
@@ -25,7 +24,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -222,19 +221,16 @@ class AtaDeviceClimate(MelCloudClimate):
         """Return the temperature we try to reach."""
         return self._device.target_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        set_dict: dict[str, Any] = {}
-        if ATTR_HVAC_MODE in kwargs:
-            self._apply_set_hvac_mode(
-                kwargs.get(ATTR_HVAC_MODE, self.hvac_mode), set_dict
-            )
+        if hvac_mode is not None:
+            self._apply_set_hvac_mode(hvac_mode, {})
 
-        if ATTR_TEMPERATURE in kwargs:
-            set_dict["target_temperature"] = kwargs.get(ATTR_TEMPERATURE)
-
-        if set_dict:
-            await self._device.set(set_dict)
+        await self._device.set({"target_temperature": temperature})
 
     @property
     def fan_mode(self) -> str | None:
@@ -385,8 +381,10 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         """Return the temperature we try to reach."""
         return self._zone.target_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await self._zone.set_target_temperature(
-            kwargs.get("temperature", self.target_temperature)
-        )
+        await self._zone.set_target_temperature(temperature)

--- a/homeassistant/components/melissa/climate.py
+++ b/homeassistant/components/melissa/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from homeassistant.components.climate import (
     FAN_AUTO,
@@ -14,7 +13,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import PRECISION_WHOLE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -142,10 +141,13 @@ class MelissaClimate(ClimateEntity):
         """Return the maximum supported temperature for the thermostat."""
         return 30
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temp = kwargs.get(ATTR_TEMPERATURE)
-        await self.async_send({self._api.TEMP: temp})
+        await self.async_send({self._api.TEMP: temperature})
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set fan mode."""

--- a/homeassistant/components/mill/climate.py
+++ b/homeassistant/components/mill/climate.py
@@ -1,7 +1,5 @@
 """Support for mill wifi-enabled home heaters."""
 
-from typing import Any
-
 import mill
 from mill_local import OperationMode
 import voluptuous as vol
@@ -14,7 +12,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_IP_ADDRESS,
     CONF_USERNAME,
     PRECISION_TENTHS,
@@ -122,10 +119,12 @@ class MillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntity):
 
         self._update_attr(heater)
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self.coordinator.mill_data_connection.set_heater_temp(
             self._id, float(temperature)
         )
@@ -212,10 +211,12 @@ class LocalMillHeater(CoordinatorEntity[MillDataUpdateCoordinator], ClimateEntit
 
         self._update_attr()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self.coordinator.mill_data_connection.set_target_temperature(
             float(temperature)
         )

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -287,11 +287,13 @@ class ModbusThermostat(BaseStructPlatform, RestoreEntity, ClimateEntity):
 
         await self.async_update()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        target_temperature = (
-            float(kwargs[ATTR_TEMPERATURE]) - self._offset
-        ) / self._scale
+        target_temperature = (temperature - self._offset) / self._scale
         if self._data_type in (
             DataType.INT16,
             DataType.INT32,

--- a/homeassistant/components/moehlenhoff_alpha2/climate.py
+++ b/homeassistant/components/moehlenhoff_alpha2/climate.py
@@ -10,7 +10,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -101,13 +101,14 @@ class Alpha2Climate(CoordinatorEntity[Alpha2BaseCoordinator], ClimateEntity):
         """Return the temperature we try to reach."""
         return float(self.heat_area.get("T_TARGET", 0.0))
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (target_temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-
         await self.coordinator.async_set_target_temperature(
-            self.heat_area_id, target_temperature
+            self.heat_area_id, temperature
         )
 
     @property

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -23,7 +23,6 @@ from homeassistant.components.climate import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_SUGGESTED_AREA,
-    ATTR_TEMPERATURE,
     PRECISION_HALVES,
     STATE_OFF,
     UnitOfTemperature,
@@ -379,10 +378,14 @@ class NetatmoThermostat(NetatmoBaseEntity, ClimateEntity):
 
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature for 2 hours."""
         await self._room.async_therm_set(
-            STATE_NETATMO_MANUAL, min(kwargs[ATTR_TEMPERATURE], DEFAULT_MAX_TEMP)
+            STATE_NETATMO_MANUAL, min(temperature, DEFAULT_MAX_TEMP)
         )
         self.async_write_ha_state()
 

--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -2,13 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pynobo import nobo
 
 from homeassistant.components.climate import (
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     PRESET_AWAY,
     PRESET_COMFORT,
     PRESET_ECO,
@@ -135,16 +131,18 @@ class NoboZone(ClimateEntity):
             self._id,
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
-        """Set new target temperature."""
-        if ATTR_TARGET_TEMP_LOW in kwargs:
-            low = round(kwargs[ATTR_TARGET_TEMP_LOW])
-            high = round(kwargs[ATTR_TARGET_TEMP_HIGH])
-            low = min(low, high)
-            high = max(low, high)
-            await self._nobo.async_update_zone(
-                self._id, temp_comfort_c=high, temp_eco_c=low
-            )
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
+        """Set new target temperature range."""
+        temperature_low = min(temperature_low, temperature_high)
+        temperature_high = max(temperature_low, temperature_high)
+        await self._nobo.async_update_zone(
+            self._id, temp_comfort_c=temperature_high, temp_eco_c=temperature_low
+        )
 
     async def async_update(self) -> None:
         """Fetch new state data for this zone."""

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from pyotgw import vars as gw_vars
 
@@ -18,7 +17,6 @@ from homeassistant.components.climate import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_TEMPERATURE,
     CONF_ID,
     PRECISION_HALVES,
     PRECISION_TENTHS,
@@ -247,13 +245,13 @@ class OpenThermClimate(ClimateEntity):
         """Set the preset mode."""
         _LOGGER.warning("Changing preset mode is not supported")
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if ATTR_TEMPERATURE in kwargs:
-            temp = float(kwargs[ATTR_TEMPERATURE])
-            if temp == self.target_temperature:
-                return
-            self._new_target_temperature = await self._gateway.gateway.set_target_temp(
-                temp, self.temporary_ovrd_mode
-            )
-            self.async_write_ha_state()
+        self._new_target_temperature = await self._gateway.gateway.set_target_temp(
+            temperature, self.temporary_ovrd_mode
+        )
+        self.async_write_ha_state()

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_heater_with_adjustable_temperature_setpoint.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import (
@@ -15,7 +13,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -149,9 +147,12 @@ class AtlanticElectricalHeaterWithAdjustableTemperatureSetpoint(
             return temperature.value_as_float
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
         await self.executor.async_execute_command(
             OverkizCommand.SET_TARGET_TEMPERATURE, temperature
         )

--- a/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_electrical_towel_dryer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -13,7 +13,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -102,10 +102,12 @@ class AtlanticElectricalTowelDryer(OverkizEntity, ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         if self.hvac_mode == HVACMode.AUTO:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_DEROGATED_TARGET_TEMPERATURE, temperature

--- a/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
+++ b/homeassistant/components/overkiz/climate_entities/atlantic_pass_apc_heating_zone.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -16,7 +16,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -193,10 +193,12 @@ class AtlanticPassAPCHeatingZone(OverkizEntity, ClimateEntity):
             float, self.executor.select_state(OverkizState.CORE_TARGET_TEMPERATURE)
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         if self.hvac_mode == HVACMode.AUTO:
             await self.executor.async_execute_command(
                 OverkizCommand.SET_COMFORT_HEATING_TARGET_TEMPERATURE,

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_hlrrwifi.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_hlrrwifi.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import (
@@ -20,7 +18,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -187,9 +185,12 @@ class HitachiAirToAirHeatPumpHLRRWIFI(OverkizEntity, ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = cast(float, kwargs.get(ATTR_TEMPERATURE))
         await self._global_control(target_temperature=int(temperature))
 
     @property

--- a/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_ovp.py
+++ b/homeassistant/components/overkiz/climate_entities/hitachi_air_to_air_heat_pump_ovp.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import (
@@ -20,7 +18,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -192,9 +190,13 @@ class HitachiAirToAirHeatPumpOVP(OverkizEntity, ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        await self._global_control(target_temperature=int(kwargs[ATTR_TEMPERATURE]))
+        await self._global_control(target_temperature=int(temperature))
 
     @property
     def preset_mode(self) -> str | None:

--- a/homeassistant/components/overkiz/climate_entities/somfy_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate_entities/somfy_heating_temperature_interface.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
 from homeassistant.components.climate import (
@@ -16,7 +14,7 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..coordinator import OverkizDataUpdateCoordinator
 from ..entity import OverkizEntity
@@ -172,10 +170,12 @@ class SomfyHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
             return temperature.value_as_float
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         if (
             mode := self.device.states[
                 OverkizState.OVP_HEATING_TEMPERATURE_INTERFACE_SETPOINT_MODE

--- a/homeassistant/components/overkiz/climate_entities/somfy_thermostat.py
+++ b/homeassistant/components/overkiz/climate_entities/somfy_thermostat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -14,7 +14,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -125,10 +125,12 @@ class SomfyThermostat(OverkizEntity, ClimateEntity):
             self.executor.select_state(OverkizState.CORE_DEROGATED_TARGET_TEMPERATURE),
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         await self.executor.async_execute_command(
             OverkizCommand.SET_DEROGATION,
             temperature,

--- a/homeassistant/components/overkiz/climate_entities/valve_heating_temperature_interface.py
+++ b/homeassistant/components/overkiz/climate_entities/valve_heating_temperature_interface.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 from pyoverkiz.enums import OverkizCommand, OverkizCommandParam, OverkizState
 
@@ -17,7 +17,6 @@ from homeassistant.components.climate import (
     HVACMode,
     UnitOfTemperature,
 )
-from homeassistant.const import ATTR_TEMPERATURE
 
 from ..const import DOMAIN
 from ..coordinator import OverkizDataUpdateCoordinator
@@ -98,13 +97,15 @@ class ValveHeatingTemperatureInterface(OverkizEntity, ClimateEntity):
 
         return None
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
-
         await self.executor.async_execute_command(
             OverkizCommand.SET_DEROGATION,
-            float(temperature),
+            temperature,
             OverkizCommandParam.FURTHER_NOTICE,
         )
 

--- a/homeassistant/components/radiotherm/climate.py
+++ b/homeassistant/components/radiotherm/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 import radiotherm
 
 from homeassistant.components.climate import (
@@ -18,7 +16,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -81,7 +79,7 @@ PARALLEL_UPDATES = 1
 CONF_HOLD_TEMP = "hold_temp"
 
 
-def round_temp(temperature):
+def round_temp(temperature: float) -> float:
     """Round a temperature to the resolution of the thermostat.
 
     RadioThermostats can handle 0.5 degree temps so the input
@@ -170,16 +168,18 @@ class RadioThermostat(RadioThermostatEntity, ClimateEntity):
             elif self.hvac_action == HVACAction.HEATING:
                 self._attr_target_temperature = data["t_heat"]
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self.hass.async_add_executor_job(self._set_temperature, temperature)
         self._attr_target_temperature = temperature
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
-    def _set_temperature(self, temperature: int) -> None:
+    def _set_temperature(self, temperature: float) -> None:
         """Set new target temperature."""
         temperature = round_temp(temperature)
         if self.hvac_mode == HVACMode.COOL:

--- a/homeassistant/components/screenlogic/climate.py
+++ b/homeassistant/components/screenlogic/climate.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 import logging
-from typing import Any
 
 from screenlogicpy.const.common import UNIT, ScreenLogicCommunicationError
 from screenlogicpy.const.data import ATTR, DEVICE, VALUE
@@ -19,7 +18,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -145,11 +144,12 @@ class ScreenLogicClimate(ScreenLogicPushEntity, ClimateEntity, RestoreEntity):
             return HEAT_MODE(self._last_preset).title
         return HEAT_MODE(self.entity_data[VALUE.HEAT_MODE][ATTR.VALUE]).title
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Change the setpoint of the heater."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            raise ValueError(f"Expected attribute {ATTR_TEMPERATURE}")
-
         try:
             await self.gateway.async_set_heat_temp(
                 int(self._data_key), int(temperature)

--- a/homeassistant/components/senz/climate.py
+++ b/homeassistant/components/senz/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from aiosenz import MODE_AUTO, Thermostat
 
 from homeassistant.components.climate import (
@@ -13,7 +11,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_TENTHS, UnitOfTemperature
+from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -105,8 +103,11 @@ class SENZClimate(CoordinatorEntity, ClimateEntity):
             await self._thermostat.manual()
         await self.coordinator.async_request_refresh()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temp: float = kwargs[ATTR_TEMPERATURE]
-        await self._thermostat.manual(temp)
+        await self._thermostat.manual(temperature)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/smarttub/climate.py
+++ b/homeassistant/components/smarttub/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from smarttub import Spa
 
 from homeassistant.components.climate import (
@@ -15,7 +13,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -119,9 +117,12 @@ class SmartTubThermostat(SmartTubEntity, ClimateEntity):
         """Return the target water temperature."""
         return self.spa_status.set_temperature
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        temperature = kwargs[ATTR_TEMPERATURE]
         await self.spa.set_temperature(temperature)
         await self.coordinator.async_refresh()
 

--- a/homeassistant/components/switchbee/climate.py
+++ b/homeassistant/components/switchbee/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from switchbee.api.central_unit import SwitchBeeDeviceOfflineError, SwitchBeeError
 from switchbee.const import (
     ApiAttribute,
@@ -24,7 +22,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -142,9 +140,13 @@ class SwitchBeeClimateEntity(SwitchBeeDeviceEntity[SwitchBeeThermostat], Climate
                 power=ApiStateCommand.ON, mode=HVAC_MODE_HASS_TO_SB[hvac_mode]
             )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await self._operate(target_temperature=kwargs[ATTR_TEMPERATURE])
+        await self._operate(target_temperature=int(temperature))
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set AC fan mode."""

--- a/homeassistant/components/switchbot_cloud/climate.py
+++ b/homeassistant/components/switchbot_cloud/climate.py
@@ -1,7 +1,5 @@
 """Support for SwitchBot Air Conditioner remotes."""
 
-from typing import Any
-
 from switchbot_api import AirConditionerCommands
 
 import homeassistant.components.climate as FanState
@@ -11,7 +9,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -78,7 +76,7 @@ class SwitchBotCloudAirConditionner(SwitchBotCloudEntity, ClimateEntity):
     ]
     _attr_hvac_mode = HVACMode.FAN_ONLY
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_target_temperature = 21
+    _attr_target_temperature = 21.0
     _attr_name = None
     _enable_turn_on_off_backwards_compatibility = False
 
@@ -112,10 +110,12 @@ class SwitchBotCloudAirConditionner(SwitchBotCloudEntity, ClimateEntity):
         self._attr_fan_mode = fan_mode
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set target temperature."""
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
         await self._do_send_command(temperature=temperature)
         self._attr_target_temperature = temperature
         self.async_write_ha_state()

--- a/homeassistant/components/switcher_kis/climate.py
+++ b/homeassistant/components/switcher_kis/climate.py
@@ -26,7 +26,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
@@ -183,7 +183,11 @@ class SwitcherClimateEntity(
                 f"response/error: {response or error}"
             )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
         if not self._remote.modes_features[self.coordinator.data.mode][
             "temperature_control"
@@ -191,9 +195,6 @@ class SwitcherClimateEntity(
             raise HomeAssistantError(
                 "Current mode doesn't support setting Target Temperature"
             )
-
-        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is None:
-            raise ValueError("No target temperature provided")
 
         await self._async_control_breeze_device(target_temp=int(temperature))
 

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -2,15 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -97,17 +95,20 @@ class TeslemetryClimateEntity(TeslemetryVehicleEntity, ClimateEntity):
             ("climate_state_climate_keeper_mode", "off"),
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the climate temperature."""
-        temp = kwargs[ATTR_TEMPERATURE]
         with handle_command():
             await self.wake_up_if_asleep()
             await self.api.set_temps(
-                driver_temp=temp,
-                passenger_temp=temp,
+                driver_temp=temperature,
+                passenger_temp=temperature,
             )
 
-        self.set((f"climate_state_{self.key}_setting", temp))
+        self.set((f"climate_state_{self.key}_setting", temperature))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from tessie_api import (
     set_climate_keeper_mode,
     set_temperature,
@@ -12,13 +10,12 @@ from tessie_api import (
 )
 
 from homeassistant.components.climate import (
-    ATTR_HVAC_MODE,
     ClimateEntity,
     ClimateEntityFeature,
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
+from homeassistant.const import PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -112,14 +109,17 @@ class TessieClimateEntity(TessieEntity, ClimateEntity):
             ("climate_state_climate_keeper_mode", "off"),
         )
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set the climate temperature."""
-        if mode := kwargs.get(ATTR_HVAC_MODE):
-            await self.async_set_hvac_mode(mode)
+        if hvac_mode is not None:
+            await self.async_set_hvac_mode(hvac_mode)
 
-        if temp := kwargs.get(ATTR_TEMPERATURE):
-            await self.run(set_temperature, temperature=temp)
-            self.set(("climate_state_driver_temp_setting", temp))
+        await self.run(set_temperature, temperature=temperature)
+        self.set(("climate_state_driver_temp_setting", temperature))
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the climate mode and state."""

--- a/homeassistant/components/tfiac/climate.py
+++ b/homeassistant/components/tfiac/climate.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from concurrent import futures
 from datetime import timedelta
 import logging
-from typing import Any
 
 from pytfiac import Tfiac
 import voluptuous as vol
@@ -24,7 +23,7 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.const import ATTR_TEMPERATURE, CONF_HOST, UnitOfTemperature
+from homeassistant.const import CONF_HOST, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -173,10 +172,13 @@ class TfiacClimate(ClimateEntity):
         """List of available swing modes."""
         return SUPPORT_SWING
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self._client.set_state(TARGET_TEMP, temp)
+        await self._client.set_state(TARGET_TEMP, temperature)
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""

--- a/homeassistant/components/toon/climate.py
+++ b/homeassistant/components/toon/climate.py
@@ -22,7 +22,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -105,9 +105,12 @@ class ToonThermostatDevice(ToonDisplayDeviceEntity, ClimateEntity):
         return {"heating_type": self.coordinator.data.agreement.heating_type}
 
     @toon_exception_handler
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Change the setpoint of the thermostat."""
-        temperature = kwargs.get(ATTR_TEMPERATURE)
         await self.coordinator.toon.set_current_setpoint(temperature)
 
     @toon_exception_handler

--- a/homeassistant/components/velbus/climate.py
+++ b/homeassistant/components/velbus/climate.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 from velbusaio.channels import Temperature as VelbusTemp
 
 from homeassistant.components.climate import (
@@ -12,7 +10,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -67,11 +65,13 @@ class VelbusClimate(VelbusEntity, ClimateEntity):
         return self._channel.get_state()
 
     @api_call
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperatures."""
-        if (temp := kwargs.get(ATTR_TEMPERATURE)) is None:
-            return
-        await self._channel.set_temp(temp)
+        await self._channel.set_temp(temperature)
         self.async_write_ha_state()
 
     @api_call

--- a/homeassistant/components/whirlpool/climate.py
+++ b/homeassistant/components/whirlpool/climate.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from aiohttp import ClientSession
 from whirlpool.aircon import Aircon, FanSpeed as AirconFanSpeed, Mode as AirconMode
@@ -24,7 +23,7 @@ from homeassistant.components.climate import (
     HVACMode,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -158,9 +157,13 @@ class AirConEntity(ClimateEntity):
         """Return the temperature we try to reach."""
         return self._aircon.get_temp()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature(
+        self,
+        temperature: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set new target temperature."""
-        await self._aircon.set_temp(kwargs.get(ATTR_TEMPERATURE))
+        await self._aircon.set_temp(temperature)
 
     @property
     def current_humidity(self) -> int:

--- a/homeassistant/components/yolink/climate.py
+++ b/homeassistant/components/yolink/climate.py
@@ -8,8 +8,6 @@ from yolink.const import ATTR_DEVICE_THERMOSTAT
 from yolink.thermostat_request_builder import ThermostatRequestBuilder, ThermostatState
 
 from homeassistant.components.climate import (
-    ATTR_TARGET_TEMP_HIGH,
-    ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_ON,
     PRESET_ECO,
@@ -130,24 +128,25 @@ class YoLinkClimateEntity(YoLinkEntity, ClimateEntity):
         self._attr_fan_mode = fan_mode
         self.async_write_ha_state()
 
-    async def async_set_temperature(self, **kwargs: Any) -> None:
+    async def async_set_target_temperature_range(
+        self,
+        temperature_high: float,
+        temperature_low: float,
+        hvac_mode: HVACMode | None = None,
+    ) -> None:
         """Set temperature."""
-        target_temp_low = kwargs.get(ATTR_TARGET_TEMP_LOW)
-        target_temp_high = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        if target_temp_low is not None:
-            await self.call_device(
-                ThermostatRequestBuilder.set_state_request(
-                    ThermostatState(lowTemp=target_temp_low)
-                )
+        await self.call_device(
+            ThermostatRequestBuilder.set_state_request(
+                ThermostatState(lowTemp=temperature_low)
             )
-            self._attr_target_temperature_low = target_temp_low
-        if target_temp_high is not None:
-            await self.call_device(
-                ThermostatRequestBuilder.set_state_request(
-                    ThermostatState(highTemp=target_temp_high)
-                )
+        )
+        await self.call_device(
+            ThermostatRequestBuilder.set_state_request(
+                ThermostatState(highTemp=temperature_high)
             )
-            self._attr_target_temperature_high = target_temp_high
+        )
+        self._attr_target_temperature_low = temperature_low
+        self._attr_target_temperature_high = temperature_high
         await self.coordinator.async_refresh()
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

For climate set_temperature, the logic has been divided between set_target_temperature and set_target_temperature_range. This still will work for external components implementing the `set_temperature` methods.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In the ClimateEntity, the `set_temperature` method had 2 possible options given the parameters passed to the service. For that reason, (and in order to make components implementations easier) it has been splited into `set_target_temperature` when a single temperature value is being passed on the service, and `set_target_temperature_range` when a range of temperatures is being given.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Architectural discussion: https://github.com/home-assistant/architecture/discussions/1071
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
