### PR TITLE
Fix zha ikea starkvind capabilities and modes being incorrectly exposed

### DIFF
--- a/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
+++ b/homeassistant/components/zha/core/cluster_handlers/manufacturerspecific.py
@@ -401,6 +401,11 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
         return self.cluster.get("fan_mode")
 
     @property
+    def fan_speed(self) -> int | None:
+        """Return current fan speed."""
+        return self.cluster.get("fan_speed")
+
+    @property
     def fan_mode_sequence(self) -> int | None:
         """Return possible fan mode speeds."""
         return self.cluster.get("fan_mode_sequence")
@@ -412,6 +417,7 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
     async def async_update(self) -> None:
         """Retrieve latest state."""
         await self.get_attribute_value("fan_mode", from_cache=False)
+        await self.get_attribute_value("fan_speed", from_cache=False)
 
     @callback
     def attribute_updated(self, attrid: int, value: Any, _: Any) -> None:
@@ -420,7 +426,7 @@ class IkeaAirPurifierClusterHandler(ClusterHandler):
         self.debug(
             "Attribute report '%s'[%s] = %s", self.cluster.name, attr_name, value
         )
-        if attr_name == "fan_mode":
+        if attr_name in ("fan_mode", "fan_speed"):
             self.async_send_signal(
                 f"{self.unique_id}_{SIGNAL_ATTR_UPDATED}", attrid, attr_name, value
             )

--- a/tests/components/zha/test_fan.py
+++ b/tests/components/zha/test_fan.py
@@ -647,17 +647,17 @@ async def test_fan_ikea(
     ),
     [
         (None, STATE_OFF, None, None),
-        ({"fan_mode": 0}, STATE_OFF, 0, None),
-        ({"fan_mode": 1}, STATE_ON, 10, PRESET_MODE_AUTO),
-        ({"fan_mode": 10}, STATE_ON, 20, "Speed 1"),
-        ({"fan_mode": 15}, STATE_ON, 30, "Speed 1.5"),
-        ({"fan_mode": 20}, STATE_ON, 40, "Speed 2"),
-        ({"fan_mode": 25}, STATE_ON, 50, "Speed 2.5"),
-        ({"fan_mode": 30}, STATE_ON, 60, "Speed 3"),
-        ({"fan_mode": 35}, STATE_ON, 70, "Speed 3.5"),
-        ({"fan_mode": 40}, STATE_ON, 80, "Speed 4"),
-        ({"fan_mode": 45}, STATE_ON, 90, "Speed 4.5"),
-        ({"fan_mode": 50}, STATE_ON, 100, "Speed 5"),
+        ({"fan_mode": 0, "fan_speed": 0}, STATE_OFF, 0, None),
+        ({"fan_mode": 1, "fan_speed": 6}, STATE_ON, 60, PRESET_MODE_AUTO),
+        ({"fan_mode": 2, "fan_speed": 2}, STATE_ON, 20, None),
+        ({"fan_mode": 3, "fan_speed": 3}, STATE_ON, 30, None),
+        ({"fan_mode": 4, "fan_speed": 4}, STATE_ON, 40, None),
+        ({"fan_mode": 5, "fan_speed": 5}, STATE_ON, 50, None),
+        ({"fan_mode": 6, "fan_speed": 6}, STATE_ON, 60, None),
+        ({"fan_mode": 7, "fan_speed": 7}, STATE_ON, 70, None),
+        ({"fan_mode": 8, "fan_speed": 8}, STATE_ON, 80, None),
+        ({"fan_mode": 9, "fan_speed": 9}, STATE_ON, 90, None),
+        ({"fan_mode": 10, "fan_speed": 10}, STATE_ON, 100, None),
     ],
 )
 async def test_fan_ikea_init(
@@ -691,7 +691,7 @@ async def test_fan_ikea_update_entity(
 ) -> None:
     """Test ZHA fan platform."""
     cluster = zigpy_device_ikea.endpoints.get(1).ikea_airpurifier
-    cluster.PLUGGED_ATTR_READS = {"fan_mode": 0}
+    cluster.PLUGGED_ATTR_READS = {"fan_mode": 0, "fan_speed": 0}
 
     zha_device = await zha_device_joined_restored(zigpy_device_ikea)
     entity_id = find_entity_id(Platform.FAN, zha_device, hass)
@@ -713,22 +713,22 @@ async def test_fan_ikea_update_entity(
     )
     assert hass.states.get(entity_id).state == STATE_OFF
     if zha_device_joined_restored.name == "zha_device_joined":
-        assert cluster.read_attributes.await_count == 4
+        assert cluster.read_attributes.await_count == 5
     else:
-        assert cluster.read_attributes.await_count == 7
+        assert cluster.read_attributes.await_count == 8
 
-    cluster.PLUGGED_ATTR_READS = {"fan_mode": 1}
+    cluster.PLUGGED_ATTR_READS = {"fan_mode": 1, "fan_speed": 6}
     await hass.services.async_call(
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == STATE_ON
-    assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 10
+    assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE] == 60
     assert hass.states.get(entity_id).attributes[ATTR_PRESET_MODE] is PRESET_MODE_AUTO
     assert hass.states.get(entity_id).attributes[ATTR_PERCENTAGE_STEP] == 100 / 10
     if zha_device_joined_restored.name == "zha_device_joined":
-        assert cluster.read_attributes.await_count == 5
+        assert cluster.read_attributes.await_count == 7
     else:
-        assert cluster.read_attributes.await_count == 8
+        assert cluster.read_attributes.await_count == 10
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/97440.
Previously starkvind exposed 10 speed settings and no modes, where 10% corresponded to auto mode and 20%-100% corresponded to fixed speeds.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This patch correctly exposes auto mode as a mode. It also adds support for showing the actual fan speed while auto mode is enabled.
Starkvind supports 9 fan speeds. Because 9 doesn't neatly fit into 100% I cheated a bit and divided the 100% into 10% increments, where trying to set the fan to 10% sets it to 20% instead. I believe that this gives the overall better user experience compared to having 11.11% increments. The 5 speed modes present on the physical interface of the device correspond to HA speed settings 20%, 40%, 60% and 100%.

This patch depends on https://github.com/zigpy/zha-device-handlers/pull/3088 being merged and released.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
