### PR TITLE
Refactor ConfigStore to avoid needing to pass config_dir

### DIFF
--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -95,9 +95,7 @@ async def async_migrator(
     return config
 
 
-def get_internal_store_manager(
-    hass: HomeAssistant, config_dir: str | None = None
-) -> _StoreManager:
+def get_internal_store_manager(hass: HomeAssistant) -> _StoreManager:
     """Get the store manager.
 
     This function is not part of the API and should only be
@@ -105,7 +103,7 @@ def get_internal_store_manager(
     guaranteed to be stable.
     """
     if STORAGE_MANAGER not in hass.data:
-        manager = _StoreManager(hass, config_dir or hass.config.config_dir)
+        manager = _StoreManager(hass)
         hass.data[STORAGE_MANAGER] = manager
     return hass.data[STORAGE_MANAGER]
 
@@ -116,13 +114,13 @@ class _StoreManager:
     The store manager is used to cache and manage storage files.
     """
 
-    def __init__(self, hass: HomeAssistant, config_dir: str) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Initialize storage manager class."""
         self._hass = hass
         self._invalidated: set[str] = set()
         self._files: set[str] | None = None
         self._data_preload: dict[str, json_util.JsonValueType] = {}
-        self._storage_path: Path = Path(config_dir).joinpath(STORAGE_DIR)
+        self._storage_path: Path = Path(hass.config.config_dir).joinpath(STORAGE_DIR)
         self._cancel_cleanup: asyncio.TimerHandle | None = None
 
     async def async_initialize(self) -> None:
@@ -251,7 +249,6 @@ class Store(Generic[_T]):
         encoder: type[JSONEncoder] | None = None,
         minor_version: int = 1,
         read_only: bool = False,
-        config_dir: str | None = None,
     ) -> None:
         """Initialize storage class."""
         self.version = version
@@ -268,7 +265,7 @@ class Store(Generic[_T]):
         self._atomic_writes = atomic_writes
         self._read_only = read_only
         self._next_write_time = 0.0
-        self._manager = get_internal_store_manager(hass, config_dir)
+        self._manager = get_internal_store_manager(hass)
 
     @cached_property
     def path(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2288,6 +2288,7 @@ async def test_additional_data_in_core_config(
 ) -> None:
     """Test that we can handle additional data in core configuration."""
     config = ha.Config(hass, "/test/ha-config")
+    config.async_initialize()
     hass_storage[ha.CORE_STORAGE_KEY] = {
         "version": 1,
         "data": {"location_name": "Test Name", "additional_valid_key": "value"},
@@ -2301,6 +2302,7 @@ async def test_incorrect_internal_external_url(
 ) -> None:
     """Test that we warn when detecting invalid internal/external url."""
     config = ha.Config(hass, "/test/ha-config")
+    config.async_initialize()
 
     hass_storage[ha.CORE_STORAGE_KEY] = {
         "version": 1,
@@ -2314,6 +2316,7 @@ async def test_incorrect_internal_external_url(
     assert "Invalid internal_url set" not in caplog.text
 
     config = ha.Config(hass, "/test/ha-config")
+    config.async_initialize()
 
     hass_storage[ha.CORE_STORAGE_KEY] = {
         "version": 1,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor ConfigStore to avoid needing to pass config_dir

Fixes the benchmark script as it failed with `AttributeError: 'HomeAssistant' object has no attribute 'config'`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
