### PR TITLE
Migrate sabnzbd to use data update coordinator

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1184,6 +1184,7 @@ omit =
     homeassistant/components/rympro/coordinator.py
     homeassistant/components/rympro/sensor.py
     homeassistant/components/sabnzbd/__init__.py
+    homeassistant/components/sabnzbd/coordinator.py
     homeassistant/components/sabnzbd/sensor.py
     homeassistant/components/saj/sensor.py
     homeassistant/components/satel_integra/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1177,8 +1177,8 @@ build.json @home-assistant/supervisor
 /tests/components/ruuvitag_ble/ @akx
 /homeassistant/components/rympro/ @OnFreund @elad-bar @maorcc
 /tests/components/rympro/ @OnFreund @elad-bar @maorcc
-/homeassistant/components/sabnzbd/ @shaiu
-/tests/components/sabnzbd/ @shaiu
+/homeassistant/components/sabnzbd/ @shaiu @jpbede
+/tests/components/sabnzbd/ @shaiu @jpbede
 /homeassistant/components/saj/ @fredericvl
 /homeassistant/components/samsungtv/ @chemelli74 @epenet
 /tests/components/samsungtv/ @chemelli74 @epenet

--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -172,12 +172,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not sab_api:
         raise ConfigEntryNotReady
 
+    await migrate_unique_id(hass, entry)
+    update_device_identifiers(hass, entry)
+
     coordinator = SabnzbdUpdateCoordinator(hass, sab_api)
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-
-    await migrate_unique_id(hass, entry)
-    update_device_identifiers(hass, entry)
 
     @callback
     def extract_api(

--- a/homeassistant/components/sabnzbd/__init__.py
+++ b/homeassistant/components/sabnzbd/__init__.py
@@ -6,7 +6,6 @@ from collections.abc import Callable, Coroutine
 import logging
 from typing import Any
 
-from pysabnzbd import SabnzbdApiException
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry, ConfigEntryState
@@ -23,9 +22,7 @@ from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import async_get
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.entity_registry import RegistryEntry, async_migrate_entries
-from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -37,15 +34,11 @@ from .const import (
     DEFAULT_SPEED_LIMIT,
     DEFAULT_SSL,
     DOMAIN,
-    KEY_API,
-    KEY_API_DATA,
-    KEY_NAME,
     SERVICE_PAUSE,
     SERVICE_RESUME,
     SERVICE_SET_SPEED,
-    SIGNAL_SABNZBD_UPDATED,
-    UPDATE_INTERVAL,
 )
+from .coordinator import SabnzbdUpdateCoordinator
 from .sab import get_client
 from .sensor import OLD_SENSOR_KEYS
 
@@ -179,30 +172,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not sab_api:
         raise ConfigEntryNotReady
 
-    sab_api_data = SabnzbdApiData(sab_api)
-
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        KEY_API: sab_api,
-        KEY_API_DATA: sab_api_data,
-        KEY_NAME: entry.data[CONF_NAME],
-    }
+    coordinator = SabnzbdUpdateCoordinator(hass, sab_api)
+    await coordinator.async_config_entry_first_refresh()
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     await migrate_unique_id(hass, entry)
     update_device_identifiers(hass, entry)
 
     @callback
     def extract_api(
-        func: Callable[[ServiceCall, SabnzbdApiData], Coroutine[Any, Any, None]],
+        func: Callable[
+            [ServiceCall, SabnzbdUpdateCoordinator], Coroutine[Any, Any, None]
+        ],
     ) -> Callable[[ServiceCall], Coroutine[Any, Any, None]]:
         """Define a decorator to get the correct api for a service call."""
 
         async def wrapper(call: ServiceCall) -> None:
             """Wrap the service function."""
             entry_id = async_get_entry_id_for_service_call(hass, call)
-            api_data = hass.data[DOMAIN][entry_id][KEY_API_DATA]
+            coordinator: SabnzbdUpdateCoordinator = hass.data[DOMAIN][entry_id]
 
             try:
-                await func(call, api_data)
+                await func(call, coordinator)
             except Exception as err:
                 raise HomeAssistantError(
                     f"Error while executing {func.__name__}: {err}"
@@ -211,17 +202,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return wrapper
 
     @extract_api
-    async def async_pause_queue(call: ServiceCall, api: SabnzbdApiData) -> None:
-        await api.async_pause_queue()
+    async def async_pause_queue(
+        call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
+    ) -> None:
+        await coordinator.sab_api.pause_queue()
 
     @extract_api
-    async def async_resume_queue(call: ServiceCall, api: SabnzbdApiData) -> None:
-        await api.async_resume_queue()
+    async def async_resume_queue(
+        call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
+    ) -> None:
+        await coordinator.sab_api.resume_queue()
 
     @extract_api
-    async def async_set_queue_speed(call: ServiceCall, api: SabnzbdApiData) -> None:
+    async def async_set_queue_speed(
+        call: ServiceCall, coordinator: SabnzbdUpdateCoordinator
+    ) -> None:
         speed = call.data.get(ATTR_SPEED)
-        await api.async_set_queue_speed(speed)
+        await coordinator.sab_api.set_speed_limit(speed)
 
     for service, method, schema in (
         (SERVICE_PAUSE, async_pause_queue, SERVICE_BASE_SCHEMA),
@@ -232,18 +229,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             continue
 
         hass.services.async_register(DOMAIN, service, method, schema=schema)
-
-    async def async_update_sabnzbd(now):
-        """Refresh SABnzbd queue data."""
-        try:
-            await sab_api.refresh_data()
-            async_dispatcher_send(hass, SIGNAL_SABNZBD_UPDATED, None)
-        except SabnzbdApiException as err:
-            _LOGGER.error(err)
-
-    entry.async_on_unload(
-        async_track_time_interval(hass, async_update_sabnzbd, UPDATE_INTERVAL)
-    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -268,42 +253,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, service_name)
 
     return unload_ok
-
-
-class SabnzbdApiData:
-    """Class for storing/refreshing sabnzbd api queue data."""
-
-    def __init__(self, sab_api):
-        """Initialize component."""
-        self.sab_api = sab_api
-
-    async def async_pause_queue(self):
-        """Pause Sabnzbd queue."""
-
-        try:
-            return await self.sab_api.pause_queue()
-        except SabnzbdApiException as err:
-            _LOGGER.error(err)
-            return False
-
-    async def async_resume_queue(self):
-        """Resume Sabnzbd queue."""
-
-        try:
-            return await self.sab_api.resume_queue()
-        except SabnzbdApiException as err:
-            _LOGGER.error(err)
-            return False
-
-    async def async_set_queue_speed(self, limit):
-        """Set speed limit for the Sabnzbd queue."""
-
-        try:
-            return await self.sab_api.set_speed_limit(limit)
-        except SabnzbdApiException as err:
-            _LOGGER.error(err)
-            return False
-
-    def get_queue_field(self, field):
-        """Return the value for the given field from the Sabnzbd queue."""
-        return self.sab_api.queue.get(field)

--- a/homeassistant/components/sabnzbd/const.py
+++ b/homeassistant/components/sabnzbd/const.py
@@ -1,7 +1,5 @@
 """Constants for the Sabnzbd component."""
 
-from datetime import timedelta
-
 DOMAIN = "sabnzbd"
 DATA_SABNZBD = "sabnzbd"
 
@@ -14,14 +12,6 @@ DEFAULT_PORT = 8080
 DEFAULT_SPEED_LIMIT = "100"
 DEFAULT_SSL = False
 
-UPDATE_INTERVAL = timedelta(seconds=30)
-
 SERVICE_PAUSE = "pause"
 SERVICE_RESUME = "resume"
 SERVICE_SET_SPEED = "set_speed"
-
-SIGNAL_SABNZBD_UPDATED = "sabnzbd_updated"
-
-KEY_API = "api"
-KEY_API_DATA = "api_data"
-KEY_NAME = "name"

--- a/homeassistant/components/sabnzbd/coordinator.py
+++ b/homeassistant/components/sabnzbd/coordinator.py
@@ -1,0 +1,40 @@
+"""DataUpdateCoordinator for the SABnzbd integration."""
+
+from datetime import timedelta
+import logging
+from typing import Any
+
+from pysabnzbd import SabnzbdApi, SabnzbdApiException
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SabnzbdUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """The SABnzbd update coordinator."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        sab_api: SabnzbdApi,
+    ) -> None:
+        """Initialize the SABnzbd update coordinator."""
+        self.sab_api = sab_api
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="SABnzbd",
+            update_interval=timedelta(seconds=30),
+        )
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Get the latest data from the SABnzbd API."""
+        try:
+            await self.sab_api.refresh_data()
+        except SabnzbdApiException as err:
+            raise UpdateFailed("Error while fetching data") from err
+
+        return self.sab_api.queue

--- a/homeassistant/components/sabnzbd/manifest.json
+++ b/homeassistant/components/sabnzbd/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "sabnzbd",
   "name": "SABnzbd",
-  "codeowners": ["@shaiu"],
+  "codeowners": ["@shaiu", "@jpbede"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sabnzbd",
   "iot_class": "local_polling",

--- a/homeassistant/components/sabnzbd/sensor.py
+++ b/homeassistant/components/sabnzbd/sensor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 
 from homeassistant.components.sensor import (
@@ -28,7 +27,6 @@ class SabnzbdSensorEntityDescription(SensorEntityDescription):
     """Describes Sabnzbd sensor entity."""
 
     key: str
-    value_fn: Callable[[StateType], StateType] = lambda value: value
 
 
 SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
@@ -40,9 +38,8 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         key="kbpersec",
         translation_key="speed",
         device_class=SensorDeviceClass.DATA_RATE,
-        native_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        native_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
         state_class=SensorStateClass.MEASUREMENT,
-        value_fn=lambda value: float(value) / 1024 if value is not None else None,
     ),
     SabnzbdSensorEntityDescription(
         key="mb",
@@ -167,6 +164,4 @@ class SabnzbdSensor(CoordinatorEntity[SabnzbdUpdateCoordinator], SensorEntity):
     @property
     def native_value(self) -> StateType:
         """Return latest sensor data."""
-        return self.entity_description.value_fn(
-            self.coordinator.data.get(self.entity_description.key)
-        )
+        return self.coordinator.data.get(self.entity_description.key)

--- a/homeassistant/components/sabnzbd/sensor.py
+++ b/homeassistant/components/sabnzbd/sensor.py
@@ -39,6 +39,8 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         translation_key="speed",
         device_class=SensorDeviceClass.DATA_RATE,
         native_unit_of_measurement=UnitOfDataRate.KILOBYTES_PER_SECOND,
+        suggested_unit_of_measurement=UnitOfDataRate.MEGABYTES_PER_SECOND,
+        suggested_display_precision=1,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     SabnzbdSensorEntityDescription(
@@ -73,6 +75,7 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         key="noofslots_total",
         translation_key="queue_count",
         state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=2,
     ),
     SabnzbdSensorEntityDescription(
         key="day_size",
@@ -81,6 +84,7 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_SIZE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
     ),
     SabnzbdSensorEntityDescription(
         key="week_size",
@@ -89,6 +93,7 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_SIZE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
     ),
     SabnzbdSensorEntityDescription(
         key="month_size",
@@ -97,6 +102,7 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.DATA_SIZE,
         entity_registry_enabled_default=False,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
     ),
     SabnzbdSensorEntityDescription(
         key="total_size",
@@ -104,6 +110,7 @@ SENSOR_TYPES: tuple[SabnzbdSensorEntityDescription, ...] = (
         native_unit_of_measurement=UnitOfInformation.GIGABYTES,
         device_class=SensorDeviceClass.DATA_SIZE,
         state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
     ),
 )
 


### PR DESCRIPTION
## Proposed change
Migrate `sabnzbd` to use a `DataUpdateCoordinator` instead of the dispatcher in order to add other entity platforms later.

Also add myself as code owner, as I start to refactor the integration a bit and maybe the package as well, to add typing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
