### PR TITLE
Use is in FlowResultType enum comparison in tests

### DIFF
--- a/tests/components/abode/test_init.py
+++ b/tests/components/abode/test_init.py
@@ -8,7 +8,6 @@ from jaraco.abode.exceptions import (
     Exception as AbodeException,
 )
 
-from homeassistant import data_entry_flow
 from homeassistant.components.abode import (
     DOMAIN as ABODE_DOMAIN,
     SERVICE_CAPTURE_IMAGE,
@@ -19,6 +18,7 @@ from homeassistant.components.alarm_control_panel import DOMAIN as ALARM_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .common import setup_platform
 
@@ -82,7 +82,7 @@ async def test_invalid_credentials(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.abode.config_flow.AbodeFlowHandler.async_step_reauth",
             return_value={
-                "type": data_entry_flow.FlowResultType.FORM,
+                "type": FlowResultType.FORM,
                 "flow_id": "mock_flow",
                 "step_id": "reauth_confirm",
             },

--- a/tests/components/application_credentials/test_init.py
+++ b/tests/components/application_credentials/test_init.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.setup import async_setup_component
 
@@ -163,7 +164,7 @@ class OAuthFixture:
         )
 
         result = await self.hass.config_entries.flow.async_configure(result["flow_id"])
-        assert result.get("type") == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result.get("type") is FlowResultType.CREATE_ENTRY
         assert result.get("title") == self.title
         assert "data" in result
         assert "token" in result["data"]
@@ -420,7 +421,7 @@ async def test_config_flow_no_credentials(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_credentials"
 
 
@@ -447,7 +448,7 @@ async def test_config_flow_other_domain(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_credentials"
 
 
@@ -470,7 +471,7 @@ async def test_config_flow(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
     result = await oauth_fixture.complete_external_step(result)
     assert (
         result["data"].get("auth_implementation") == "fake_integration_some_client_id"
@@ -535,14 +536,14 @@ async def test_config_flow_multiple_entries(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "pick_implementation"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={"implementation": "fake_integration_some_client_id2"},
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
     oauth_fixture.client_id = CLIENT_ID + "2"
     oauth_fixture.title = CLIENT_ID + "2"
     result = await oauth_fixture.complete_external_step(result)
@@ -572,7 +573,7 @@ async def test_config_flow_create_delete_credential(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_credentials"
 
 
@@ -589,7 +590,7 @@ async def test_config_flow_with_config_credential(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = DEFAULT_IMPORT_NAME
     result = await oauth_fixture.complete_external_step(result)
     # Uses the imported auth domain for compatibility
@@ -607,7 +608,7 @@ async def test_import_without_setup(hass: HomeAssistant, config_credential) -> N
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -636,7 +637,7 @@ async def test_websocket_without_platform(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.ABORT
+    assert result.get("type") is FlowResultType.ABORT
     assert result.get("reason") == "missing_configuration"
 
 
@@ -711,7 +712,7 @@ async def test_platform_with_auth_implementation(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = DEFAULT_IMPORT_NAME
     result = await oauth_fixture.complete_external_step(result)
     # Uses the imported auth domain for compatibility
@@ -769,7 +770,7 @@ async def test_name(
     result = await hass.config_entries.flow.async_init(
         TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result.get("type") == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result.get("type") is FlowResultType.EXTERNAL_STEP
     oauth_fixture.title = NAME
     result = await oauth_fixture.complete_external_step(result)
     assert (

--- a/tests/components/aussie_broadband/test_init.py
+++ b/tests/components/aussie_broadband/test_init.py
@@ -5,9 +5,9 @@ from unittest.mock import patch
 from aiohttp import ClientConnectionError
 from aussiebb.exceptions import AuthenticationException, UnrecognisedServiceType
 
-from homeassistant import data_entry_flow
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .common import setup_platform
 
@@ -25,7 +25,7 @@ async def test_auth_failure(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.aussie_broadband.config_flow.AussieBroadbandConfigFlow.async_step_reauth",
         return_value={
-            "type": data_entry_flow.FlowResultType.FORM,
+            "type": FlowResultType.FORM,
             "flow_id": "mock_flow",
             "step_id": "reauth_confirm",
         },

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -1,9 +1,9 @@
 """Tests for the mfa setup flow."""
 
-from homeassistant import data_entry_flow
 from homeassistant.auth import auth_manager_from_config
 from homeassistant.components.auth import mfa_setup_flow
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 from tests.common import CLIENT_ID, MockUser, ensure_auth_manager_loaded
@@ -75,7 +75,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == data_entry_flow.FlowResultType.FORM
+    assert flow["type"] is FlowResultType.FORM
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
@@ -94,7 +94,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert flow["type"] is FlowResultType.CREATE_ENTRY
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -75,6 +75,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
+    # Cannot use identity `is` check here as the value is parsed from JSON
     assert flow["type"] == FlowResultType.FORM.value
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
@@ -94,6 +95,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
+    # Cannot use identity `is` check here as the value is parsed from JSON
     assert flow["type"] == FlowResultType.CREATE_ENTRY.value
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -75,7 +75,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] is FlowResultType.FORM
+    assert flow["type"] == FlowResultType.FORM
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
@@ -94,7 +94,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] is FlowResultType.CREATE_ENTRY
+    assert flow["type"] == FlowResultType.CREATE_ENTRY
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/auth/test_mfa_setup_flow.py
+++ b/tests/components/auth/test_mfa_setup_flow.py
@@ -75,7 +75,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == FlowResultType.FORM
+    assert flow["type"] == FlowResultType.FORM.value
     assert flow["handler"] == "example_module"
     assert flow["step_id"] == "init"
     assert flow["data_schema"][0] == {"type": "string", "name": "pin", "required": True}
@@ -94,7 +94,7 @@ async def test_ws_setup_depose_mfa(
     assert result["success"]
 
     flow = result["result"]
-    assert flow["type"] == FlowResultType.CREATE_ENTRY
+    assert flow["type"] == FlowResultType.CREATE_ENTRY.value
     assert flow["handler"] == "example_module"
     assert flow["data"]["result"] is None
 

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -7,9 +7,10 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components.cloud import account_link
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.util.dt import utcnow
 
@@ -203,7 +204,7 @@ async def test_implementation(
             TEST_DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-    assert result["type"] == data_entry_flow.FlowResultType.EXTERNAL_STEP
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
     assert result["url"] == "http://example.com/auth"
 
     flow_finished.set_result(

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -13,6 +13,7 @@ from homeassistant.components.config import config_entries
 from homeassistant.config_entries import HANDLERS, ConfigFlow
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_flow, config_validation as cv
 from homeassistant.loader import IntegrationNotFound
 from homeassistant.setup import async_setup_component
@@ -1305,7 +1306,7 @@ async def test_ignore_flow(
         result = await hass.config_entries.flow.async_init(
             "test", context={"source": core_ce.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         await ws_client.send_json(
             {

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -6,10 +6,11 @@ import json
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import dialogflow, intent_script
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 SESSION_ID = "a9b84cec-46b6-484e-8f31-f65dba03ae6d"
@@ -88,10 +89,10 @@ async def fixture(hass, hass_client_no_auth):
     result = await hass.config_entries.flow.async_init(
         "dialogflow", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     return await hass_client_no_auth(), webhook_id

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -156,7 +156,7 @@ async def test_new_dashboard_fix_reauth(
                 "unique_id": mock_config_entry.unique_id,
             },
         )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
     assert len(mock_get_encryption_key.mock_calls) == 0
 

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -607,7 +607,7 @@ async def test_connection_aborted_wrong_device(
         "esphome", context={"source": config_entries.SOURCE_DHCP}, data=service_info
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_HOST] == "192.168.43.184"
     await hass.async_block_till_done()

--- a/tests/components/flexit_bacnet/conftest.py
+++ b/tests/components/flexit_bacnet/conftest.py
@@ -22,7 +22,7 @@ async def flow_id(hass: HomeAssistant) -> str:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {}
 
     return result["flow_id"]

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import zone
 from homeassistant.components.geofency import CONF_MOBILE_BEACONS, DOMAIN
 from homeassistant.config import async_process_ha_core_config
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
@@ -157,10 +158,10 @@ async def webhook_id(hass, geofency_client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -5,13 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import gpslogger, zone
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.gpslogger import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
@@ -65,10 +66,10 @@ async def webhook_id(hass, gpslogger_client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/hisense_aehw4a1/test_init.py
+++ b/tests/components/hisense_aehw4a1/test_init.py
@@ -4,9 +4,10 @@ from unittest.mock import patch
 
 from pyaehw4a1 import exceptions
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import hisense_aehw4a1
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 
@@ -27,10 +28,10 @@ async def test_creating_entry_sets_up_climate_discovery(hass: HomeAssistant) -> 
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
+++ b/tests/components/homeassistant_hardware/test_silabs_multiprotocol_addon.py
@@ -230,7 +230,7 @@ async def test_option_flow_install_multi_pan_addon(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -239,7 +239,7 @@ async def test_option_flow_install_multi_pan_addon(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -247,7 +247,7 @@ async def test_option_flow_install_multi_pan_addon(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
         hass,
@@ -266,7 +266,7 @@ async def test_option_flow_install_multi_pan_addon(
     start_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_install_multi_pan_addon_zha(
@@ -305,7 +305,7 @@ async def test_option_flow_install_multi_pan_addon_zha(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -314,7 +314,7 @@ async def test_option_flow_install_multi_pan_addon_zha(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -330,7 +330,7 @@ async def test_option_flow_install_multi_pan_addon_zha(
         return_value=11,
     ):
         result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
         hass,
@@ -361,7 +361,7 @@ async def test_option_flow_install_multi_pan_addon_zha(
     start_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_install_multi_pan_addon_zha_other_radio(
@@ -400,7 +400,7 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -409,7 +409,7 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -418,7 +418,7 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
 
     addon_info.return_value["hostname"] = "core-silabs-multiprotocol"
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
         hass,
@@ -437,7 +437,7 @@ async def test_option_flow_install_multi_pan_addon_zha_other_radio(
     start_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     # Check the ZHA entry data is not changed
     assert zha_config_entry.data == {
@@ -469,7 +469,7 @@ async def test_option_flow_non_hassio(
     ):
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "not_hassio"
 
 
@@ -490,11 +490,11 @@ async def test_option_flow_addon_installed_other_device(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_installed_other_device"
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 @pytest.mark.parametrize(
@@ -528,30 +528,30 @@ async def test_option_flow_addon_installed_same_device_reconfigure_unexpected_us
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "reconfigure_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "notify_unknown_multipan_user"
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "change_channel"
     assert get_suggested(result["data_schema"].schema, "channel") == suggested_channel
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"channel": "14"}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "notify_channel_change"
     assert result["description_placeholders"] == {"delay_minutes": "5"}
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     assert mock_multiprotocol_platform.change_channel_calls == [(14, 300)]
     assert multipan_manager._channel == 14
@@ -601,26 +601,26 @@ async def test_option_flow_addon_installed_same_device_reconfigure_expected_user
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "reconfigure_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "change_channel"
     assert get_suggested(result["data_schema"].schema, "channel") == suggested_channel
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {"channel": "14"}
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "notify_channel_change"
     assert result["description_placeholders"] == {"delay_minutes": "5"}
 
     result = await hass.config_entries.options.async_configure(result["flow_id"], {})
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     for domain in ["otbr", "zha"]:
         assert mock_multiprotocol_platforms[domain].change_channel_calls == [(14, 300)]
@@ -664,14 +664,14 @@ async def test_option_flow_addon_installed_same_device_uninstall(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     # Make sure the flasher addon is installed
@@ -685,14 +685,14 @@ async def test_option_flow_addon_installed_same_device_uninstall(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
 
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_flasher_addon"
     assert result["progress_action"] == "install_addon"
 
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "uninstall_multiprotocol_addon"
     assert result["progress_action"] == "uninstall_multiprotocol_addon"
 
@@ -700,7 +700,7 @@ async def test_option_flow_addon_installed_same_device_uninstall(
     uninstall_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_flasher_addon"
     assert result["progress_action"] == "start_flasher_addon"
     assert result["description_placeholders"] == {"addon_name": "Silicon Labs Flasher"}
@@ -709,7 +709,7 @@ async def test_option_flow_addon_installed_same_device_uninstall(
     install_addon.assert_called_once_with(hass, "core_silabs_flasher")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     # Check the ZHA config entry data is updated
     assert zha_config_entry.data == {
@@ -748,21 +748,21 @@ async def test_option_flow_addon_installed_same_device_do_not_uninstall_multi_pa
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: False}
     )
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_flasher_already_running_failure(
@@ -791,14 +791,14 @@ async def test_option_flow_flasher_already_running_failure(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     # The flasher addon is already installed and running, this is bad
@@ -808,7 +808,7 @@ async def test_option_flow_flasher_already_running_failure(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_already_running"
 
 
@@ -838,14 +838,14 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     addon_store_info.return_value = {
@@ -857,7 +857,7 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "uninstall_multiprotocol_addon"
     assert result["progress_action"] == "uninstall_multiprotocol_addon"
 
@@ -865,7 +865,7 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     uninstall_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_flasher_addon"
     assert result["progress_action"] == "start_flasher_addon"
     assert result["description_placeholders"] == {"addon_name": "Silicon Labs Flasher"}
@@ -879,7 +879,7 @@ async def test_option_flow_addon_installed_same_device_flasher_already_installed
     install_addon.assert_not_called()
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_flasher_install_failure(
@@ -919,14 +919,14 @@ async def test_option_flow_flasher_install_failure(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     addon_store_info.return_value = {
@@ -939,7 +939,7 @@ async def test_option_flow_flasher_install_failure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
 
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_flasher_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -947,7 +947,7 @@ async def test_option_flow_flasher_install_failure(
     install_addon.assert_called_once_with(hass, "core_silabs_flasher")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_install_failed"
 
 
@@ -977,20 +977,20 @@ async def test_option_flow_flasher_addon_flash_failure(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "uninstall_multiprotocol_addon"
     assert result["progress_action"] == "uninstall_multiprotocol_addon"
 
@@ -1000,7 +1000,7 @@ async def test_option_flow_flasher_addon_flash_failure(
     uninstall_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_flasher_addon"
     assert result["progress_action"] == "start_flasher_addon"
     assert result["description_placeholders"] == {"addon_name": "Silicon Labs Flasher"}
@@ -1008,7 +1008,7 @@ async def test_option_flow_flasher_addon_flash_failure(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_start_failed"
     assert result["description_placeholders"]["addon_name"] == "Silicon Labs Flasher"
 
@@ -1055,21 +1055,21 @@ async def test_option_flow_uninstall_migration_initiate_failure(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"], {silabs_multiprotocol_addon.CONF_DISABLE_MULTI_PAN: True}
     )
 
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "zha_migration_failed"
     mock_initiate_migration.assert_called_once()
 
@@ -1116,14 +1116,14 @@ async def test_option_flow_uninstall_migration_finish_failure(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.MENU
+    assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "addon_menu"
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {"next_step_id": "uninstall_addon"},
     )
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "uninstall_addon"
 
     result = await hass.config_entries.options.async_configure(
@@ -1134,7 +1134,7 @@ async def test_option_flow_uninstall_migration_finish_failure(
     uninstall_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_flasher_addon"
     assert result["progress_action"] == "start_flasher_addon"
     assert result["description_placeholders"] == {"addon_name": "Silicon Labs Flasher"}
@@ -1142,7 +1142,7 @@ async def test_option_flow_uninstall_migration_finish_failure(
     await hass.async_block_till_done()
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "zha_migration_failed"
 
 
@@ -1163,7 +1163,7 @@ async def test_option_flow_do_not_install_multi_pan_addon(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1172,7 +1172,7 @@ async def test_option_flow_do_not_install_multi_pan_addon(
             "enable_multi_pan": False,
         },
     )
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
 
 async def test_option_flow_install_multi_pan_addon_install_fails(
@@ -1197,7 +1197,7 @@ async def test_option_flow_install_multi_pan_addon_install_fails(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1206,7 +1206,7 @@ async def test_option_flow_install_multi_pan_addon_install_fails(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -1214,7 +1214,7 @@ async def test_option_flow_install_multi_pan_addon_install_fails(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_install_failed"
 
 
@@ -1240,7 +1240,7 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1249,7 +1249,7 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -1257,7 +1257,7 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
         hass,
@@ -1276,7 +1276,7 @@ async def test_option_flow_install_multi_pan_addon_start_fails(
     start_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_start_failed"
 
 
@@ -1302,7 +1302,7 @@ async def test_option_flow_install_multi_pan_addon_set_options_fails(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1311,7 +1311,7 @@ async def test_option_flow_install_multi_pan_addon_set_options_fails(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -1319,7 +1319,7 @@ async def test_option_flow_install_multi_pan_addon_set_options_fails(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_set_config_failed"
 
 
@@ -1342,7 +1342,7 @@ async def test_option_flow_addon_info_fails(
     config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "addon_info_failed"
 
 
@@ -1379,7 +1379,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_1(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1388,7 +1388,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_1(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -1396,7 +1396,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_1(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "zha_migration_failed"
     set_addon_options.assert_not_called()
 
@@ -1435,7 +1435,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_2(
     zha_config_entry.add_to_hass(hass)
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "addon_not_installed"
 
     result = await hass.config_entries.options.async_configure(
@@ -1444,7 +1444,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_2(
             "enable_multi_pan": True,
         },
     )
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "install_addon"
     assert result["progress_action"] == "install_addon"
 
@@ -1452,7 +1452,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_2(
     install_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.SHOW_PROGRESS
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
     assert result["step_id"] == "start_addon"
     set_addon_options.assert_called_once_with(
         hass,
@@ -1471,7 +1471,7 @@ async def test_option_flow_install_multi_pan_addon_zha_migration_fails_step_2(
     start_addon.assert_called_once_with(hass, "core_silabs_multiprotocol")
 
     result = await hass.config_entries.options.async_configure(result["flow_id"])
-    assert result["type"] == FlowResultType.ABORT
+    assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "zha_migration_failed"
 
 

--- a/tests/components/ifttt/test_init.py
+++ b/tests/components/ifttt/test_init.py
@@ -1,9 +1,10 @@
 """Test the init file of IFTTT."""
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import ifttt
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.typing import ClientSessionGenerator
 
@@ -20,10 +21,10 @@ async def test_config_flow_registers_webhook(
     result = await hass.config_entries.flow.async_init(
         "ifttt", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     ifttt_events = []

--- a/tests/components/locative/test_init.py
+++ b/tests/components/locative/test_init.py
@@ -5,12 +5,13 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import locative
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.locative import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
@@ -40,10 +41,10 @@ async def webhook_id(hass, locative_client):
     result = await hass.config_entries.flow.async_init(
         "locative", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     return result["result"].data["webhook_id"]

--- a/tests/components/mailgun/test_init.py
+++ b/tests/components/mailgun/test_init.py
@@ -5,11 +5,12 @@ import hmac
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import mailgun, webhook
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import CONF_API_KEY, CONF_DOMAIN
 from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
 API_KEY = "abc123"
@@ -38,10 +39,10 @@ async def webhook_id_with_api_key(hass):
     result = await hass.config_entries.flow.async_init(
         "mailgun", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     return result["result"].data["webhook_id"]
 
@@ -58,10 +59,10 @@ async def webhook_id_without_api_key(hass):
     result = await hass.config_entries.flow.async_init(
         "mailgun", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     return result["result"].data["webhook_id"]
 

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import ps4
 from homeassistant.components.media_player import (
     ATTR_MEDIA_CONTENT_TYPE,
@@ -27,6 +27,7 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -47,7 +48,7 @@ MOCK_FLOW_RESULT = {
     "version": VERSION,
     "minor_version": 1,
     "handler": DOMAIN,
-    "type": data_entry_flow.FlowResultType.CREATE_ENTRY,
+    "type": FlowResultType.CREATE_ENTRY,
     "title": "test_ps4",
     "data": MOCK_DATA,
     "options": {},
@@ -132,7 +133,7 @@ async def test_creating_entry_sets_up_media_player(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done()
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import sonos, zeroconf
 from homeassistant.components.sonos import SonosDiscoveryManager
 from homeassistant.components.sonos.const import (
@@ -16,6 +16,7 @@ from homeassistant.components.sonos.const import (
 )
 from homeassistant.components.sonos.exception import SonosUpdateError
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
@@ -46,10 +47,10 @@ async def test_creating_entry_sets_up_media_player(
         )
 
         # Confirmation form
-        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["type"] is FlowResultType.FORM
 
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
         await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/synology_dsm/test_init.py
+++ b/tests/components/synology_dsm/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 from synology_dsm.exceptions import SynologyDSMLoginInvalidException
 
-from homeassistant import data_entry_flow
 from homeassistant.components.synology_dsm.const import DOMAIN, SERVICES
 from homeassistant.const import (
     CONF_HOST,
@@ -15,6 +14,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 
 from .consts import HOST, MACS, PASSWORD, PORT, USE_SSL, USERNAME
 
@@ -57,7 +57,7 @@ async def test_reauth_triggered(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.synology_dsm.config_flow.SynologyDSMFlowHandler.async_step_reauth",
             return_value={
-                "type": data_entry_flow.FlowResultType.FORM,
+                "type": FlowResultType.FORM,
                 "flow_id": "mock_flow",
                 "step_id": "reauth_confirm",
             },

--- a/tests/components/systemmonitor/test_init.py
+++ b/tests/components/systemmonitor/test_init.py
@@ -38,7 +38,7 @@ async def test_adding_processor_to_options(
         mock_added_config_entry.entry_id
     )
 
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "init"
 
     result = await hass.config_entries.options.async_configure(
@@ -49,7 +49,7 @@ async def test_adding_processor_to_options(
     )
     await hass.async_block_till_done()
 
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "binary_sensor": {
             CONF_PROCESS: ["python3", "pip", "systemd"],

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -94,6 +94,7 @@ async def test_migrate_process_sensor(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
+    # Cannot use identity `is` check here as the value is parsed from JSON
     assert data["type"] == FlowResultType.CREATE_ENTRY.value
     await hass.async_block_till_done()
 
@@ -192,5 +193,6 @@ async def test_other_fixable_issues(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
+    # Cannot use identity `is` check here as the value is parsed from JSON
     assert data["type"] == FlowResultType.CREATE_ENTRY.value
     await hass.async_block_till_done()

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -94,7 +94,7 @@ async def test_migrate_process_sensor(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] is FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.system_monitor_process_python3")
@@ -192,5 +192,5 @@ async def test_other_fixable_issues(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] is FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -94,7 +94,7 @@ async def test_migrate_process_sensor(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY.value
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.system_monitor_process_python3")
@@ -192,5 +192,5 @@ async def test_other_fixable_issues(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] == FlowResultType.CREATE_ENTRY.value
     await hass.async_block_till_done()

--- a/tests/components/systemmonitor/test_repairs.py
+++ b/tests/components/systemmonitor/test_repairs.py
@@ -94,7 +94,7 @@ async def test_migrate_process_sensor(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()
 
     state = hass.states.get("binary_sensor.system_monitor_process_python3")
@@ -192,5 +192,5 @@ async def test_other_fixable_issues(
     assert resp.status == HTTPStatus.OK
     data = await resp.json()
 
-    assert data["type"] == FlowResultType.CREATE_ENTRY
+    assert data["type"] is FlowResultType.CREATE_ENTRY
     await hass.async_block_till_done()

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -5,13 +5,14 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import traccar, zone
 from homeassistant.components.device_tracker import DOMAIN as DEVICE_TRACKER_DOMAIN
 from homeassistant.components.traccar import DOMAIN, TRACKER_UPDATE
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
@@ -65,10 +66,10 @@ async def webhook_id_fixture(hass, client):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
 
     await hass.async_block_till_done()
     return result["result"].data["webhook_id"]

--- a/tests/components/twilio/test_init.py
+++ b/tests/components/twilio/test_init.py
@@ -1,9 +1,10 @@
 """Test the init file of Twilio."""
 
-from homeassistant import config_entries, data_entry_flow
+from homeassistant import config_entries
 from homeassistant.components import twilio
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 
 from tests.typing import ClientSessionGenerator
 
@@ -19,10 +20,10 @@ async def test_config_flow_registers_webhook(
     result = await hass.config_entries.flow.async_init(
         "twilio", context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == data_entry_flow.FlowResultType.FORM, result
+    assert result["type"] is FlowResultType.FORM, result
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     webhook_id = result["result"].data["webhook_id"]
 
     twilio_events = []

--- a/tests/components/youless/test_config_flows.py
+++ b/tests/components/youless/test_config_flows.py
@@ -26,7 +26,7 @@ async def test_full_flow(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") == FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
 
@@ -42,7 +42,7 @@ async def test_full_flow(hass: HomeAssistant) -> None:
             {"host": "localhost"},
         )
 
-    assert result2.get("type") == FlowResultType.CREATE_ENTRY
+    assert result2.get("type") is FlowResultType.CREATE_ENTRY
     assert result2.get("title") == "localhost"
     assert len(mocked_youless.mock_calls) == 1
 
@@ -53,7 +53,7 @@ async def test_not_found(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": SOURCE_USER}
     )
 
-    assert result.get("type") == FlowResultType.FORM
+    assert result.get("type") is FlowResultType.FORM
     assert result.get("errors") == {}
     assert result.get("step_id") == "user"
 
@@ -67,5 +67,5 @@ async def test_not_found(hass: HomeAssistant) -> None:
             {"host": "localhost"},
         )
 
-    assert result2.get("type") == FlowResultType.FORM
+    assert result2.get("type") is FlowResultType.FORM
     assert len(mocked_youless.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Similar to #114669, which only looked at config flow tests.

Also favour `from homeassistant.data_entry_flow import FlowResultType` over `from homeassistant import data_entry_flow` to match the codebase.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
