### PR TITLE
System Bridge coordinator and connector refactor

### DIFF
--- a/homeassistant/components/system_bridge/const.py
+++ b/homeassistant/components/system_bridge/const.py
@@ -1,15 +1,21 @@
 """Constants for the System Bridge integration."""
 
+from typing import Final
+
+from systembridgemodels.modules import Module
+
 DOMAIN = "system_bridge"
 
-MODULES = [
-    "battery",
-    "cpu",
-    "disks",
-    "displays",
-    "gpus",
-    "media",
-    "memory",
-    "processes",
-    "system",
+MODULES: Final[list[Module]] = [
+    Module.BATTERY,
+    Module.CPU,
+    Module.DISKS,
+    Module.DISPLAYS,
+    Module.GPUS,
+    Module.MEDIA,
+    Module.MEMORY,
+    Module.PROCESSES,
+    Module.SYSTEM,
 ]
+
+DATA_WAIT_TIMEOUT: Final[int] = 10

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -149,10 +149,10 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             self.websocket_client.connected,
         )
 
-        await self.check_websocket_connected()
-
         if not self.registered:
             try:
+                await self.check_websocket_connected()
+
                 self.hass.async_create_background_task(
                     self._listen_for_data(),
                     name="System Bridge WebSocket Listener",

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -160,14 +160,18 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             try:
                 await self.check_websocket_connected()
 
+                self.logger.debug("Create listener task for %s", self.title)
                 self.listen_task = self.hass.async_create_background_task(
                     self._listen_for_data(),
                     name="System Bridge WebSocket Listener",
+                    eager_start=False,
                 )
+                self.logger.debug("Listening for data from %s", self.title)
 
                 await self.websocket_client.register_data_listener(
                     RegisterDataListener(modules=MODULES)
                 )
+                self.logger.debug("Registered data listener for %s", self.title)
 
                 self.last_update_success = True
                 self.async_update_listeners()

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -134,14 +134,14 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             await self.clean_disconnect()
         except (ConnectionClosedException, ConnectionResetError) as exception:
             self.logger.debug(
-                "[_listen_for_data] Websocket connection closed for %s. Will retry: %s",
+                "[_listen_for_data] Websocket connection closed for %s: %s",
                 self.title,
                 exception,
             )
             await self.clean_disconnect()
         except ConnectionErrorException as exception:
             self.logger.debug(
-                "[_listen_for_data] Connection error occurred for %s. Will retry: %s",
+                "[_listen_for_data] Connection error occurred for %s: %s",
                 self.title,
                 exception,
             )
@@ -173,14 +173,14 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
                 raise ConfigEntryAuthFailed from exception
             except (ConnectionClosedException, ConnectionErrorException) as exception:
                 self.logger.warning(
-                    "Connection error occurred for %s. Will retry: %s",
+                    "Connection error occurred for %s: %s",
                     self.title,
                     exception,
                 )
                 await self.clean_disconnect()
             except TimeoutError as exception:
                 self.logger.warning(
-                    "Timed out waiting for %s. Will retry: %s",
+                    "Timed out waiting for %s: %s",
                     self.title,
                     exception,
                 )

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -149,7 +149,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
 
     async def _async_update_data(self) -> SystemBridgeData:
         """Update System Bridge data from WebSocket."""
-        if not self.registered:
+        if not self.registered or not self.websocket_client.connected:
             try:
                 await self.check_websocket_connected()
 

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -72,6 +72,11 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
 
     async def check_websocket_connected(self) -> None:
         """Check if WebSocket is connected."""
+        self.logger.debug(
+            "[check_websocket_connected] WebSocket connected: %s",
+            self.websocket_client.connected,
+        )
+
         if not self.websocket_client.connected:
             self.registered = False
             await self.websocket_client.connect()
@@ -144,11 +149,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
 
     async def _async_update_data(self) -> SystemBridgeData:
         """Update System Bridge data from WebSocket."""
-        self.logger.debug(
-            "[_async_update_data] WebSocket Connected: %s",
-            self.websocket_client.connected,
-        )
-
         if not self.registered:
             try:
                 await self.check_websocket_connected()

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -93,6 +93,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             self.unsub = None
         self.last_update_success = False
         self.async_update_listeners()
+        self.registered = False
 
     async def async_get_data(
         self,

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Callable
 from datetime import timedelta
 import logging
@@ -18,8 +17,12 @@ from systembridgemodels.media_directories import MediaDirectory
 from systembridgemodels.media_files import MediaFile, MediaFiles
 from systembridgemodels.media_get_file import MediaGetFile
 from systembridgemodels.media_get_files import MediaGetFiles
-from systembridgemodels.modules import GetData, RegisterDataListener
-from systembridgemodels.response import Response
+from systembridgemodels.modules import (
+    GetData,
+    Module,
+    ModulesData,
+    RegisterDataListener,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -51,7 +54,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
         self.title = entry.title
         self.unsub: Callable | None = None
 
-        self.systembridge_data = SystemBridgeData()
         self.websocket_client = WebSocketClient(
             entry.data[CONF_HOST],
             entry.data[CONF_PORT],
@@ -68,6 +70,8 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             update_interval=timedelta(seconds=30),
         )
 
+        self.data = SystemBridgeData()
+
     @property
     def is_ready(self) -> bool:
         """Return if the data is ready."""
@@ -81,13 +85,21 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
 
     async def async_get_data(
         self,
-        modules: list[str],
-    ) -> Response:
+        modules: list[Module],
+    ) -> ModulesData:
         """Get data from WebSocket."""
         if not self.websocket_client.connected:
-            await self._setup_websocket()
+            await self.websocket_client.connect()
 
-        return await self.websocket_client.get_data(GetData(modules=modules))
+        modules_data = await self.websocket_client.get_data(GetData(modules=modules))
+
+        # Merge new data with existing data
+        for module in MODULES:
+            if hasattr(modules_data, module):
+                self.logger.debug("[async_get_data] Set new data for: %s", module)
+                setattr(self.data, module, getattr(modules_data, module))
+
+        return modules_data
 
     async def async_get_media_directories(self) -> list[MediaDirectory]:
         """Get media directories."""
@@ -125,9 +137,9 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
         module: Any,
     ) -> None:
         """Handle data from the WebSocket client."""
-        self.logger.debug("Set new data for: %s", module_name)
-        setattr(self.systembridge_data, module_name, module)
-        self.async_set_updated_data(self.systembridge_data)
+        self.logger.debug("[async_handle_module] Set new data for: %s", module_name)
+        setattr(self.data, module_name, module)
+        self.async_set_updated_data(self.data)
 
     async def _listen_for_data(self) -> None:
         """Listen for events from the WebSocket."""
@@ -147,7 +159,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             self.async_update_listeners()
         except (ConnectionClosedException, ConnectionResetError) as exception:
             self.logger.debug(
-                "Websocket connection closed for %s. Will retry: %s",
+                "[_listen_for_data] Websocket connection closed for %s. Will retry: %s",
                 self.title,
                 exception,
             )
@@ -158,7 +170,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             self.async_update_listeners()
         except ConnectionErrorException as exception:
             self.logger.debug(
-                "Connection error occurred for %s. Will retry: %s",
+                "[_listen_for_data] Connection error occurred for %s. Will retry: %s",
                 self.title,
                 exception,
             )
@@ -171,9 +183,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
     async def _setup_websocket(self) -> None:
         """Use WebSocket for updates."""
         try:
-            async with asyncio.timeout(20):
-                await self.websocket_client.connect()
-
             self.hass.async_create_background_task(
                 self._listen_for_data(),
                 name="System Bridge WebSocket Listener",
@@ -182,6 +191,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             await self.websocket_client.register_data_listener(
                 RegisterDataListener(modules=MODULES)
             )
+
             self.last_update_success = True
             self.async_update_listeners()
         except AuthenticationException as exception:
@@ -220,7 +230,7 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
 
         async def close_websocket(_) -> None:
             """Close WebSocket connection."""
-            await self.websocket_client.close()
+            await self.websocket_client.close(True)
 
         # Clean disconnect WebSocket on Home Assistant shutdown
         self.unsub = self.hass.bus.async_listen_once(
@@ -230,12 +240,12 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
     async def _async_update_data(self) -> SystemBridgeData:
         """Update System Bridge data from WebSocket."""
         self.logger.debug(
-            "_async_update_data - WebSocket Connected: %s",
+            "[_async_update_data] WebSocket Connected: %s",
             self.websocket_client.connected,
         )
         if not self.websocket_client.connected:
             await self._setup_websocket()
 
-        self.logger.debug("_async_update_data done")
+        self.logger.debug("[_async_update_data] Done")
 
-        return self.systembridge_data
+        return self.data

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -13,10 +13,6 @@ from systembridgeconnector.exceptions import (
     ConnectionErrorException,
 )
 from systembridgeconnector.websocket_client import WebSocketClient
-from systembridgemodels.media_directories import MediaDirectory
-from systembridgemodels.media_files import MediaFile, MediaFiles
-from systembridgemodels.media_get_file import MediaGetFile
-from systembridgemodels.media_get_files import MediaGetFiles
 from systembridgemodels.modules import (
     GetData,
     Module,
@@ -109,36 +105,6 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
                 setattr(self.data, module, getattr(modules_data, module))
 
         return modules_data
-
-    async def async_get_media_directories(self) -> list[MediaDirectory]:
-        """Get media directories."""
-        return await self.websocket_client.get_directories()
-
-    async def async_get_media_files(
-        self,
-        base: str,
-        path: str | None = None,
-    ) -> MediaFiles:
-        """Get media files."""
-        return await self.websocket_client.get_files(
-            MediaGetFiles(
-                base=base,
-                path=path,
-            )
-        )
-
-    async def async_get_media_file(
-        self,
-        base: str,
-        path: str,
-    ) -> MediaFile | None:
-        """Get media file."""
-        return await self.websocket_client.get_file(
-            MediaGetFile(
-                base=base,
-                path=path,
-            )
-        )
 
     async def async_handle_module(
         self,

--- a/homeassistant/components/system_bridge/coordinator.py
+++ b/homeassistant/components/system_bridge/coordinator.py
@@ -149,6 +149,8 @@ class SystemBridgeDataUpdateCoordinator(DataUpdateCoordinator[SystemBridgeData])
             self.websocket_client.connected,
         )
 
+        await self.check_websocket_connected()
+
         if not self.registered:
             try:
                 self.hass.async_create_background_task(

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -11,7 +11,7 @@
   "loggers": ["systembridgeconnector"],
   "quality_scale": "silver",
   "requirements": [
-    "systembridgeconnector==4.1.0.dev0",
+    "systembridgeconnector==4.1.0.dev1",
     "systembridgemodels==4.1.0"
   ],
   "zeroconf": ["_system-bridge._tcp.local."]

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -10,9 +10,6 @@
   "iot_class": "local_push",
   "loggers": ["systembridgeconnector"],
   "quality_scale": "silver",
-  "requirements": [
-    "systembridgeconnector==4.1.0.dev1",
-    "systembridgemodels==4.1.0"
-  ],
+  "requirements": ["systembridgeconnector==4.1.0", "systembridgemodels==4.1.0"],
   "zeroconf": ["_system-bridge._tcp.local."]
 }

--- a/homeassistant/components/system_bridge/manifest.json
+++ b/homeassistant/components/system_bridge/manifest.json
@@ -10,6 +10,9 @@
   "iot_class": "local_push",
   "loggers": ["systembridgeconnector"],
   "quality_scale": "silver",
-  "requirements": ["systembridgeconnector==4.0.3", "systembridgemodels==4.0.4"],
+  "requirements": [
+    "systembridgeconnector==4.1.0.dev0",
+    "systembridgemodels==4.1.0"
+  ],
   "zeroconf": ["_system-bridge._tcp.local."]
 }

--- a/homeassistant/components/system_bridge/media_source.py
+++ b/homeassistant/components/system_bridge/media_source.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from systembridgemodels.media_directories import MediaDirectory
 from systembridgemodels.media_files import MediaFile, MediaFiles
+from systembridgemodels.media_get_files import MediaGetFiles
 
 from homeassistant.components.media_player import MediaClass
 from homeassistant.components.media_source import MEDIA_CLASS_MAP, MEDIA_MIME_TYPES
@@ -68,7 +69,7 @@ class SystemBridgeSource(MediaSource):
             coordinator: SystemBridgeDataUpdateCoordinator = self.hass.data[DOMAIN].get(
                 entry.entry_id
             )
-            directories = await coordinator.async_get_media_directories()
+            directories = await coordinator.websocket_client.get_directories()
             return _build_root_paths(entry, directories)
 
         entry_id, path = item.identifier.split("~~", 1)
@@ -80,8 +81,11 @@ class SystemBridgeSource(MediaSource):
 
         path_split = path.split("/", 1)
 
-        files = await coordinator.async_get_media_files(
-            path_split[0], path_split[1] if len(path_split) > 1 else None
+        files = await coordinator.websocket_client.get_files(
+            MediaGetFiles(
+                base=path_split[0],
+                path=path_split[1] if len(path_split) > 1 else None,
+            )
         )
 
         return _build_media_items(entry, files, path, item.identifier)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2679,10 +2679,10 @@ switchbot-api==2.2.1
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==5.0.0.dev2
+systembridgeconnector==4.1.0.dev0
 
 # homeassistant.components.system_bridge
-systembridgemodels==4.0.4
+systembridgemodels==4.1.0
 
 # homeassistant.components.tailscale
 tailscale==0.6.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2679,7 +2679,7 @@ switchbot-api==2.2.1
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.1.0.dev1
+systembridgeconnector==4.1.0
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2679,7 +2679,7 @@ switchbot-api==2.2.1
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.0.3
+systembridgeconnector==5.0.0.dev2
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2679,7 +2679,7 @@ switchbot-api==2.2.1
 synology-srm==0.2.0
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.1.0.dev0
+systembridgeconnector==4.1.0.dev1
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2104,7 +2104,7 @@ surepy==0.9.0
 switchbot-api==2.2.1
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.1.0.dev1
+systembridgeconnector==4.1.0
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2104,7 +2104,7 @@ surepy==0.9.0
 switchbot-api==2.2.1
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.1.0.dev0
+systembridgeconnector==4.1.0.dev1
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2104,7 +2104,7 @@ surepy==0.9.0
 switchbot-api==2.2.1
 
 # homeassistant.components.system_bridge
-systembridgeconnector==4.0.3
+systembridgeconnector==5.0.0.dev2
 
 # homeassistant.components.system_bridge
 systembridgemodels==4.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2104,10 +2104,10 @@ surepy==0.9.0
 switchbot-api==2.2.1
 
 # homeassistant.components.system_bridge
-systembridgeconnector==5.0.0.dev2
+systembridgeconnector==4.1.0.dev0
 
 # homeassistant.components.system_bridge
-systembridgemodels==4.0.4
+systembridgemodels==4.1.0
 
 # homeassistant.components.tailscale
 tailscale==0.6.1

--- a/tests/components/system_bridge/__init__.py
+++ b/tests/components/system_bridge/__init__.py
@@ -1,20 +1,19 @@
 """Tests for the System Bridge integration."""
 
 from collections.abc import Awaitable, Callable
-from dataclasses import asdict
 from ipaddress import ip_address
 from typing import Any
 
-from systembridgeconnector.const import TYPE_DATA_UPDATE
-from systembridgemodels.const import MODEL_SYSTEM
-from systembridgemodels.modules import System
+from systembridgeconnector.const import EventType
+from systembridgemodels.fixtures.modules.system import FIXTURE_SYSTEM
+from systembridgemodels.modules import Module, ModulesData
 from systembridgemodels.response import Response
 
 from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 
-FIXTURE_MAC_ADDRESS = "aa:bb:cc:dd:ee:ff"
-FIXTURE_UUID = "e91bf575-56f3-4c83-8f42-70ac17adcd33"
+FIXTURE_MAC_ADDRESS = FIXTURE_SYSTEM.mac_address
+FIXTURE_UUID = FIXTURE_SYSTEM.uuid
 
 FIXTURE_AUTH_INPUT = {CONF_TOKEN: "abc-123-def-456-ghi"}
 
@@ -60,47 +59,25 @@ FIXTURE_ZEROCONF_BAD = zeroconf.ZeroconfServiceInfo(
     },
 )
 
-
-FIXTURE_SYSTEM = System(
-    boot_time=1,
-    fqdn="",
-    hostname="1.1.1.1",
-    ip_address_4="1.1.1.1",
-    mac_address=FIXTURE_MAC_ADDRESS,
-    platform="",
-    platform_version="",
-    uptime=1,
-    uuid=FIXTURE_UUID,
-    version="",
-    version_latest="",
-    version_newer_available=False,
-    users=[],
-)
-
-FIXTURE_DATA_RESPONSE = Response(
-    id="1234",
-    type=TYPE_DATA_UPDATE,
-    subtype=None,
-    message="Data received",
-    module=MODEL_SYSTEM,
-    data=asdict(FIXTURE_SYSTEM),
+FIXTURE_DATA_RESPONSE = ModulesData(
+    system=FIXTURE_SYSTEM,
 )
 
 FIXTURE_DATA_RESPONSE_BAD = Response(
     id="1234",
-    type=TYPE_DATA_UPDATE,
+    type=EventType.DATA_UPDATE,
     subtype=None,
     message="Data received",
-    module=MODEL_SYSTEM,
+    module=Module.SYSTEM,
     data={},
 )
 
 FIXTURE_DATA_RESPONSE_BAD = Response(
     id="1234",
-    type=TYPE_DATA_UPDATE,
+    type=EventType.DATA_UPDATE,
     subtype=None,
     message="Data received",
-    module=MODEL_SYSTEM,
+    module=Module.SYSTEM,
     data={},
 )
 
@@ -113,4 +90,4 @@ async def mock_data_listener(
     """Mock websocket data listener."""
     if callback is not None:
         # Simulate data received from the websocket
-        await callback(MODEL_SYSTEM, FIXTURE_SYSTEM)
+        await callback(Module.SYSTEM, FIXTURE_SYSTEM)

--- a/tests/components/system_bridge/__init__.py
+++ b/tests/components/system_bridge/__init__.py
@@ -4,34 +4,49 @@ from collections.abc import Awaitable, Callable
 from ipaddress import ip_address
 from typing import Any
 
-from systembridgeconnector.const import EventType
+from systembridgemodels.fixtures.modules.battery import FIXTURE_BATTERY
+from systembridgemodels.fixtures.modules.cpu import FIXTURE_CPU
+from systembridgemodels.fixtures.modules.disks import FIXTURE_DISKS
+from systembridgemodels.fixtures.modules.displays import FIXTURE_DISPLAYS
+from systembridgemodels.fixtures.modules.gpus import FIXTURE_GPUS
+from systembridgemodels.fixtures.modules.media import FIXTURE_MEDIA
+from systembridgemodels.fixtures.modules.memory import FIXTURE_MEMORY
+from systembridgemodels.fixtures.modules.processes import FIXTURE_PROCESSES
 from systembridgemodels.fixtures.modules.system import FIXTURE_SYSTEM
 from systembridgemodels.modules import Module, ModulesData
-from systembridgemodels.response import Response
 
 from homeassistant.components import zeroconf
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+FIXTURE_TITLE = "TestSystem"
+
+FIXTURE_REQUEST_ID = "test"
 
 FIXTURE_MAC_ADDRESS = FIXTURE_SYSTEM.mac_address
 FIXTURE_UUID = FIXTURE_SYSTEM.uuid
 
-FIXTURE_AUTH_INPUT = {CONF_TOKEN: "abc-123-def-456-ghi"}
+FIXTURE_AUTH_INPUT = {
+    CONF_TOKEN: "abc-123-def-456-ghi",
+}
 
 FIXTURE_USER_INPUT = {
     CONF_TOKEN: "abc-123-def-456-ghi",
-    CONF_HOST: "test-bridge",
+    CONF_HOST: "127.0.0.1",
     CONF_PORT: "9170",
 }
 
 FIXTURE_ZEROCONF_INPUT = {
     CONF_TOKEN: "abc-123-def-456-ghi",
-    CONF_HOST: "1.1.1.1",
+    CONF_HOST: FIXTURE_USER_INPUT[CONF_HOST],
     CONF_PORT: "9170",
 }
 
 FIXTURE_ZEROCONF = zeroconf.ZeroconfServiceInfo(
-    ip_address=ip_address("1.1.1.1"),
-    ip_addresses=[ip_address("1.1.1.1")],
+    ip_address=ip_address(FIXTURE_USER_INPUT[CONF_HOST]),
+    ip_addresses=[ip_address(FIXTURE_USER_INPUT[CONF_HOST])],
     port=9170,
     hostname="test-bridge.local.",
     type="_system-bridge._tcp.local.",
@@ -40,7 +55,7 @@ FIXTURE_ZEROCONF = zeroconf.ZeroconfServiceInfo(
         "address": "http://test-bridge:9170",
         "fqdn": "test-bridge",
         "host": "test-bridge",
-        "ip": "1.1.1.1",
+        "ip": FIXTURE_USER_INPUT[CONF_HOST],
         "mac": FIXTURE_MAC_ADDRESS,
         "port": "9170",
         "uuid": FIXTURE_UUID,
@@ -48,8 +63,8 @@ FIXTURE_ZEROCONF = zeroconf.ZeroconfServiceInfo(
 )
 
 FIXTURE_ZEROCONF_BAD = zeroconf.ZeroconfServiceInfo(
-    ip_address=ip_address("1.1.1.1"),
-    ip_addresses=[ip_address("1.1.1.1")],
+    ip_address=ip_address(FIXTURE_USER_INPUT[CONF_HOST]),
+    ip_addresses=[ip_address(FIXTURE_USER_INPUT[CONF_HOST])],
     port=9170,
     hostname="test-bridge.local.",
     type="_system-bridge._tcp.local.",
@@ -63,31 +78,33 @@ FIXTURE_DATA_RESPONSE = ModulesData(
     system=FIXTURE_SYSTEM,
 )
 
-FIXTURE_DATA_RESPONSE_BAD = Response(
-    id="1234",
-    type=EventType.DATA_UPDATE,
-    subtype=None,
-    message="Data received",
-    module=Module.SYSTEM,
-    data={},
-)
 
-FIXTURE_DATA_RESPONSE_BAD = Response(
-    id="1234",
-    type=EventType.DATA_UPDATE,
-    subtype=None,
-    message="Data received",
-    module=Module.SYSTEM,
-    data={},
-)
+async def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+) -> bool:
+    """Fixture for setting up the component."""
+    config_entry.add_to_hass(hass)
+
+    setup_result = await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    return setup_result
 
 
 async def mock_data_listener(
-    self,
     callback: Callable[[str, Any], Awaitable[None]] | None = None,
     _: bool = False,
 ):
     """Mock websocket data listener."""
     if callback is not None:
         # Simulate data received from the websocket
+        await callback(Module.BATTERY, FIXTURE_BATTERY)
+        await callback(Module.CPU, FIXTURE_CPU)
+        await callback(Module.DISKS, FIXTURE_DISKS)
+        await callback(Module.DISPLAYS, FIXTURE_DISPLAYS)
+        await callback(Module.GPUS, FIXTURE_GPUS)
+        await callback(Module.MEDIA, FIXTURE_MEDIA)
+        await callback(Module.MEMORY, FIXTURE_MEMORY)
+        await callback(Module.PROCESSES, FIXTURE_PROCESSES)
         await callback(Module.SYSTEM, FIXTURE_SYSTEM)

--- a/tests/components/system_bridge/conftest.py
+++ b/tests/components/system_bridge/conftest.py
@@ -1,0 +1,190 @@
+"""Fixtures for System Bridge integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from systembridgeconnector.const import EventKey, EventType
+from systembridgemodels.fixtures.modules.battery import FIXTURE_BATTERY
+from systembridgemodels.fixtures.modules.cpu import FIXTURE_CPU
+from systembridgemodels.fixtures.modules.disks import FIXTURE_DISKS
+from systembridgemodels.fixtures.modules.displays import FIXTURE_DISPLAYS
+from systembridgemodels.fixtures.modules.gpus import FIXTURE_GPUS
+from systembridgemodels.fixtures.modules.media import FIXTURE_MEDIA
+from systembridgemodels.fixtures.modules.memory import FIXTURE_MEMORY
+from systembridgemodels.fixtures.modules.networks import FIXTURE_NETWORKS
+from systembridgemodels.fixtures.modules.processes import FIXTURE_PROCESSES
+from systembridgemodels.fixtures.modules.sensors import FIXTURE_SENSORS
+from systembridgemodels.fixtures.modules.system import FIXTURE_SYSTEM
+from systembridgemodels.media_directories import MediaDirectory
+from systembridgemodels.media_files import MediaFile, MediaFiles
+from systembridgemodels.modules import Module, ModulesData, RegisterDataListener
+from systembridgemodels.response import Response
+
+from homeassistant.components.system_bridge.config_flow import SystemBridgeConfigFlow
+from homeassistant.components.system_bridge.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from . import (
+    FIXTURE_REQUEST_ID,
+    FIXTURE_TITLE,
+    FIXTURE_USER_INPUT,
+    FIXTURE_UUID,
+    mock_data_listener,
+    setup_integration,
+)
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock ConfigEntry."""
+    return MockConfigEntry(
+        title=FIXTURE_TITLE,
+        domain=DOMAIN,
+        unique_id=FIXTURE_UUID,
+        version=SystemBridgeConfigFlow.VERSION,
+        minor_version=SystemBridgeConfigFlow.MINOR_VERSION,
+        data={
+            CONF_HOST: FIXTURE_USER_INPUT[CONF_HOST],
+            CONF_PORT: FIXTURE_USER_INPUT[CONF_PORT],
+            CONF_TOKEN: FIXTURE_USER_INPUT[CONF_TOKEN],
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+def mock_setup_notify_platform() -> Generator[AsyncMock, None, None]:
+    """Mock notify platform setup."""
+    with patch(
+        "homeassistant.helpers.discovery.async_load_platform",
+    ) as mock_setup_notify_platform:
+        yield mock_setup_notify_platform
+
+
+@pytest.fixture
+def mock_version() -> Generator[AsyncMock, None, None]:
+    """Return a mocked Version class."""
+    with patch(
+        "homeassistant.components.system_bridge.Version",
+        autospec=True,
+    ) as mock_version:
+        version = mock_version.return_value
+        version.check_supported.return_value = True
+
+        yield version
+
+
+@pytest.fixture
+def mock_websocket_client(
+    register_data_listener_model: RegisterDataListener = RegisterDataListener(
+        modules=[Module.SYSTEM]
+    ),
+) -> Generator[MagicMock, None, None]:
+    """Return a mocked WebSocketClient client."""
+
+    with (
+        patch(
+            "homeassistant.components.system_bridge.coordinator.WebSocketClient",
+            autospec=True,
+        ) as mock_websocket_client,
+        patch(
+            "homeassistant.components.system_bridge.config_flow.WebSocketClient",
+            new=mock_websocket_client,
+        ),
+    ):
+        websocket_client = mock_websocket_client.return_value
+        websocket_client.connected = False
+        websocket_client.get_data.return_value = ModulesData(
+            battery=FIXTURE_BATTERY,
+            cpu=FIXTURE_CPU,
+            disks=FIXTURE_DISKS,
+            displays=FIXTURE_DISPLAYS,
+            gpus=FIXTURE_GPUS,
+            media=FIXTURE_MEDIA,
+            memory=FIXTURE_MEMORY,
+            networks=FIXTURE_NETWORKS,
+            processes=FIXTURE_PROCESSES,
+            sensors=FIXTURE_SENSORS,
+            system=FIXTURE_SYSTEM,
+        )
+        websocket_client.register_data_listener.return_value = Response(
+            id=FIXTURE_REQUEST_ID,
+            type=EventType.DATA_LISTENER_REGISTERED,
+            message="Data listener registered",
+            data={EventKey.MODULES: register_data_listener_model.modules},
+        )
+        # Trigger callback when listener is registered
+        websocket_client.listen.side_effect = mock_data_listener
+
+        websocket_client.get_directories.return_value = [
+            MediaDirectory(
+                key="documents",
+                path="/home/user/documents",
+            )
+        ]
+        websocket_client.get_files.return_value = MediaFiles(
+            files=[
+                MediaFile(
+                    name="testsubdirectory",
+                    path="testsubdirectory",
+                    fullpath="/home/user/documents/testsubdirectory",
+                    size=100,
+                    last_accessed=1630000000,
+                    created=1630000000,
+                    modified=1630000000,
+                    is_directory=True,
+                    is_file=False,
+                    is_link=False,
+                ),
+                MediaFile(
+                    name="testfile.txt",
+                    path="testfile.txt",
+                    fullpath="/home/user/documents/testfile.txt",
+                    size=100,
+                    last_accessed=1630000000,
+                    created=1630000000,
+                    modified=1630000000,
+                    is_directory=False,
+                    is_file=True,
+                    is_link=False,
+                    mime_type="text/plain",
+                ),
+                MediaFile(
+                    name="testfile.jpg",
+                    path="testfile.jpg",
+                    fullpath="/home/user/documents/testimage.jpg",
+                    size=100,
+                    last_accessed=1630000000,
+                    created=1630000000,
+                    modified=1630000000,
+                    is_directory=False,
+                    is_file=True,
+                    is_link=False,
+                    mime_type="image/jpeg",
+                ),
+            ],
+            path="",
+        )
+
+        yield websocket_client
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_version: MagicMock,
+    mock_websocket_client: MagicMock,
+) -> MockConfigEntry:
+    """Initialize the System Bridge integration."""
+    assert await setup_integration(hass, mock_config_entry)
+
+    assert mock_config_entry.state == ConfigEntryState.LOADED
+
+    return mock_config_entry

--- a/tests/components/system_bridge/conftest.py
+++ b/tests/components/system_bridge/conftest.py
@@ -185,6 +185,6 @@ async def init_integration(
     """Initialize the System Bridge integration."""
     assert await setup_integration(hass, mock_config_entry)
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     return mock_config_entry

--- a/tests/components/system_bridge/conftest.py
+++ b/tests/components/system_bridge/conftest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from typing import Final
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -39,6 +40,10 @@ from . import (
 )
 
 from tests.common import MockConfigEntry
+
+REGISTER_MODULES: Final[list[Module]] = [
+    Module.SYSTEM,
+]
 
 
 @pytest.fixture
@@ -83,7 +88,7 @@ def mock_version() -> Generator[AsyncMock, None, None]:
 @pytest.fixture
 def mock_websocket_client(
     register_data_listener_model: RegisterDataListener = RegisterDataListener(
-        modules=[Module.SYSTEM]
+        modules=REGISTER_MODULES,
     ),
 ) -> Generator[MagicMock, None, None]:
     """Return a mocked WebSocketClient client."""

--- a/tests/components/system_bridge/snapshots/test_media_source.ambr
+++ b/tests/components/system_bridge/snapshots/test_media_source.ambr
@@ -1,0 +1,61 @@
+# serializer version: 1
+# name: test_directory[system_bridge_media_source_directory]
+  dict({
+    'can_expand': True,
+    'can_play': False,
+    'children_media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_content_type': '',
+    'not_shown': 0,
+    'thumbnail': None,
+    'title': 'TestSystem - documents',
+  })
+# ---
+# name: test_entry[system_bridge_media_source_entry]
+  dict({
+    'can_expand': True,
+    'can_play': False,
+    'children_media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_content_type': '',
+    'not_shown': 0,
+    'thumbnail': None,
+    'title': 'TestSystem',
+  })
+# ---
+# name: test_file[system_bridge_media_source_file_image]
+  dict({
+    'mime_type': 'image/jpeg',
+    'url': 'http://127.0.0.1:9170/api/media/file/data?token=abc-123-def-456-ghi&base=documents&path=testimage.jpg',
+  })
+# ---
+# name: test_file[system_bridge_media_source_file_text]
+  dict({
+    'mime_type': 'text/plain',
+    'url': 'http://127.0.0.1:9170/api/media/file/data?token=abc-123-def-456-ghi&base=documents&path=testfile.txt',
+  })
+# ---
+# name: test_root[system_bridge_media_source_root]
+  dict({
+    'can_expand': True,
+    'can_play': False,
+    'children_media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_content_type': '',
+    'not_shown': 0,
+    'thumbnail': None,
+    'title': 'System Bridge',
+  })
+# ---
+# name: test_subdirectory[system_bridge_media_source_subdirectory]
+  dict({
+    'can_expand': True,
+    'can_play': False,
+    'children_media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_class': <MediaClass.DIRECTORY: 'directory'>,
+    'media_content_type': '',
+    'not_shown': 0,
+    'thumbnail': None,
+    'title': 'TestSystem - documents/testsubdirectory',
+  })
+# ---

--- a/tests/components/system_bridge/test_config_flow.py
+++ b/tests/components/system_bridge/test_config_flow.py
@@ -69,7 +69,7 @@ async def test_user_flow(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "test-bridge"
+    assert result2["title"] == "127.0.0.1"
     assert result2["data"] == FIXTURE_USER_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -441,7 +441,7 @@ async def test_zeroconf_flow(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "1.1.1.1"
+    assert result2["title"] == "127.0.0.1"
     assert result2["data"] == FIXTURE_ZEROCONF_INPUT
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/system_bridge/test_media_source.py
+++ b/tests/components/system_bridge/test_media_source.py
@@ -1,0 +1,148 @@
+"""Test the System Bridge integration."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import paths
+
+from homeassistant.components.media_player.errors import BrowseError
+from homeassistant.components.media_source import (
+    DOMAIN as MEDIA_SOURCE_DOMAIN,
+    URI_SCHEME,
+    async_browse_media,
+    async_resolve_media,
+)
+from homeassistant.components.system_bridge.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(autouse=True)
+async def setup_component(hass: HomeAssistant) -> None:
+    """Set up component."""
+    assert await async_setup_component(
+        hass,
+        MEDIA_SOURCE_DOMAIN,
+        {},
+    )
+
+
+async def test_root(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test root media browsing."""
+    browse_media_root = await async_browse_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}",
+    )
+
+    assert browse_media_root.as_dict() == snapshot(
+        name=f"{DOMAIN}_media_source_root",
+        exclude=paths("children", "media_content_id"),
+    )
+
+
+async def test_entry(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test browsing entry."""
+    browse_media_entry = await async_browse_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}/{init_integration.entry_id}",
+    )
+
+    assert browse_media_entry.as_dict() == snapshot(
+        name=f"{DOMAIN}_media_source_entry",
+        exclude=paths("children", "media_content_id"),
+    )
+
+
+async def test_directory(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test browsing directory."""
+    browse_media_directory = await async_browse_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}/{init_integration.entry_id}~~documents",
+    )
+
+    assert browse_media_directory.as_dict() == snapshot(
+        name=f"{DOMAIN}_media_source_directory",
+        exclude=paths("children", "media_content_id"),
+    )
+
+
+async def test_subdirectory(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test browsing directory."""
+    browse_media_directory = await async_browse_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}/{init_integration.entry_id}~~documents/testsubdirectory",
+    )
+
+    assert browse_media_directory.as_dict() == snapshot(
+        name=f"{DOMAIN}_media_source_subdirectory",
+        exclude=paths("children", "media_content_id"),
+    )
+
+
+async def test_file(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test browsing file."""
+    resolve_media_file = await async_resolve_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}/{init_integration.entry_id}~~documents/testfile.txt~~text/plain",
+        None,
+    )
+
+    assert resolve_media_file == snapshot(
+        name=f"{DOMAIN}_media_source_file_text",
+    )
+
+    resolve_media_file = await async_resolve_media(
+        hass,
+        f"{URI_SCHEME}{DOMAIN}/{init_integration.entry_id}~~documents/testimage.jpg~~image/jpeg",
+        None,
+    )
+
+    assert resolve_media_file == snapshot(
+        name=f"{DOMAIN}_media_source_file_image",
+    )
+
+
+async def test_bad_entry(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test invalid entry raises BrowseError."""
+    with pytest.raises(BrowseError):
+        await async_browse_media(
+            hass,
+            f"{URI_SCHEME}{DOMAIN}/badentryid",
+        )
+
+    with pytest.raises(BrowseError):
+        await async_browse_media(
+            hass,
+            f"{URI_SCHEME}{DOMAIN}/badentryid~~baddirectory",
+        )
+
+    with pytest.raises(ValueError):
+        await async_resolve_media(
+            hass,
+            f"{URI_SCHEME}{DOMAIN}/badentryid~~baddirectory/badfile.txt~~text/plain",
+            None,
+        )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A few fundamental changes to the coordinator and websocket client, as well as other efficiencies found during tests.

- The `get_data` method now actually returns data. This removes the need for HA to wait for the initial module data as this is returned in a single call, and updated as changes come in from the registered listener.
- Preparation for tests, PR to be opened after this one.
- Removed/Replaced some redundant methods.
- Merged a lot of duplicate code.
- Initial loading time improved.
- Code readability improvements.


**Package changes**:

https://github.com/timmo001/system-bridge-connector/releases/tag/4.1.0
https://github.com/timmo001/system-bridge-connector/compare/4.0.3...4.1.0

https://github.com/timmo001/system-bridge-models/releases/tag/4.1.0
https://github.com/timmo001/system-bridge-models/compare/4.0.4...4.1.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
