### PR TITLE
Reduce august polling frequency

### DIFF
--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 from functools import partial
 import logging
+from time import monotonic
 
 from aiohttp import ClientError
 from yalexs.activity import Activity, ActivityType
@@ -25,6 +26,8 @@ _LOGGER = logging.getLogger(__name__)
 
 ACTIVITY_STREAM_FETCH_LIMIT = 10
 ACTIVITY_CATCH_UP_FETCH_LIMIT = 2500
+
+INITIAL_LOCK_RESYNC_TIME = 60
 
 # If there is a storm of activity (ie lock, unlock, door open, door close, etc)
 # we want to debounce the updates so we don't hammer the activity api too much.
@@ -62,6 +65,7 @@ class ActivityStream(AugustSubscriberMixin):
         self.pubnub = pubnub
         self._update_debounce: dict[str, Debouncer] = {}
         self._update_debounce_jobs: dict[str, HassJob] = {}
+        self._start_time: float | None = None
 
     @callback
     def _async_update_house_id_later(self, debouncer: Debouncer, _: datetime) -> None:
@@ -70,6 +74,7 @@ class ActivityStream(AugustSubscriberMixin):
 
     async def async_setup(self) -> None:
         """Token refresh check and catch up the activity stream."""
+        self._start_time = monotonic()
         update_debounce = self._update_debounce
         update_debounce_jobs = self._update_debounce_jobs
         for house_id in self._house_ids:
@@ -140,20 +145,28 @@ class ActivityStream(AugustSubscriberMixin):
 
         debouncer = self._update_debounce[house_id]
         debouncer.async_schedule_call()
+
         # Schedule two updates past the debounce time
         # to ensure we catch the case where the activity
         # api does not update right away and we need to poll
         # it again. Sometimes the lock operator or a doorbell
         # will not show up in the activity stream right away.
         job = self._update_debounce_jobs[house_id]
-        for step in (1, 2):
-            future_updates.append(
-                async_call_later(
-                    self._hass,
-                    (step * ACTIVITY_DEBOUNCE_COOLDOWN) + 0.1,
-                    job,
+        # Only do additional polls if we are past
+        # the initial lock resync time so avoid a storm
+        # of activity at setup.
+        if (
+            self._start_time
+            and monotonic() - self._start_time > INITIAL_LOCK_RESYNC_TIME
+        ):
+            for step in (1, 2):
+                future_updates.append(
+                    async_call_later(
+                        self._hass,
+                        (step * ACTIVITY_DEBOUNCE_COOLDOWN) + 0.1,
+                        job,
+                    )
                 )
-            )
 
     async def _async_update_house_id(self, house_id: str) -> None:
         """Update device activities for a house."""

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -31,7 +31,7 @@ INITIAL_LOCK_RESYNC_TIME = 60
 
 # If there is a storm of activity (ie lock, unlock, door open, door close, etc)
 # we want to debounce the updates so we don't hammer the activity api too much.
-ACTIVITY_DEBOUNCE_COOLDOWN = 3
+ACTIVITY_DEBOUNCE_COOLDOWN = 4
 
 
 @callback

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -159,7 +159,7 @@ class ActivityStream(AugustSubscriberMixin):
             or monotonic() - self._start_time < INITIAL_LOCK_RESYNC_TIME
         ):
             _LOGGER.debug(
-                "Skipping additional updates because we are in the initial lock resync time"
+                "Skipping additional updates due to ongoing initial lock resync time"
             )
             return
 

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -152,7 +152,7 @@ class ActivityStream(AugustSubscriberMixin):
         # it again. Sometimes the lock operator or a doorbell
         # will not show up in the activity stream right away.
         # Only do additional polls if we are past
-        # the initial lock resync time so avoid a storm
+        # the initial lock resync time to avoid a storm
         # of activity at setup.
         if (
             not self._start_time

--- a/homeassistant/components/august/const.py
+++ b/homeassistant/components/august/const.py
@@ -40,7 +40,7 @@ ATTR_OPERATION_TAG = "tag"
 # Limit battery, online, and hardware updates to hourly
 # in order to reduce the number of api requests and
 # avoid hitting rate limits
-MIN_TIME_BETWEEN_DETAIL_UPDATES = timedelta(hours=1)
+MIN_TIME_BETWEEN_DETAIL_UPDATES = timedelta(hours=24)
 
 # Activity needs to be checked more frequently as the
 # doorbell motion and rings are included here

--- a/homeassistant/components/august/subscriber.py
+++ b/homeassistant/components/august/subscriber.py
@@ -51,9 +51,10 @@ class AugustSubscriberMixin:
 
     @callback
     def _async_cancel_update_interval(self, _: Event | None = None) -> None:
-        self._stop_interval = None
+        """Cancel the scheduled update."""
         if self._unsub_interval:
             self._unsub_interval()
+            self._unsub_interval = None
 
     @callback
     def _async_setup_listeners(self) -> None:
@@ -66,11 +67,12 @@ class AugustSubscriberMixin:
             name="august refresh",
         )
 
-        self._stop_interval = self._hass.bus.async_listen(
-            EVENT_HOMEASSISTANT_STOP,
-            self._async_cancel_update_interval,
-            run_immediately=True,
-        )
+        if not self._stop_interval:
+            self._stop_interval = self._hass.bus.async_listen(
+                EVENT_HOMEASSISTANT_STOP,
+                self._async_cancel_update_interval,
+                run_immediately=True,
+            )
 
     @callback
     def async_unsubscribe_device_id(
@@ -87,9 +89,6 @@ class AugustSubscriberMixin:
         if self._unsub_interval:
             self._unsub_interval()
             self._unsub_interval = None
-        if self._stop_interval:
-            self._stop_interval()
-            self._stop_interval = None
 
     @callback
     def async_signal_device_id_update(self, device_id: str) -> None:

--- a/homeassistant/components/august/subscriber.py
+++ b/homeassistant/components/august/subscriber.py
@@ -85,10 +85,7 @@ class AugustSubscriberMixin:
 
         if self._subscriptions:
             return
-
-        if self._unsub_interval:
-            self._unsub_interval()
-            self._unsub_interval = None
+        self._async_cancel_update_interval()
 
     @callback
     def async_signal_device_id_update(self, device_id: str) -> None:

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -8,6 +8,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from yalexs.pubnub_async import AugustPubNub
 
+from homeassistant.components.august.activity import INITIAL_LOCK_RESYNC_TIME
 from homeassistant.components.lock import (
     DOMAIN as LOCK_DOMAIN,
     STATE_JAMMED,
@@ -233,7 +234,7 @@ async def test_one_lock_operation_pubnub_connected(
         == STATE_UNKNOWN
     )
 
-    freezer.tick(60)
+    freezer.tick(INITIAL_LOCK_RESYNC_TIME)
 
     pubnub.message(
         pubnub,
@@ -245,7 +246,7 @@ async def test_one_lock_operation_pubnub_connected(
             },
         ),
     )
-    await hass.async_block_till_done(wait_background_tasks=True)
+    await hass.async_block_till_done()
 
     lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
     assert lock_online_with_doorsense_name.state == STATE_UNLOCKED

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -4,6 +4,7 @@ import datetime
 from unittest.mock import Mock
 
 from aiohttp import ClientResponseError
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from yalexs.pubnub_async import AugustPubNub
 
@@ -155,7 +156,9 @@ async def test_one_lock_operation(
 
 
 async def test_one_lock_operation_pubnub_connected(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test lock and unlock operations are async when pubnub is connected."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
@@ -229,6 +232,23 @@ async def test_one_lock_operation_pubnub_connected(
         hass.states.get("sensor.online_with_doorsense_name_operator").state
         == STATE_UNKNOWN
     )
+
+    freezer.tick(60)
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=lock_one.pubsub_channel,
+            timetoken=(dt_util.utcnow().timestamp() + 2) * 10000000,
+            message={
+                "status": "kAugLockState_Unlocked",
+            },
+        ),
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_UNLOCKED
 
 
 async def test_lock_jammed(hass: HomeAssistant) -> None:


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since most data comes in via pubnub and we only need the battery status from the lock detail API we can reduce the polling to every 24 hours instead of every hour per lock.

Additionally the activity polls are reduced since each lock wakes up at startup and would poll the activity api.  We now avoid the additional polling (which is for the doorbells) during the first 60 seconds since it could generate 3*number of locks calls to the activity api

The polling was overloading the vendor's API.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
