### PR TITLE
Improve performance of system_log traceback handling

### DIFF
--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -870,7 +870,10 @@ class LogRelayHandler(logging.Handler):
     def emit(self, record: LogRecord) -> None:
         """Relay log message via dispatcher."""
         entry = LogEntry(
-            record, self.paths_re, figure_out_source=record.levelno >= logging.WARNING
+            record,
+            self.paths_re,
+            formatter=self.formatter,
+            figure_out_source=record.levelno >= logging.WARNING,
         )
         async_dispatcher_send(
             self.hass,

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -471,7 +471,7 @@ async def test__figure_out_source(hass: HomeAssistant) -> None:
     file, line_no = system_log._figure_out_source(
         mock_record,
         paths_re,
-        traceback.extract_tb(exc_info[2]),
+        list(traceback.walk_tb(exc_info[2])),
     )
     assert file == __file__
     assert line_no != 5

--- a/tests/components/system_log/test_init.py
+++ b/tests/components/system_log/test_init.py
@@ -478,3 +478,28 @@ async def test__figure_out_source(hass: HomeAssistant) -> None:
 
     entry = system_log.LogEntry(mock_record, paths_re, figure_out_source=False)
     assert entry.source == ("figure_out_source is False", 5)
+
+
+async def test_formatting_exception(hass: HomeAssistant) -> None:
+    """Test that exceptions are formatted correctly."""
+    try:
+        raise ValueError("test")
+    except ValueError as ex:
+        exc_info = (type(ex), ex, ex.__traceback__)
+    mock_record = MagicMock(
+        pathname="figure_out_source is False",
+        lineno=5,
+        exc_info=exc_info,
+        exc_text=None,
+    )
+    regex_str = f"({__file__})"
+    paths_re = re.compile(regex_str)
+
+    mock_formatter = MagicMock(
+        formatException=MagicMock(return_value="formatted exception")
+    )
+    entry = system_log.LogEntry(
+        mock_record, paths_re, formatter=mock_formatter, figure_out_source=False
+    )
+    assert entry.exception == "formatted exception"
+    assert mock_record.exc_text == "formatted exception"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Switch system_log to use `tracekback.walk_tb` instead of `traceback.extract_tb`
  `traceback.extract_tb` calls linecache on each line and filename which can result in blocking I/O in the event loop
   Since we only need the filename and the line number we can use the much simpler `walk_tb` call
- Use the built-in exception formatter since it can cache the exception in `exc_text` which avoids having to construct it multiple times

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
