### PR TITLE
Migrate matrix to use run_immediately for start listener

### DIFF
--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -220,7 +220,7 @@ class MatrixBot:
             )  # milliseconds.
 
         self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, handle_startup, run_immediately=False
+            EVENT_HOMEASSISTANT_START, handle_startup, run_immediately=True
         )
 
     def _load_commands(self, commands: list[ConfigCommand]) -> None:

--- a/tests/components/matrix/conftest.py
+++ b/tests/components/matrix/conftest.py
@@ -281,6 +281,9 @@ async def matrix_bot(
     assert await async_setup_component(hass, MATRIX_DOMAIN, MOCK_CONFIG_DATA)
     assert await async_setup_component(hass, NOTIFY_DOMAIN, MOCK_CONFIG_DATA)
     await hass.async_block_till_done()
+
+    # Accessing hass.data in tests is not desirable, but all the tests here
+    # currently do this.
     assert isinstance(matrix_bot := hass.data[MATRIX_DOMAIN], MatrixBot)
 
     await hass.async_start()

--- a/tests/components/matrix/test_rooms.py
+++ b/tests/components/matrix/test_rooms.py
@@ -1,14 +1,37 @@
 """Test MatrixBot._join."""
 
+import pytest
+
 from homeassistant.components.matrix import MatrixBot
+from homeassistant.components.matrix.const import DOMAIN as MATRIX_DOMAIN
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_CONFIG_DATA
 
 from tests.components.matrix.conftest import TEST_BAD_ROOM, TEST_JOINABLE_ROOMS
 
 
-async def test_join(hass, matrix_bot: MatrixBot, caplog):
+async def test_join(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    mock_client,
+    mock_save_json,
+    mock_allowed_path,
+) -> None:
     """Test joining configured rooms."""
+    assert await async_setup_component(hass, MATRIX_DOMAIN, MOCK_CONFIG_DATA)
+    assert await async_setup_component(hass, NOTIFY_DOMAIN, MOCK_CONFIG_DATA)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-    await hass.async_start()
+    # Accessing hass.data in tests is not desirable, but all the tests here
+    # currently do this.
+    matrix_bot = hass.data[MATRIX_DOMAIN]
+
     for room_id in TEST_JOINABLE_ROOMS:
         assert f"Joined or already in room '{room_id}'" in caplog.messages
 
@@ -21,7 +44,7 @@ async def test_join(hass, matrix_bot: MatrixBot, caplog):
     )
 
 
-async def test_resolve_aliases(hass, matrix_bot: MatrixBot):
+async def test_resolve_aliases(hass: HomeAssistant, matrix_bot: MatrixBot) -> None:
     """Test resolving configured room aliases into room ids."""
 
     await hass.async_start()

--- a/tests/components/matrix/test_rooms.py
+++ b/tests/components/matrix/test_rooms.py
@@ -24,7 +24,6 @@ async def test_join(
     """Test joining configured rooms."""
     assert await async_setup_component(hass, MATRIX_DOMAIN, MOCK_CONFIG_DATA)
     assert await async_setup_component(hass, NOTIFY_DOMAIN, MOCK_CONFIG_DATA)
-    await hass.async_block_till_done(wait_background_tasks=True)
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done(wait_background_tasks=True)
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate matrix to use run_immediately for start listener

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
