### PR TITLE
Add binary sensor entities to Traccar Server

### DIFF
--- a/homeassistant/components/traccar_server/__init__.py
+++ b/homeassistant/components/traccar_server/__init__.py
@@ -30,7 +30,11 @@ from .const import (
 )
 from .coordinator import TraccarServerCoordinator
 
-PLATFORMS: list[Platform] = [Platform.DEVICE_TRACKER, Platform.SENSOR]
+PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/traccar_server/binary_sensor.py
+++ b/homeassistant/components/traccar_server/binary_sensor.py
@@ -9,6 +9,7 @@ from typing import Generic, Literal, TypeVar, cast
 from pytraccar import DeviceModel
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -41,6 +42,7 @@ TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS = (
         key="attributes.motion",
         data_key="position",
         translation_key="motion",
+        device_class=BinarySensorDeviceClass.MOTION,
         value_fn=lambda x: x["attributes"].get("motion", False),
     ),
     TraccarServerBinarySensorEntityDescription[DeviceModel](

--- a/homeassistant/components/traccar_server/binary_sensor.py
+++ b/homeassistant/components/traccar_server/binary_sensor.py
@@ -38,6 +38,12 @@ class TraccarServerBinarySensorEntityDescription(
 
 TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS = (
     TraccarServerBinarySensorEntityDescription[DeviceModel](
+        key="attributes.motion",
+        data_key="position",
+        translation_key="motion",
+        value_fn=lambda x: x["attributes"].get("motion", False),
+    ),
+    TraccarServerBinarySensorEntityDescription[DeviceModel](
         key="status",
         data_key="device",
         translation_key="status",

--- a/homeassistant/components/traccar_server/binary_sensor.py
+++ b/homeassistant/components/traccar_server/binary_sensor.py
@@ -1,0 +1,91 @@
+"""Support for Traccar server binary sensors."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar, cast
+
+from pytraccar import DeviceModel
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TraccarServerCoordinator
+from .entity import TraccarServerEntity
+
+_T = TypeVar("_T")
+
+
+@dataclass(frozen=True, kw_only=True)
+class TraccarServerBinarySensorEntityDescription(
+    Generic[_T], BinarySensorEntityDescription
+):
+    """Describe Traccar Server sensor entity."""
+
+    data_key: Literal["position", "device", "geofence", "attributes"]
+    entity_registry_enabled_default = False
+    entity_category = EntityCategory.DIAGNOSTIC
+    value_fn: Callable[[_T], bool | None]
+
+
+TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS = (
+    TraccarServerBinarySensorEntityDescription[DeviceModel](
+        key="status",
+        data_key="device",
+        translation_key="status",
+        value_fn=lambda x: None if (s := x["status"]) == "unknown" else s == "online",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up binary sensor entities."""
+    coordinator: TraccarServerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        TraccarServerBinarySensor(
+            coordinator=coordinator,
+            device=entry["device"],
+            description=cast(TraccarServerBinarySensorEntityDescription, description),
+        )
+        for entry in coordinator.data.values()
+        for description in TRACCAR_SERVER_BINARY_SENSOR_ENTITY_DESCRIPTIONS
+    )
+
+
+class TraccarServerBinarySensor(TraccarServerEntity, BinarySensorEntity):
+    """Represent a traccar server binary sensor."""
+
+    _attr_has_entity_name = True
+    entity_description: TraccarServerBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: TraccarServerCoordinator,
+        device: DeviceModel,
+        description: TraccarServerBinarySensorEntityDescription[_T],
+    ) -> None:
+        """Initialize the Traccar Server sensor."""
+        super().__init__(coordinator, device)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{device['uniqueId']}_{description.data_key}_{description.key}"
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return if the binary sensor is on or not."""
+        return self.entity_description.value_fn(
+            getattr(self, f"traccar_{self.entity_description.data_key}")
+        )

--- a/homeassistant/components/traccar_server/device_tracker.py
+++ b/homeassistant/components/traccar_server/device_tracker.py
@@ -9,14 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    ATTR_CATEGORY,
-    ATTR_MOTION,
-    ATTR_STATUS,
-    ATTR_TRACCAR_ID,
-    ATTR_TRACKER,
-    DOMAIN,
-)
+from .const import ATTR_CATEGORY, ATTR_MOTION, ATTR_TRACCAR_ID, ATTR_TRACKER, DOMAIN
 from .coordinator import TraccarServerCoordinator
 from .entity import TraccarServerEntity
 
@@ -47,7 +40,6 @@ class TraccarServerDeviceTracker(TraccarServerEntity, TrackerEntity):
             **self.traccar_attributes,
             ATTR_CATEGORY: self.traccar_device["category"],
             ATTR_MOTION: self.traccar_position["attributes"].get("motion", False),
-            ATTR_STATUS: self.traccar_device["status"],
             ATTR_TRACCAR_ID: self.traccar_device["id"],
             ATTR_TRACKER: DOMAIN,
         }

--- a/homeassistant/components/traccar_server/device_tracker.py
+++ b/homeassistant/components/traccar_server/device_tracker.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import ATTR_CATEGORY, ATTR_MOTION, ATTR_TRACCAR_ID, ATTR_TRACKER, DOMAIN
+from .const import ATTR_CATEGORY, ATTR_TRACCAR_ID, ATTR_TRACKER, DOMAIN
 from .coordinator import TraccarServerCoordinator
 from .entity import TraccarServerEntity
 
@@ -39,7 +39,6 @@ class TraccarServerDeviceTracker(TraccarServerEntity, TrackerEntity):
         return {
             **self.traccar_attributes,
             ATTR_CATEGORY: self.traccar_device["category"],
-            ATTR_MOTION: self.traccar_position["attributes"].get("motion", False),
             ATTR_TRACCAR_ID: self.traccar_device["id"],
             ATTR_TRACKER: DOMAIN,
         }

--- a/homeassistant/components/traccar_server/icons.json
+++ b/homeassistant/components/traccar_server/icons.json
@@ -1,5 +1,14 @@
 {
   "entity": {
+    "binary_sensor": {
+      "status": {
+        "default": "mdi:access-point-minus",
+        "state": {
+          "off": "mdi:access-point-off",
+          "on": "mdi:access-point"
+        }
+      }
+    },
     "sensor": {
       "altitude": {
         "default": "mdi:altimeter"

--- a/homeassistant/components/traccar_server/strings.json
+++ b/homeassistant/components/traccar_server/strings.json
@@ -43,6 +43,15 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "status": {
+        "name": "Status",
+        "state": {
+          "off": "Offline",
+          "on": "Online"
+        }
+      }
+    },
     "sensor": {
       "address": {
         "name": "Address"

--- a/homeassistant/components/traccar_server/strings.json
+++ b/homeassistant/components/traccar_server/strings.json
@@ -44,6 +44,13 @@
   },
   "entity": {
     "binary_sensor": {
+      "motion": {
+        "name": "Motion",
+        "state": {
+          "off": "Stopped",
+          "on": "Moving"
+        }
+      },
       "status": {
         "name": "Status",
         "state": {

--- a/tests/components/traccar_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/traccar_server/snapshots/test_diagnostics.ambr
@@ -95,6 +95,7 @@
         'enity_id': 'binary_sensor.x_wing_motion',
         'state': dict({
           'attributes': dict({
+            'device_class': 'motion',
             'friendly_name': 'X-Wing Motion',
           }),
           'state': 'off',

--- a/tests/components/traccar_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/traccar_server/snapshots/test_diagnostics.ambr
@@ -82,12 +82,22 @@
             'gps_accuracy': 3.5,
             'latitude': '**REDACTED**',
             'longitude': '**REDACTED**',
-            'motion': False,
             'source_type': 'gps',
             'traccar_id': 0,
             'tracker': 'traccar_server',
           }),
           'state': 'not_home',
+        }),
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': False,
+        'enity_id': 'binary_sensor.x_wing_motion',
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Motion',
+          }),
+          'state': 'off',
         }),
         'unit_of_measurement': None,
       }),
@@ -243,6 +253,12 @@
     'entities': list([
       dict({
         'disabled': True,
+        'enity_id': 'binary_sensor.x_wing_motion',
+        'state': None,
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': True,
         'enity_id': 'binary_sensor.x_wing_status',
         'state': None,
         'unit_of_measurement': None,
@@ -361,6 +377,12 @@
     'entities': list([
       dict({
         'disabled': True,
+        'enity_id': 'binary_sensor.x_wing_motion',
+        'state': None,
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': True,
         'enity_id': 'binary_sensor.x_wing_status',
         'state': None,
         'unit_of_measurement': None,
@@ -406,7 +428,6 @@
             'gps_accuracy': 3.5,
             'latitude': '**REDACTED**',
             'longitude': '**REDACTED**',
-            'motion': False,
             'source_type': 'gps',
             'traccar_id': 0,
             'tracker': 'traccar_server',

--- a/tests/components/traccar_server/snapshots/test_diagnostics.ambr
+++ b/tests/components/traccar_server/snapshots/test_diagnostics.ambr
@@ -84,11 +84,21 @@
             'longitude': '**REDACTED**',
             'motion': False,
             'source_type': 'gps',
-            'status': 'online',
             'traccar_id': 0,
             'tracker': 'traccar_server',
           }),
           'state': 'not_home',
+        }),
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': False,
+        'enity_id': 'binary_sensor.x_wing_status',
+        'state': dict({
+          'attributes': dict({
+            'friendly_name': 'X-Wing Status',
+          }),
+          'state': 'on',
         }),
         'unit_of_measurement': None,
       }),
@@ -233,6 +243,12 @@
     'entities': list([
       dict({
         'disabled': True,
+        'enity_id': 'binary_sensor.x_wing_status',
+        'state': None,
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': True,
         'enity_id': 'sensor.x_wing_battery',
         'state': None,
         'unit_of_measurement': '%',
@@ -345,6 +361,12 @@
     'entities': list([
       dict({
         'disabled': True,
+        'enity_id': 'binary_sensor.x_wing_status',
+        'state': None,
+        'unit_of_measurement': None,
+      }),
+      dict({
+        'disabled': True,
         'enity_id': 'sensor.x_wing_battery',
         'state': None,
         'unit_of_measurement': '%',
@@ -386,7 +408,6 @@
             'longitude': '**REDACTED**',
             'motion': False,
             'source_type': 'gps',
-            'status': 'online',
             'traccar_id': 0,
             'tracker': 'traccar_server',
           }),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The following attributes have been removed from `device_tracker` entities provided by the Traccar server integration:
- `motion`
- `status`

All of these are now dedicated binary sensor entities that you can enable.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implements binary sensor platform for the Traccar Server integration, to initialize this, all current attributes that should be binary sensor entities on the existing device tracker entities now have dedicated binary sensor entities instead.

As there can be no deprecation when removing attributes, they have just been removed in this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32139

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
