### PR TITLE
Add diagnostic platform to utility_meter

### DIFF
--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -43,6 +43,7 @@ ATTR_TARIFF = "tariff"
 ATTR_TARIFFS = "tariffs"
 ATTR_VALUE = "value"
 ATTR_CRON_PATTERN = "cron pattern"
+ATTR_NEXT_RESET = "next_reset"
 
 SIGNAL_START_PAUSE_METER = "utility_meter_start_pause"
 SIGNAL_RESET_METER = "utility_meter_reset"

--- a/homeassistant/components/utility_meter/diagnostics.py
+++ b/homeassistant/components/utility_meter/diagnostics.py
@@ -1,0 +1,35 @@
+"""Diagnostics support for Utility Meter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DATA_TARIFF_SENSORS, DATA_UTILITY
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    tariff_sensors = []
+
+    for sensor in hass.data[DATA_UTILITY][entry.entry_id][DATA_TARIFF_SENSORS]:
+        restored_last_extra_data = await sensor.async_get_last_extra_data()
+
+        tariff_sensors.append(
+            {
+                "name": sensor.name,
+                "next_reset": sensor.next_reset,
+                "extra_attributes": sensor.extra_state_attributes,
+                "last_sensor_data": restored_last_extra_data,
+            }
+        )
+
+    return {
+        "config_entry": entry,
+        "tariff_sensors": tariff_sensors,
+    }

--- a/homeassistant/components/utility_meter/diagnostics.py
+++ b/homeassistant/components/utility_meter/diagnostics.py
@@ -24,7 +24,6 @@ async def async_get_config_entry_diagnostics(
             {
                 "name": sensor.name,
                 "entity_id": sensor.entity_id,
-                "next_reset": sensor.next_reset,
                 "extra_attributes": sensor.extra_state_attributes,
                 "last_sensor_data": restored_last_extra_data,
             }

--- a/homeassistant/components/utility_meter/diagnostics.py
+++ b/homeassistant/components/utility_meter/diagnostics.py
@@ -23,6 +23,7 @@ async def async_get_config_entry_diagnostics(
         tariff_sensors.append(
             {
                 "name": sensor.name,
+                "entity_id": sensor.entity_id,
                 "next_reset": sensor.next_reset,
                 "extra_attributes": sensor.extra_state_attributes,
                 "last_sensor_data": restored_last_extra_data,

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -58,6 +58,7 @@ from homeassistant.util.enum import try_parse_enum
 
 from .const import (
     ATTR_CRON_PATTERN,
+    ATTR_NEXT_RESET,
     ATTR_VALUE,
     BIMONTHLY,
     CONF_CRON_PATTERN,
@@ -424,7 +425,7 @@ class UtilityMeterSensor(RestoreSensor):
         self._sensor_periodically_resetting = periodically_resetting
         self._tariff = tariff
         self._tariff_entity = tariff_entity
-        self.next_reset = None
+        self._next_reset = None
 
     def start(self, attributes: Mapping[str, Any]) -> None:
         """Initialize unit and state upon source initial update."""
@@ -565,14 +566,14 @@ class UtilityMeterSensor(RestoreSensor):
         """Program the reset of the utility meter."""
         if self._cron_pattern is not None:
             tz = dt_util.get_time_zone(self.hass.config.time_zone)
-            self.next_reset = croniter(self._cron_pattern, dt_util.now(tz)).get_next(
+            self._next_reset = croniter(self._cron_pattern, dt_util.now(tz)).get_next(
                 datetime
             )  # we need timezone for DST purposes (see issue #102984)
             self.async_on_remove(
                 async_track_point_in_time(
                     self.hass,
                     self._async_reset_meter,
-                    self.next_reset,
+                    self._next_reset,
                 )
             )
 
@@ -756,6 +757,8 @@ class UtilityMeterSensor(RestoreSensor):
         # in extra state attributes.
         if last_reset := self._last_reset:
             state_attr[ATTR_LAST_RESET] = last_reset.isoformat()
+        if self._next_reset is not None:
+            state_attr[ATTR_NEXT_RESET] = self._next_reset.isoformat()
 
         return state_attr
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -374,6 +374,7 @@ class UtilityMeterSensor(RestoreSensor):
 
     _attr_translation_key = "utility_meter"
     _attr_should_poll = False
+    _unrecorded_attributes = frozenset({ATTR_NEXT_RESET})
 
     def __init__(
         self,

--- a/tests/components/utility_meter/snapshots/test_diagnostics.ambr
+++ b/tests/components/utility_meter/snapshots/test_diagnostics.ambr
@@ -1,0 +1,65 @@
+# serializer version: 1
+# name: test_diagnostics
+  dict({
+    'config_entry': dict({
+      'data': dict({
+      }),
+      'disabled_by': None,
+      'domain': 'utility_meter',
+      'minor_version': 1,
+      'options': dict({
+        'cycle': 'monthly',
+        'delta_values': False,
+        'name': 'Energy Bill',
+        'net_consumption': False,
+        'offset': 0,
+        'periodically_resetting': True,
+        'source': 'sensor.input1',
+        'tariffs': list([
+          'tariff0',
+          'tariff1',
+        ]),
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': 'Energy Bill',
+      'unique_id': None,
+      'version': 2,
+    }),
+    'tariff_sensors': list([
+      dict({
+        'entity_id': 'sensor.energy_bill_tariff0',
+        'extra_attributes': dict({
+          'cron pattern': '0 0 1 * *',
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 'None',
+          'meter_period': 'monthly',
+          'next_reset': '2024-05-01T00:00:00-07:00',
+          'source': 'sensor.input1',
+          'status': 'collecting',
+          'tariff': 'tariff0',
+        }),
+        'last_sensor_data': None,
+        'name': 'Energy Bill tariff0',
+      }),
+      dict({
+        'entity_id': 'sensor.energy_bill_tariff1',
+        'extra_attributes': dict({
+          'cron pattern': '0 0 1 * *',
+          'last_period': '0',
+          'last_reset': '2024-04-05T00:00:00+00:00',
+          'last_valid_state': 'None',
+          'meter_period': 'monthly',
+          'next_reset': '2024-05-01T00:00:00-07:00',
+          'source': 'sensor.input1',
+          'status': 'paused',
+          'tariff': 'tariff1',
+        }),
+        'last_sensor_data': None,
+        'name': 'Energy Bill tariff1',
+      }),
+    ]),
+  })
+# ---

--- a/tests/components/utility_meter/test_diagnostics.py
+++ b/tests/components/utility_meter/test_diagnostics.py
@@ -1,0 +1,181 @@
+"""Test Utility Meter diagnostics."""
+
+from aiohttp.test_utils import TestClient
+from freezegun import freeze_time
+
+from homeassistant.auth.models import Credentials
+from homeassistant.components.utility_meter.const import DOMAIN
+from homeassistant.components.utility_meter.sensor import ATTR_LAST_RESET
+from homeassistant.core import HomeAssistant, State
+
+from tests.common import (
+    CLIENT_ID,
+    MockConfigEntry,
+    MockUser,
+    mock_restore_cache_with_extra_data,
+)
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def generate_new_hass_access_token(
+    hass: HomeAssistant, hass_admin_user: MockUser, hass_admin_credential: Credentials
+) -> str:
+    """Return an access token to access Home Assistant."""
+    await hass.auth.async_link_user(hass_admin_user, hass_admin_credential)
+
+    refresh_token = await hass.auth.async_create_refresh_token(
+        hass_admin_user, CLIENT_ID, credential=hass_admin_credential
+    )
+    return hass.auth.async_create_access_token(refresh_token)
+
+
+def _get_test_client_generator(
+    hass: HomeAssistant, aiohttp_client: ClientSessionGenerator, new_token: str
+):
+    """Return a test client generator.""."""
+
+    async def auth_client() -> TestClient:
+        return await aiohttp_client(
+            hass.http.app, headers={"Authorization": f"Bearer {new_token}"}
+        )
+
+    return auth_client
+
+
+@freeze_time("2024-04-06 00:00:00+00:00")
+async def test_diagnostics(
+    hass: HomeAssistant,
+    aiohttp_client: ClientSessionGenerator,
+    hass_admin_user: MockUser,
+    hass_admin_credential: Credentials,
+    socket_enabled: None,
+) -> None:
+    """Test generating diagnostics for a config entry."""
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "cycle": "monthly",
+            "delta_values": False,
+            "name": "Energy Bill",
+            "net_consumption": False,
+            "offset": 0,
+            "periodically_resetting": True,
+            "source": "sensor.input1",
+            "tariffs": [
+                "tariff0",
+                "tariff1",
+            ],
+        },
+        title="Energy Bill",
+    )
+
+    last_reset = "2024-04-05T00:00:00+00:00"
+
+    # Set up the sensors restore data
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    "sensor.energy_bill_tariff0",
+                    "3",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                    },
+                ),
+                {},
+            ),
+            (
+                State(
+                    "sensor.energy_bill_tariff1",
+                    "7",
+                    attributes={
+                        ATTR_LAST_RESET: last_reset,
+                    },
+                ),
+                {},
+            ),
+        ],
+    )
+
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Since we are freezing time only when we enter this test, we need to
+    # manually create a new token and clients since the token created by
+    # the fixtures would not be valid.
+    new_token = await generate_new_hass_access_token(
+        hass, hass_admin_user, hass_admin_credential
+    )
+
+    diag = await get_diagnostics_for_config_entry(
+        hass, _get_test_client_generator(hass, aiohttp_client, new_token), config_entry
+    )
+
+    assert diag == {
+        "config_entry": {
+            "data": {},
+            "disabled_by": None,
+            "domain": "utility_meter",
+            "entry_id": config_entry.entry_id,
+            "minor_version": 1,
+            "options": {
+                "cycle": "monthly",
+                "delta_values": False,
+                "name": "Energy Bill",
+                "net_consumption": False,
+                "offset": 0,
+                "periodically_resetting": True,
+                "source": "sensor.input1",
+                "tariffs": [
+                    "tariff0",
+                    "tariff1",
+                ],
+            },
+            "pref_disable_new_entities": False,
+            "pref_disable_polling": False,
+            "source": "user",
+            "title": "Energy Bill",
+            "unique_id": None,
+            "version": 2,
+        },
+        "tariff_sensors": [
+            {
+                "entity_id": "sensor.energy_bill_tariff0",
+                "extra_attributes": {
+                    "cron pattern": "0 0 1 * *",
+                    "last_period": "0",
+                    "last_reset": last_reset,
+                    "last_valid_state": "None",
+                    "meter_period": "monthly",
+                    "source": "sensor.input1",
+                    "status": "collecting",
+                    "tariff": "tariff0",
+                },
+                "last_sensor_data": None,
+                "name": "Energy Bill tariff0",
+                "next_reset": "2024-05-01T00:00:00-07:00",
+            },
+            {
+                "entity_id": "sensor.energy_bill_tariff1",
+                "extra_attributes": {
+                    "cron pattern": "0 0 1 * *",
+                    "last_period": "0",
+                    "last_reset": last_reset,
+                    "last_valid_state": "None",
+                    "meter_period": "monthly",
+                    "source": "sensor.input1",
+                    "status": "paused",
+                    "tariff": "tariff1",
+                },
+                "last_sensor_data": None,
+                "name": "Energy Bill tariff1",
+                "next_reset": "2024-05-01T00:00:00-07:00",
+            },
+        ],
+    }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It is very difficult to debug issues when utility_meters are setup using config_flows

Currently there is an outstanding issue https://github.com/home-assistant/core/issues/114547 that requires information on when the next reset is supposed to happen.

This PR will address both situations

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
