### PR TITLE
Use is in ConfigEntryState enum comparison in tests (N-Z)

### DIFF
--- a/tests/components/neato/test_config_flow.py
+++ b/tests/components/neato/test_config_flow.py
@@ -10,6 +10,7 @@ from homeassistant.components.application_credentials import (
     async_import_client_credential,
 )
 from homeassistant.components.neato.const import NEATO_DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -158,6 +159,6 @@ async def test_reauth(
 
     assert result3["type"] is FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
-    assert new_entry.state == config_entries.ConfigEntryState.LOADED
+    assert new_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(NEATO_DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/nest/test_init.py
+++ b/tests/components/nest/test_init.py
@@ -206,7 +206,7 @@ async def test_unload_entry(hass: HomeAssistant, setup_platform) -> None:
     assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_remove_entry(

--- a/tests/components/nest/test_media_source.py
+++ b/tests/components/nest/test_media_source.py
@@ -296,7 +296,7 @@ async def test_integration_unloaded(hass: HomeAssistant, auth, setup_platform) -
     assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
     # No devices returned
     browse = await async_browse_media(hass, f"{URI_SCHEME}{DOMAIN}")
@@ -1166,10 +1166,10 @@ async def test_media_store_persistence(
     await hass.async_block_till_done()
 
     # Unload the integration.
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     # Now rebuild the entire integration and verify that all persisted storage
     # can be re-loaded from disk.

--- a/tests/components/netatmo/test_config_flow.py
+++ b/tests/components/netatmo/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.netatmo.const import (
     OAUTH2_AUTHORIZE,
     OAUTH2_TOKEN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -275,7 +276,7 @@ async def test_reauth(
 
     new_entry = hass.config_entries.async_entries(DOMAIN)[0]
 
-    assert new_entry.state == config_entries.ConfigEntryState.LOADED
+    assert new_entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1
 
@@ -322,6 +323,6 @@ async def test_reauth(
 
     assert result3["type"] is FlowResultType.ABORT
     assert result3["reason"] == "reauth_successful"
-    assert new_entry2.state == config_entries.ConfigEntryState.LOADED
+    assert new_entry2.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -9,9 +9,9 @@ from pyatmo.const import ALL_SCOPES
 import pytest
 from syrupy import SnapshotAssertion
 
-from homeassistant import config_entries
 from homeassistant.components import cloud
 from homeassistant.components.netatmo import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_WEBHOOK_ID, Platform
 from homeassistant.core import CoreState, HomeAssistant
 import homeassistant.helpers.device_registry as dr
@@ -82,7 +82,7 @@ async def test_setup_component(
     mock_impl.assert_called_once()
     mock_webhook.assert_called_once()
 
-    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert hass.config_entries.async_entries(DOMAIN)
     assert len(hass.states.async_all()) > 0
 
@@ -425,7 +425,7 @@ async def test_setup_component_invalid_token_scope(hass: HomeAssistant) -> None:
     mock_impl.assert_called_once()
     mock_webhook.assert_not_called()
 
-    assert config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
     assert hass.config_entries.async_entries(DOMAIN)
 
     notifications = async_get_persistent_notifications(hass)
@@ -479,7 +479,7 @@ async def test_setup_component_invalid_token(
     mock_impl.assert_called_once()
     mock_webhook.assert_not_called()
 
-    assert config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
     assert hass.config_entries.async_entries(DOMAIN)
     notifications = async_get_persistent_notifications(hass)
     assert len(notifications) > 0

--- a/tests/components/netgear_lte/test_init.py
+++ b/tests/components/netgear_lte/test_init.py
@@ -13,7 +13,7 @@ from .conftest import CONF_DATA
 async def test_setup_unload(hass: HomeAssistant, setup_integration: None) -> None:
     """Test setup and unload."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -29,7 +29,7 @@ async def test_async_setup_entry_not_ready(
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_device(

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -17,7 +17,7 @@ from tests.typing import WebSocketGenerator
 async def test_setup_retry_client_os_error(hass: HomeAssistant) -> None:
     """Verify we retry setup on aiohttp.ClientOSError."""
     config_entry = await async_init_integration(hass, exception=aiohttp.ClientOSError)
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def remove_device(ws_client, device_id, config_entry_id):

--- a/tests/components/nibe_heatpump/__init__.py
+++ b/tests/components/nibe_heatpump/__init__.py
@@ -64,7 +64,7 @@ async def async_add_entry(hass: HomeAssistant, data: dict[str, Any]) -> MockConf
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     return entry
 
 

--- a/tests/components/nina/test_binary_sensor.py
+++ b/tests/components/nina/test_binary_sensor.py
@@ -65,7 +65,7 @@ async def test_sensors(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(conf_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert conf_entry.state == ConfigEntryState.LOADED
+        assert conf_entry.state is ConfigEntryState.LOADED
 
         state_w1 = hass.states.get("binary_sensor.warning_aach_stadt_1")
         entry_w1 = entity_registry.async_get("binary_sensor.warning_aach_stadt_1")
@@ -181,7 +181,7 @@ async def test_sensors_without_corona_filter(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(conf_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert conf_entry.state == ConfigEntryState.LOADED
+        assert conf_entry.state is ConfigEntryState.LOADED
 
         state_w1 = hass.states.get("binary_sensor.warning_aach_stadt_1")
         entry_w1 = entity_registry.async_get("binary_sensor.warning_aach_stadt_1")
@@ -309,7 +309,7 @@ async def test_sensors_with_area_filter(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(conf_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert conf_entry.state == ConfigEntryState.LOADED
+        assert conf_entry.state is ConfigEntryState.LOADED
 
         state_w1 = hass.states.get("binary_sensor.warning_aach_stadt_1")
         entry_w1 = entity_registry.async_get("binary_sensor.warning_aach_stadt_1")

--- a/tests/components/nina/test_init.py
+++ b/tests/components/nina/test_init.py
@@ -64,7 +64,7 @@ async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Test the configuration entry."""
     entry: MockConfigEntry = await init_integration(hass)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_sensors_connection_error(hass: HomeAssistant) -> None:
@@ -82,4 +82,4 @@ async def test_sensors_connection_error(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(conf_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert conf_entry.state == ConfigEntryState.SETUP_RETRY
+        assert conf_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -85,4 +85,4 @@ async def init_integration(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/oncue/test_binary_sensor.py
+++ b/tests/components/oncue/test_binary_sensor.py
@@ -25,7 +25,7 @@ async def test_binary_sensors(hass: HomeAssistant) -> None:
     with _patch_login_and_data():
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.states.async_all("binary_sensor")) == 1
     assert (
@@ -47,7 +47,7 @@ async def test_binary_sensors_not_unavailable(hass: HomeAssistant) -> None:
     with _patch_login_and_data_unavailable():
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.states.async_all("binary_sensor")) == 1
     assert (

--- a/tests/components/oncue/test_init.py
+++ b/tests/components/oncue/test_init.py
@@ -29,10 +29,10 @@ async def test_config_entry_reload(hass: HomeAssistant) -> None:
     with _patch_login_and_data():
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_login_error(hass: HomeAssistant) -> None:
@@ -49,7 +49,7 @@ async def test_config_entry_login_error(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_config_entry_retry_later(hass: HomeAssistant) -> None:
@@ -66,4 +66,4 @@ async def test_config_entry_retry_later(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/oncue/test_sensor.py
+++ b/tests/components/oncue/test_sensor.py
@@ -40,7 +40,7 @@ async def test_sensors(hass: HomeAssistant, patcher, connections) -> None:
     with patcher():
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_registry = er.async_get(hass)
     ent = entity_registry.async_get("sensor.my_generator_latest_firmware")
@@ -167,7 +167,7 @@ async def test_sensors_unavailable(hass: HomeAssistant, patcher, connections) ->
     with patcher():
         await async_setup_component(hass, oncue.DOMAIN, {oncue.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert len(hass.states.async_all("sensor")) == 25
     assert (

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -59,11 +59,11 @@ async def test_form(hass: HomeAssistant) -> None:
 
         conf_entries = hass.config_entries.async_entries(DOMAIN)
         entry = conf_entries[0]
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
         await hass.config_entries.async_unload(conf_entries[0].entry_id)
         await hass.async_block_till_done()
-        assert entry.state == ConfigEntryState.NOT_LOADED
+        assert entry.state is ConfigEntryState.NOT_LOADED
 
         assert result["type"] is FlowResultType.CREATE_ENTRY
         assert result["title"] == CONFIG[CONF_NAME]
@@ -88,7 +88,7 @@ async def test_form_options(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
@@ -107,7 +107,7 @@ async def test_form_options(hass: HomeAssistant) -> None:
 
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
         result = await hass.config_entries.options.async_init(config_entry.entry_id)
 
@@ -126,7 +126,7 @@ async def test_form_options(hass: HomeAssistant) -> None:
 
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_form_invalid_api_key(hass: HomeAssistant) -> None:

--- a/tests/components/ourgroceries/test_init.py
+++ b/tests/components/ourgroceries/test_init.py
@@ -21,10 +21,10 @@ async def test_load_unload(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
-    assert ourgroceries_config_entry.state == ConfigEntryState.LOADED
+    assert ourgroceries_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(ourgroceries_config_entry.entry_id)
-    assert ourgroceries_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert ourgroceries_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.fixture

--- a/tests/components/peco/test_init.py
+++ b/tests/components/peco/test_init.py
@@ -51,11 +51,11 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entries[0].entry_id)
     await hass.async_block_till_done()
-    assert entries[0].state == ConfigEntryState.NOT_LOADED
+    assert entries[0].state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize(
@@ -81,7 +81,7 @@ async def test_update_timeout(hass: HomeAssistant, sensor) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get(f"sensor.{sensor}") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(
@@ -106,7 +106,7 @@ async def test_total_update_timeout(hass: HomeAssistant, sensor) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get(f"sensor.{sensor}") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(
@@ -132,7 +132,7 @@ async def test_http_error(hass: HomeAssistant, sensor: str) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get(f"sensor.{sensor}") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(
@@ -158,7 +158,7 @@ async def test_bad_json(hass: HomeAssistant, sensor: str) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get(f"sensor.{sensor}") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_unresponsive_meter_error(hass: HomeAssistant) -> None:
@@ -192,7 +192,7 @@ async def test_unresponsive_meter_error(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.meter_status") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_meter_http_error(hass: HomeAssistant) -> None:
@@ -226,7 +226,7 @@ async def test_meter_http_error(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.meter_status") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_meter_bad_json(hass: HomeAssistant) -> None:
@@ -260,7 +260,7 @@ async def test_meter_bad_json(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.meter_status") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_meter_timeout(hass: HomeAssistant) -> None:
@@ -294,7 +294,7 @@ async def test_meter_timeout(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.meter_status") is None
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_meter_data(hass: HomeAssistant) -> None:
@@ -329,4 +329,4 @@ async def test_meter_data(hass: HomeAssistant) -> None:
 
     assert hass.states.get("binary_sensor.meter_status") is not None
     assert hass.states.get("binary_sensor.meter_status").state == "on"
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/peco/test_sensor.py
+++ b/tests/components/peco/test_sensor.py
@@ -57,7 +57,7 @@ async def test_sensor_available(
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     sensor_entity = hass.states.get(f"sensor.total_{sensor}")
     assert sensor_entity is not None
@@ -91,7 +91,7 @@ async def test_sensor_available(
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 2
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     sensor_entity = hass.states.get(f"sensor.bucks_{sensor}")
     assert sensor_entity is not None

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -13,6 +13,7 @@ from tesla_powerwall import (
 from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.powerwall.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -524,7 +525,7 @@ async def test_dhcp_discovery_updates_unique_id_when_entry_is_failed(
         unique_id="1.2.3.4",
     )
     entry.add_to_hass(hass)
-    entry.mock_state(hass, config_entries.ConfigEntryState.SETUP_ERROR)
+    entry.mock_state(hass, ConfigEntryState.SETUP_ERROR)
     mock_powerwall = await _mock_powerwall_site_name(hass, "Some site")
 
     with (

--- a/tests/components/powerwall/test_init.py
+++ b/tests/components/powerwall/test_init.py
@@ -66,7 +66,7 @@ async def test_update_data_reauthenticate_on_access_denied(hass: HomeAssistant) 
 
         async_fire_time_changed(hass, utcnow() + datetime.timedelta(minutes=1))
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
         flows = hass.config_entries.flow.async_progress(DOMAIN)
         assert len(flows) == 1

--- a/tests/components/private_ble_device/__init__.py
+++ b/tests/components/private_ble_device/__init__.py
@@ -5,8 +5,8 @@ import time
 
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
-from homeassistant import config_entries
 from homeassistant.components.private_ble_device.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -38,7 +38,7 @@ async def async_mock_config_entry(hass: HomeAssistant, irk: str = DUMMY_IRK) -> 
     entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     await hass.async_block_till_done()
 
 

--- a/tests/components/proximity/test_diagnostics.py
+++ b/tests/components/proximity/test_diagnostics.py
@@ -67,7 +67,7 @@ async def test_entry_diagnostics(
     mock_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_entry.state == ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
 
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, mock_entry

--- a/tests/components/prusalink/test_init.py
+++ b/tests/components/prusalink/test_init.py
@@ -25,12 +25,12 @@ async def test_unloading(
 ) -> None:
     """Test unloading prusalink."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     assert hass.states.async_entity_ids_count() > 0
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
     for state in hass.states.async_all():
         assert state.state == "unavailable"
@@ -42,7 +42,7 @@ async def test_failed_update(
 ) -> None:
     """Test failed update marks prusalink unavailable."""
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     with (
         patch(
@@ -121,7 +121,7 @@ async def test_migration_from_1_1_to_1_2_outdated_firmware(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     assert entry.minor_version == 1
     assert (DOMAIN, "firmware_5_1_required") in issue_registry.issues
 
@@ -130,7 +130,7 @@ async def test_migration_from_1_1_to_1_2_outdated_firmware(
     await hass.async_block_till_done()
 
     # Integration should be running now, the issue should be gone
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.minor_version == 2
     assert (DOMAIN, "firmware_5_1_required") not in issue_registry.issues
 
@@ -149,4 +149,4 @@ async def test_migration_fails_on_future_version(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR

--- a/tests/components/pushbullet/test_init.py
+++ b/tests/components/pushbullet/test_init.py
@@ -26,7 +26,7 @@ async def test_async_setup_entry_success(
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with patch(
         "homeassistant.components.pushbullet.api.PushBulletNotificationProvider.start"
@@ -49,7 +49,7 @@ async def test_setup_entry_failed_invalid_key(hass: HomeAssistant) -> None:
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_entry_failed_conn_error(hass: HomeAssistant) -> None:
@@ -65,7 +65,7 @@ async def test_setup_entry_failed_conn_error(hass: HomeAssistant) -> None:
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_async_unload_entry(hass: HomeAssistant, requests_mock_fixture) -> None:
@@ -78,8 +78,8 @@ async def test_async_unload_entry(hass: HomeAssistant, requests_mock_fixture) ->
 
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/pushover/test_init.py
+++ b/tests/components/pushover/test_init.py
@@ -35,7 +35,7 @@ async def test_async_setup_entry_success(
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_unique_id_updated(hass: HomeAssistant, mock_pushover: MagicMock) -> None:
@@ -44,7 +44,7 @@ async def test_unique_id_updated(hass: HomeAssistant, mock_pushover: MagicMock) 
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.unique_id is None
 
 
@@ -60,7 +60,7 @@ async def test_async_setup_entry_failed_invalid_api_key(
     mock_pushover.side_effect = BadAPIRequestError("400: application token is invalid")
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_async_setup_entry_failed_conn_error(
@@ -75,7 +75,7 @@ async def test_async_setup_entry_failed_conn_error(
     mock_pushover.side_effect = BadAPIRequestError
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_async_setup_entry_failed_json_error(
@@ -92,4 +92,4 @@ async def test_async_setup_entry_failed_json_error(
     )
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -16,7 +16,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test unload."""
     entry = await setup_integration(hass, aioclient_mock)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -31,7 +31,7 @@ async def test_async_setup_entry_not_ready(
     """Test that it throws ConfigEntryNotReady when exception occurs during setup."""
     entry = await setup_integration(hass, aioclient_mock, connection_error=True)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     assert not hass.data.get(DOMAIN)
 
 
@@ -43,7 +43,7 @@ async def test_async_setup_entry_auth_failed(
     mock_connection_invalid_auth(aioclient_mock)
     await hass.config_entries.async_setup(entry.entry_id)
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/rainbird/test_binary_sensor.py
+++ b/tests/components/rainbird/test_binary_sensor.py
@@ -32,7 +32,7 @@ async def setup_config_entry(
 ) -> list[Platform]:
     """Fixture to setup the config entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -73,7 +73,7 @@ async def test_no_unique_id(
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     rainsensor = hass.states.get("binary_sensor.rain_bird_controller_rainsensor")
     assert rainsensor is not None

--- a/tests/components/rainbird/test_calendar.py
+++ b/tests/components/rainbird/test_calendar.py
@@ -87,7 +87,7 @@ async def setup_config_entry(
 ) -> list[Platform]:
     """Fixture to setup the config entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.fixture(autouse=True)
@@ -191,7 +191,7 @@ async def test_event_state(
     freezer.move_to(freeze_time)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get(TEST_ENTITY)
     assert state is not None
@@ -295,7 +295,7 @@ async def test_no_unique_id(
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get(TEST_ENTITY)
     assert state is not None

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -159,7 +159,7 @@ async def test_multiple_config_entries(
 ) -> None:
     """Test setting up multiple config entries that refer to different devices."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     responses.clear()
     responses.extend(config_flow_responses)
@@ -234,7 +234,7 @@ async def test_duplicate_config_entries(
 ) -> None:
     """Test that a device can not be registered twice."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     responses.clear()
     responses.extend(config_flow_responses)
@@ -299,7 +299,7 @@ async def test_options_flow(hass: HomeAssistant, mock_setup: Mock) -> None:
 
     # Assert single config entry is loaded
     config_entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     # Initiate the options flow
     result = await hass.config_entries.options.async_init(config_entry.entry_id)

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -37,7 +37,7 @@ async def test_init_success(
     """Test successful setup and unload."""
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -112,17 +112,17 @@ async def test_fix_unique_id(
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.NOT_LOADED
+    assert entries[0].state is ConfigEntryState.NOT_LOADED
     assert entries[0].unique_id is None
     assert entries[0].data.get(CONF_MAC) is None
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     # Verify config entry now has a unique id
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
-    assert entries[0].state == ConfigEntryState.LOADED
+    assert entries[0].state is ConfigEntryState.LOADED
     assert entries[0].unique_id == MAC_ADDRESS_UNIQUE_ID
     assert entries[0].data.get(CONF_MAC) == MAC_ADDRESS
 
@@ -170,7 +170,7 @@ async def test_fix_unique_id_failure(
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     # Config entry is loaded, but not updated
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id is None
 
     assert expected_warning in caplog.text
@@ -204,7 +204,7 @@ async def test_fix_unique_id_duplicate(
     responses.extend(responses_copy)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.unique_id == MAC_ADDRESS_UNIQUE_ID
 
     assert "Unable to fix missing unique id (already exists)" in caplog.text
@@ -305,7 +305,7 @@ async def test_fix_entity_unique_ids(
     )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_entry = entity_registry.async_get(entity_entry.id)
     assert entity_entry
@@ -421,7 +421,7 @@ async def test_fix_duplicate_device_ids(
     assert len(device_entries) == 2
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     # Only the device with the new format exists
     device_entries = dr.async_entries_for_config_entry(

--- a/tests/components/rainbird/test_number.py
+++ b/tests/components/rainbird/test_number.py
@@ -38,7 +38,7 @@ async def setup_config_entry(
 ) -> list[Platform]:
     """Fixture to setup the config entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -155,7 +155,7 @@ async def test_no_unique_id(
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     raindelay = hass.states.get("number.rain_bird_controller_rain_delay")
     assert raindelay is not None

--- a/tests/components/rainbird/test_sensor.py
+++ b/tests/components/rainbird/test_sensor.py
@@ -32,7 +32,7 @@ async def setup_config_entry(
 ) -> list[Platform]:
     """Fixture to setup the config entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,7 @@ async def test_sensor_no_unique_id(
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     raindelay = hass.states.get("sensor.rain_bird_controller_raindelay")
     assert raindelay is not None

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -44,7 +44,7 @@ async def setup_config_entry(
 ) -> list[Platform]:
     """Fixture to setup the config entry."""
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -294,7 +294,7 @@ async def test_no_unique_id(
     responses.insert(0, mock_response_error(HTTPStatus.SERVICE_UNAVAILABLE))
 
     await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     zone = hass.states.get("switch.rain_bird_sprinkler_3")
     assert zone is not None

--- a/tests/components/raspberry_pi/test_init.py
+++ b/tests/components/raspberry_pi/test_init.py
@@ -118,4 +118,4 @@ async def test_setup_entry_wait_hassio(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert len(mock_get_os_info.mock_calls) == 1
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/reolink/test_config_flow.py
+++ b/tests/components/reolink/test_config_flow.py
@@ -452,7 +452,7 @@ async def test_dhcp_ip_update(
 
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     if not last_update_success:
         # ensure the last_update_succes is False for the device_coordinator.

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -68,7 +68,7 @@ async def test_failures_parametrized(
     """Test outcomes when changing errors."""
     setattr(reolink_connect, attr, value)
     assert await hass.config_entries.async_setup(config_entry.entry_id) is (
-        expected == ConfigEntryState.LOADED
+        expected is ConfigEntryState.LOADED
     )
     await hass.async_block_till_done()
 
@@ -88,7 +88,7 @@ async def test_firmware_error_twice(
         assert await hass.config_entries.async_setup(config_entry.entry_id) is True
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     entity_id = f"{Platform.UPDATE}.{TEST_NVR_NAME}_firmware"
     assert hass.states.is_state(entity_id, STATE_OFF)

--- a/tests/components/rfxtrx/test_switch.py
+++ b/tests/components/rfxtrx/test_switch.py
@@ -4,8 +4,8 @@ from unittest.mock import call
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant, State
 
@@ -286,4 +286,4 @@ async def test_unknown_event_code(hass: HomeAssistant, rfxtrx) -> None:
     assert len(conf_entries) == 1
 
     entry = conf_entries[0]
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/rova/test_init.py
+++ b/tests/components/rova/test_init.py
@@ -24,12 +24,12 @@ async def test_reload(
     """Test reloading the integration."""
     await setup_with_selected_platforms(hass, mock_config_entry, [Platform.SENSOR])
 
-    assert mock_config_entry.state == ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_service(
@@ -68,7 +68,7 @@ async def test_retry_after_failure(
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_issue_if_not_rova_area(
@@ -83,5 +83,5 @@ async def test_issue_if_not_rova_area(
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert len(issue_registry.issues) == 1

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -43,6 +43,7 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
     CONF_ID,
@@ -1770,7 +1771,7 @@ async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     """Test reauthenticate websocket."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_ENTRYDATA_WS)
     entry.add_to_hass(hass)
-    assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -1787,7 +1788,7 @@ async def test_form_reauth_websocket(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result2["type"] is FlowResultType.ABORT
     assert result2["reason"] == "reauth_successful"
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.usefixtures("rest_api")
@@ -1860,7 +1861,7 @@ async def test_form_reauth_encrypted(hass: HomeAssistant) -> None:
 
     entry = MockConfigEntry(domain=DOMAIN, data=encrypted_entry_data)
     entry.add_to_hass(hass)
-    assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -1908,7 +1909,7 @@ async def test_form_reauth_encrypted(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
         assert result["type"] is FlowResultType.ABORT
         assert result["reason"] == "reauth_successful"
-        assert entry.state == config_entries.ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
 
     authenticator_mock.assert_called_once()
     assert authenticator_mock.call_args[0] == ("fake_host",)

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -95,7 +95,7 @@ async def test_setup_without_port_device_offline(hass: HomeAssistant) -> None:
 
     config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
     assert len(config_entries_domain) == 1
-    assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
+    assert config_entries_domain[0].state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.usefixtures("remotews", "remoteencws_failing", "rest_api")
@@ -166,7 +166,7 @@ async def test_reauth_triggered_encrypted(hass: HomeAssistant) -> None:
     del encrypted_entry_data[CONF_SESSION_ID]
 
     entry = await setup_samsungtv_entry(hass, encrypted_entry_data)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     flows_in_progress = [
         flow
         for flow in hass.config_entries.flow.async_progress()

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -6,8 +6,8 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.scrape.const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -117,16 +117,16 @@ async def test_setup_config_no_sensors(
 async def test_setup_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
     """Test setup entry."""
 
-    assert loaded_entry.state == config_entries.ConfigEntryState.LOADED
+    assert loaded_entry.state is ConfigEntryState.LOADED
 
 
 async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) -> None:
     """Test unload an entry."""
 
-    assert loaded_entry.state == config_entries.ConfigEntryState.LOADED
+    assert loaded_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(loaded_entry.entry_id)
     await hass.async_block_till_done()
-    assert loaded_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert loaded_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def remove_device(ws_client, device_id, config_entry_id):

--- a/tests/components/script/test_blueprint.py
+++ b/tests/components/script/test_blueprint.py
@@ -8,9 +8,9 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components import script
 from homeassistant.components.blueprint.models import Blueprint, DomainBlueprints
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, template
 from homeassistant.setup import async_setup_component
@@ -48,7 +48,7 @@ async def test_confirmable_notification(
 ) -> None:
     """Test confirmable notification blueprint."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
 
     frodo = device_registry.async_get_or_create(

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -7,9 +7,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components import script
 from homeassistant.components.script import DOMAIN, EVENT_SCRIPT_STARTED, ScriptEntity
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_NAME,
@@ -729,7 +729,7 @@ async def test_extraction_functions(
 ) -> None:
     """Test extraction functions."""
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
 
     device_in_both = device_registry.async_get_or_create(

--- a/tests/components/sensibo/test_init.py
+++ b/tests/components/sensibo/test_init.py
@@ -6,10 +6,9 @@ from unittest.mock import patch
 
 from pysensibo.model import SensiboData
 
-from homeassistant import config_entries
 from homeassistant.components.sensibo.const import DOMAIN
 from homeassistant.components.sensibo.util import NoUsernameError
-from homeassistant.config_entries import SOURCE_USER, ConfigEntry
+from homeassistant.config_entries import SOURCE_USER, ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
@@ -49,7 +48,7 @@ async def test_setup_entry(hass: HomeAssistant, get_data: SensiboData) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_migrate_entry(hass: HomeAssistant, get_data: SensiboData) -> None:
@@ -81,7 +80,7 @@ async def test_migrate_entry(hass: HomeAssistant, get_data: SensiboData) -> None
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 2
     assert entry.unique_id == "username"
 
@@ -113,7 +112,7 @@ async def test_migrate_entry_fails(hass: HomeAssistant, get_data: SensiboData) -
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
     assert entry.version == 1
     assert entry.unique_id == "12"
 
@@ -147,10 +146,10 @@ async def test_unload_entry(hass: HomeAssistant, get_data: SensiboData) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def remove_device(ws_client, device_id, config_entry_id):

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -479,7 +479,7 @@ async def test_block_set_mode_auth_error(
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
@@ -489,7 +489,7 @@ async def test_block_set_mode_auth_error(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -527,7 +527,7 @@ async def test_block_restored_climate_auth_error(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # Make device online with auth error
     monkeypatch.setattr(mock_block_device, "initialized", True)
@@ -537,7 +537,7 @@ async def test_block_restored_climate_auth_error(
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/shelly/test_coordinator.py
+++ b/tests/components/shelly/test_coordinator.py
@@ -159,14 +159,14 @@ async def test_block_polling_auth_error(
     )
     entry = await init_integration(hass, 1)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # Move time to generate polling
     freezer.tick(timedelta(seconds=UPDATE_PERIOD_MULTIPLIER * 15))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -198,11 +198,11 @@ async def test_block_rest_update_auth_error(
         AsyncMock(side_effect=InvalidAuthError),
     )
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await mock_rest_update(hass, freezer)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -468,7 +468,7 @@ async def test_rpc_reload_with_invalid_auth(
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -620,14 +620,14 @@ async def test_rpc_reconnect_auth_error(
         ),
     )
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     # Move time to generate reconnect
     freezer.tick(timedelta(seconds=RPC_RECONNECT_INTERVAL))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -659,11 +659,11 @@ async def test_rpc_polling_auth_error(
         ),
     )
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await mock_polling_rpc_update(hass, freezer)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/shelly/test_init.py
+++ b/tests/components/shelly/test_init.py
@@ -163,7 +163,7 @@ async def test_device_connection_error(
     )
 
     entry = await init_integration(hass, gen)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize("gen", [1, 2, 3])
@@ -183,7 +183,7 @@ async def test_mac_mismatch_error(
     )
 
     entry = await init_integration(hass, gen)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize("gen", [1, 2, 3])
@@ -203,7 +203,7 @@ async def test_device_auth_error(
     )
 
     entry = await init_integration(hass, gen)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/shelly/test_number.py
+++ b/tests/components/shelly/test_number.py
@@ -197,7 +197,7 @@ async def test_block_set_value_auth_error(
     mock_block_device.mock_update()
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         NUMBER_DOMAIN,
@@ -207,7 +207,7 @@ async def test_block_set_value_auth_error(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -98,7 +98,7 @@ async def test_block_set_state_auth_error(
     )
     entry = await init_integration(hass, 1)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -108,7 +108,7 @@ async def test_block_set_state_auth_error(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -242,7 +242,7 @@ async def test_rpc_auth_error(
     )
     entry = await init_integration(hass, 2)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
@@ -252,7 +252,7 @@ async def test_rpc_auth_error(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/shelly/test_update.py
+++ b/tests/components/shelly/test_update.py
@@ -199,7 +199,7 @@ async def test_block_update_auth_error(
     )
     entry = await init_integration(hass, 1)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
@@ -209,7 +209,7 @@ async def test_block_update_auth_error(
     )
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -651,7 +651,7 @@ async def test_rpc_update_auth_error(
     )
     entry = await init_integration(hass, 2)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.services.async_call(
         UPDATE_DOMAIN,
@@ -661,7 +661,7 @@ async def test_rpc_update_auth_error(
     )
 
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/slack/test_init.py
+++ b/tests/components/slack/test_init.py
@@ -13,7 +13,7 @@ async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -
     """Test Slack setup."""
     entry: ConfigEntry = await async_init_integration(hass, aioclient_mock)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert entry.data == CONF_DATA
 
@@ -26,7 +26,7 @@ async def test_async_setup_entry_not_ready(
         hass, aioclient_mock, error="cannot_connect"
     )
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_async_setup_entry_invalid_auth(
@@ -37,4 +37,4 @@ async def test_async_setup_entry_invalid_auth(
         hass, aioclient_mock, error="invalid_auth"
     )
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR

--- a/tests/components/speedtestdotnet/test_init.py
+++ b/tests/components/speedtestdotnet/test_init.py
@@ -46,7 +46,7 @@ async def test_entry_lifecycle(hass: HomeAssistant, mock_api: MagicMock) -> None
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert hass.data[DOMAIN]
 
     assert await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/sql/test_init.py
+++ b/tests/components/sql/test_init.py
@@ -7,11 +7,11 @@ from unittest.mock import patch
 import pytest
 import voluptuous as vol
 
-from homeassistant import config_entries
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.util import get_instance
 from homeassistant.components.sql import validate_sql_select
 from homeassistant.components.sql.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
@@ -21,17 +21,17 @@ from . import YAML_CONFIG_INVALID, YAML_CONFIG_NO_DB, init_integration
 async def test_setup_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test setup entry."""
     config_entry = await init_integration(hass)
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_unload_entry(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     """Test unload an entry."""
     config_entry = await init_integration(hass)
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_config(recorder_mock: Recorder, hass: HomeAssistant) -> None:

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -121,7 +121,7 @@ async def test_flow_entry_already_configured(
 ) -> None:
     """Test user input for config_entry that already exists."""
     # Verify mock config setup from fixture
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
     assert init_integration.data[CONF_ID] == ACCNT_ID
     assert init_integration.unique_id == ACCNT_ID
 
@@ -144,7 +144,7 @@ async def test_flow_multiple_configs(
 ) -> None:
     """Test multiple config entries."""
     # Verify mock config setup from fixture
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
     assert init_integration.data[CONF_ID] == ACCNT_ID
     assert init_integration.unique_id == ACCNT_ID
 

--- a/tests/components/srp_energy/test_init.py
+++ b/tests/components/srp_energy/test_init.py
@@ -6,12 +6,12 @@ from homeassistant.core import HomeAssistant
 
 async def test_setup_entry(hass: HomeAssistant, init_integration) -> None:
     """Test setup entry."""
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
 
 
 async def test_unload_entry(hass: HomeAssistant, init_integration) -> None:
     """Test being able to unload an entry."""
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/srp_energy/test_sensor.py
+++ b/tests/components/srp_energy/test_sensor.py
@@ -21,7 +21,7 @@ from tests.common import MockConfigEntry
 async def test_loading_sensors(hass: HomeAssistant, init_integration) -> None:
     """Test the srp energy sensors."""
     # Validate the Config Entry was initialized
-    assert init_integration.state == ConfigEntryState.LOADED
+    assert init_integration.state is ConfigEntryState.LOADED
 
     # Check sensors were loaded
     assert len(hass.states.async_all()) == 1

--- a/tests/components/starlink/test_init.py
+++ b/tests/components/starlink/test_init.py
@@ -31,7 +31,7 @@ async def test_successful_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        assert entry.state == ConfigEntryState.LOADED
+        assert entry.state is ConfigEntryState.LOADED
         assert entry.entry_id in hass.data[DOMAIN]
 
 

--- a/tests/components/steam_online/test_init.py
+++ b/tests/components/steam_online/test_init.py
@@ -17,7 +17,7 @@ async def test_setup(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
@@ -33,7 +33,7 @@ async def test_async_setup_entry_auth_failed(hass: HomeAssistant) -> None:
         interface.side_effect = steam.api.HTTPError("401")
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/steamist/__init__.py
+++ b/tests/components/steamist/__init__.py
@@ -74,7 +74,7 @@ async def _async_setup_entry_with_status(
     with _patch_status(status, client):
         await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     return client, config_entry
 
 

--- a/tests/components/steamist/test_init.py
+++ b/tests/components/steamist/test_init.py
@@ -49,7 +49,7 @@ async def test_config_entry_reload(hass: HomeAssistant) -> None:
     )
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_retry_later(hass: HomeAssistant) -> None:
@@ -65,7 +65,7 @@ async def test_config_entry_retry_later(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
         await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_config_entry_fills_unique_id_with_directed_discovery(
@@ -101,7 +101,7 @@ async def test_config_entry_fills_unique_id_with_directed_discovery(
     ):
         await async_setup_component(hass, steamist.DOMAIN, {steamist.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
 
     assert config_entry.unique_id == FORMATTED_MAC_ADDRESS
     assert config_entry.data[CONF_NAME] == DEVICE_NAME

--- a/tests/components/stt/test_init.py
+++ b/tests/components/stt/test_init.py
@@ -370,9 +370,9 @@ async def test_config_entry_unload(
 ) -> None:
     """Test we can unload config entry."""
     config_entry = await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     await hass.config_entries.async_unload(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_restore_state(
@@ -388,7 +388,7 @@ async def test_restore_state(
     config_entry = await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get(entity_id)
     assert state
     assert state.state == timestamp

--- a/tests/components/switch_as_x/test_init.py
+++ b/tests/components/switch_as_x/test_init.py
@@ -949,7 +949,7 @@ async def test_migrate(
     await hass.async_block_till_done()
 
     # Check migration was successful and added invert option
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.options == {
         CONF_ENTITY_ID: "switch.test",
         CONF_INVERT: False,
@@ -988,7 +988,7 @@ async def test_migrate_from_future(
     await hass.async_block_till_done()
 
     # Check migration was not successful and did not add invert option
-    assert config_entry.state == ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
     assert config_entry.options == {
         CONF_ENTITY_ID: "switch.test",
         CONF_TARGET_DOMAIN: target_domain,

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -55,7 +55,7 @@ async def test_setup_entry_success(
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
@@ -104,7 +104,7 @@ async def test_setup_entry_fails_when_refreshing(
     mock_get_status.side_effect = CannotConnect
     entry = configure_integration(hass)
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()

--- a/tests/components/system_bridge/test_init.py
+++ b/tests/components/system_bridge/test_init.py
@@ -46,7 +46,7 @@ async def test_migration_minor_1_to_2(hass: HomeAssistant) -> None:
         CONF_PORT: FIXTURE_USER_INPUT[CONF_PORT],
         CONF_TOKEN: FIXTURE_USER_INPUT[CONF_TOKEN],
     }
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
 
 async def test_migration_minor_future_version(hass: HomeAssistant) -> None:
@@ -80,4 +80,4 @@ async def test_migration_minor_future_version(hass: HomeAssistant) -> None:
     assert config_entry.version == config_entry_version
     assert config_entry.minor_version == config_entry_minor_version
     assert config_entry.data == config_entry_data
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/systemmonitor/test_init.py
+++ b/tests/components/systemmonitor/test_init.py
@@ -21,7 +21,7 @@ async def test_load_unload_entry(
 ) -> None:
     """Test load and unload an entry."""
 
-    assert mock_added_config_entry.state == ConfigEntryState.LOADED
+    assert mock_added_config_entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(mock_added_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_added_config_entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/tami4/test_init.py
+++ b/tests/components/tami4/test_init.py
@@ -13,7 +13,7 @@ async def test_init_success(mock_api, hass: HomeAssistant) -> None:
     """Test setup and that we can create the entry."""
 
     entry = await create_config_entry(hass)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -23,7 +23,7 @@ async def test_init_with_api_error(mock_api, hass: HomeAssistant) -> None:
     """Test init with api error."""
 
     entry = await create_config_entry(hass)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tankerkoenig/test_coordinator.py
+++ b/tests/components/tankerkoenig/test_coordinator.py
@@ -34,7 +34,7 @@ async def test_rate_limit(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test detection of API rate limit."""
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get("binary_sensor.station_somewhere_street_1_status")
     assert state
     assert state.state == "on"

--- a/tests/components/tesla_wall_connector/test_init.py
+++ b/tests/components/tesla_wall_connector/test_init.py
@@ -2,7 +2,7 @@
 
 from tesla_wall_connector.exceptions import WallConnectorConnectionError
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from .conftest import create_wall_connector_entry
@@ -13,7 +13,7 @@ async def test_init_success(hass: HomeAssistant) -> None:
 
     entry = await create_wall_connector_entry(hass)
 
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_init_while_offline(hass: HomeAssistant) -> None:
@@ -22,7 +22,7 @@ async def test_init_while_offline(hass: HomeAssistant) -> None:
         hass, side_effect=WallConnectorConnectionError
     )
 
-    assert entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_unload(hass: HomeAssistant) -> None:
@@ -30,7 +30,7 @@ async def test_load_unload(hass: HomeAssistant) -> None:
 
     entry = await create_wall_connector_entry(hass)
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/todo/test_init.py
+++ b/tests/components/todo/test_init.py
@@ -180,14 +180,14 @@ async def test_unload_entry(
     """Test unloading a config entry with a todo entity."""
 
     config_entry = await create_mock_platform(hass, [test_entity])
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     state = hass.states.get("todo.entity1")
     assert state
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     state = hass.states.get("todo.entity1")
     assert not state

--- a/tests/components/todoist/test_init.py
+++ b/tests/components/todoist/test_init.py
@@ -21,10 +21,10 @@ async def test_load_unload(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
 
-    assert todoist_config_entry.state == ConfigEntryState.LOADED
+    assert todoist_config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(todoist_config_entry.entry_id)
-    assert todoist_config_entry.state == ConfigEntryState.NOT_LOADED
+    assert todoist_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @pytest.mark.parametrize("todoist_api_status", [HTTPStatus.INTERNAL_SERVER_ERROR])
@@ -35,4 +35,4 @@ async def test_init_failure(
     todoist_config_entry: MockConfigEntry | None,
 ) -> None:
     """Test an initialization error on integration load."""
-    assert todoist_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert todoist_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.components.tplink import (
     SmartDeviceException,
 )
 from homeassistant.components.tplink.const import CONF_DEVICE_CONFIG
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_ALIAS,
     CONF_DEVICE,
@@ -770,7 +771,7 @@ async def test_integration_discovery_with_ip_change(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 0
@@ -803,7 +804,7 @@ async def test_integration_discovery_with_ip_change(
     mock_connect["connect"].return_value = bulb
     await hass.config_entries.async_reload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     # Check that init set the new host correctly before calling connect
     assert config.host == "127.0.0.1"
     config.host = "127.0.0.2"
@@ -822,7 +823,7 @@ async def test_dhcp_discovery_with_ip_change(
     with patch("homeassistant.components.tplink.Discover.discover", return_value={}):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 0
@@ -851,7 +852,7 @@ async def test_reauth(
     mock_added_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
-    assert mock_added_config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_added_config_entry.state is ConfigEntryState.LOADED
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
     [result] = flows
@@ -888,7 +889,7 @@ async def test_reauth_update_from_discovery(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -924,7 +925,7 @@ async def test_reauth_update_from_discovery_with_ip_change(
     with patch("homeassistant.components.tplink.Discover.discover", return_value={}):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -967,7 +968,7 @@ async def test_reauth_no_update_if_config_and_ip_the_same(
     )
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_config_entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -1013,7 +1014,7 @@ async def test_reauth_errors(
     mock_added_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
-    assert mock_added_config_entry.state is config_entries.ConfigEntryState.LOADED
+    assert mock_added_config_entry.state is ConfigEntryState.LOADED
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
     [result] = flows
@@ -1155,8 +1156,8 @@ async def test_reauth_update_other_flows(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert mock_config_entry2.state == config_entries.ConfigEntryState.SETUP_ERROR
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry2.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     mock_connect["connect"].side_effect = default_side_effect
 
     await hass.async_block_till_done()

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -77,10 +77,10 @@ async def test_config_entry_reload(hass: HomeAssistant) -> None:
     with _patch_discovery(), _patch_single_discovery(), _patch_connect():
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.LOADED
+        assert already_migrated_config_entry.state is ConfigEntryState.LOADED
         await hass.config_entries.async_unload(already_migrated_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.NOT_LOADED
+        assert already_migrated_config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_retry(hass: HomeAssistant) -> None:
@@ -96,7 +96,7 @@ async def test_config_entry_retry(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_dimmer_switch_unique_id_fix_original_entity_still_exists(
@@ -154,7 +154,7 @@ async def test_config_entry_wrong_mac_Address(
     with _patch_discovery(), _patch_single_discovery(), _patch_connect():
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
-        assert already_migrated_config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert already_migrated_config_entry.state is ConfigEntryState.SETUP_RETRY
 
     assert (
         "Unexpected device found at 127.0.0.1; expected aa:bb:cc:dd:ee:f0, found aa:bb:cc:dd:ee:ff"

--- a/tests/components/traccar_server/test_config_flow.py
+++ b/tests/components/traccar_server/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.traccar_server.const import (
     DOMAIN,
     EVENTS,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -62,7 +63,7 @@ async def test_form(
         CONF_SSL: False,
         CONF_VERIFY_SSL: True,
     }
-    assert result["result"].state == config_entries.ConfigEntryState.LOADED
+    assert result["result"].state is ConfigEntryState.LOADED
 
 
 @pytest.mark.parametrize(
@@ -120,7 +121,7 @@ async def test_form_cannot_connect(
         CONF_VERIFY_SSL: True,
     }
 
-    assert result["result"].state == config_entries.ConfigEntryState.LOADED
+    assert result["result"].state is ConfigEntryState.LOADED
 
 
 async def test_options(
@@ -242,7 +243,7 @@ async def test_import_from_yaml(
     assert result["title"] == f"{data[CONF_HOST]}:{data[CONF_PORT]}"
     assert result["data"] == data
     assert result["options"] == options
-    assert result["result"].state == config_entries.ConfigEntryState.LOADED
+    assert result["result"].state is ConfigEntryState.LOADED
 
 
 async def test_abort_import_already_configured(hass: HomeAssistant) -> None:

--- a/tests/components/trafikverket_camera/test_coordinator.py
+++ b/tests/components/trafikverket_camera/test_coordinator.py
@@ -12,10 +12,9 @@ from pytrafikverket.exceptions import (
     UnknownError,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.trafikverket_camera.const import DOMAIN
 from homeassistant.components.trafikverket_camera.coordinator import CameraData
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -65,22 +64,22 @@ async def test_coordinator(
         (
             InvalidAuthentication,
             ConfigEntryAuthFailed,
-            config_entries.ConfigEntryState.SETUP_ERROR,
+            ConfigEntryState.SETUP_ERROR,
         ),
         (
             NoCameraFound,
             UpdateFailed,
-            config_entries.ConfigEntryState.SETUP_RETRY,
+            ConfigEntryState.SETUP_RETRY,
         ),
         (
             MultipleCamerasFound,
             UpdateFailed,
-            config_entries.ConfigEntryState.SETUP_RETRY,
+            ConfigEntryState.SETUP_RETRY,
         ),
         (
             UnknownError,
             UpdateFailed,
-            config_entries.ConfigEntryState.SETUP_RETRY,
+            ConfigEntryState.SETUP_RETRY,
         ),
     ],
 )
@@ -152,4 +151,4 @@ async def test_coordinator_failed_get_image(
     mock_data.assert_called_once()
     state = hass.states.get("camera.test_camera")
     assert state is None
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/trafikverket_camera/test_init.py
+++ b/tests/components/trafikverket_camera/test_init.py
@@ -9,10 +9,9 @@ import pytest
 from pytrafikverket.exceptions import UnknownError
 from pytrafikverket.trafikverket_camera import CameraInfo
 
-from homeassistant import config_entries
 from homeassistant.components.trafikverket_camera import async_migrate_entry
 from homeassistant.components.trafikverket_camera.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -50,7 +49,7 @@ async def test_setup_entry(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(mock_tvt_camera.mock_calls) == 1
 
 
@@ -82,10 +81,10 @@ async def test_unload_entry(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_migrate_entry(
@@ -115,7 +114,7 @@ async def test_migrate_entry(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.version == 3
     assert entry.unique_id == "trafikverket_camera-1234"
     assert entry.data == ENTRY_CONFIG
@@ -165,7 +164,7 @@ async def test_migrate_entry_fails_with_error(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
     assert entry.version == version
     assert entry.unique_id == unique_id
     assert len(mock_tvt_camera.mock_calls) == 1
@@ -229,7 +228,7 @@ async def test_migrate_entry_fails_no_id(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.MIGRATION_ERROR
+    assert entry.state is ConfigEntryState.MIGRATION_ERROR
     assert entry.version == version
     assert entry.unique_id == unique_id
     assert len(mock_tvt_camera.mock_calls) == 1

--- a/tests/components/trafikverket_ferry/test_init.py
+++ b/tests/components/trafikverket_ferry/test_init.py
@@ -6,9 +6,8 @@ from unittest.mock import patch
 
 from pytrafikverket.trafikverket_ferry import FerryStop
 
-from homeassistant import config_entries
 from homeassistant.components.trafikverket_ferry.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import ENTRY_CONFIG
@@ -34,7 +33,7 @@ async def test_setup_entry(hass: HomeAssistant, get_ferries: list[FerryStop]) ->
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(mock_tvt_ferry.mock_calls) == 1
 
 
@@ -56,7 +55,7 @@ async def test_unload_entry(hass: HomeAssistant, get_ferries: list[FerryStop]) -
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/trafikverket_train/test_init.py
+++ b/tests/components/trafikverket_train/test_init.py
@@ -8,9 +8,8 @@ from pytrafikverket.exceptions import InvalidAuthentication, NoTrainStationFound
 from pytrafikverket.trafikverket_train import TrainStop
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant import config_entries
 from homeassistant.components.trafikverket_train.const import DOMAIN
-from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import EntityRegistry
 
@@ -43,12 +42,12 @@ async def test_unload_entry(hass: HomeAssistant, get_trains: list[TrainStop]) ->
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert len(mock_tv_train.mock_calls) == 1
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_auth_failed(
@@ -74,7 +73,7 @@ async def test_auth_failed(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
     active_flows = entry.async_get_active_flows(hass, (SOURCE_REAUTH))
     for flow in active_flows:
@@ -104,7 +103,7 @@ async def test_no_stations(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_migrate_entity_unique_id(
@@ -144,7 +143,7 @@ async def test_migrate_entity_unique_id(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     entity = entity_registry.async_get(entity.entity_id)
     assert entity.unique_id == f"{entry.entry_id}-departure_time"

--- a/tests/components/transmission/test_init.py
+++ b/tests/components/transmission/test_init.py
@@ -41,7 +41,7 @@ async def test_successful_config_entry(hass: HomeAssistant) -> None:
 
     await hass.config_entries.async_setup(entry.entry_id)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_config_flow_entry_migrate_1_1_to_1_2(hass: HomeAssistant) -> None:
@@ -76,7 +76,7 @@ async def test_setup_failed_connection_error(
     mock_api.side_effect = TransmissionConnectError()
 
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_failed_auth_error(
@@ -90,7 +90,7 @@ async def test_setup_failed_auth_error(
     mock_api.side_effect = TransmissionAuthError()
 
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_setup_failed_unexpected_error(
@@ -104,7 +104,7 @@ async def test_setup_failed_unexpected_error(
     mock_api.side_effect = TransmissionError()
 
     await hass.config_entries.async_setup(entry.entry_id)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
 
 async def test_unload_entry(hass: HomeAssistant) -> None:

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -82,7 +82,7 @@ async def test_config_entry_unload(
     assert state is None
 
     config_entry = await mock_config_entry_setup(hass, mock_tts_entity)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get(entity_id)
     assert state is not None
     assert state.state == STATE_UNKNOWN
@@ -115,7 +115,7 @@ async def test_config_entry_unload(
 
     await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     state = hass.states.get(entity_id)
     assert state is None
@@ -133,7 +133,7 @@ async def test_restore_state(
     config_entry = await mock_config_entry_setup(hass, mock_tts_entity)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get(entity_id)
     assert state
     assert state.state == timestamp

--- a/tests/components/twinkly/test_init.py
+++ b/tests/components/twinkly/test_init.py
@@ -34,11 +34,11 @@ async def test_load_unload_entry(hass: HomeAssistant) -> None:
     with patch("homeassistant.components.twinkly.Twinkly", return_value=client):
         await hass.config_entries.async_setup(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_config_entry_not_ready(hass: HomeAssistant) -> None:

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.components.unifiprotect.const import (
     CONF_OVERRIDE_CHOST,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -307,7 +308,7 @@ async def test_form_options(hass: HomeAssistant, ufp_client: ProtectApiClient) -
 
         await hass.config_entries.async_setup(mock_config.entry_id)
         await hass.async_block_till_done()
-        assert mock_config.state == config_entries.ConfigEntryState.LOADED
+        assert mock_config.state is ConfigEntryState.LOADED
 
         result = await hass.config_entries.options.async_init(mock_config.entry_id)
         assert result["type"] is FlowResultType.FORM

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -94,7 +94,7 @@ async def test_setup_multiple(
         await hass.config_entries.async_setup(mock_config.entry_id)
         await hass.async_block_till_done()
 
-        assert mock_config.state == ConfigEntryState.LOADED
+        assert mock_config.state is ConfigEntryState.LOADED
         assert ufp.api.update.called
         assert mock_config.unique_id == ufp.api.bootstrap.nvr.mac
 
@@ -158,7 +158,7 @@ async def test_setup_cloud_account(
 
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     await hass.async_block_till_done()
-    assert ufp.entry.state == ConfigEntryState.LOADED
+    assert ufp.entry.state is ConfigEntryState.LOADED
 
     await ws_client.send_json({"id": 1, "type": "repairs/list_issues"})
     msg = await ws_client.receive_json()

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -16,6 +16,7 @@ from pyuptimerobot import (
 
 from homeassistant import config_entries
 from homeassistant.components.uptimerobot.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
 
@@ -116,6 +117,6 @@ async def setup_uptimerobot_integration(hass: HomeAssistant) -> MockConfigEntry:
 
     assert hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state == STATE_ON
     assert hass.states.get(UPTIMEROBOT_SENSOR_TEST_ENTITY).state == STATE_UP
-    assert mock_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
 
     return mock_entry

--- a/tests/components/uptimerobot/test_init.py
+++ b/tests/components/uptimerobot/test_init.py
@@ -11,6 +11,7 @@ from homeassistant.components.uptimerobot.const import (
     COORDINATOR_UPDATE_INTERVAL,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -44,7 +45,7 @@ async def test_reauthentication_trigger_in_setup(
 
     flows = hass.config_entries.flow.async_progress()
 
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert mock_config_entry.reason == "could not authenticate"
 
     assert len(flows) == 1
@@ -74,7 +75,7 @@ async def test_reauthentication_trigger_key_read_only(
 
     flows = hass.config_entries.flow.async_progress()
 
-    assert mock_config_entry.state == config_entries.ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
     assert (
         mock_config_entry.reason
         == "Wrong API key type detected, use the 'main' API key"
@@ -102,7 +103,7 @@ async def test_reauthentication_trigger_after_setup(
     mock_config_entry = await setup_uptimerobot_integration(hass)
 
     binary_sensor = hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY)
-    assert mock_config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
     assert binary_sensor.state == STATE_ON
 
     with patch(
@@ -146,7 +147,7 @@ async def test_integration_reload(
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert hass.states.get(UPTIMEROBOT_BINARY_SENSOR_TEST_ENTITY).state == STATE_ON
 
 

--- a/tests/components/valve/test_init.py
+++ b/tests/components/valve/test_init.py
@@ -205,7 +205,7 @@ async def test_valve_setup(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     for entity in mock_config_entry[1]:
         entity_id = entity.entity_id
         state = hass.states.get(entity_id)
@@ -215,7 +215,7 @@ async def test_valve_setup(
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
     for entity in mock_config_entry[1]:
         entity_id = entity.entity_id

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -20,12 +20,12 @@ async def test_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> N
     await hass.async_block_till_done()
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
     assert not hass.data.get(DOMAIN)
 
 

--- a/tests/components/venstar/test_init.py
+++ b/tests/components/venstar/test_init.py
@@ -54,11 +54,11 @@ async def test_setup_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_setup_entry_exception(hass: HomeAssistant) -> None:
@@ -97,4 +97,4 @@ async def test_setup_entry_exception(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/version/common.py
+++ b/tests/components/version/common.py
@@ -15,6 +15,7 @@ from homeassistant.components.version.const import (
     UPDATE_COORDINATOR_UPDATE_INTERVAL,
     VERSION_SOURCE_LOCAL,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 
@@ -75,6 +76,6 @@ async def setup_version_integration(
         assert await hass.config_entries.async_setup(mock_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert mock_entry.state == config_entries.ConfigEntryState.LOADED
+    assert mock_entry.state is ConfigEntryState.LOADED
 
     return mock_entry

--- a/tests/components/version/test_config_flow.py
+++ b/tests/components/version/test_config_flow.py
@@ -18,6 +18,7 @@ from homeassistant.components.version.const import (
     VERSION_SOURCE_PYPI,
     VERSION_SOURCE_VERSIONS,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -31,7 +32,7 @@ from tests.common import async_fire_time_changed
 async def test_reload_config_entry(hass: HomeAssistant) -> None:
     """Test reloading the config entry."""
     config_entry = await setup_version_integration(hass)
-    assert config_entry.state == config_entries.ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
 
     with patch(
         "pyhaversion.HaVersion.get_version",
@@ -44,7 +45,7 @@ async def test_reload_config_entry(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     entry = hass.config_entries.async_get_entry(config_entry.entry_id)
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_basic_form(hass: HomeAssistant) -> None:

--- a/tests/components/voip/conftest.py
+++ b/tests/components/voip/conftest.py
@@ -38,7 +38,7 @@ async def setup_voip(hass: HomeAssistant, config_entry: MockConfigEntry) -> None
         return_value=(Mock(), AsyncMock()),
     ):
         assert await async_setup_component(hass, DOMAIN, {})
-        assert config_entry.state == ConfigEntryState.LOADED
+        assert config_entry.state is ConfigEntryState.LOADED
         yield
 
 

--- a/tests/components/wake_word/test_init.py
+++ b/tests/components/wake_word/test_init.py
@@ -165,9 +165,9 @@ async def test_config_entry_unload(
 ) -> None:
     """Test we can unload config entry."""
     config_entry = await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     await hass.config_entries.async_unload(config_entry.entry_id)
-    assert config_entry.state == ConfigEntryState.NOT_LOADED
+    assert config_entry.state is ConfigEntryState.NOT_LOADED
 
 
 @freeze_time("2023-06-22 10:30:00+00:00")
@@ -268,7 +268,7 @@ async def test_restore_state(
     config_entry = await mock_config_entry_setup(hass, tmp_path, mock_provider_entity)
     await hass.async_block_till_done()
 
-    assert config_entry.state == ConfigEntryState.LOADED
+    assert config_entry.state is ConfigEntryState.LOADED
     state = hass.states.get(entity_id)
     assert state
     assert state.state == timestamp

--- a/tests/components/wallbox/test_config_flow.py
+++ b/tests/components/wallbox/test_config_flow.py
@@ -17,6 +17,7 @@ from homeassistant.components.wallbox.const import (
     CHARGER_MAX_CHARGING_CURRENT_KEY,
     DOMAIN,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -145,7 +146,7 @@ async def test_form_validate_input(hass: HomeAssistant) -> None:
 async def test_form_reauth(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     """Test we handle reauth flow."""
     await setup_integration(hass, entry)
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
@@ -185,7 +186,7 @@ async def test_form_reauth(hass: HomeAssistant, entry: MockConfigEntry) -> None:
 async def test_form_reauth_invalid(hass: HomeAssistant, entry: MockConfigEntry) -> None:
     """Test we handle reauth invalid flow."""
     await setup_integration(hass, entry)
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with requests_mock.Mocker() as mock_request:
         mock_request.get(

--- a/tests/components/wallbox/test_init.py
+++ b/tests/components/wallbox/test_init.py
@@ -28,10 +28,10 @@ async def test_wallbox_setup_unload_entry(
     """Test Wallbox Unload."""
 
     await setup_integration(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_wallbox_unload_entry_connection_error(
@@ -40,10 +40,10 @@ async def test_wallbox_unload_entry_connection_error(
     """Test Wallbox Unload Connection Error."""
 
     await setup_integration_connection_error(hass, entry)
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_wallbox_refresh_failed_connection_error_auth(
@@ -52,7 +52,7 @@ async def test_wallbox_refresh_failed_connection_error_auth(
     """Test Wallbox setup with connection error."""
 
     await setup_integration(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
@@ -71,7 +71,7 @@ async def test_wallbox_refresh_failed_connection_error_auth(
         await wallbox.async_refresh()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_wallbox_refresh_failed_invalid_auth(
@@ -80,7 +80,7 @@ async def test_wallbox_refresh_failed_invalid_auth(
     """Test Wallbox setup with authentication error."""
 
     await setup_integration(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
@@ -99,7 +99,7 @@ async def test_wallbox_refresh_failed_invalid_auth(
         await wallbox.async_refresh()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_wallbox_refresh_failed_connection_error(
@@ -108,7 +108,7 @@ async def test_wallbox_refresh_failed_connection_error(
     """Test Wallbox setup with connection error."""
 
     await setup_integration(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     with requests_mock.Mocker() as mock_request:
         mock_request.get(
@@ -127,7 +127,7 @@ async def test_wallbox_refresh_failed_connection_error(
         await wallbox.async_refresh()
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_wallbox_refresh_failed_read_only(
@@ -136,7 +136,7 @@ async def test_wallbox_refresh_failed_read_only(
     """Test Wallbox setup for read-only user."""
 
     await setup_integration_read_only(hass, entry)
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state == ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/waqi/test_sensor.py
+++ b/tests/components/waqi/test_sensor.py
@@ -52,4 +52,4 @@ async def test_updating_failed(
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-    assert mock_config_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/weatherkit/test_setup.py
+++ b/tests/components/weatherkit/test_setup.py
@@ -7,8 +7,8 @@ from apple_weatherkit.client import (
     WeatherKitApiClientError,
 )
 
-from homeassistant import config_entries
 from homeassistant.components.weatherkit.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from . import EXAMPLE_CONFIG_DATA
@@ -65,4 +65,4 @@ async def test_client_error_handling(hass: HomeAssistant) -> None:
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state == config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/webostv/test_init.py
+++ b/tests/components/webostv/test_init.py
@@ -18,7 +18,7 @@ async def test_reauth_setup_entry(hass: HomeAssistant, client, monkeypatch) -> N
     monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
     entry = await setup_webostv(hass)
 
-    assert entry.state == ConfigEntryState.SETUP_ERROR
+    assert entry.state is ConfigEntryState.SETUP_ERROR
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1
@@ -37,5 +37,5 @@ async def test_key_update_setup_entry(hass: HomeAssistant, client, monkeypatch) 
     monkeypatch.setattr(client, "client_key", "new_key")
     entry = await setup_webostv(hass)
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data[CONF_CLIENT_SECRET] == "new_key"

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -794,12 +794,12 @@ async def test_reauth_reconnect(hass: HomeAssistant, client, monkeypatch) -> Non
     monkeypatch.setattr(client, "is_connected", Mock(return_value=False))
     monkeypatch.setattr(client, "connect", Mock(side_effect=WebOsTvPairError))
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=20))
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     flows = hass.config_entries.flow.async_progress()
     assert len(flows) == 1

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, AsyncMock, Mock, patch
 import pytest
 import voluptuous as vol
 
-from homeassistant import config_entries, loader
+from homeassistant import loader
 from homeassistant.components.device_automation import toggle_entity
 from homeassistant.components.websocket_api import const
 from homeassistant.components.websocket_api.auth import (
@@ -17,6 +17,7 @@ from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH_REQUIRED,
 )
 from homeassistant.components.websocket_api.const import FEATURE_COALESCE_MESSAGES, URL
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import SIGNAL_BOOTSTRAP_INTEGRATIONS
 from homeassistant.core import Context, HomeAssistant, State, SupportsResponse, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -2433,7 +2434,7 @@ async def test_execute_script_with_dynamically_validated_action(
     )
 
     config_entry = MockConfigEntry(domain="fake_integration", data={})
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.LOADED)
+    config_entry.mock_state(hass, ConfigEntryState.LOADED)
     config_entry.add_to_hass(hass)
     device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/tests/components/wiz/test_binary_sensor.py
+++ b/tests/components/wiz/test_binary_sensor.py
@@ -1,8 +1,8 @@
 """Tests for WiZ binary_sensor platform."""
 
-from homeassistant import config_entries
 from homeassistant.components import wiz
 from homeassistant.components.wiz.binary_sensor import OCCUPANCY_UNIQUE_ID
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -70,7 +70,7 @@ async def test_binary_sensor_restored_from_registry(hass: HomeAssistant) -> None
 
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED
 
 
 async def test_binary_sensor_never_created_no_error_on_unload(
@@ -80,4 +80,4 @@ async def test_binary_sensor_never_created_no_error_on_unload(
     _, entry = await async_setup_integration(hass)
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == config_entries.ConfigEntryState.NOT_LOADED
+    assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/wiz/test_config_flow.py
+++ b/tests/components/wiz/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant import config_entries
 from homeassistant.components import dhcp
 from homeassistant.components.wiz.config_flow import CONF_DEVICE
 from homeassistant.components.wiz.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -344,7 +345,7 @@ async def test_discovered_by_dhcp_or_integration_discovery_avoid_waiting_for_ret
     bulb.getMac = AsyncMock(side_effect=OSError)
     _, entry = await async_setup_integration(hass, wizlight=bulb)
     assert entry.data[CONF_HOST] == FAKE_IP
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     bulb.getMac = AsyncMock(return_value=FAKE_MAC)
 
     with _patch_wizlight():
@@ -355,7 +356,7 @@ async def test_discovered_by_dhcp_or_integration_discovery_avoid_waiting_for_ret
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_setup_via_discovery(hass: HomeAssistant) -> None:

--- a/tests/components/wiz/test_init.py
+++ b/tests/components/wiz/test_init.py
@@ -3,8 +3,8 @@
 import datetime
 from unittest.mock import AsyncMock, patch
 
-from homeassistant import config_entries
 from homeassistant.components.wiz.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_FRIENDLY_NAME, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -28,21 +28,21 @@ async def test_setup_retry(hass: HomeAssistant) -> None:
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     bulb.getMac = AsyncMock(side_effect=OSError)
     _, entry = await async_setup_integration(hass, wizlight=bulb)
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     bulb.getMac = AsyncMock(return_value=FAKE_MAC)
 
     with _patch_discovery(), _patch_wizlight(device=bulb):
         await hass.async_block_till_done()
         async_fire_time_changed(hass, utcnow() + datetime.timedelta(minutes=15))
         await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
 
 async def test_cleanup_on_shutdown(hass: HomeAssistant) -> None:
     """Test the socket is cleaned up on shutdown."""
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     _, entry = await async_setup_integration(hass, wizlight=bulb)
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
     bulb.async_close.assert_called_once()
@@ -64,7 +64,7 @@ async def test_cleanup_on_failed_first_update(hass: HomeAssistant) -> None:
     ):
         await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
         await hass.async_block_till_done()
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
     bulb.async_close.assert_called_once()
 
 
@@ -73,14 +73,14 @@ async def test_wrong_device_now_has_our_ip(hass: HomeAssistant) -> None:
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     bulb.mac = "dddddddddddd"
     _, entry = await async_setup_integration(hass, wizlight=bulb)
-    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_reload_on_title_change(hass: HomeAssistant) -> None:
     """Test the integration gets reloaded when the title is updated."""
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     _, entry = await async_setup_integration(hass, wizlight=bulb)
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     await hass.async_block_till_done()
 
     with _patch_discovery(), _patch_wizlight(device=bulb):

--- a/tests/components/workday/test_init.py
+++ b/tests/components/workday/test_init.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from freezegun.api import FrozenDateTimeFactory
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import UTC
 
@@ -35,7 +35,7 @@ async def test_update_options(
     freezer.move_to(datetime(2023, 4, 12, 12, tzinfo=UTC))  # Monday
 
     entry = await init_integration(hass, TEST_CONFIG_WITH_PROVINCE)
-    assert entry.state == config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.update_listeners is not None
     state = hass.states.get("binary_sensor.workday_sensor")
     assert state.state == "on"
@@ -47,6 +47,6 @@ async def test_update_options(
     await hass.async_block_till_done()
 
     entry_check = hass.config_entries.async_get_entry("1")
-    assert entry_check.state == config_entries.ConfigEntryState.LOADED
+    assert entry_check.state is ConfigEntryState.LOADED
     state = hass.states.get("binary_sensor.workday_sensor")
     assert state.state == "off"

--- a/tests/components/yolink/test_config_flow.py
+++ b/tests/components/yolink/test_config_flow.py
@@ -7,6 +7,7 @@ from yolink.const import OAUTH2_AUTHORIZE, OAUTH2_TOKEN
 
 from homeassistant import config_entries, setup
 from homeassistant.components import application_credentials
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
@@ -108,7 +109,7 @@ async def test_full_flow(
 
     assert DOMAIN in hass.config.components
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state is config_entries.ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
 
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
     assert len(mock_setup.mock_calls) == 1

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.config_entries import (
     SOURCE_USB,
     SOURCE_USER,
     SOURCE_ZEROCONF,
+    ConfigEntryState,
 )
 from homeassistant.const import CONF_SOURCE
 from homeassistant.core import HomeAssistant
@@ -1552,7 +1553,7 @@ async def test_options_flow_defaults(
     mock_async_unload.assert_called_once_with(entry.entry_id)
 
     # Unload it ourselves
-    entry.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
 
     # Reconfigure ZHA
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
@@ -1735,7 +1736,7 @@ async def test_options_flow_restarts_running_zha_if_cancelled(
             flow["flow_id"], user_input={}
         )
 
-    entry.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
 
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(
@@ -1790,7 +1791,7 @@ async def test_options_flow_migration_reset_old_adapter(
             flow["flow_id"], user_input={}
         )
 
-    entry.mock_state(hass, config_entries.ConfigEntryState.NOT_LOADED)
+    entry.mock_state(hass, ConfigEntryState.NOT_LOADED)
 
     assert result1["step_id"] == "prompt_migrate_or_reconfigure"
     result2 = await hass.config_entries.options.async_configure(

--- a/tests/components/zha/test_radio_manager.py
+++ b/tests/components/zha/test_radio_manager.py
@@ -10,11 +10,11 @@ import zigpy.config
 from zigpy.config import CONF_DEVICE_PATH
 import zigpy.types
 
-from homeassistant import config_entries
 from homeassistant.components.usb import UsbServiceInfo
 from homeassistant.components.zha import radio_manager
 from homeassistant.components.zha.core.const import DOMAIN, RadioType
 from homeassistant.components.zha.radio_manager import ProbeResult, ZhaRadioManager
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -224,7 +224,7 @@ async def test_migrate_matching_port_config_entry_not_loaded(
         title="Test",
     )
     config_entry.add_to_hass(hass)
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.SETUP_IN_PROGRESS)
+    config_entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
 
     migration_data = {
         "new_discovery_info": {
@@ -284,7 +284,7 @@ async def test_migrate_matching_port_retry(
         title="Test",
     )
     config_entry.add_to_hass(hass)
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.SETUP_IN_PROGRESS)
+    config_entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
 
     migration_data = {
         "new_discovery_info": {
@@ -389,7 +389,7 @@ async def test_migrate_initiate_failure(
         title="Test",
     )
     config_entry.add_to_hass(hass)
-    config_entry.mock_state(hass, config_entries.ConfigEntryState.SETUP_IN_PROGRESS)
+    config_entry.mock_state(hass, ConfigEntryState.SETUP_IN_PROGRESS)
 
     migration_data = {
         "new_discovery_info": {

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -154,7 +154,7 @@ async def test_multipan_firmware_repair(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -203,7 +203,7 @@ async def test_multipan_firmware_no_repair_on_probe_failure(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -241,7 +241,7 @@ async def test_multipan_firmware_retry_on_probe_ezsp(
         await hass.async_block_till_done()
 
         # The config entry state is `SETUP_RETRY`, not `SETUP_ERROR`!
-        assert config_entry.state == ConfigEntryState.SETUP_RETRY
+        assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -308,7 +308,7 @@ async def test_inconsistent_settings_keep_new(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
@@ -388,7 +388,7 @@ async def test_inconsistent_settings_restore_old(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-        assert config_entry.state == ConfigEntryState.SETUP_ERROR
+        assert config_entry.state is ConfigEntryState.SETUP_ERROR
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -673,7 +673,7 @@ async def test_addon_options_changed(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
+    assert entry.state is ConfigEntryState.LOADED
     assert entry.data["usb_path"] == new_device
     assert entry.data["s0_legacy_key"] == new_s0_legacy_key
     assert entry.data["s2_access_control_key"] == new_s2_access_control_key


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, similar to #114669

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
