### PR TITLE
Use EventStateChangedData type when firing state changed event

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -164,6 +164,19 @@ class ConfigSource(enum.StrEnum):
     YAML = "yaml"
 
 
+class EventStateChangedData(TypedDict):
+    """EventStateChanged data."""
+
+    entity_id: str
+    old_state: State | None
+    new_state: State | None
+
+
+if not TYPE_CHECKING:
+    # Use plain dict at runtime for performance
+    EventStateChangedData = dict
+
+
 # SOURCE_* are deprecated as of Home Assistant 2022.2, use ConfigSource instead
 _DEPRECATED_SOURCE_DISCOVERED = DeprecatedConstantEnum(
     ConfigSource.DISCOVERED, "2025.1"
@@ -2025,7 +2038,9 @@ class StateMachine:
         old_state.expire()
         self._bus._async_fire(  # pylint: disable=protected-access
             EVENT_STATE_CHANGED,
-            {"entity_id": entity_id, "old_state": old_state, "new_state": None},
+            EventStateChangedData(
+                entity_id=entity_id, old_state=old_state, new_state=None
+            ),
             context=context,
         )
         return True
@@ -2176,7 +2191,9 @@ class StateMachine:
         self._states[entity_id] = state
         self._bus._async_fire(  # pylint: disable=protected-access
             EVENT_STATE_CHANGED,
-            {"entity_id": entity_id, "old_state": old_state, "new_state": state},
+            EventStateChangedData(
+                entity_id=entity_id, old_state=old_state, new_state=state
+            ),
             context=context,
             time_fired=timestamp,
         )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -172,11 +172,6 @@ class EventStateChangedData(TypedDict):
     new_state: State | None
 
 
-if not TYPE_CHECKING:
-    # Use plain dict at runtime for performance
-    EventStateChangedData = dict
-
-
 # SOURCE_* are deprecated as of Home Assistant 2022.2, use ConfigSource instead
 _DEPRECATED_SOURCE_DISCOVERED = DeprecatedConstantEnum(
     ConfigSource.DISCOVERED, "2025.1"
@@ -2036,11 +2031,14 @@ class StateMachine:
             return False
 
         old_state.expire()
+        state_changed_data: EventStateChangedData = {
+            "entity_id": entity_id,
+            "old_state": old_state,
+            "new_state": None,
+        }
         self._bus._async_fire(  # pylint: disable=protected-access
             EVENT_STATE_CHANGED,
-            EventStateChangedData(
-                entity_id=entity_id, old_state=old_state, new_state=None
-            ),
+            state_changed_data,
             context=context,
         )
         return True
@@ -2189,11 +2187,14 @@ class StateMachine:
         if old_state is not None:
             old_state.expire()
         self._states[entity_id] = state
+        state_changed_data: EventStateChangedData = {
+            "entity_id": entity_id,
+            "old_state": old_state,
+            "new_state": state,
+        }
         self._bus._async_fire(  # pylint: disable=protected-access
             EVENT_STATE_CHANGED,
-            EventStateChangedData(
-                entity_id=entity_id, old_state=old_state, new_state=state
-            ),
+            state_changed_data,
             context=context,
             time_fired=timestamp,
         )

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -11,15 +11,7 @@ import functools as ft
 import logging
 from random import randint
 import time
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Concatenate,
-    Generic,
-    ParamSpec,
-    TypedDict,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
 
 import attr
 
@@ -33,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
+    EventStateChangedData,
     HassJob,
     HassJobType,
     HomeAssistant,
@@ -161,14 +154,6 @@ class TrackTemplateResult:
     template: Template
     last_result: Any
     result: Any
-
-
-class EventStateChangedData(TypedDict):
-    """EventStateChanged data."""
-
-    entity_id: str
-    old_state: State | None
-    new_state: State | None
 
 
 def threaded_listener_factory(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
-    EventStateChangedData,
+    EventStateChangedData as EventStateChangedData,  # noqa: PLC0414
     HassJob,
     HassJobType,
     HomeAssistant,

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -25,6 +25,7 @@ from homeassistant.const import (
 from homeassistant.core import (
     CALLBACK_TYPE,
     Event,
+    # Explicit reexport of 'EventStateChangedData' for backwards compatibility
     EventStateChangedData as EventStateChangedData,  # noqa: PLC0414
     HassJob,
     HassJobType,


### PR DESCRIPTION
## Proposed change
Improve typing by passing a TypedDict instance for `EventStateChangedData` instead of a dict to `_async_fire`. As this event is fired a lot, I've added a guard clause to fallback to `dict` at runtime.


> [!IMPORTANT]
> See https://github.com/home-assistant/core/pull/114740#discussion_r1549572311. As this is performance critical creating a new variable with a type assignment is the best option.


--
_Previous comment_

### Some performance tests
```py
from timeit import timeit

setup = """\
from typing import TypedDict, Literal, TYPE_CHECKING

class Data(TypedDict):
    action: Literal["create", "remove", "update"]
    floor_id: str
"""

fallback = """
if not TYPE_CHECKING:
    Data = dict
"""

print(f"TypedDict (without fallback): {timeit('Data(action="create", floor_id="1")', setup=setup)}")
print(f"TypedDict: {timeit('Data(action="create", floor_id="1")', setup=setup+fallback)}")
print(f"dict call: {timeit('dict(action="create", floor_id="1")')}")
print(f"dict expr: {timeit('{"action": "create", "floor_id": "1"}')}")
```

```
TypedDict (without fallback): 0.1299701250391081
TypedDict: 0.05231791699770838
dict call: 0.0533004580065608
dict expr: 0.036470500053837895
```

As seen above, using a plain `TypedDict` is a major performance impact (if used frequently). The fallback assignment to `dict` is basically similar to the explicit `dict` call. Although the fastest option would still be the explicit dict expression, I think the tradeoff compared to the `dict` call fallback solution is acceptable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
