### PR TITLE
Add lock to switchbot_cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -20,6 +20,7 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VACUUM,
+    Platform.LOCK,
 ]
 
 
@@ -31,6 +32,7 @@ class SwitchbotDevices:
     switches: list[Device | Remote] = field(default_factory=list)
     sensors: list[Device] = field(default_factory=list)
     vacuums: list[Device] = field(default_factory=list)
+    locks: list[Device] = field(default_factory=list)
 
 
 @dataclass
@@ -97,6 +99,10 @@ def make_device_data(
                 prepare_device(hass, api, device, coordinators_by_id)
             )
 
+        if isinstance(device, Device) and device.device_type.endswith("Smart Lock"):
+            devices_data.locks.append(
+                prepare_device(hass, api, device, coordinators_by_id)
+            )
     return devices_data
 
 

--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -99,7 +99,7 @@ def make_device_data(
                 prepare_device(hass, api, device, coordinators_by_id)
             )
 
-        if isinstance(device, Device) and device.device_type.endswith("Smart Lock"):
+        if isinstance(device, Device) and device.device_type.startswith("Smart Lock"):
             devices_data.locks.append(
                 prepare_device(hass, api, device, coordinators_by_id)
             )

--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -17,10 +17,10 @@ from .coordinator import SwitchBotCoordinator
 _LOGGER = getLogger(__name__)
 PLATFORMS: list[Platform] = [
     Platform.CLIMATE,
+    Platform.LOCK,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VACUUM,
-    Platform.LOCK,
 ]
 
 

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -1,0 +1,64 @@
+"""Support for the Switchbot lock."""
+
+from typing import Any
+
+from switchbot_api import LockCommands
+
+from homeassistant.components.lock import LockEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import SwitchbotCloudData
+from .const import DOMAIN
+from .entity import SwitchBotCloudEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up SwitchBot Cloud entry."""
+    data: SwitchbotCloudData = hass.data[DOMAIN][config.entry_id]
+    async_add_entities(
+        SwitchBotCloudLock(data.api, device, coordinator)
+        for device, coordinator in data.devices.locks
+    )
+
+
+class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
+    """Representation of a SwitchBot lock."""
+
+    _attr_translation_key = "lock"
+    _attr_name = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if coord_data := self.coordinator.data:
+            self._attr_is_locked = coord_data["lockState"] == "locked"
+            self.async_write_ha_state()
+
+    async def async_lock(self, **kwargs: Any) -> None:
+        """Lock the lock."""
+        await self.send_command(LockCommands.LOCK)
+        self._attr_is_locked = True
+        self.async_write_ha_state()
+
+    async def async_unlock(self, **kwargs: Any) -> None:
+        """Unlock the lock."""
+
+        await self.send_command(LockCommands.UNLOCK)
+        self._attr_is_locked = False
+        # if self._device.is_night_latch_enabled():
+        #     self._last_run_success = await self._device.unlock_without_unlatch()
+        # else:
+        #     self._last_run_success = await self._device.unlock()
+        self.async_write_ha_state()
+
+    async def async_open(self, **kwargs: Any) -> None:
+        """Open the lock."""
+        await self.send_command(LockCommands.UNLOCK)
+        self._attr_is_locked = False
+        self.async_write_ha_state()

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -55,6 +55,4 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the lock."""
-        await self.send_command(LockCommands.UNLOCK)
-        self._attr_is_locked = False
-        self.async_write_ha_state()
+        await self.async_unlock(kwargs)

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -51,10 +51,6 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
 
         await self.send_command(LockCommands.UNLOCK)
         self._attr_is_locked = False
-        # if self._device.is_night_latch_enabled():
-        #     self._last_run_success = await self._device.unlock_without_unlatch()
-        # else:
-        #     self._last_run_success = await self._device.unlock()
         self.async_write_ha_state()
 
     async def async_open(self, **kwargs: Any) -> None:

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -30,7 +30,6 @@ async def async_setup_entry(
 class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
     """Representation of a SwitchBot lock."""
 
-    _attr_translation_key = "lock"
     _attr_name = None
 
     @callback

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -53,6 +53,3 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
         self._attr_is_locked = False
         self.async_write_ha_state()
 
-    async def async_open(self, **kwargs: Any) -> None:
-        """Open the lock."""
-        await self.async_unlock(**kwargs)

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -55,4 +55,4 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
 
     async def async_open(self, **kwargs: Any) -> None:
         """Open the lock."""
-        await self.async_unlock(kwargs)
+        await self.async_unlock(**kwargs)

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -41,13 +41,13 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
 
     async def async_lock(self, **kwargs: Any) -> None:
         """Lock the lock."""
-        await self.send_command(LockCommands.LOCK)
+        await self.send_api_command(LockCommands.LOCK)
         self._attr_is_locked = True
         self.async_write_ha_state()
 
     async def async_unlock(self, **kwargs: Any) -> None:
         """Unlock the lock."""
 
-        await self.send_command(LockCommands.UNLOCK)
+        await self.send_api_command(LockCommands.UNLOCK)
         self._attr_is_locked = False
         self.async_write_ha_state()

--- a/homeassistant/components/switchbot_cloud/lock.py
+++ b/homeassistant/components/switchbot_cloud/lock.py
@@ -51,4 +51,3 @@ class SwitchBotCloudLock(SwitchBotCloudEntity, LockEntity):
         await self.send_command(LockCommands.UNLOCK)
         self._attr_is_locked = False
         self.async_write_ha_state()
-

--- a/tests/components/switchbot_cloud/conftest.py
+++ b/tests/components/switchbot_cloud/conftest.py
@@ -5,6 +5,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from homeassistant.components.switchbot_cloud import SwitchBotAPI
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock]:
@@ -14,3 +16,17 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         return_value=True,
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_list_devices():
+    """Mock list_devices."""
+    with patch.object(SwitchBotAPI, "list_devices") as mock_list_devices:
+        yield mock_list_devices
+
+
+@pytest.fixture
+def mock_get_status():
+    """Mock get_status."""
+    with patch.object(SwitchBotAPI, "get_status") as mock_get_status:
+        yield mock_get_status

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -8,12 +8,7 @@ from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.switchbot_cloud import SwitchBotAPI
 from homeassistant.components.switchbot_cloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    EVENT_HOMEASSISTANT_START,
-    SERVICE_LOCK,
-    SERVICE_UNLOCK,
-)
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.core import HomeAssistant
 
 from . import configure_integration
@@ -38,9 +33,6 @@ async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> 
 
     assert entry.state is ConfigEntryState.LOADED
     assert len(hass.data[DOMAIN][entry.entry_id].devices.locks) == 1
-
-    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
-    await hass.async_block_till_done()
 
     lock_id = "lock.lock_1"
     assert hass.states.get(lock_id).state == LockState.LOCKED

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from switchbot_api import Device
 
-from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.switchbot_cloud import SwitchBotAPI
 from homeassistant.components.switchbot_cloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -13,8 +13,6 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     SERVICE_LOCK,
     SERVICE_UNLOCK,
-    STATE_LOCKED,
-    STATE_UNLOCKED,
 )
 from homeassistant.core import HomeAssistant
 
@@ -45,16 +43,16 @@ async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> 
     await hass.async_block_till_done()
 
     lock_id = "lock.lock_1"
-    assert hass.states.get(lock_id).state == STATE_LOCKED
+    assert hass.states.get(lock_id).state == LockState.LOCKED
 
     with patch.object(SwitchBotAPI, "send_command"):
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: lock_id}, blocking=True
         )
-    assert hass.states.get(lock_id).state == STATE_UNLOCKED
+    assert hass.states.get(lock_id).state == LockState.UNLOCKED
 
     with patch.object(SwitchBotAPI, "send_command"):
         await hass.services.async_call(
             LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: lock_id}, blocking=True
         )
-    assert hass.states.get(lock_id).state == STATE_LOCKED
+    assert hass.states.get(lock_id).state == LockState.LOCKED

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -1,4 +1,4 @@
-"""Test for the switchbot_cloud lock"""
+"""Test for the switchbot_cloud lock."""
 
 from unittest.mock import patch
 
@@ -22,6 +22,7 @@ from . import configure_integration
 
 
 async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> None:
+    """Test locking and unlocking."""
     mock_list_devices.return_value = [
         Device(
             deviceId="lock-id-1",

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -1,0 +1,59 @@
+"""Test for the switchbot_cloud lock"""
+
+from unittest.mock import patch
+
+from switchbot_api import Device
+
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.switchbot_cloud import SwitchBotAPI
+from homeassistant.components.switchbot_cloud.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
+    SERVICE_LOCK,
+    SERVICE_UNLOCK,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+)
+from homeassistant.core import HomeAssistant
+
+from . import configure_integration
+
+
+async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> None:
+    mock_list_devices.return_value = [
+        Device(
+            deviceId="lock-id-1",
+            deviceName="lock-1",
+            deviceType="Smart Lock",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+
+    mock_get_status.return_value = {"lockState": "locked"}
+
+    entry = configure_integration(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert len(hass.data[DOMAIN][entry.entry_id].devices.locks) == 1
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done()
+
+    lock_id = "lock.lock_1"
+    assert hass.states.get(lock_id).state == STATE_LOCKED
+
+    with patch.object(SwitchBotAPI, "send_command"):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_UNLOCK, {ATTR_ENTITY_ID: lock_id}, blocking=True
+        )
+    assert hass.states.get(lock_id).state == STATE_UNLOCKED
+
+    with patch.object(SwitchBotAPI, "send_command"):
+        await hass.services.async_call(
+            LOCK_DOMAIN, SERVICE_LOCK, {ATTR_ENTITY_ID: lock_id}, blocking=True
+        )
+    assert hass.states.get(lock_id).state == STATE_LOCKED

--- a/tests/components/switchbot_cloud/test_lock.py
+++ b/tests/components/switchbot_cloud/test_lock.py
@@ -6,7 +6,6 @@ from switchbot_api import Device
 
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
 from homeassistant.components.switchbot_cloud import SwitchBotAPI
-from homeassistant.components.switchbot_cloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_LOCK, SERVICE_UNLOCK
 from homeassistant.core import HomeAssistant
@@ -32,7 +31,6 @@ async def test_lock(hass: HomeAssistant, mock_list_devices, mock_get_status) -> 
     await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    assert len(hass.data[DOMAIN][entry.entry_id].devices.locks) == 1
 
     lock_id = "lock.lock_1"
     assert hass.states.get(lock_id).state == LockState.LOCKED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This PR adds support for the SwitchBot Lock to the SwitchBot Cloud integration.
This requires a minor version bump to the switchbot_api package, see [release notes](https://github.com/SeraphicCorp/py-switchbot-api/releases/tag/v2.1.0).


Docs: https://github.com/home-assistant/home-assistant.io/pull/32196

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
