### PR TITLE
Avoid checking for polling if an entity fails to add

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -632,7 +632,7 @@ class EntityPlatform:
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
             or not any(
-                # Entity may have failed to add or called add_to_platform_abort
+                # Entity may have failed to add or called `add_to_platform_abort`
                 # so we check if the entity is in self.entities before
                 # checking `entity.should_poll` since `should_poll` may need to
                 # check `self.hass` which will be `None` if the entity did not add

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -632,6 +632,10 @@ class EntityPlatform:
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
             or not any(
+                # Entity may have failed to add or called add_to_platform_abort
+                # so we check if the entity is in the platform entities before
+                # checking if it should poll should `should_poll` may need to
+                # check `self.hass` which will be None if the entity did not add
                 entity.entity_id
                 and entity.entity_id in self.entities
                 and entity.should_poll

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -42,7 +42,6 @@ from . import (
     service,
     translation,
 )
-from .entity import EntityPlatformState
 from .entity_registry import EntityRegistry, RegistryEntryDisabler, RegistryEntryHider
 from .event import async_call_later, async_track_time_interval
 from .issue_registry import IssueSeverity, async_create_issue
@@ -633,8 +632,8 @@ class EntityPlatform:
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
             or not any(
-                # pylint: disable=protected-access
-                entity._platform_state is EntityPlatformState.ADDED
+                entity.entity_id
+                and entity.entity_id in self.entities
                 and entity.should_poll
                 for entity in entities
             )

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -633,9 +633,9 @@ class EntityPlatform:
             or self._async_unsub_polling is not None
             or not any(
                 # Entity may have failed to add or called add_to_platform_abort
-                # so we check if the entity is in the platform entities before
-                # checking if it should poll should `should_poll` may need to
-                # check `self.hass` which will be None if the entity did not add
+                # so we check if the entity is in self.entities before
+                # checking `entity.should_poll` since `should_poll` may need to
+                # check `self.hass` which will be `None` if the entity did not add
                 entity.entity_id
                 and entity.entity_id in self.entities
                 and entity.should_poll

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -42,6 +42,7 @@ from . import (
     service,
     translation,
 )
+from .entity import EntityPlatformState
 from .entity_registry import EntityRegistry, RegistryEntryDisabler, RegistryEntryHider
 from .event import async_call_later, async_track_time_interval
 from .issue_registry import IssueSeverity, async_create_issue
@@ -631,7 +632,12 @@ class EntityPlatform:
         if (
             (self.config_entry and self.config_entry.pref_disable_polling)
             or self._async_unsub_polling is not None
-            or not any(entity.should_poll for entity in entities)
+            or not any(
+                # pylint: disable=protected-access
+                entity._platform_state is EntityPlatformState.ADDED
+                and entity.should_poll
+                for entity in entities
+            )
         ):
             return
 

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -99,7 +99,7 @@ async def test_polling_check_works_if_entity_add_fails(
     broken_poll_ent.async_update = AsyncMock(side_effect=Exception("Broken"))
 
     await component.async_add_entities(
-        [working_poll_ent, broken_poll_ent], update_before_add=True
+        [broken_poll_ent, working_poll_ent], update_before_add=True
     )
 
     working_poll_ent.async_update.reset_mock()

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -85,9 +85,16 @@ async def test_polling_check_works_if_entity_add_fails(
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))
     await component.async_setup({})
 
-    working_poll_ent = MockEntity(should_poll=True)
+    class MockEntityNeedsSelfHassInShouldPoll(MockEntity):
+        """Mock entity that needs self.hass in should_poll."""
+
+        def should_poll(self) -> bool:
+            """Return True if entity has to be polled."""
+            return self.hass is not None
+
+    working_poll_ent = MockEntityNeedsSelfHassInShouldPoll(should_poll=True)
     working_poll_ent.async_update = AsyncMock()
-    broken_poll_ent = MockEntity(should_poll=True)
+    broken_poll_ent = MockEntityNeedsSelfHassInShouldPoll(should_poll=True)
     broken_poll_ent.async_update = AsyncMock(side_effect=Exception("Broken"))
 
     await component.async_add_entities(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -88,9 +88,10 @@ async def test_polling_check_works_if_entity_add_fails(
     class MockEntityNeedsSelfHassInShouldPoll(MockEntity):
         """Mock entity that needs self.hass in should_poll."""
 
+        @property
         def should_poll(self) -> bool:
             """Return True if entity has to be polled."""
-            return self.hass is not None
+            return self.hass.data is not None
 
     working_poll_ent = MockEntityNeedsSelfHassInShouldPoll(should_poll=True)
     working_poll_ent.async_update = AsyncMock()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid checking for polling if an entity fails to add or the add is aborted

Some entities access `self.hass` in `should_poll` which will be unset if `entity_platform` called `add_to_platform_abort` or the entity otherwise failed to add.

This problem is limited to custom components because there are no core integrations that access `self.hass` in `should_poll`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
