### PR TITLE
Set core State last_updated_timestamp when firing state changes

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1674,7 +1674,11 @@ class State:
         # the recorder or websocket_api so we do not need to
         # generate it lazily.
         self.last_updated_timestamp = (
-            last_updated_timestamp or self.last_updated.timestamp()
+            # We round to 6 decimal places to match the precision
+            # of .timestamp()
+            round(last_updated_timestamp, 6)
+            if last_updated_timestamp
+            else self.last_updated.timestamp()
         )
 
     @cached_property

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1670,8 +1670,12 @@ class State:
         self.context = context or Context()
         self.state_info = state_info
         self.domain, self.object_id = split_entity_id(self.entity_id)
-        if last_updated_timestamp:
-            self.__dict__["last_updated_timestamp"] = last_updated_timestamp
+        # last_updated_timestamp will nearly always be called by
+        # the recorder or websocket_api so we do not need to
+        # generate it lazily.
+        self.last_updated_timestamp = (
+            last_updated_timestamp or self.last_updated.timestamp()
+        )
 
     @cached_property
     def name(self) -> str:
@@ -1693,11 +1697,6 @@ class State:
         if self.last_reported == self.last_updated:
             return self.last_updated_timestamp
         return self.last_reported.timestamp()
-
-    @cached_property
-    def last_updated_timestamp(self) -> float:
-        """Timestamp of last update."""
-        return self.last_updated.timestamp()
 
     @cached_property
     def _as_dict(self) -> dict[str, Any]:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1642,6 +1642,7 @@ class State:
         context: Context | None = None,
         validate_entity_id: bool | None = True,
         state_info: StateInfo | None = None,
+        last_updated_timestamp: float | None = None,
     ) -> None:
         """Initialize a new state."""
         state = str(state)
@@ -1669,6 +1670,8 @@ class State:
         self.context = context or Context()
         self.state_info = state_info
         self.domain, self.object_id = split_entity_id(self.entity_id)
+        if last_updated_timestamp:
+            self.__dict__["last_updated_timestamp"] = last_updated_timestamp
 
     @cached_property
     def name(self) -> str:
@@ -2184,6 +2187,7 @@ class StateMachine:
             context,
             old_state is None,
             state_info,
+            timestamp,
         )
         if old_state is not None:
             old_state.expire()

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1673,13 +1673,12 @@ class State:
         # last_updated_timestamp will nearly always be called by
         # the recorder or websocket_api so we do not need to
         # generate it lazily.
-        self.last_updated_timestamp = (
+        if last_updated_timestamp is not None:
             # We round to 6 decimal places to match the precision
             # of .timestamp()
-            round(last_updated_timestamp, 6)
-            if last_updated_timestamp
-            else self.last_updated.timestamp()
-        )
+            self.last_updated_timestamp = round(last_updated_timestamp, 6)
+        else:
+            self.last_updated_timestamp = self.last_updated.timestamp()
 
     @cached_property
     def name(self) -> str:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2856,6 +2856,27 @@ def test_state_timestamps() -> None:
     assert state.last_updated_timestamp == now.timestamp()
 
 
+def test_state_timestamps_with_timestamp_passed() -> None:
+    """Test timestamp functions for State."""
+    now = dt_util.utcnow()
+    state = ha.State(
+        "light.bedroom",
+        "on",
+        {"brightness": 100},
+        last_changed=now,
+        last_reported=now,
+        last_updated=now,
+        context=ha.Context(id="1234"),
+        last_updated_timestamp=now.timestamp(),
+    )
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+
+
 async def test_state_firing_event_matches_context_id_ulid_time(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2877,6 +2877,28 @@ def test_state_timestamps_with_timestamp_passed() -> None:
     assert state.last_updated_timestamp == now.timestamp()
 
 
+def test_state_timestamps_rounds_timestamp_passed() -> None:
+    """Test timestamp functions for State."""
+    timestamp = time.time()
+    now = dt_util.utc_from_timestamp(timestamp)
+    state = ha.State(
+        "light.bedroom",
+        "on",
+        {"brightness": 100},
+        last_changed=now,
+        last_reported=now,
+        last_updated=now,
+        context=ha.Context(id="1234"),
+        last_updated_timestamp=timestamp,
+    )
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+
+
 async def test_state_firing_event_matches_context_id_ulid_time(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
async_fire already knows the timestamp, pass it to core State so it does not have to be converted later as it will always be called for the recorder or websocket_api.

When I was looking at the recorder conversion in #114911 I realized we mostly had the same value over and over. When looking at a profile of setting states at startup, I realized we already have the timestamp value now so we can avoid the conversion completely 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
