### PR TITLE
Use is in ConfigEntryState enum comparison in tests (A-M)

### DIFF
--- a/tests/components/agent_dvr/test_init.py
+++ b/tests/components/agent_dvr/test_init.py
@@ -31,7 +31,7 @@ async def test_setup_config_and_unload(
 ) -> None:
     """Test setup and unload."""
     entry = await init_integration(hass, aioclient_mock)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -50,7 +50,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
         side_effect=AgentError,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     with _patch_init_agent(await _create_mocked_agent(available=False)):
         await hass.config_entries.async_reload(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/aladdin_connect/test_cover.py
+++ b/tests/components/aladdin_connect/test_cover.py
@@ -114,7 +114,7 @@ async def test_cover_operation(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert COVER_DOMAIN in hass.config.components
 

--- a/tests/components/aladdin_connect/test_init.py
+++ b/tests/components/aladdin_connect/test_init.py
@@ -93,7 +93,7 @@ async def test_setup_component_no_error(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
 
@@ -135,12 +135,12 @@ async def test_load_and_unload(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     assert await config_entry.async_unload(hass)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_stale_device_removal(
@@ -190,7 +190,7 @@ async def test_stale_device_removal(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     device_registry = dr.async_get(hass)
@@ -220,7 +220,7 @@ async def test_stale_device_removal(
 
     assert await config_entry.async_unload(hass)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     mock_aladdinconnect_api.get_doors = AsyncMock(return_value=[DEVICE_CONFIG_OPEN])
     with patch(
@@ -230,7 +230,7 @@ async def test_stale_device_removal(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
     device_entries = dr.async_entries_for_config_entry(

--- a/tests/components/analytics_insights/test_init.py
+++ b/tests/components/analytics_insights/test_init.py
@@ -21,9 +21,9 @@ async def test_load_unload_entry(
     await setup_integration(hass, mock_config_entry)
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/android_ip_webcam/test_init.py
+++ b/tests/components/android_ip_webcam/test_init.py
@@ -30,7 +30,7 @@ async def test_successful_config_entry(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_failed_connection_error(
@@ -47,7 +47,7 @@ async def test_setup_failed_connection_error(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_failed_invalid_auth(
@@ -64,7 +64,7 @@ async def test_setup_failed_invalid_auth(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_unload_entry(hass: HomeAssistant, aioclient_mock_fixture) -> None:

--- a/tests/components/androidtv/test_media_player.py
+++ b/tests/components/androidtv/test_media_player.py
@@ -591,7 +591,7 @@ async def test_setup_fail(
 
         await async_update_entity(hass, entity_id)
         state = hass.states.get(entity_id)
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
         assert state is None
 
 

--- a/tests/components/anthemav/test_init.py
+++ b/tests/components/anthemav/test_init.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, AsyncMock, patch
 from anthemav.device_error import DeviceError
 import pytest
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
@@ -24,13 +24,13 @@ async def test_load_unload_config_entry(
     mock_connection_create.assert_called_with(
         host="1.1.1.1", port=14999, update_callback=ANY
     )
-    assert init_integration.state == config_entries.ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
 
     # unload
     await hass.config_entries.async_unload(init_integration.entry_id)
     await hass.async_block_till_done()
     # assert unload and avr is closed
-    assert init_integration.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert init_integration.state is ConfigEntryState.NOT_LOADED
     mock_anthemav.close.assert_called_once()
 
 
@@ -46,7 +46,7 @@ async def test_config_entry_not_ready_when_oserror(
         mock_config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert mock_config_entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+        assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_anthemav_dispatcher_signal(

--- a/tests/components/asuswrt/test_diagnostics.py
+++ b/tests/components/asuswrt/test_diagnostics.py
@@ -30,7 +30,7 @@ async def test_diagnostics(
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     entry_dict = async_redact_data(mock_config_entry.as_dict(), TO_REDACT)
 

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components import automation
 from homeassistant.components.blueprint import models
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -48,7 +48,7 @@ async def test_notify_leaving_zone(
 ) -> None:
     """Test notifying leaving a zone blueprint."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
 
     device = device_registry.async_get_or_create(

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -8,7 +8,6 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components import automation
 from homeassistant.components.automation import (
     ATTR_SOURCE,
@@ -18,6 +17,7 @@ from homeassistant.components.automation import (
     SERVICE_TRIGGER,
     AutomationEntity,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
@@ -1615,7 +1615,7 @@ async def test_extraction_functions(
 ) -> None:
     """Test extraction functions."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
 
     condition_device = device_registry.async_get_or_create(

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 
 async def test_setup_entry(hass: HomeAssistant, setup_config_entry) -> None:
     """Test successful setup of entry."""
-    assert setup_config_entry.state == ConfigEntryState.LOADED
+    assert setup_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_entry_fails(hass: HomeAssistant, config_entry) -> None:
@@ -24,15 +24,15 @@ async def test_setup_entry_fails(hass: HomeAssistant, config_entry) -> None:
 
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_unload_entry(hass: HomeAssistant, setup_config_entry) -> None:
     """Test successful unload of entry."""
-    assert setup_config_entry.state == ConfigEntryState.LOADED
+    assert setup_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(setup_config_entry.entry_id)
-    assert setup_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert setup_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize("config_entry_version", [1])
@@ -49,5 +49,5 @@ async def test_migrate_entry(hass: HomeAssistant, config_entry) -> None:
     with patch("homeassistant.components.axis.async_setup_entry", return_value=True):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.version == 3

--- a/tests/components/azure_devops/test_init.py
+++ b/tests/components/azure_devops/test_init.py
@@ -24,12 +24,12 @@ async def test_load_unload_entry(
     assert mock_devops_client.authorize.call_count == 1
     assert mock_devops_client.get_builds.call_count == 2
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_remove(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_auth_failed(
@@ -45,7 +45,7 @@ async def test_auth_failed(
 
     assert not mock_devops_client.authorized
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_update_failed(
@@ -60,7 +60,7 @@ async def test_update_failed(
 
     assert mock_devops_client.get_builds.call_count == 1
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_no_builds(
@@ -75,4 +75,4 @@ async def test_no_builds(
 
     assert mock_devops_client.get_builds.call_count == 1
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/azure_event_hub/conftest.py
+++ b/tests/components/azure_event_hub/conftest.py
@@ -52,7 +52,7 @@ async def mock_entry_fixture(hass, filter_schema, mock_create_batch, mock_send_b
     assert await async_setup_component(
         hass, DOMAIN, {DOMAIN: {CONF_FILTER: filter_schema}}
     )
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # Clear the component_loaded event from the queue.
     async_fire_time_changed(
@@ -70,7 +70,7 @@ async def mock_entry_fixture(hass, filter_schema, mock_create_batch, mock_send_b
 @pytest.fixture(name="entry_with_one_event")
 async def mock_entry_with_one_event(hass, entry):
     """Use the entry and add a single test event to the queue."""
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     hass.states.async_set("sensor.test", STATE_ON)
     return entry
 

--- a/tests/components/azure_event_hub/test_init.py
+++ b/tests/components/azure_event_hub/test_init.py
@@ -69,7 +69,7 @@ async def test_unload_entry(hass: HomeAssistant, entry, mock_create_batch) -> No
     """
     assert await hass.config_entries.async_unload(entry.entry_id)
     mock_create_batch.add.assert_not_called()
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_failed_test_connection(
@@ -85,7 +85,7 @@ async def test_failed_test_connection(
     entry.add_to_hass(hass)
     mock_get_eventhub_properties.side_effect = EventHubError("Test")
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_send_batch_error(

--- a/tests/components/baf/test_init.py
+++ b/tests/components/baf/test_init.py
@@ -37,7 +37,7 @@ async def test_config_entry_wrong_uuid(
     with _patch_device_init(DeviceUUIDMismatchError):
         await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
         await hass.async_block_till_done()
-    assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
     assert (
         "Unexpected device found at 127.0.0.1; expected 12340, found 1234"
         in caplog.text

--- a/tests/components/balboa/test_init.py
+++ b/tests/components/balboa/test_init.py
@@ -16,9 +16,9 @@ async def test_setup_entry(
     hass: HomeAssistant, client: MagicMock, integration: MockConfigEntry
 ) -> None:
     """Validate that setup entry also configure the client."""
-    assert integration.state == ConfigEntryState.LOADED
+    assert integration.state is ConfigEntryState.LOADED
     await hass.config_entries.async_unload(integration.entry_id)
-    assert integration.state == ConfigEntryState.NOT_LOADED
+    assert integration.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_entry_fails(hass: HomeAssistant, client: MagicMock) -> None:
@@ -36,7 +36,7 @@ async def test_setup_entry_fails(hass: HomeAssistant, client: MagicMock) -> None
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     client.connect.return_value = True
     client.async_configuration_loaded.return_value = False
@@ -44,4 +44,4 @@ async def test_setup_entry_fails(hass: HomeAssistant, client: MagicMock) -> None
     await hass.config_entries.async_reload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/blebox/test_config_flow.py
+++ b/tests/components/blebox/test_config_flow.py
@@ -9,6 +9,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.blebox import config_flow
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -203,7 +204,7 @@ async def test_async_setup_entry(hass: HomeAssistant, valid_feature_mock) -> Non
     await hass.async_block_till_done()
 
     assert hass.config_entries.async_entries() == [config]
-    assert config.state is config_entries.ConfigEntryState.LOADED
+    assert config.state is ConfigEntryState.LOADED
 
 
 async def test_async_remove_entry(hass: HomeAssistant, valid_feature_mock) -> None:
@@ -219,7 +220,7 @@ async def test_async_remove_entry(hass: HomeAssistant, valid_feature_mock) -> No
     await hass.async_block_till_done()
 
     assert hass.config_entries.async_entries() == []
-    assert config.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert config.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_flow_with_zeroconf(hass: HomeAssistant) -> None:

--- a/tests/components/blue_current/test_init.py
+++ b/tests/components/blue_current/test_init.py
@@ -41,11 +41,11 @@ async def test_load_unload_entry(
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.NOT_LOADED
+        assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -288,14 +288,14 @@ async def test_setup_and_retry_adapter_not_yet_available(
 
     assert "Failed to start Bluetooth" in caplog.text
     assert len(bluetooth.async_discovered_service_info(hass)) == 0
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner.start",
     ):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
         await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner.stop",
@@ -327,7 +327,7 @@ async def test_no_race_during_manual_reload_in_retry_state(
 
     assert "Failed to start Bluetooth" in caplog.text
     assert len(bluetooth.async_discovered_service_info(hass)) == 0
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner.start",
@@ -335,7 +335,7 @@ async def test_no_race_during_manual_reload_in_retry_state(
         await hass.config_entries.async_reload(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner.stop",
@@ -2866,7 +2866,7 @@ async def test_three_adapters_one_missing(
     entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_auto_detect_bluetooth_adapters_linux(

--- a/tests/components/bluetooth/test_scanner.py
+++ b/tests/components/bluetooth/test_scanner.py
@@ -48,7 +48,7 @@ async def test_config_entry_can_be_reloaded_when_stop_raises(
 ) -> None:
     """Test we can reload if stopping the scanner raises."""
     entry = hass.config_entries.async_entries(bluetooth.DOMAIN)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with patch(
         "habluetooth.scanner.OriginalBleakScanner.stop",
@@ -57,7 +57,7 @@ async def test_config_entry_can_be_reloaded_when_stop_raises(
         await hass.config_entries.async_reload(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert "Error stopping scanner" in caplog.text
 
 

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -37,10 +37,10 @@ async def test_load_unload(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
-    assert bring_config_entry.state == ConfigEntryState.LOADED
+    assert bring_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(bring_config_entry.entry_id)
-    assert bring_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert bring_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(

--- a/tests/components/caldav/test_init.py
+++ b/tests/components/caldav/test_init.py
@@ -23,15 +23,15 @@ async def test_load_unload(
     config_entry: MockConfigEntry,
 ) -> None:
     """Test loading and unloading of the config entry."""
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     with patch("homeassistant.components.caldav.config_flow.caldav.DAVClient"):
         await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -57,7 +57,7 @@ async def test_client_failure(
 ) -> None:
     """Test CalDAV client failures in setup."""
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     with patch(
         "homeassistant.components.caldav.config_flow.caldav.DAVClient"

--- a/tests/components/coinbase/test_init.py
+++ b/tests/components/coinbase/test_init.py
@@ -2,13 +2,13 @@
 
 from unittest.mock import patch
 
-from homeassistant import config_entries
 from homeassistant.components.coinbase.const import (
     API_TYPE_VAULT,
     CONF_CURRENCIES,
     CONF_EXCHANGE_RATES,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -45,12 +45,12 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         entry = await init_mock_coinbase(hass)
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -212,7 +212,7 @@ async def test_client_connection_error(hass: HomeAssistant, mock_daikin) -> None
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_timeout_error(hass: HomeAssistant, mock_daikin) -> None:
@@ -228,4 +228,4 @@ async def test_timeout_error(hass: HomeAssistant, mock_daikin) -> None:
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -7,13 +7,14 @@ import pytest
 from pytest_unordered import unordered
 import voluptuous as vol
 
-from homeassistant import config_entries, loader
+from homeassistant import loader
 from homeassistant.components import automation, device_automation
 from homeassistant.components.device_automation import (
     InvalidDeviceAutomationConfig,
     toggle_entity,
 )
 from homeassistant.components.websocket_api.const import TYPE_RESULT
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -976,7 +977,7 @@ async def test_automation_with_dynamically_validated_action(
     module.async_validate_action_config = AsyncMock()
 
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1078,7 +1079,7 @@ async def test_automation_with_dynamically_validated_condition(
     module.async_validate_condition_config = AsyncMock()
 
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1192,7 +1193,7 @@ async def test_automation_with_dynamically_validated_trigger(
     module.async_validate_trigger_config = AsyncMock(wraps=lambda hass, config: config)
 
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1293,7 +1294,7 @@ async def test_automation_with_bad_action(
 ) -> None:
     """Test automation with bad device action."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1327,7 +1328,7 @@ async def test_automation_with_bad_condition_action(
 ) -> None:
     """Test automation with bad device action."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1360,7 +1361,7 @@ async def test_automation_with_bad_condition(
 ) -> None:
     """Test automation with bad device condition."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1525,7 +1526,7 @@ async def test_automation_with_bad_sub_condition(
 ) -> None:
     """Test automation with bad device condition under and/or conditions."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1563,7 +1564,7 @@ async def test_automation_with_bad_trigger(
 ) -> None:
     """Test automation with bad device trigger."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/tests/components/device_tracker/test_config_entry.py
+++ b/tests/components/device_tracker/test_config_entry.py
@@ -336,14 +336,14 @@ async def test_load_unload_entry(
 ) -> None:
     """Test loading and unloading a config entry with a device tracker entity."""
     config_entry = await create_mock_platform(hass, config_entry, [tracker_entity])
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get(entity_id)
     assert state
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     state = hass.states.get(entity_id)
     assert not state
@@ -436,7 +436,7 @@ async def test_tracker_entity_state(
 ) -> None:
     """Test tracker entity state and state attributes."""
     config_entry = await create_mock_platform(hass, config_entry, [tracker_entity])
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     hass.states.async_set(
         "zone.home",
         "0",
@@ -482,7 +482,7 @@ async def test_scanner_entity_state(
     )
 
     config_entry = await create_mock_platform(hass, config_entry, [scanner_entity])
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_state = hass.states.get(entity_id)
     assert entity_state

--- a/tests/components/devolo_home_control/test_diagnostics.py
+++ b/tests/components/devolo_home_control/test_diagnostics.py
@@ -32,7 +32,7 @@ async def test_entry_diagnostics(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
         result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
         assert result == snapshot

--- a/tests/components/devolo_home_network/test_diagnostics.py
+++ b/tests/components/devolo_home_network/test_diagnostics.py
@@ -25,7 +25,7 @@ async def test_entry_diagnostics(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     result = await get_diagnostics_for_config_entry(hass, hass_client, entry)
     assert result == snapshot

--- a/tests/components/dlink/test_init.py
+++ b/tests/components/dlink/test_init.py
@@ -19,7 +19,7 @@ async def test_setup_config_and_unload(
     await setup_integration()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -37,7 +37,7 @@ async def test_legacy_setup_config_and_unload(
     await setup_integration_legacy()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -56,7 +56,7 @@ async def test_async_setup_entry_not_ready(
     """Test that it throws ConfigEntryNotReady when exception occurs during legacy setup."""
     with patch_setup(mocked_plug_legacy_no_auth):
         await hass.config_entries.async_setup(config_entry_with_uid.entry_id)
-    assert config_entry_with_uid.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry_with_uid.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_device_info(

--- a/tests/components/dnsip/test_config_flow.py
+++ b/tests/components/dnsip/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.dnsip.const import (
     CONF_RESOLVER_IPV6,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -227,7 +228,7 @@ async def test_options_flow(hass: HomeAssistant) -> None:
         "resolver_ipv6": "2001:4860:4860::8888",
     }
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_options_flow_empty_return(hass: HomeAssistant) -> None:

--- a/tests/components/dnsip/test_init.py
+++ b/tests/components/dnsip/test_init.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from homeassistant import config_entries
 from homeassistant.components.dnsip.const import (
     CONF_HOSTNAME,
     CONF_IPV4,
@@ -13,7 +12,7 @@ from homeassistant.components.dnsip.const import (
     CONF_RESOLVER_IPV6,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
@@ -49,7 +48,7 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/dremel_3d_printer/test_init.py
+++ b/tests/components/dremel_3d_printer/test_init.py
@@ -27,7 +27,7 @@ async def test_setup(
     with patch(MOCKED_MODEL, return_value=model) as mock:
         await hass.config_entries.async_setup(config_entry.entry_id)
         assert await async_setup_component(hass, DOMAIN, {})
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert mock.called
 
     with patch(MOCKED_MODEL, return_value=model) as mock:
@@ -50,7 +50,7 @@ async def test_async_setup_entry_not_ready(
         await hass.config_entries.async_setup(config_entry.entry_id)
     assert await async_setup_component(hass, DOMAIN, {})
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
@@ -60,7 +60,7 @@ async def test_update_failed(
     """Test coordinator throws UpdateFailed after failed update."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert await async_setup_component(hass, DOMAIN, {})
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     with patch(
         "homeassistant.components.dremel_3d_printer.Dremel3DPrinter.refresh",

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -13,13 +13,13 @@ from unittest.mock import DEFAULT, MagicMock
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.sensor import (
     ATTR_OPTIONS,
     ATTR_STATE_CLASS,
     SensorDeviceClass,
     SensorStateClass,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
@@ -1325,7 +1325,7 @@ async def test_reconnect(hass: HomeAssistant, dsmr_connection_fixture) -> None:
 
     await hass.config_entries.async_unload(mock_entry.entry_id)
 
-    assert mock_entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert mock_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_gas_meter_providing_energy_reading(

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -28,7 +28,7 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.entry_id in hass.data[DOMAIN]
 
     assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/dynalite/test_config_flow.py
+++ b/tests/components/dynalite/test_config_flow.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components import dynalite
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_PORT
 from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -21,9 +22,9 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("first_con", "second_con", "exp_type", "exp_result", "exp_reason"),
     [
-        (True, True, "create_entry", config_entries.ConfigEntryState.LOADED, ""),
+        (True, True, "create_entry", ConfigEntryState.LOADED, ""),
         (False, False, "abort", None, "cannot_connect"),
-        (True, False, "create_entry", config_entries.ConfigEntryState.SETUP_RETRY, ""),
+        (True, False, "create_entry", ConfigEntryState.SETUP_RETRY, ""),
     ],
 )
 async def test_flow(
@@ -138,7 +139,7 @@ async def test_two_entries(hass: HomeAssistant) -> None:
             data={dynalite.CONF_HOST: host2},
         )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"].state == config_entries.ConfigEntryState.LOADED
+    assert result["result"].state is ConfigEntryState.LOADED
 
 
 async def test_setup_user(hass):
@@ -163,7 +164,7 @@ async def test_setup_user(hass):
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["result"].state == config_entries.ConfigEntryState.LOADED
+    assert result["result"].state is ConfigEntryState.LOADED
     assert result["title"] == host
     assert result["data"] == {
         "host": host,

--- a/tests/components/eafm/test_sensor.py
+++ b/tests/components/eafm/test_sensor.py
@@ -5,7 +5,7 @@ import datetime
 import aiohttp
 import pytest
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -37,7 +37,7 @@ async def async_setup_test_fixture(hass, mock_get_station, initial_value):
     entry.add_to_hass(hass)
 
     assert await async_setup_component(hass, "eafm", {})
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     await hass.async_block_till_done()
 
     async def poll(value):

--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -16,7 +16,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test unload."""
     entry = await init_integration(hass, aioclient_mock)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -32,7 +32,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
         efergymock.side_effect = (exceptions.ConnectError, exceptions.DataError)
         await hass.config_entries.async_setup(entry.entry_id)
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-        assert entry.state == ConfigEntryState.SETUP_RETRY
+        assert entry.state is ConfigEntryState.SETUP_RETRY
         assert not hass.data.get(DOMAIN)
 
 
@@ -43,7 +43,7 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant) -> None:
         efergymock.side_effect = exceptions.InvalidAuth
         await hass.config_entries.async_setup(entry.entry_id)
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-        assert entry.state == ConfigEntryState.SETUP_ERROR
+        assert entry.state is ConfigEntryState.SETUP_ERROR
         assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/energenie_power_sockets/test_init.py
+++ b/tests/components/energenie_power_sockets/test_init.py
@@ -23,7 +23,7 @@ async def test_load_unload_entry(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.entry_id in hass.data[DOMAIN]
 
     assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/energenie_power_sockets/test_switch.py
+++ b/tests/components/energenie_power_sockets/test_switch.py
@@ -117,7 +117,7 @@ async def test_switch_setup(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.entry_id in hass.data[DOMAIN]
 
     state = hass.states.get(f"switch.{entity_name}")

--- a/tests/components/esphome/test_dashboard.py
+++ b/tests/components/esphome/test_dashboard.py
@@ -60,7 +60,7 @@ async def test_restore_dashboard_storage_end_to_end(
     ) as mock_dashboard_api:
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
         assert mock_dashboard_api.mock_calls[0][1][0] == "http://new-host:6052"
 
 
@@ -74,7 +74,7 @@ async def test_setup_dashboard_fails(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
         await dashboard.async_set_dashboard_info(hass, "test-slug", "test-host", 6052)
-        assert mock_config_entry.state == ConfigEntryState.LOADED
+        assert mock_config_entry.state is ConfigEntryState.LOADED
         assert mock_get_devices.call_count == 1
 
     # The dashboard addon might recover later so we still
@@ -109,7 +109,7 @@ async def test_setup_dashboard_fails_when_already_setup(
         await dashboard.async_set_dashboard_info(hass, "test-slug", "test-host", 6052)
         await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     assert mock_get_devices.call_count == 1
     # We still setup, and reload, but we do not do the reauths
     assert dashboard.STORAGE_KEY in hass_storage
@@ -120,7 +120,7 @@ async def test_new_info_reload_config_entries(
     hass: HomeAssistant, init_integration, mock_dashboard
 ) -> None:
     """Test config entries are reloaded when new info is set."""
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
 
     with patch("homeassistant.components.esphome.async_setup_entry") as mock_setup:
         await dashboard.async_set_dashboard_info(hass, "test-slug", "test-host", 6052)

--- a/tests/components/evil_genius_labs/test_init.py
+++ b/tests/components/evil_genius_labs/test_init.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.evil_genius_labs import PLATFORMS
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 
@@ -14,4 +14,4 @@ async def test_setup_unload_entry(
     """Test setting up and unloading a config entry."""
     assert len(hass.states.async_entity_ids()) == 1
     assert await hass.config_entries.async_unload(config_entry.entry_id)
-    assert config_entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/fastdotcom/test_init.py
+++ b/tests/components/fastdotcom/test_init.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant import config_entries
 from homeassistant.components.fastdotcom.const import DEFAULT_NAME, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_UNKNOWN
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import issue_registry as ir
@@ -31,10 +31,10 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_from_import(hass: HomeAssistant) -> None:
@@ -72,7 +72,7 @@ async def test_delayed_speedtest_during_startup(
         await hass.async_block_till_done()
     hass.set_state(original_state)
 
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get("sensor.fast_com_download")
     # Assert state is Unknown as fast.com isn't starting until HA has started
     assert state.state is STATE_UNKNOWN
@@ -87,7 +87,7 @@ async def test_delayed_speedtest_during_startup(
     assert state is not None
     assert state.state == "5.0"
 
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_service_deprecated(

--- a/tests/components/fitbit/test_init.py
+++ b/tests/components/fitbit/test_init.py
@@ -34,15 +34,15 @@ async def test_setup(
     setup_credentials: None,
 ) -> None:
     """Test setting up the integration."""
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     assert await integration_setup()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -68,7 +68,7 @@ async def test_token_refresh_failure(
     )
 
     assert not await integration_setup()
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize("token_expiration_time", [12345])
@@ -88,7 +88,7 @@ async def test_token_refresh_success(
     )
 
     assert await integration_setup()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     # Verify token request
     assert len(aioclient_mock.mock_calls) == 1
@@ -132,7 +132,7 @@ async def test_token_requires_reauth(
     )
 
     assert not await integration_setup()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -147,7 +147,7 @@ async def test_device_update_coordinator_failure(
     requests_mock: Mocker,
 ) -> None:
     """Test case where the device update coordinator fails on the first request."""
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     requests_mock.register_uri(
         "GET",
@@ -156,7 +156,7 @@ async def test_device_update_coordinator_failure(
     )
 
     assert not await integration_setup()
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_device_update_coordinator_reauth(
@@ -167,7 +167,7 @@ async def test_device_update_coordinator_reauth(
     requests_mock: Mocker,
 ) -> None:
     """Test case where the device update coordinator fails on the first request."""
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     requests_mock.register_uri(
         "GET",
@@ -179,7 +179,7 @@ async def test_device_update_coordinator_reauth(
     )
 
     assert not await integration_setup()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/flexit_bacnet/test_init.py
+++ b/tests/components/flexit_bacnet/test_init.py
@@ -18,7 +18,7 @@ async def test_loading_and_unloading_config_entry(
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.CLIMATE])
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -33,4 +33,4 @@ async def test_failed_initialization(
     mock_flexit_bacnet.update.side_effect = DecodingError
     mock_config_entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/flipr/test_init.py
+++ b/tests/components/flipr/test_init.py
@@ -26,4 +26,4 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         await hass.config_entries.async_unload(entry.entry_id)
-        assert entry.state == ConfigEntryState.NOT_LOADED
+        assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/flux_led/test_init.py
+++ b/tests/components/flux_led/test_init.py
@@ -98,10 +98,10 @@ async def test_config_entry_reload(hass: HomeAssistant) -> None:
     with _patch_discovery(), _patch_wifibulb():
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.NOT_LOADED
+        assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_retry(hass: HomeAssistant) -> None:
@@ -113,7 +113,7 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
     with _patch_discovery(no_device=True), _patch_wifibulb(no_device=True):
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_config_entry_retry_right_away_on_discovery(hass: HomeAssistant) -> None:
@@ -125,7 +125,7 @@ async def test_config_entry_retry_right_away_on_discovery(hass: HomeAssistant) -
     with _patch_discovery(no_device=True), _patch_wifibulb(no_device=True):
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     with _patch_discovery(), _patch_wifibulb():
         await hass.config_entries.flow.async_init(
@@ -134,7 +134,7 @@ async def test_config_entry_retry_right_away_on_discovery(hass: HomeAssistant) -
             data=DHCP_DISCOVERY,
         )
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_coordinator_retry_right_away_on_discovery_already_setup(
@@ -152,7 +152,7 @@ async def test_coordinator_retry_right_away_on_discovery_already_setup(
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_id = "light.bulb_rgbcw_ddeeff"
     assert entity_registry.async_get(entity_id).unique_id == MAC_ADDRESS
@@ -219,7 +219,7 @@ async def test_config_entry_fills_unique_id_with_directed_discovery(
     ):
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
     assert config_entry.unique_id == MAC_ADDRESS
     assert config_entry.title == title
@@ -235,7 +235,7 @@ async def test_time_sync_startup_and_next_day(hass: HomeAssistant) -> None:
     with _patch_discovery(), _patch_wifibulb(device=bulb):
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(bulb.async_set_time.mock_calls) == 1
     async_fire_time_changed(hass, utcnow() + timedelta(hours=24))

--- a/tests/components/forecast_solar/test_energy.py
+++ b/tests/components/forecast_solar/test_energy.py
@@ -25,7 +25,7 @@ async def test_energy_solar_forecast(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     assert await energy.async_get_solar_forecast(hass, mock_config_entry.entry_id) == {
         "wh_hours": {

--- a/tests/components/forecast_solar/test_init.py
+++ b/tests/components/forecast_solar/test_init.py
@@ -29,7 +29,7 @@ async def test_load_unload_config_entry(
     mock_config_entry.add_to_hass(hass)
     await async_setup_component(hass, "forecast_solar", {})
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/freedompro/test_init.py
+++ b/tests/components/freedompro/test_init.py
@@ -43,7 +43,7 @@ async def test_config_not_ready(hass: HomeAssistant) -> None:
     ):
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.state == ConfigEntryState.SETUP_RETRY
+        assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_unload_entry(
@@ -53,9 +53,9 @@ async def test_unload_entry(
     entry = init_integration
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -26,7 +26,7 @@ async def test_button_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     buttons = hass.states.async_all(BUTTON_DOMAIN)
     assert len(buttons) == 4
@@ -57,7 +57,7 @@ async def test_buttons(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     button = hass.states.get(entity_id)
     assert button
@@ -91,7 +91,7 @@ async def test_wol_button(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     button = hass.states.get("button.printer_wake_on_lan")
     assert button
@@ -125,7 +125,7 @@ async def test_wol_button_new_device(
     mesh_data = copy.deepcopy(MOCK_MESH_DATA)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert hass.states.get("button.printer_wake_on_lan")
     assert not hass.states.get("button.server_wake_on_lan")
@@ -156,7 +156,7 @@ async def test_wol_button_absent_for_mesh_slave(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     button = hass.states.get("button.printer_wake_on_lan")
     assert button is None
@@ -182,7 +182,7 @@ async def test_wol_button_absent_for_non_lan_device(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     button = hass.states.get("button.printer_wake_on_lan")
     assert button is None

--- a/tests/components/fritz/test_diagnostics.py
+++ b/tests/components/fritz/test_diagnostics.py
@@ -28,7 +28,7 @@ async def test_entry_diagnostics(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     entry_dict = entry.as_dict()
     for key in TO_REDACT:

--- a/tests/components/fritz/test_image.py
+++ b/tests/components/fritz/test_image.py
@@ -105,7 +105,7 @@ async def test_image_entity(
         await hass.config_entries.async_setup(entry.entry_id)
 
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # test image entity is generated as expected
     states = hass.states.async_all(IMAGE_DOMAIN)
@@ -155,7 +155,7 @@ async def test_image_update(
         await hass.config_entries.async_setup(entry.entry_id)
 
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     client = await hass_client()
     resp = await client.get("/api/image_proxy/image.mock_title_guestwifi")
@@ -191,7 +191,7 @@ async def test_image_update_unavailable(
         await hass.config_entries.async_setup(entry.entry_id)
 
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get("image.mock_title_guestwifi")
     assert state

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -29,10 +29,10 @@ async def test_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_options_reload(
@@ -53,7 +53,7 @@ async def test_options_reload(
     ) as mock_reload:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
         result = await hass.config_entries.options.async_init(entry.entry_id)
         await hass.async_block_till_done()
@@ -82,7 +82,7 @@ async def test_setup_auth_fail(hass: HomeAssistant, error) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @pytest.mark.parametrize(
@@ -102,4 +102,4 @@ async def test_setup_fail(hass: HomeAssistant, error) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/fritz/test_sensor.py
+++ b/tests/components/fritz/test_sensor.py
@@ -107,7 +107,7 @@ async def test_sensor_setup(hass: HomeAssistant, fc_class_mock, fh_class_mock) -
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     sensors = hass.states.async_all(SENSOR_DOMAIN)
     assert len(sensors) == len(SENSOR_TYPES)

--- a/tests/components/fritz/test_switch.py
+++ b/tests/components/fritz/test_switch.py
@@ -180,7 +180,7 @@ async def test_switch_setup(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     switches = hass.states.async_all(Platform.SWITCH)
     assert len(switches) == 3

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -40,7 +40,7 @@ async def test_update_entities_initialized(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     updates = hass.states.async_all(UPDATE_DOMAIN)
     assert len(updates) == 1
@@ -61,7 +61,7 @@ async def test_update_available(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     update = hass.states.get("update.mock_title_fritz_os")
     assert update is not None
@@ -84,7 +84,7 @@ async def test_no_update_available(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     update = hass.states.get("update.mock_title_fritz_os")
     assert update is not None
@@ -112,7 +112,7 @@ async def test_available_update_can_be_installed(
 
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
         update = hass.states.get("update.mock_title_fritz_os")
         assert update is not None

--- a/tests/components/generic/test_config_flow.py
+++ b/tests/components/generic/test_config_flow.py
@@ -27,6 +27,7 @@ from homeassistant.components.stream import (
     CONF_USE_WALLCLOCK_AS_TIMESTAMPS,
 )
 from homeassistant.components.stream.worker import StreamWorkerError
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_AUTHENTICATION,
     CONF_NAME,
@@ -804,11 +805,11 @@ async def test_unload_entry(hass: HomeAssistant, fakeimg_png) -> None:
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_entry.state is config_entries.ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(mock_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert mock_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_reload_on_title_change(hass: HomeAssistant) -> None:
@@ -823,7 +824,7 @@ async def test_reload_on_title_change(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_entry.state is config_entries.ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("camera.my_title").attributes["friendly_name"] == "My Title"
 
     hass.config_entries.async_update_entry(mock_entry, title="New Title")

--- a/tests/components/github/common.py
+++ b/tests/components/github/common.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 
-from homeassistant import config_entries
 from homeassistant.components.github.const import CONF_REPOSITORIES, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
@@ -50,4 +50,4 @@ async def setup_github_integration(
     await hass.async_block_till_done()
 
     assert setup_result
-    assert mock_config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/glances/test_init.py
+++ b/tests/components/glances/test_init.py
@@ -27,7 +27,7 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_entry_deprecated_version(
@@ -45,7 +45,7 @@ async def test_entry_deprecated_version(
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     issue = issue_registry.async_get_issue(DOMAIN, "deprecated_version")
     assert issue is not None

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -25,7 +25,7 @@ async def test_setup_config_and_unload(hass: HomeAssistant) -> None:
     with patch("homeassistant.components.goalzero.Yeti", return_value=mocked_yeti):
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -46,7 +46,7 @@ async def test_setup_config_entry_incorrectly_formatted_mac(
     with patch("homeassistant.components.goalzero.Yeti", return_value=mocked_yeti):
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -64,7 +64,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
         side_effect=exceptions.ConnectError,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_update_failed(

--- a/tests/components/google/test_init.py
+++ b/tests/components/google/test_init.py
@@ -116,7 +116,7 @@ async def test_unload_entry(
     assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -959,4 +959,4 @@ async def test_remove_entry(
     assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_remove(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/google_tasks/test_init.py
+++ b/tests/components/google_tasks/test_init.py
@@ -30,7 +30,7 @@ async def test_setup(
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.services.async_services().get(DOMAIN)
 
 

--- a/tests/components/hardkernel/test_init.py
+++ b/tests/components/hardkernel/test_init.py
@@ -101,4 +101,4 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert len(mock_get_os_info.mock_calls) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/hassio/test_sensor.py
+++ b/tests/components/hassio/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.components.hassio import (
     HassioAPIError,
 )
 from homeassistant.components.hassio.const import REQUEST_REFRESH_DELAY
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -317,7 +318,7 @@ async def test_stats_addon_sensor(
     freezer.tick(config_entries.RELOAD_AFTER_UPDATE_DELAY)
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
-    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     # Verify the entity is still enabled
     assert entity_registry.async_get(entity_id).disabled_by is None
 

--- a/tests/components/holiday/test_init.py
+++ b/tests/components/holiday/test_init.py
@@ -20,10 +20,10 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     state: ConfigEntryState = entry.state
-    assert state == ConfigEntryState.NOT_LOADED
+    assert state is ConfigEntryState.NOT_LOADED

--- a/tests/components/homeassistant_green/test_init.py
+++ b/tests/components/homeassistant_green/test_init.py
@@ -105,4 +105,4 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert len(mock_get_os_info.mock_calls) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/homeassistant_sky_connect/test_init.py
+++ b/tests/components/homeassistant_sky_connect/test_init.py
@@ -299,7 +299,7 @@ async def test_setup_entry_wait_usb(hass: HomeAssistant) -> None:
         return_value=False,
     ) as mock_is_plugged_in:
         await hass.config_entries.async_setup(config_entry.entry_id)
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
         assert len(hass.config_entries.async_entries(DOMAIN)) == 1
         # USB discovery starts, config entry should be removed
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -340,7 +340,7 @@ async def test_setup_entry_addon_info_fails(
     ):
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_addon_not_running(
@@ -373,5 +373,5 @@ async def test_setup_entry_addon_not_running(
     ):
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
         start_addon.assert_called_once()

--- a/tests/components/homeassistant_yellow/test_init.py
+++ b/tests/components/homeassistant_yellow/test_init.py
@@ -294,7 +294,7 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert len(mock_get_os_info.mock_calls) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_addon_info_fails(
@@ -325,7 +325,7 @@ async def test_setup_entry_addon_info_fails(
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
 
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_addon_not_running(
@@ -355,5 +355,5 @@ async def test_setup_entry_addon_not_running(
         assert not await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
     start_addon.assert_called_once()

--- a/tests/components/homekit/test_init.py
+++ b/tests/components/homekit/test_init.py
@@ -126,7 +126,7 @@ async def test_bridge_with_triggers(
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
         await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
 

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -370,7 +370,7 @@ async def test_handle_events_late_setup(
 
     await hass.config_entries.async_unload(helper.config_entry.entry_id)
     await hass.async_block_till_done()
-    assert helper.config_entry.state == ConfigEntryState.NOT_LOADED
+    assert helper.config_entry.state is ConfigEntryState.NOT_LOADED
 
     assert await async_setup_component(
         hass,
@@ -424,7 +424,7 @@ async def test_handle_events_late_setup(
 
     await hass.config_entries.async_setup(helper.config_entry.entry_id)
     await hass.async_block_till_done()
-    assert helper.config_entry.state == ConfigEntryState.LOADED
+    assert helper.config_entry.state is ConfigEntryState.LOADED
 
     # Make sure first automation (only) fires for single press
     helper.pairing.testing.update_named_service(

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -155,13 +155,13 @@ async def test_offline_device_raises(hass: HomeAssistant, controller) -> None:
         )
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     is_connected = True
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
 
@@ -212,13 +212,13 @@ async def test_ble_device_only_checks_is_available(
         )
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     is_available = True
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
     is_available = False

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -31,12 +31,12 @@ async def test_load_unload_entry(
     await setup_integration(hass, mock_config_entry)
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ async def test_update_failed(
     await setup_integration(hass, mock_config_entry)
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_websocket_not_available(
@@ -105,13 +105,13 @@ async def test_websocket_not_available(
     assert "Failed to connect to websocket. Trying to reconnect: Boom" in caplog.text
     assert mock_automower_client.auth.websocket_connect.call_count == 1
     assert mock_automower_client.start_listening.call_count == 1
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     freezer.tick(timedelta(seconds=2))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     assert mock_automower_client.auth.websocket_connect.call_count == 2
     assert mock_automower_client.start_listening.call_count == 2
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_device_info(

--- a/tests/components/insteon/test_config_flow.py
+++ b/tests/components/insteon/test_config_flow.py
@@ -30,6 +30,7 @@ from homeassistant.components.insteon.const import (
     CONF_X10,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_DEVICE,
@@ -136,7 +137,7 @@ async def test_fail_on_existing(hass: HomeAssistant) -> None:
         options={},
     )
     config_entry.add_to_hass(hass)
-    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/iotawatt/test_init.py
+++ b/tests/components/iotawatt/test_init.py
@@ -24,7 +24,7 @@ async def test_setup_connection_failed(
     mock_iotawatt.connect.side_effect = httpx.ConnectError("")
     assert await async_setup_component(hass, "iotawatt", {})
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_auth_failed(hass: HomeAssistant, mock_iotawatt, entry) -> None:
@@ -32,4 +32,4 @@ async def test_setup_auth_failed(hass: HomeAssistant, mock_iotawatt, entry) -> N
     mock_iotawatt.connect.return_value = False
     assert await async_setup_component(hass, "iotawatt", {})
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/islamic_prayer_times/test_init.py
+++ b/tests/components/islamic_prayer_times/test_init.py
@@ -7,10 +7,10 @@ from freezegun import freeze_time
 from prayer_times_calculator.exceptions import InvalidResponseError
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components import islamic_prayer_times
 from homeassistant.components.islamic_prayer_times.const import CONF_CALC_METHOD
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -43,7 +43,7 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert entry.state is config_entries.ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_failed(hass: HomeAssistant) -> None:
@@ -62,7 +62,7 @@ async def test_setup_failed(hass: HomeAssistant) -> None:
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+        assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
@@ -81,7 +81,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
 
         assert await hass.config_entries.async_unload(entry.entry_id)
         await hass.async_block_till_done()
-        assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+        assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_options_listener(hass: HomeAssistant) -> None:
@@ -122,7 +122,7 @@ async def test_update_failed(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert entry.state is config_entries.ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
     with patch(
         "prayer_times_calculator.PrayerTimesCalculator.fetch_prayer_times"

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -87,7 +87,7 @@ async def test_form_options(
 
     await hass.async_block_till_done()
 
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_form_invalid_auth(hass: HomeAssistant) -> None:

--- a/tests/components/knx/test_init.py
+++ b/tests/components/knx/test_init.py
@@ -11,7 +11,6 @@ from xknx.io import (
     SecureConfig,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.knx.config_flow import DEFAULT_ROUTING_IA
 from homeassistant.components.knx.const import (
     CONF_KNX_AUTOMATIC,
@@ -40,6 +39,7 @@ from homeassistant.components.knx.const import (
     DOMAIN as KNX_DOMAIN,
     KNXConfigEntryData,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 
@@ -287,4 +287,4 @@ async def test_async_remove_entry(
     await hass.async_block_till_done()
 
     assert hass.config_entries.async_entries() == []
-    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/lacrosse_view/test_init.py
+++ b/tests/components/lacrosse_view/test_init.py
@@ -35,11 +35,11 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert entries[0].state == ConfigEntryState.NOT_LOADED
+    assert entries[0].state is ConfigEntryState.NOT_LOADED
 
 
 async def test_login_error(hass: HomeAssistant) -> None:
@@ -54,7 +54,7 @@ async def test_login_error(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.SETUP_ERROR
+    assert entries[0].state is ConfigEntryState.SETUP_ERROR
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert flows
     assert len(flows) == 1
@@ -76,7 +76,7 @@ async def test_http_error(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.SETUP_RETRY
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_new_token(hass: HomeAssistant, freezer: FrozenDateTimeFactory) -> None:
@@ -98,7 +98,7 @@ async def test_new_token(hass: HomeAssistant, freezer: FrozenDateTimeFactory) ->
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     with (
         patch("lacrosse_view.LaCrosse.login", return_value=True) as login,
@@ -135,7 +135,7 @@ async def test_failed_token(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     with patch("lacrosse_view.LaCrosse.login", side_effect=LoginError("Test")):
         freezer.tick(timedelta(hours=1))
@@ -145,7 +145,7 @@ async def test_failed_token(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert flows

--- a/tests/components/lacrosse_view/test_sensor.py
+++ b/tests/components/lacrosse_view/test_sensor.py
@@ -43,7 +43,7 @@ async def test_entities_added(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get("sensor.test_temperature")
 
 
@@ -67,7 +67,7 @@ async def test_sensor_permission(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.SETUP_ERROR
+    assert entries[0].state is ConfigEntryState.SETUP_ERROR
     assert not hass.states.get("sensor.test_temperature")
     assert "This account does not have permission to read Test" in caplog.text
 
@@ -92,7 +92,7 @@ async def test_field_not_supported(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get("sensor.test_some_unsupported_field") is None
     assert "Unsupported sensor field" in caplog.text
 
@@ -128,7 +128,7 @@ async def test_field_types(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get(f"sensor.test_{entity_id}").state == expected
 
 
@@ -151,7 +151,7 @@ async def test_no_field(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get("sensor.test_temperature").state == "unavailable"
 
 
@@ -174,5 +174,5 @@ async def test_field_data_missing(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get("sensor.test_temperature").state == "unknown"

--- a/tests/components/lamarzocco/test_config_flow.py
+++ b/tests/components/lamarzocco/test_config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.components.lamarzocco.const import (
     CONF_USE_BLUETOOTH,
     DOMAIN,
 )
-from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult, FlowResultType
@@ -346,7 +346,7 @@ async def test_options_flow(
 ) -> None:
     """Test options flow."""
     await async_init_integration(hass, mock_config_entry)
-    assert mock_config_entry.state is config_entries.ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
 

--- a/tests/components/laundrify/test_init.py
+++ b/tests/components/laundrify/test_init.py
@@ -20,7 +20,7 @@ async def test_setup_entry_api_unauthorized(
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
     assert not hass.data.get(DOMAIN)
 
 
@@ -35,7 +35,7 @@ async def test_setup_entry_api_cannot_connect(
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
@@ -46,7 +46,7 @@ async def test_setup_entry_successful(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_entry_unload(hass: HomeAssistant) -> None:
@@ -56,4 +56,4 @@ async def test_setup_entry_unload(hass: HomeAssistant) -> None:
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/lawn_mower/test_init.py
+++ b/tests/components/lawn_mower/test_init.py
@@ -114,13 +114,13 @@ async def test_lawn_mower_setup(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get(entity1.entity_id)
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     entity_state = hass.states.get(entity1.entity_id)
 
     assert entity_state

--- a/tests/components/lcn/test_init.py
+++ b/tests/components/lcn/test_init.py
@@ -20,12 +20,12 @@ from .conftest import MockPchkConnectionManager, setup_component
 async def test_async_setup_entry(hass: HomeAssistant, entry, lcn_connection) -> None:
     """Test a successful setup entry and unload of entry."""
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
 
 
@@ -36,7 +36,7 @@ async def test_async_setup_multiple_entries(hass: HomeAssistant, entry, entry2) 
             config_entry.add_to_hass(hass)
             await hass.config_entries.async_setup(config_entry.entry_id)
             await hass.async_block_till_done()
-            assert config_entry.state == ConfigEntryState.LOADED
+            assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 2
 
@@ -44,7 +44,7 @@ async def test_async_setup_multiple_entries(hass: HomeAssistant, entry, entry2) 
         assert await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.NOT_LOADED
+        assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     assert not hass.data.get(DOMAIN)
 
@@ -96,7 +96,7 @@ async def test_async_setup_entry_raises_authentication_error(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_entry_raises_license_error(
@@ -110,7 +110,7 @@ async def test_async_setup_entry_raises_license_error(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_entry_raises_timeout_error(
@@ -122,7 +122,7 @@ async def test_async_setup_entry_raises_timeout_error(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_from_configuration_yaml(hass: HomeAssistant) -> None:

--- a/tests/components/lidarr/test_init.py
+++ b/tests/components/lidarr/test_init.py
@@ -14,7 +14,7 @@ async def test_setup(
     """Test setup."""
     await setup_integration()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -30,7 +30,7 @@ async def test_async_setup_entry_not_ready(
     await setup_integration()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
@@ -41,7 +41,7 @@ async def test_async_setup_entry_auth_failed(
     await setup_integration()
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/lifx/test_init.py
+++ b/tests/components/lifx/test_init.py
@@ -87,10 +87,10 @@ async def test_config_entry_reload(hass: HomeAssistant) -> None:
     with _patch_discovery(), _patch_config_flow_try_connect(), _patch_device():
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.LOADED
+        assert already_migrated_config_entry.state is ConfigEntryState.LOADED
         await hass.config_entries.async_unload(already_migrated_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.NOT_LOADED
+        assert already_migrated_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_retry(hass: HomeAssistant) -> None:
@@ -106,7 +106,7 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_get_version_fails(hass: HomeAssistant) -> None:
@@ -123,7 +123,7 @@ async def test_get_version_fails(hass: HomeAssistant) -> None:
     with _patch_discovery(device=bulb), _patch_device(device=bulb):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_dns_error_at_startup(hass: HomeAssistant) -> None:
@@ -158,7 +158,7 @@ async def test_dns_error_at_startup(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_config_entry_wrong_serial(
@@ -173,7 +173,7 @@ async def test_config_entry_wrong_serial(
     with _patch_discovery(), _patch_config_flow_try_connect(), _patch_device():
         await async_setup_component(hass, lifx.DOMAIN, {lifx.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert (
         "Unexpected device found at 127.0.0.1; expected aa:bb:cc:dd:ee:c0, found aa:bb:cc:dd:ee:cc"

--- a/tests/components/linear_garage_door/test_coordinator.py
+++ b/tests/components/linear_garage_door/test_coordinator.py
@@ -38,7 +38,7 @@ async def test_invalid_password(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.SETUP_ERROR
+    assert entries[0].state is ConfigEntryState.SETUP_ERROR
     flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
     assert flows
     assert len(flows) == 1
@@ -70,4 +70,4 @@ async def test_invalid_login(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.SETUP_RETRY
+    assert entries[0].state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/linear_garage_door/test_cover.py
+++ b/tests/components/linear_garage_door/test_cover.py
@@ -32,7 +32,7 @@ async def test_data(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert hass.states.get("cover.test_garage_1").state == STATE_OPEN
     assert hass.states.get("cover.test_garage_2").state == STATE_CLOSED
     assert hass.states.get("cover.test_garage_3").state == STATE_OPENING

--- a/tests/components/linear_garage_door/test_init.py
+++ b/tests/components/linear_garage_door/test_init.py
@@ -53,7 +53,7 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     entries = hass.config_entries.async_entries(DOMAIN)
     assert entries
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     with patch(
         "homeassistant.components.linear_garage_door.coordinator.Linear.close",
@@ -61,4 +61,4 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     ):
         await hass.config_entries.async_unload(entries[0].entry_id)
         await hass.async_block_till_done()
-    assert entries[0].state == ConfigEntryState.NOT_LOADED
+    assert entries[0].state is ConfigEntryState.NOT_LOADED

--- a/tests/components/local_calendar/test_init.py
+++ b/tests/components/local_calendar/test_init.py
@@ -17,7 +17,7 @@ async def test_load_unload(
 ) -> None:
     """Test loading and unloading a config entry."""
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get(TEST_ENTITY)
     assert state
@@ -26,7 +26,7 @@ async def test_load_unload(
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == "unavailable"
@@ -54,7 +54,7 @@ async def test_load_failure(
 ) -> None:
     """Test failures loading the store."""
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     state = hass.states.get(TEST_ENTITY)
     assert not state

--- a/tests/components/local_ip/test_init.py
+++ b/tests/components/local_ip/test_init.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from homeassistant import config_entries
 from homeassistant.components.local_ip import DOMAIN
 from homeassistant.components.network import MDNS_TARGET_IP, async_get_source_ip
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -17,7 +17,7 @@ async def test_basic_setup(hass: HomeAssistant, mock_get_source_ip) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     local_ip = await async_get_source_ip(hass, target_ip=MDNS_TARGET_IP)
     state = hass.states.get(f"sensor.{DOMAIN}")
@@ -26,4 +26,4 @@ async def test_basic_setup(hass: HomeAssistant, mock_get_source_ip) -> None:
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/local_todo/test_init.py
+++ b/tests/components/local_todo/test_init.py
@@ -17,7 +17,7 @@ async def test_load_unload(
 ) -> None:
     """Test loading and unloading a config entry."""
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get(TEST_ENTITY)
     assert state
@@ -26,7 +26,7 @@ async def test_load_unload(
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.state == "unavailable"
@@ -54,7 +54,7 @@ async def test_load_failure(
 ) -> None:
     """Test failures loading the todo store."""
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     state = hass.states.get(TEST_ENTITY)
     assert not state

--- a/tests/components/lyric/test_config_flow.py
+++ b/tests/components/lyric/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.lyric.const import DOMAIN, OAUTH2_AUTHORIZE, OAUTH2_TOKEN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -105,7 +106,7 @@ async def test_full_flow(
 
     assert DOMAIN in hass.config.components
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/matter/test_init.py
+++ b/tests/components/matter/test_init.py
@@ -68,7 +68,7 @@ async def test_entry_setup_unload(
     await hass.async_block_till_done()
 
     assert matter_client.connect.call_count == 1
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
     assert entity_state.state != STATE_UNAVAILABLE
@@ -76,7 +76,7 @@ async def test_entry_setup_unload(
     await hass.config_entries.async_unload(entry.entry_id)
 
     assert matter_client.disconnect.call_count == 1
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
     assert entity_state.state == STATE_UNAVAILABLE
@@ -210,12 +210,12 @@ async def test_listen_failure_config_entry_loaded(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     listen_block.set()
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     assert matter_client.disconnect.call_count == 1
 
 

--- a/tests/components/mikrotik/test_init.py
+++ b/tests/components/mikrotik/test_init.py
@@ -34,7 +34,7 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
     entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_hub_connection_error(hass: HomeAssistant, mock_api: MagicMock) -> None:
@@ -49,7 +49,7 @@ async def test_hub_connection_error(hass: HomeAssistant, mock_api: MagicMock) ->
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_hub_authentication_error(
@@ -66,7 +66,7 @@ async def test_hub_authentication_error(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:
@@ -83,5 +83,5 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     assert entry.entry_id not in hass.data[DOMAIN]

--- a/tests/components/minecraft_server/test_init.py
+++ b/tests/components/minecraft_server/test_init.py
@@ -134,12 +134,12 @@ async def test_setup_and_unload_entry(
     ):
         assert await hass.config_entries.async_setup(java_mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert java_mock_config_entry.state == ConfigEntryState.LOADED
+        assert java_mock_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(java_mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert not hass.data.get(DOMAIN)
-    assert java_mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert java_mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_entry_lookup_failure(
@@ -157,7 +157,7 @@ async def test_setup_entry_lookup_failure(
         )
 
     await hass.async_block_till_done()
-    assert java_mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert java_mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_init_failure(
@@ -175,7 +175,7 @@ async def test_setup_entry_init_failure(
         )
 
     await hass.async_block_till_done()
-    assert java_mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert java_mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_entry_not_ready(
@@ -199,7 +199,7 @@ async def test_setup_entry_not_ready(
         )
 
     await hass.async_block_till_done()
-    assert java_mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert java_mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_entry_migration(
@@ -246,7 +246,7 @@ async def test_entry_migration(
         CONF_ADDRESS: TEST_ADDRESS,
     }
     assert migrated_config_entry.version == 3
-    assert migrated_config_entry.state == ConfigEntryState.LOADED
+    assert migrated_config_entry.state is ConfigEntryState.LOADED
 
     # Test migrated device entry.
     device_entry = device_registry.async_get(device_entry_id)
@@ -305,7 +305,7 @@ async def test_entry_migration_host_only(
         CONF_ADDRESS: TEST_HOST,
     }
     assert v1_mock_config_entry.version == 3
-    assert v1_mock_config_entry.state == ConfigEntryState.LOADED
+    assert v1_mock_config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_entry_migration_v3_failure(
@@ -335,4 +335,4 @@ async def test_entry_migration_v3_failure(
 
     # Test config entry.
     assert v1_mock_config_entry.version == 2
-    assert v1_mock_config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert v1_mock_config_entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/modem_callerid/test_init.py
+++ b/tests/components/modem_callerid/test_init.py
@@ -30,7 +30,7 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
         patch("phone_modem.PhoneModem._modem_sm"),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
@@ -45,7 +45,7 @@ async def test_async_setup_entry_not_ready(hass: HomeAssistant) -> None:
         modemmock.side_effect = exceptions.SerialError
         await hass.config_entries.async_setup(entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/mqtt/test_util.py
+++ b/tests/components/mqtt/test_util.py
@@ -162,7 +162,7 @@ async def test_waiting_for_client_not_loaded(
     for _ in range(4):
         hass.async_create_task(_async_just_in_time_subscribe())
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     assert await hass.config_entries.async_setup(entry.entry_id)
     assert len(unsubs) == 4
     for unsub in unsubs:
@@ -182,7 +182,7 @@ async def test_waiting_for_client_loaded(
         unsub = await mqtt.async_subscribe(hass, "test_topic", lambda msg: None)
 
     entry = hass.config_entries.async_entries(mqtt.DATA_MQTT)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await _async_just_in_time_subscribe()
 
@@ -209,13 +209,13 @@ async def test_waiting_for_client_entry_fails(
         assert not await mqtt.async_wait_for_mqtt_client(hass)
 
     hass.async_create_task(_async_just_in_time_subscribe())
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     with patch(
         "homeassistant.components.mqtt.async_setup_entry",
         side_effect=Exception,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_waiting_for_client_setup_fails(
@@ -237,12 +237,12 @@ async def test_waiting_for_client_setup_fails(
         assert not await mqtt.async_wait_for_mqtt_client(hass)
 
     hass.async_create_task(_async_just_in_time_subscribe())
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
     # Simulate MQTT setup fails before the client would become available
     mqtt_client_mock.connect.side_effect = Exception
     assert not await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 @patch("homeassistant.components.mqtt.util.AVAILABILITY_TIMEOUT", 0.01)
@@ -260,7 +260,7 @@ async def test_waiting_for_client_timeout(
     )
     entry.add_to_hass(hass)
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
     # returns False after timeout
     assert not await mqtt.async_wait_for_mqtt_client(hass)
 
@@ -284,7 +284,7 @@ async def test_waiting_for_client_with_disabled_entry(
         entry.entry_id, ConfigEntryDisabler.USER
     )
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
     # returns False because entry is disabled
     assert not await mqtt.async_wait_for_mqtt_client(hass)

--- a/tests/components/mystrom/test_init.py
+++ b/tests/components/mystrom/test_init.py
@@ -113,7 +113,7 @@ async def test_init_of_unknown_bulb(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_init_of_unknown_device(
@@ -127,7 +127,7 @@ async def test_init_of_unknown_device(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_init_cannot_connect_because_of_device_info(
@@ -145,7 +145,7 @@ async def test_init_cannot_connect_because_of_device_info(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_init_cannot_connect_because_of_get_state(
@@ -168,4 +168,4 @@ async def test_init_cannot_connect_because_of_get_state(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/myuplink/test_init.py
+++ b/tests/components/myuplink/test_init.py
@@ -26,12 +26,12 @@ async def test_load_unload_entry(
     await setup_integration(hass, mock_config_entry)
     entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_remove(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, similar to #114669

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
