### PR TITLE
Ensure async_test_home_assistant is passed a str in storage tests

### DIFF
--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -627,7 +627,7 @@ async def test_saving_load_round_trip(tmpdir: py.path.local) -> None:
     """Test saving and loading round trip."""
     loop = asyncio.get_running_loop()
     config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
 
         class NamedTupleSubclass(NamedTuple):
             """A NamedTuple subclass."""
@@ -671,7 +671,7 @@ async def test_loading_corrupt_core_file(
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
-    async with async_test_home_assistant(config_dir=tmp_storage) as hass:
+    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
         storage_key = "core.anything"
         store = storage.Store(
             hass, MOCK_VERSION_2, storage_key, minor_version=MOCK_MINOR_VERSION_1
@@ -730,7 +730,7 @@ async def test_loading_corrupt_file_known_domain(
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
-    async with async_test_home_assistant(config_dir=tmp_storage) as hass:
+    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
         hass.config.components.add("testdomain")
         storage_key = "testdomain.testkey"
 
@@ -787,7 +787,7 @@ async def test_os_error_is_fatal(tmpdir: py.path.local) -> None:
     """Test OSError during load is fatal."""
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=tmp_storage) as hass:
+    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
         store = storage.Store(
             hass, MOCK_VERSION_2, MOCK_KEY, minor_version=MOCK_MINOR_VERSION_1
         )
@@ -817,7 +817,7 @@ async def test_json_load_failure(tmpdir: py.path.local) -> None:
     """Test json load raising HomeAssistantError."""
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=tmp_storage) as hass:
+    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
         store = storage.Store(
             hass, MOCK_VERSION_2, MOCK_KEY, minor_version=MOCK_MINOR_VERSION_1
         )
@@ -883,7 +883,7 @@ async def test_store_manager_caching(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         assert (
             store_manager.async_fetch("integration1") is None
@@ -957,7 +957,7 @@ async def test_store_manager_caching(
 
         await hass.async_stop(force=True)
 
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         assert store_manager.async_fetch("integration1") is None
         assert store_manager.async_fetch("integration2") is None
@@ -992,7 +992,7 @@ async def test_store_manager_caching(
 
     # Now make sure everything still works when we do not
     # manually load the storage manager
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         integration1 = storage.Store(hass, 1, "integration1")
         assert await integration1.async_load() == {"integration1": "updated"}
         await integration1.async_save({"integration1": "updated2"})
@@ -1006,7 +1006,7 @@ async def test_store_manager_caching(
         await hass.async_stop(force=True)
 
     # Now remove the stores
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         await store_manager.async_preload(["integration1", "integration2"])
@@ -1031,7 +1031,7 @@ async def test_store_manager_caching(
         await hass.async_stop(force=True)
 
     # Now make sure the stores are removed and another run works
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         await store_manager.async_preload(["integration1"])
@@ -1058,7 +1058,7 @@ async def test_store_manager_sub_dirs(tmpdir: py.path.local) -> None:
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         assert store_manager.async_fetch("subdir/integration1") is None
@@ -1087,7 +1087,7 @@ async def test_store_manager_cleanup_after_started(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         hass.set_state(CoreState.not_running)
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
@@ -1137,7 +1137,7 @@ async def test_store_manager_cleanup_after_stop(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=config_dir) as hass:
+    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
         hass.set_state(CoreState.not_running)
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()

--- a/tests/helpers/test_storage.py
+++ b/tests/helpers/test_storage.py
@@ -627,7 +627,7 @@ async def test_saving_load_round_trip(tmpdir: py.path.local) -> None:
     """Test saving and loading round trip."""
     loop = asyncio.get_running_loop()
     config_dir = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
 
         class NamedTupleSubclass(NamedTuple):
             """A NamedTuple subclass."""
@@ -671,7 +671,7 @@ async def test_loading_corrupt_core_file(
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
-    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
+    async with async_test_home_assistant(config_dir=tmp_storage.strpath) as hass:
         storage_key = "core.anything"
         store = storage.Store(
             hass, MOCK_VERSION_2, storage_key, minor_version=MOCK_MINOR_VERSION_1
@@ -730,7 +730,7 @@ async def test_loading_corrupt_file_known_domain(
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
 
-    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
+    async with async_test_home_assistant(config_dir=tmp_storage.strpath) as hass:
         hass.config.components.add("testdomain")
         storage_key = "testdomain.testkey"
 
@@ -787,7 +787,7 @@ async def test_os_error_is_fatal(tmpdir: py.path.local) -> None:
     """Test OSError during load is fatal."""
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
+    async with async_test_home_assistant(config_dir=tmp_storage.strpath) as hass:
         store = storage.Store(
             hass, MOCK_VERSION_2, MOCK_KEY, minor_version=MOCK_MINOR_VERSION_1
         )
@@ -817,7 +817,7 @@ async def test_json_load_failure(tmpdir: py.path.local) -> None:
     """Test json load raising HomeAssistantError."""
     loop = asyncio.get_running_loop()
     tmp_storage = await loop.run_in_executor(None, tmpdir.mkdir, "temp_storage")
-    async with async_test_home_assistant(config_dir=str(tmp_storage)) as hass:
+    async with async_test_home_assistant(config_dir=tmp_storage.strpath) as hass:
         store = storage.Store(
             hass, MOCK_VERSION_2, MOCK_KEY, minor_version=MOCK_MINOR_VERSION_1
         )
@@ -883,7 +883,7 @@ async def test_store_manager_caching(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         assert (
             store_manager.async_fetch("integration1") is None
@@ -957,7 +957,7 @@ async def test_store_manager_caching(
 
         await hass.async_stop(force=True)
 
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         assert store_manager.async_fetch("integration1") is None
         assert store_manager.async_fetch("integration2") is None
@@ -992,7 +992,7 @@ async def test_store_manager_caching(
 
     # Now make sure everything still works when we do not
     # manually load the storage manager
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         integration1 = storage.Store(hass, 1, "integration1")
         assert await integration1.async_load() == {"integration1": "updated"}
         await integration1.async_save({"integration1": "updated2"})
@@ -1006,7 +1006,7 @@ async def test_store_manager_caching(
         await hass.async_stop(force=True)
 
     # Now remove the stores
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         await store_manager.async_preload(["integration1", "integration2"])
@@ -1031,7 +1031,7 @@ async def test_store_manager_caching(
         await hass.async_stop(force=True)
 
     # Now make sure the stores are removed and another run works
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         await store_manager.async_preload(["integration1"])
@@ -1058,7 +1058,7 @@ async def test_store_manager_sub_dirs(tmpdir: py.path.local) -> None:
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
         assert store_manager.async_fetch("subdir/integration1") is None
@@ -1087,7 +1087,7 @@ async def test_store_manager_cleanup_after_started(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         hass.set_state(CoreState.not_running)
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()
@@ -1137,7 +1137,7 @@ async def test_store_manager_cleanup_after_stop(
 
     config_dir = await loop.run_in_executor(None, _setup_mock_storage)
 
-    async with async_test_home_assistant(config_dir=str(config_dir)) as hass:
+    async with async_test_home_assistant(config_dir=config_dir.strpath) as hass:
         hass.set_state(CoreState.not_running)
         store_manager = storage.get_internal_store_manager(hass)
         await store_manager.async_initialize()


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A Path worked, but it was technically typed to want a str and might break in the future


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
