### PR TITLE
Set last_reset for Solax daily totals

### DIFF
--- a/homeassistant/components/solax/coordinator.py
+++ b/homeassistant/components/solax/coordinator.py
@@ -1,9 +1,87 @@
 """Constants for the solax integration."""
 
-from solax import InverterResponse
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, override
 
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from solax import InverterResponse, RealTimeAPI
+from solax.inverter import InverterError
+
+from homeassistant.core import CALLBACK_TYPE, callback
+from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
 
 
-class SolaxDataUpdateCoordinator(DataUpdateCoordinator[InverterResponse]):
+@dataclass(slots=True)
+class Reset:
+    """Daily reset event."""
+
+    start_of_local_day: datetime
+
+
+type SolaxDataUpdate = InverterResponse | Reset
+
+
+class SolaxDataUpdateCoordinator(DataUpdateCoordinator[SolaxDataUpdate]):
     """DataUpdateCoordinator for solax."""
+
+    def __init__(self, api: RealTimeAPI, *args, **kwargs) -> None:
+        """Initialize DataUpdateCoordinator."""
+
+        super().__init__(*args, **kwargs)
+        self.api = api
+
+    _untrack_midnight: CALLBACK_TYPE | None = None
+
+    @override
+    async def _async_update_data(self) -> SolaxDataUpdate:
+        try:
+            return await self.api.get_data()
+        except InverterError as err:
+            raise UpdateFailed from err
+
+    @callback
+    def async_listen_for_midnight(self, today: datetime) -> None:
+        """Reset at start of local day."""
+        self.async_set_updated_data(
+            Reset(start_of_local_day=dt_util.start_of_local_day(today))
+        )
+
+    @override
+    @callback
+    def async_add_listener(
+        self, update_callback: CALLBACK_TYPE, context: Any = None
+    ) -> Callable[[], None]:
+        title_or_domain = (
+            self.config_entry.title if self.config_entry is not None else DOMAIN
+        )
+        if not self._listeners:
+            self.logger.debug("start tracking midnight for %s", title_or_domain)
+            self._untrack_midnight = async_track_time_change(
+                hass=self.hass,
+                action=self.async_listen_for_midnight,
+                hour=0,
+                minute=0,
+                second=0,
+            )
+
+        remove_listener = super().async_add_listener(
+            update_callback=update_callback, context=context
+        )
+
+        @callback
+        def wrap_remove_listener() -> None:
+            self._listeners[remove_listener] = self._listeners.pop(wrap_remove_listener)
+            remove_listener()
+            if not self._listeners and self._untrack_midnight:
+                self.logger.debug("stop tracking midnight for %s", title_or_domain)
+                self._untrack_midnight()
+                self._untrack_midnight = None
+
+        self._listeners[wrap_remove_listener] = self._listeners.pop(remove_listener)
+
+        return wrap_remove_listener

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from solax.units import Units
 
 from homeassistant.components.sensor import (
@@ -19,10 +21,12 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_change
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from . import SolaxConfigEntry
 from .const import DOMAIN, MANUFACTURER
@@ -31,57 +35,63 @@ from .coordinator import SolaxDataUpdateCoordinator
 DEFAULT_PORT = 80
 
 
-SENSOR_DESCRIPTIONS: dict[tuple[Units, bool], SensorEntityDescription] = {
-    (Units.C, False): SensorEntityDescription(
-        key=f"{Units.C}_{False}",
+SENSOR_DESCRIPTIONS: dict[tuple[Units, bool, bool], SensorEntityDescription] = {
+    (Units.C, False, False): SensorEntityDescription(
+        key=f"{Units.C}_{False}_{False}",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.KWH, False): SensorEntityDescription(
-        key=f"{Units.KWH}_{False}",
-        device_class=SensorDeviceClass.ENERGY,
+    (Units.KWH, False, True): SensorEntityDescription(
+        key=f"{Units.KWH}_{False}_{True}",
+        device_class=SensorDeviceClass.ENERGY_STORAGE,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.KWH, True): SensorEntityDescription(
-        key=f"{Units.KWH}_{True}",
+    (Units.KWH, False, False): SensorEntityDescription(
+        key=f"{Units.KWH}_{False}_{False}",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+    ),
+    (Units.KWH, True, False): SensorEntityDescription(
+        key=f"{Units.KWH}_{True}_{False}",
         device_class=SensorDeviceClass.ENERGY,
         native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
         state_class=SensorStateClass.TOTAL_INCREASING,
     ),
-    (Units.V, False): SensorEntityDescription(
-        key=f"{Units.V}_{False}",
+    (Units.V, False, False): SensorEntityDescription(
+        key=f"{Units.V}_{False}_{False}",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.A, False): SensorEntityDescription(
-        key=f"{Units.A}_{False}",
+    (Units.A, False, False): SensorEntityDescription(
+        key=f"{Units.A}_{False}_{False}",
         device_class=SensorDeviceClass.CURRENT,
         native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.W, False): SensorEntityDescription(
-        key=f"{Units.W}_{False}",
+    (Units.W, False, False): SensorEntityDescription(
+        key=f"{Units.W}_{False}_{False}",
         device_class=SensorDeviceClass.POWER,
         native_unit_of_measurement=UnitOfPower.WATT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.PERCENT, False): SensorEntityDescription(
-        key=f"{Units.PERCENT}_{False}",
+    (Units.PERCENT, False, False): SensorEntityDescription(
+        key=f"{Units.PERCENT}_{False}_{False}",
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.HZ, False): SensorEntityDescription(
-        key=f"{Units.HZ}_{False}",
+    (Units.HZ, False, False): SensorEntityDescription(
+        key=f"{Units.HZ}_{False}_{False}",
         device_class=SensorDeviceClass.FREQUENCY,
         native_unit_of_measurement=UnitOfFrequency.HERTZ,
         state_class=SensorStateClass.MEASUREMENT,
     ),
-    (Units.NONE, False): SensorEntityDescription(
-        key=f"{Units.NONE}_{False}",
+    (Units.NONE, False, False): SensorEntityDescription(
+        key=f"{Units.NONE}_{False}_{False}",
     ),
 }
 
@@ -98,29 +108,43 @@ async def async_setup_entry(
     serial = resp.serial_number
     version = resp.version
     entities: list[InverterSensorEntity] = []
+    last_reset = dt_util.start_of_local_day()
     for sensor, (idx, measurement) in api.inverter.sensor_map().items():
-        description = SENSOR_DESCRIPTIONS[(measurement.unit, measurement.is_monotonic)]
+        description = SENSOR_DESCRIPTIONS[
+            (measurement.unit, measurement.is_monotonic, measurement.storage)
+        ]
 
         uid = f"{serial}-{idx}"
-        entities.append(
-            InverterSensorEntity(
-                coordinator,
-                api.inverter.manufacturer,
-                uid,
-                serial,
-                version,
-                sensor,
-                description.native_unit_of_measurement,
-                description.state_class,
-                description.device_class,
-            )
+        entity = InverterSensorEntity(
+            coordinator,
+            api.inverter.manufacturer,
+            uid,
+            serial,
+            version,
+            sensor,
+            description.native_unit_of_measurement,
+            description.state_class,
+            description.device_class,
+            last_reset if measurement.resets_daily else None,
         )
+        if measurement.resets_daily:
+            entry.async_on_unload(
+                async_track_time_change(
+                    hass=hass,
+                    action=entity.async_listen_for_midnight,
+                    hour=0,
+                    minute=0,
+                    second=0,
+                )
+            )
+        entities.append(entity)
     async_add_entities(entities)
 
 
 class InverterSensorEntity(CoordinatorEntity, SensorEntity):
     """Class for a sensor."""
 
+    value: Any
     _attr_should_poll = False
 
     def __init__(
@@ -134,6 +158,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
         unit: str | None,
         state_class: SensorStateClass | str | None,
         device_class: SensorDeviceClass | None,
+        last_reset=None,
     ) -> None:
         """Initialize an inverter sensor."""
         super().__init__(coordinator)
@@ -141,6 +166,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_name = f"{manufacturer} {serial} {key}"
         self._attr_native_unit_of_measurement = unit
         self._attr_state_class = state_class
+        self._attr_last_reset = last_reset
         self._attr_device_class = device_class
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
@@ -149,6 +175,13 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
             sw_version=version,
         )
         self.key = key
+
+    @callback
+    def async_listen_for_midnight(self, today: datetime) -> None:
+        """Reset at midnight."""
+        self._attr_last_reset = dt_util.start_of_local_day(today)
+        self.value = 0
+        self.async_schedule_update_ha_state()
 
     @property
     def native_value(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR competes with #107615 to fix #109504.
I added the `resets_daily` and `storage` properties to solax==3.1.0.
This allows us to further distinguish between `UnitOfEnergy.KILO_WATT_HOUR` sensors: grand totals, daily totals and energy storage levels. (Energy storage and daily totals were lumped together.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #109504
- This PR is related to issue: #107615
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
