### PR TITLE
Deprecate calling async_listen and async_listen_once with run_immediately

### DIFF
--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -342,7 +342,6 @@ async def async_enable_proactive_mode(
         EVENT_STATE_CHANGED,
         _async_entity_state_listener,
         event_filter=_async_entity_state_filter,
-        run_immediately=True,
     )
 
 

--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -397,7 +397,6 @@ class APIDomainServicesView(HomeAssistantView):
         cancel_listen = hass.bus.async_listen(
             EVENT_STATE_CHANGED,
             _async_save_changed_entities,
-            run_immediately=True,
         )
 
         try:

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -102,9 +102,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await manager.disconnect()
 
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, on_hass_stop, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/august/subscriber.py
+++ b/homeassistant/components/august/subscriber.py
@@ -71,7 +71,6 @@ class AugustSubscriberMixin:
             self._stop_interval = self._hass.bus.async_listen(
                 EVENT_HOMEASSISTANT_STOP,
                 self._async_cancel_update_interval,
-                run_immediately=True,
             )
 
     @callback

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -782,7 +782,6 @@ class AutomationEntity(BaseAutomationEntity, RestoreEntity):
         self.hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STARTED,
             self._async_enable_automation,
-            run_immediately=True,
         )
         self.async_write_ha_state()
 

--- a/homeassistant/components/azure_event_hub/__init__.py
+++ b/homeassistant/components/azure_event_hub/__init__.py
@@ -158,7 +158,7 @@ class AzureEventHub:
         """
         logging.getLogger("azure.eventhub").setLevel(logging.WARNING)
         self._listener_remover = self.hass.bus.async_listen(
-            MATCH_ALL, self.async_listen, run_immediately=True
+            MATCH_ALL, self.async_listen
         )
         self._schedule_next_send()
 

--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -166,9 +166,7 @@ async def _async_start_adapter_discovery(
         """Shutdown debouncer."""
         discovery_debouncer.async_shutdown()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_shutdown_debouncer, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown_debouncer)
 
     async def _async_call_debouncer(now: datetime.datetime) -> None:
         """Call the debouncer at a later time."""
@@ -201,7 +199,6 @@ async def _async_start_adapter_discovery(
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP,
         hass_callback(lambda event: cancel()),
-        run_immediately=True,
     )
 
 

--- a/homeassistant/components/bluetooth/manager.py
+++ b/homeassistant/components/bluetooth/manager.py
@@ -135,11 +135,9 @@ class HomeAssistantBluetoothManager(BluetoothManager):
             self._bluetooth_adapters, self.storage
         )
         self._cancel_logging_listener = self.hass.bus.async_listen(
-            EVENT_LOGGING_CHANGED, self._async_logging_changed, run_immediately=True
+            EVENT_LOGGING_CHANGED, self._async_logging_changed
         )
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self.async_stop, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
         seen: set[str] = set()
         for address, service_info in itertools.chain(
             self._connectable_history.items(), self._all_history.items()

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -274,7 +274,6 @@ async def async_setup(hass: HomeAssistant) -> None:
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP,
         _async_save_processor_data_at_stop,
-        run_immediately=True,
     )
 
 

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -68,9 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(_async_stop_event)
     entry.async_on_unload(
-        hass.bus.async_listen(
-            EVENT_HOMEASSISTANT_STOP, _async_stop_event, run_immediately=True
-        )
+        hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, _async_stop_event)
     )
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = BondData(hub, bpup_subs)
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -412,9 +412,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             stream.add_provider("hls")
             await stream.start()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED, preload_stream, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, preload_stream)
 
     @callback
     def update_tokens(t: datetime) -> None:
@@ -432,9 +430,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Unsubscribe track time interval timer."""
         unsub()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, unsub_track_time_interval, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, unsub_track_time_interval)
 
     component.async_register_entity_service(
         SERVICE_ENABLE_MOTION, {}, "async_enable_motion_detection"

--- a/homeassistant/components/cloud/__init__.py
+++ b/homeassistant/components/cloud/__init__.py
@@ -262,9 +262,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Shutdown event."""
         await cloud.stop()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _shutdown, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _shutdown)
 
     _remote_handle_prefs_updated(cloud)
 

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -197,24 +197,20 @@ class DefaultAgent(ConversationEntity):
             self.hass.bus.async_listen(
                 ar.EVENT_AREA_REGISTRY_UPDATED,
                 self._async_clear_slot_list,
-                run_immediately=True,
             ),
             self.hass.bus.async_listen(
                 fr.EVENT_FLOOR_REGISTRY_UPDATED,
                 self._async_clear_slot_list,
-                run_immediately=True,
             ),
             self.hass.bus.async_listen(
                 er.EVENT_ENTITY_REGISTRY_UPDATED,
                 self._async_clear_slot_list,
                 event_filter=self._filter_entity_registry_changes,
-                run_immediately=True,
             ),
             self.hass.bus.async_listen(
                 EVENT_STATE_CHANGED,
                 self._async_clear_slot_list,
                 event_filter=self._filter_state_changes,
-                run_immediately=True,
             ),
             async_listen_entity_updates(self.hass, DOMAIN, self._async_clear_slot_list),
         ]

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -159,9 +159,7 @@ def _async_register_mac(
         # Enable entity
         ent_reg.async_update_entity(entity_id, disabled_by=None)
 
-    hass.bus.async_listen(
-        dr.EVENT_DEVICE_REGISTRY_UPDATED, handle_device_event, run_immediately=True
-    )
+    hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, handle_device_event)
 
 
 class BaseTrackerEntity(Entity):

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -281,9 +281,7 @@ async def _async_setup_integration(
         """
         cancel_update_stale()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _on_hass_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_hass_stop)
 
 
 @attr.s

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -162,13 +162,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             for watcher in watchers:
                 watcher.async_stop()
 
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_stop, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop)
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED, _async_initialize, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_initialize)
     return True
 
 

--- a/homeassistant/components/esphome/dashboard.py
+++ b/homeassistant/components/esphome/dashboard.py
@@ -103,7 +103,7 @@ class ESPHomeDashboardManager:
             await dashboard.async_shutdown()
 
         self._cancel_shutdown = hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, on_hass_stop, run_immediately=True
+            EVENT_HOMEASSISTANT_STOP, on_hass_stop
         )
 
         new_data = {"info": {"addon_slug": addon_slug, "host": host, "port": port}}

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -550,15 +550,12 @@ class ESPHomeManager:
         # when the CLOSE event is fired so anything using a Bluetooth
         # proxy has a chance to shut down properly.
         entry_data.cleanup_callbacks.append(
-            hass.bus.async_listen(
-                EVENT_HOMEASSISTANT_CLOSE, self.on_stop, run_immediately=True
-            )
+            hass.bus.async_listen(EVENT_HOMEASSISTANT_CLOSE, self.on_stop)
         )
         entry_data.cleanup_callbacks.append(
             hass.bus.async_listen(
                 EVENT_LOGGING_CHANGED,
                 self._async_handle_logging_changed,
-                run_immediately=True,
             )
         )
 

--- a/homeassistant/components/google_assistant/report_state.py
+++ b/homeassistant/components/google_assistant/report_state.py
@@ -190,7 +190,6 @@ def async_enable_report_state(
             EVENT_STATE_CHANGED,
             _async_entity_state_listener,
             event_filter=_async_entity_state_filter,
-            run_immediately=True,
         )
 
     unsub = async_call_later(

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -386,7 +386,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         last_timezone = new_timezone
         await hassio.update_hass_timezone(new_timezone)
 
-    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config, run_immediately=True)
+    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, push_config)
 
     push_config_task = hass.async_create_task(push_config(None), eager_start=True)
     # Start listening for problems with supervisor and making issues

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -171,9 +171,7 @@ async def async_attach_trigger(
 
     event_filter = filter_event if event_data_items or event_data_schema else None
     removes = [
-        hass.bus.async_listen(
-            event_type, handle_event, event_filter=event_filter, run_immediately=True
-        )
+        hass.bus.async_listen(event_type, handle_event, event_filter=event_filter)
         for event_type in event_types
     ]
 

--- a/homeassistant/components/homeassistant_alerts/__init__.py
+++ b/homeassistant/components/homeassistant_alerts/__init__.py
@@ -104,9 +104,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             refresh_debouncer.async_schedule_call()
 
         await coordinator.async_refresh()
-        hass.bus.async_listen(
-            EVENT_COMPONENT_LOADED, _component_loaded, run_immediately=True
-        )
+        hass.bus.async_listen(EVENT_COMPONENT_LOADED, _component_loaded)
 
     async_at_start(hass, initial_refresh)
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -351,9 +351,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, homekit.async_stop, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, homekit.async_stop)
     )
 
     entry_data = HomeKitEntryData(

--- a/homeassistant/components/homekit_controller/__init__.py
+++ b/homeassistant/components/homekit_controller/__init__.py
@@ -86,9 +86,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             )
         )
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller)
 
     return True
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -286,7 +286,6 @@ class HKDevice:
                 self.hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,
                     self._async_populate_ble_accessory_state,
-                    run_immediately=True,
                 )
             )
         else:

--- a/homeassistant/components/homekit_controller/utils.py
+++ b/homeassistant/components/homekit_controller/utils.py
@@ -77,9 +77,7 @@ async def async_get_controller(hass: HomeAssistant) -> Controller:
 
     # Right now _async_stop_homekit_controller is only called on HA exiting
     # So we don't have to worry about leaking a callback here.
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_homekit_controller)
 
     await controller.async_start()
 

--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -166,9 +166,7 @@ async def async_setup_entry(
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_stop_auto_update, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_auto_update)
     )
 
     # Register Integration-wide Services:

--- a/homeassistant/components/logbook/helpers.py
+++ b/homeassistant/components/logbook/helpers.py
@@ -176,8 +176,7 @@ def async_subscribe_events(
         target, entities_filter, entity_ids, device_ids
     )
     subscriptions.extend(
-        hass.bus.async_listen(event_type, event_forwarder, run_immediately=True)
-        for event_type in event_types
+        hass.bus.async_listen(event_type, event_forwarder) for event_type in event_types
     )
 
     if device_ids and not entity_ids:
@@ -211,7 +210,6 @@ def async_subscribe_events(
         hass.bus.async_listen(
             EVENT_STATE_CHANGED,
             _forward_state_events_filtered,
-            run_immediately=True,
         )
     )
 

--- a/homeassistant/components/matrix/__init__.py
+++ b/homeassistant/components/matrix/__init__.py
@@ -219,9 +219,7 @@ class MatrixBot:
                 loop_sleep_time=1_000,
             )  # milliseconds.
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_START, handle_startup, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, handle_startup)
 
     def _load_commands(self, commands: list[ConfigCommand]) -> None:
         for command in commands:

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -242,7 +242,6 @@ class PersonStorageCollection(collection.DictStorageCollection):
             er.EVENT_ENTITY_REGISTRY_UPDATED,
             self._entity_registry_updated,
             event_filter=self._entity_registry_filter,
-            run_immediately=True,
         )
 
     @callback

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -333,7 +333,6 @@ class Recorder(threading.Thread):
         self._event_listener = self.hass.bus.async_listen(
             MATCH_ALL,
             _event_listener,
-            run_immediately=True,
         )
         self._queue_watcher = async_track_time_interval(
             self.hass,
@@ -478,12 +477,8 @@ class Recorder(threading.Thread):
     def async_register(self) -> None:
         """Post connection initialize."""
         bus = self.hass.bus
-        bus.async_listen_once(
-            EVENT_HOMEASSISTANT_CLOSE, self._async_close, run_immediately=True
-        )
-        bus.async_listen_once(
-            EVENT_HOMEASSISTANT_FINAL_WRITE, self._async_shutdown, run_immediately=True
-        )
+        bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, self._async_close)
+        bus.async_listen_once(EVENT_HOMEASSISTANT_FINAL_WRITE, self._async_shutdown)
         async_at_started(self.hass, self._async_hass_started)
 
     @callback

--- a/homeassistant/components/recorder/entity_registry.py
+++ b/homeassistant/components/recorder/entity_registry.py
@@ -47,7 +47,6 @@ def async_setup(hass: HomeAssistant) -> None:
             er.EVENT_ENTITY_REGISTRY_UPDATED,
             _async_entity_id_changed,
             event_filter=entity_registry_changed_filter,
-            run_immediately=True,
         )
 
     async_at_start(hass, _setup_entity_registry_event_handler)

--- a/homeassistant/components/rfxtrx/__init__.py
+++ b/homeassistant/components/rfxtrx/__init__.py
@@ -280,9 +280,7 @@ async def async_setup_internal(hass: HomeAssistant, entry: ConfigEntry) -> None:
     hass.data[DOMAIN][DATA_RFXOBJECT] = rfx_object
 
     entry.async_on_unload(
-        hass.bus.async_listen(
-            dr.EVENT_DEVICE_REGISTRY_UPDATED, _updated_device, run_immediately=True
-        )
+        hass.bus.async_listen(dr.EVENT_DEVICE_REGISTRY_UPDATED, _updated_device)
     )
 
     def _shutdown_rfxtrx(event: Event) -> None:

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -149,9 +149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await bridge.async_close_remote()
 
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, stop_bridge, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_bridge)
     )
 
     await _async_update_ssdp_locations(hass, entry)

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -189,9 +189,7 @@ class ShellyBlockCoordinator(ShellyCoordinatorBase[BlockDevice]):
             self.async_add_listener(self._async_device_updates_handler)
         )
         entry.async_on_unload(
-            hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop, run_immediately=True
-            )
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
         )
 
     @callback
@@ -420,9 +418,7 @@ class ShellyRpcCoordinator(ShellyCoordinatorBase[RpcDevice]):
         self._input_event_listeners: list[Callable[[dict[str, Any]], None]] = []
 
         entry.async_on_unload(
-            hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop, run_immediately=True
-            )
+            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._handle_ha_stop)
         )
         entry.async_on_unload(entry.add_update_listener(self._async_update_listener))
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -577,7 +577,6 @@ class SonosDiscoveryManager:
             self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_STOP,
                 self._async_stop_event_listener,
-                run_immediately=True,
             )
         )
         _LOGGER.debug("Adding discovery job")
@@ -586,7 +585,6 @@ class SonosDiscoveryManager:
                 self.hass.bus.async_listen_once(
                     EVENT_HOMEASSISTANT_STOP,
                     self._stop_manual_heartbeat,
-                    run_immediately=True,
                 )
             )
             await self.async_poll_manual_hosts()

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -392,9 +392,7 @@ class Scanner:
 
         await self._async_start_ssdp_listeners()
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self.async_stop, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
         self._cancel_scan = async_track_time_interval(
             self.hass, self.async_scan, SCAN_INTERVAL, name="SSDP scanner"
         )
@@ -755,13 +753,10 @@ class Server:
     async def async_start(self) -> None:
         """Start the server."""
         bus = self.hass.bus
-        bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self.async_stop, run_immediately=True
-        )
+        bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
         bus.async_listen_once(
             EVENT_HOMEASSISTANT_STARTED,
             self._async_start_upnp_servers,
-            run_immediately=True,
         )
 
     async def _async_get_instance_udn(self) -> str:

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -214,7 +214,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     # Only pass through PyAV log messages if stream logging is above DEBUG
     cancel_logging_listener = hass.bus.async_listen(
-        EVENT_LOGGING_CHANGED, update_pyav_logging, run_immediately=True
+        EVENT_LOGGING_CHANGED, update_pyav_logging
     )
     # libav.mp4 and libav.swscaler have a few unimportant messages that are logged
     # at logging.WARNING. Set those Logger levels to logging.ERROR
@@ -266,7 +266,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         _LOGGER.debug("Stopped stream workers")
         cancel_logging_listener()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown, run_immediately=True)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, shutdown)
 
     return True
 

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -47,7 +47,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
             await self._attach_triggers()
         else:
             self._unsub_start = self.hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_START, self._attach_triggers, run_immediately=True
+                EVENT_HOMEASSISTANT_START, self._attach_triggers
             )
 
         for platform_domain in PLATFORMS:

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -68,9 +68,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             _LOGGER.error("Error storing traces", exc_info=exc)
 
     # Store traces when stopping hass
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_store_traces_at_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_store_traces_at_stop)
 
     return True
 

--- a/homeassistant/components/unifiprotect/__init__.py
+++ b/homeassistant/components/unifiprotect/__init__.py
@@ -110,9 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = data_service
     entry.async_on_unload(entry.add_update_listener(_async_options_updated))
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, data_service.async_stop, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, data_service.async_stop)
     )
 
     if not entry.options.get(CONF_ALLOW_EA, False) and (

--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -207,12 +207,8 @@ class USBDiscovery:
     async def async_setup(self) -> None:
         """Set up USB Discovery."""
         await self._async_start_monitor()
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STARTED, self.async_start, run_immediately=True
-        )
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self.async_stop, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, self.async_start)
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.async_stop)
 
     async def async_start(self, event: Event) -> None:
         """Start USB Discovery and run a manual scan."""
@@ -242,9 +238,7 @@ class USBDiscovery:
         def _stop_observer(event: Event) -> None:
             observer.stop()
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _stop_observer, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_observer)
         self.observer_active = True
 
     def _get_monitor_observer(self) -> MonitorObserver | None:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -165,7 +165,7 @@ def handle_subscribe_events(
         )
 
     connection.subscriptions[msg["id"]] = hass.bus.async_listen(
-        event_type, forward_events, run_immediately=True
+        event_type, forward_events
     )
 
     connection.send_result(msg["id"])
@@ -410,7 +410,6 @@ def handle_subscribe_entities(
             connection.user,
             msg["id"],
         ),
-        run_immediately=True,
     )
     connection.send_result(msg["id"])
 

--- a/homeassistant/components/websocket_api/http.py
+++ b/homeassistant/components/websocket_api/http.py
@@ -292,7 +292,7 @@ class WebSocketHandler:
         self._handle_task = asyncio.current_task()
 
         unsub_stop = hass.bus.async_listen(
-            EVENT_HOMEASSISTANT_STOP, self._async_handle_hass_stop, run_immediately=True
+            EVENT_HOMEASSISTANT_STOP, self._async_handle_hass_stop
         )
 
         writer = wsock._writer  # pylint: disable=protected-access

--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -96,9 +96,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         discovery_responder.stop()
         registry.stop()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _on_hass_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_hass_stop)
 
     yaml_config = config.get(DOMAIN, {})
     hass.data[DOMAIN] = WemoData(

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -127,9 +127,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_shutdown, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_shutdown)
     )
     return True
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -169,9 +169,7 @@ async def _async_get_instance(hass: HomeAssistant, **zcargs: Any) -> HaAsyncZero
 
     # Wait to the close event to shutdown zeroconf to give
     # integrations time to send a good bye message
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_CLOSE, _async_stop_zeroconf, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_stop_zeroconf)
     hass.data[DOMAIN] = aio_zc
 
     return aio_zc
@@ -248,9 +246,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     async def _async_zeroconf_hass_stop(_event: Event) -> None:
         await discovery.async_stop()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _async_zeroconf_hass_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_zeroconf_hass_stop)
     async_when_setup_or_start(hass, "frontend", _async_zeroconf_hass_start)
 
     return True

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -288,9 +288,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Handle core config updated."""
         await home_zone.async_update_config(_home_conf(hass))
 
-    hass.bus.async_listen(
-        EVENT_CORE_CONFIG_UPDATE, core_config_updated, run_immediately=True
-    )
+    hass.bus.async_listen(EVENT_CORE_CONFIG_UPDATE, core_config_updated)
 
     hass.data[DOMAIN] = storage_collection
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -636,7 +636,6 @@ class ConfigEntry:
                 self._async_cancel_retry_setup = hass.bus.async_listen(
                     EVENT_HOMEASSISTANT_STARTED,
                     functools.partial(self._async_setup_again, hass),
-                    run_immediately=True,
                 )
 
             await self._async_process_on_unload(hass)
@@ -1646,9 +1645,7 @@ class ConfigEntries:
             old_conf_migrate_func=_old_conf_migrator,
         )
 
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self._async_shutdown, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
 
         if config is None:
             self._entries = ConfigEntryItems(self.hass)

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1399,9 +1399,7 @@ class EventBus:
         self._listeners[MATCH_ALL] = self._match_all_listeners
         self._hass = hass
         self._async_logging_changed()
-        self.async_listen(
-            EVENT_LOGGING_CHANGED, self._async_logging_changed, run_immediately=True
-        )
+        self.async_listen(EVENT_LOGGING_CHANGED, self._async_logging_changed)
 
     @callback
     def _async_logging_changed(self, event: Event | None = None) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1539,7 +1539,7 @@ class EventBus:
         event_type: EventType[_DataT] | str,
         listener: Callable[[Event[_DataT]], Coroutine[Any, Any, None] | None],
         event_filter: Callable[[_DataT], bool] | None = None,
-        run_immediately: bool = True,
+        run_immediately: bool | None = None,
     ) -> CALLBACK_TYPE:
         """Listen for all events or events of a specific type.
 
@@ -1556,6 +1556,17 @@ class EventBus:
 
         This method must be run in the event loop.
         """
+        if run_immediately in (True, False):
+            # late import to avoid circular imports
+            from .helpers import frame  # pylint: disable=import-outside-toplevel
+
+            frame.report(
+                "calls `async_listen` with run_immediately, which is"
+                " deprecated and will be removed in Assistant 2025.4",
+                error_if_core=False,
+            )
+
+        run_immediately = True
         if event_filter is not None and not is_callback_check_partial(event_filter):
             raise HomeAssistantError(f"Event filter {event_filter} is not a callback")
         if event_type == EVENT_STATE_REPORTED:
@@ -1614,7 +1625,7 @@ class EventBus:
         self,
         event_type: EventType[_DataT] | str,
         listener: Callable[[Event[_DataT]], Coroutine[Any, Any, None] | None],
-        run_immediately: bool = True,
+        run_immediately: bool | None = None,
     ) -> CALLBACK_TYPE:
         """Listen once for event of a specific type.
 
@@ -1625,6 +1636,17 @@ class EventBus:
 
         This method must be run in the event loop.
         """
+        if run_immediately in (True, False):
+            # late import to avoid circular imports
+            from .helpers import frame  # pylint: disable=import-outside-toplevel
+
+            frame.report(
+                "calls `async_listen_once` with run_immediately, which is "
+                "deprecated and will be removed in Assistant 2025.4",
+                error_if_core=False,
+            )
+
+        run_immediately = True
         one_time_listener: _OneTimeListener[_DataT] = _OneTimeListener(
             self._hass, HassJob(listener)
         )

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -136,6 +136,7 @@ _P = ParamSpec("_P")
 _Ts = TypeVarTuple("_Ts")
 # Internal; not helpers.typing.UNDEFINED due to circular dependency
 _UNDEF: dict[Any, Any] = {}
+_SENTINEL = object()
 _CallableT = TypeVar("_CallableT", bound=Callable[..., Any])
 _DataT = TypeVar("_DataT", bound=Mapping[str, Any], default=Mapping[str, Any])
 CALLBACK_TYPE = Callable[[], None]
@@ -1532,7 +1533,7 @@ class EventBus:
         event_type: EventType[_DataT] | str,
         listener: Callable[[Event[_DataT]], Coroutine[Any, Any, None] | None],
         event_filter: Callable[[_DataT], bool] | None = None,
-        run_immediately: bool | None = None,
+        run_immediately: bool | object = _SENTINEL,
     ) -> CALLBACK_TYPE:
         """Listen for all events or events of a specific type.
 
@@ -1612,7 +1613,7 @@ class EventBus:
         self,
         event_type: EventType[_DataT] | str,
         listener: Callable[[Event[_DataT]], Coroutine[Any, Any, None] | None],
-        run_immediately: bool | None = None,
+        run_immediately: bool | object = _SENTINEL,
     ) -> CALLBACK_TYPE:
         """Listen once for event of a specific type.
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1560,7 +1560,7 @@ class EventBus:
 
             frame.report(
                 "calls `async_listen` with run_immediately, which is"
-                " deprecated and will be removed in Assistant 2025.4",
+                " deprecated and will be removed in Assistant 2025.5",
                 error_if_core=False,
             )
 
@@ -1640,7 +1640,7 @@ class EventBus:
 
             frame.report(
                 "calls `async_listen_once` with run_immediately, which is "
-                "deprecated and will be removed in Assistant 2025.4",
+                "deprecated and will be removed in Assistant 2025.5",
                 error_if_core=False,
             )
 

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -387,7 +387,6 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             event_type=fr.EVENT_FLOOR_REGISTRY_UPDATED,
             event_filter=_removed_from_registry_filter,
             listener=_handle_floor_registry_update,
-            run_immediately=True,
         )
 
         @callback
@@ -404,7 +403,6 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             event_type=lr.EVENT_LABEL_REGISTRY_UPDATED,
             event_filter=_removed_from_registry_filter,
             listener=_handle_label_registry_update,
-            run_immediately=True,
         )
 
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1202,7 +1202,6 @@ def async_setup_cleanup(hass: HomeAssistant, dev_reg: DeviceRegistry) -> None:
         event_type=lr.EVENT_LABEL_REGISTRY_UPDATED,
         event_filter=_label_removed_from_registry_filter,
         listener=_handle_label_registry_update,
-        run_immediately=True,
     )
 
     @callback
@@ -1236,7 +1235,6 @@ def async_setup_cleanup(hass: HomeAssistant, dev_reg: DeviceRegistry) -> None:
             entity_registry.EVENT_ENTITY_REGISTRY_UPDATED,
             _async_entity_registry_changed,
             event_filter=entity_registry_changed_filter,
-            run_immediately=True,
         )
         return
 
@@ -1246,22 +1244,17 @@ def async_setup_cleanup(hass: HomeAssistant, dev_reg: DeviceRegistry) -> None:
             entity_registry.EVENT_ENTITY_REGISTRY_UPDATED,
             _async_entity_registry_changed,
             event_filter=entity_registry_changed_filter,
-            run_immediately=True,
         )
         await debounced_cleanup.async_call()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED, startup_clean, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, startup_clean)
 
     @callback
     def _on_homeassistant_stop(event: Event) -> None:
         """Cancel debounced cleanup."""
         debounced_cleanup.async_cancel()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _on_homeassistant_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_homeassistant_stop)
 
 
 def _normalize_connections(connections: set[tuple[str, str]]) -> set[tuple[str, str]]:

--- a/homeassistant/helpers/discovery_flow.py
+++ b/homeassistant/helpers/discovery_flow.py
@@ -82,9 +82,7 @@ class FlowDispatcher:
     @callback
     def async_setup(self) -> None:
         """Set up the flow disptcher."""
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STARTED, self._async_start, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, self._async_start)
 
     async def _async_start(self, event: Event) -> None:
         """Start processing pending flows."""

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -120,9 +120,7 @@ class EntityComponent(Generic[_EntityT]):
         Note: this is only required if the integration never calls
         `setup` or `async_setup`.
         """
-        self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, self._async_shutdown, run_immediately=True
-        )
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self._async_shutdown)
 
     def setup(self, config: ConfigType) -> None:
         """Set up a full entity component.

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -677,7 +677,6 @@ class EntityRegistry(BaseRegistry):
         self.hass.bus.async_listen(
             EVENT_DEVICE_REGISTRY_UPDATED,
             self.async_device_modified,
-            run_immediately=True,
         )
 
     @callback
@@ -1478,7 +1477,6 @@ def _async_setup_cleanup(hass: HomeAssistant, registry: EntityRegistry) -> None:
         event_type=lr.EVENT_LABEL_REGISTRY_UPDATED,
         event_filter=_removed_from_registry_filter,
         listener=_handle_label_registry_update,
-        run_immediately=True,
     )
 
     @callback
@@ -1492,7 +1490,6 @@ def _async_setup_cleanup(hass: HomeAssistant, registry: EntityRegistry) -> None:
         event_type=cr.EVENT_CATEGORY_REGISTRY_UPDATED,
         event_filter=_removed_from_registry_filter,
         listener=_handle_category_registry_update,
-        run_immediately=True,
     )
 
     @callback
@@ -1511,9 +1508,7 @@ def _async_setup_cleanup(hass: HomeAssistant, registry: EntityRegistry) -> None:
         """Cancel cleanup."""
         cancel()
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, _on_homeassistant_stop, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _on_homeassistant_stop)
 
 
 @callback
@@ -1539,7 +1534,6 @@ def _async_setup_entity_restore(hass: HomeAssistant, registry: EntityRegistry) -
         EVENT_ENTITY_REGISTRY_UPDATED,
         cleanup_restored_states,
         event_filter=cleanup_restored_states_filter,
-        run_immediately=True,
     )
 
     if hass.is_running:
@@ -1556,9 +1550,7 @@ def _async_setup_entity_restore(hass: HomeAssistant, registry: EntityRegistry) -
 
             entry.write_unavailable_state(hass)
 
-    hass.bus.async_listen(
-        EVENT_HOMEASSISTANT_START, _write_unavailable_states, run_immediately=True
-    )
+    hass.bus.async_listen(EVENT_HOMEASSISTANT_START, _write_unavailable_states)
 
 
 async def async_migrate_entries(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -419,7 +419,6 @@ def _async_track_event(
             tracker.event_type,
             ft.partial(tracker.dispatcher_callable, hass, callbacks),
             event_filter=ft.partial(tracker.filter_callable, hass, callbacks),
-            run_immediately=True,
         )
 
     job = HassJob(action, f"track {tracker.event_type} event {keys}", job_type=job_type)

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -276,7 +276,6 @@ def async_track_state_change(
         EVENT_STATE_CHANGED,
         state_change_dispatcher,
         event_filter=state_change_filter,
-        run_immediately=True,
     )
 
 

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -169,7 +169,6 @@ async def async_process_integration_platforms(
                 hass,
                 integration_platforms,
             ),
-            run_immediately=True,
         )
     else:
         integration_platforms = hass.data[DATA_INTEGRATION_PLATFORMS]

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -252,7 +252,7 @@ class RestoreStateData:
 
         # Dump states when stopping hass
         self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_dump_states_at_stop, run_immediately=True
+            EVENT_HOMEASSISTANT_STOP, _async_dump_states_at_stop
         )
 
     @callback

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -47,7 +47,7 @@ def _async_at_core_state(
         if unsub:
             unsub()
 
-    unsub = hass.bus.async_listen_once(event_type, _matched_event, run_immediately=True)
+    unsub = hass.bus.async_listen_once(event_type, _matched_event)
     return cancel
 
 

--- a/homeassistant/helpers/storage.py
+++ b/homeassistant/helpers/storage.py
@@ -125,7 +125,6 @@ class _StoreManager:
         hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STARTED,
             self._async_schedule_cleanup,
-            run_immediately=True,
         )
 
     @callback
@@ -185,7 +184,6 @@ class _StoreManager:
         self._hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_STOP,
             self._async_cancel_and_cleanup,
-            run_immediately=True,
         )
 
     @callback
@@ -481,7 +479,6 @@ class Store(Generic[_T]):
             self._unsub_final_write_listener = self.hass.bus.async_listen_once(
                 EVENT_HOMEASSISTANT_FINAL_WRITE,
                 self._async_callback_final_write,
-                run_immediately=True,
             )
 
     @callback

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -212,12 +212,8 @@ def async_setup(hass: HomeAssistant) -> bool:
     cancel = async_track_time_interval(
         hass, _async_adjust_lru_sizes, timedelta(minutes=10)
     )
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_START, _async_adjust_lru_sizes, run_immediately=True
-    )
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, callback(lambda _: cancel()), run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, _async_adjust_lru_sizes)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, callback(lambda _: cancel()))
     return True
 
 

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -136,7 +136,7 @@ class DataUpdateCoordinator(BaseDataUpdateCoordinatorProtocol, Generic[_DataT]):
             await self.async_shutdown()
 
         self._unsub_shutdown = self.hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _on_hass_stop, run_immediately=True
+            EVENT_HOMEASSISTANT_STOP, _on_hass_stop
         )
 
     @callback

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -615,14 +615,11 @@ def _async_when_setup(
             EVENT_COMPONENT_LOADED,
             _matched_event,
             event_filter=_async_is_component_filter,
-            run_immediately=True,
         )
     )
     if start_event:
         listeners.append(
-            hass.bus.async_listen(
-                EVENT_HOMEASSISTANT_START, _matched_event, run_immediately=True
-            )
+            hass.bus.async_listen(EVENT_HOMEASSISTANT_START, _matched_event)
         )
 
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -918,9 +918,7 @@ class MockEntityPlatform(entity_platform.EntityPlatform):
         def _async_on_stop(_: Event) -> None:
             self.async_shutdown()
 
-        hass.bus.async_listen_once(
-            EVENT_HOMEASSISTANT_STOP, _async_on_stop, run_immediately=True
-        )
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_on_stop)
 
 
 class MockToggleEntity(entity.ToggleEntity):
@@ -1493,7 +1491,7 @@ def async_capture_events(hass: HomeAssistant, event_name: str) -> list[Event]:
     def capture_events(event: Event) -> None:
         events.append(event)
 
-    hass.bus.async_listen(event_name, capture_events, run_immediately=True)
+    hass.bus.async_listen(event_name, capture_events)
 
     return events
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -299,7 +299,6 @@ async def async_test_home_assistant(
     hass.bus.async_listen_once(
         EVENT_HOMEASSISTANT_STOP,
         hass.config_entries._async_shutdown,
-        run_immediately=True,
     )
 
     # Load the registries
@@ -358,9 +357,7 @@ async def async_test_home_assistant(
         await asyncio.sleep(0)  # Give aiohttp one loop iteration to close
         INSTANCES.remove(hass)
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_CLOSE, clear_instance, run_immediately=True
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, clear_instance)
 
     yield hass
 

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -2513,9 +2513,7 @@ async def test_recursive_automation_starting_script(
         hass.services.async_register(
             "test", "automation_started", async_service_handler
         )
-        hass.bus.async_listen(
-            "automation_triggered", async_automation_triggered, run_immediately=True
-        )
+        hass.bus.async_listen("automation_triggered", async_automation_triggered)
 
         hass.bus.async_fire("trigger_automation")
         await asyncio.wait_for(script_done_event.wait(), 10)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3378,12 +3378,6 @@ async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:
         """Mock filter."""
         return False
 
-    # run_immediately set to False
-    with pytest.raises(HomeAssistantError):
-        hass.bus.async_listen(
-            EVENT_STATE_REPORTED, listener, event_filter=filter, run_immediately=False
-        )
-
     # no filter
     with pytest.raises(HomeAssistantError):
         hass.bus.async_listen(EVENT_STATE_REPORTED, listener)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3384,3 +3384,30 @@ async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:
 
     # Both filter and run_immediately
     hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=filter)
+
+
+@pytest.mark.parametrize(
+    "run_immediately",
+    [True, False],
+)
+@pytest.mark.parametrize(
+    "method",
+    ["async_listen", "async_listen_once"],
+)
+async def test_async_listen_with_run_immediately_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    run_immediately: bool,
+    method: str,
+) -> None:
+    """Test async_add_job warns about its deprecation."""
+
+    async def _test(event: ha.Event):
+        pass
+
+    func = getattr(hass.bus, method)
+    func(EVENT_HOMEASSISTANT_START, _test, run_immediately=run_immediately)
+    assert (
+        f"Detected code that calls `{method}` with run_immediately, which is "
+        "deprecated and will be removed in Assistant 2025.5."
+    ) in caplog.text

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1174,7 +1174,7 @@ async def test_eventbus_run_immediately_callback(hass: HomeAssistant) -> None:
         """Mock listener."""
         calls.append(event)
 
-    unsub = hass.bus.async_listen("test", listener, run_immediately=True)
+    unsub = hass.bus.async_listen("test", listener)
 
     hass.bus.async_fire("test", {"event": True})
     # No async_block_till_done here
@@ -1191,7 +1191,7 @@ async def test_eventbus_run_immediately_coro(hass: HomeAssistant) -> None:
         """Mock listener."""
         calls.append(event)
 
-    unsub = hass.bus.async_listen("test", listener, run_immediately=True)
+    unsub = hass.bus.async_listen("test", listener)
 
     hass.bus.async_fire("test", {"event": True})
     # No async_block_till_done here
@@ -1208,7 +1208,7 @@ async def test_eventbus_listen_once_run_immediately_coro(hass: HomeAssistant) ->
         """Mock listener."""
         calls.append(event)
 
-    hass.bus.async_listen_once("test", listener, run_immediately=True)
+    hass.bus.async_listen_once("test", listener)
 
     hass.bus.async_fire("test", {"event": True})
     # No async_block_till_done here
@@ -3343,9 +3343,7 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     hass.states.async_set("light.bowl", "on", {})
     state_changed_events = async_capture_events(hass, EVENT_STATE_CHANGED)
     state_reported_events = []
-    hass.bus.async_listen(
-        EVENT_STATE_REPORTED, listener, event_filter=filter, run_immediately=True
-    )
+    hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=filter)
 
     hass.states.async_set("light.bowl", "on")
     await hass.async_block_till_done()
@@ -3388,9 +3386,7 @@ async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:
 
     # no filter
     with pytest.raises(HomeAssistantError):
-        hass.bus.async_listen(EVENT_STATE_REPORTED, listener, run_immediately=True)
+        hass.bus.async_listen(EVENT_STATE_REPORTED, listener)
 
     # Both filter and run_immediately
-    hass.bus.async_listen(
-        EVENT_STATE_REPORTED, listener, event_filter=filter, run_immediately=True
-    )
+    hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=filter)

--- a/tests/test_data_entry_flow.py
+++ b/tests/test_data_entry_flow.py
@@ -399,7 +399,6 @@ async def test_show_progress(hass: HomeAssistant, manager) -> None:
     hass.bus.async_listen(
         data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED,
         capture_events,
-        run_immediately=True,
     )
 
     result = await manager.async_init("test")
@@ -479,7 +478,6 @@ async def test_show_progress_error(hass: HomeAssistant, manager) -> None:
     hass.bus.async_listen(
         data_entry_flow.EVENT_DATA_ENTRY_FLOW_PROGRESSED,
         capture_events,
-        run_immediately=True,
     )
 
     result = await manager.async_init("test")


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Calling `async_listen` or `async_listen_once` with `run_immediately` is deprecated, and the keyword argument will be removed in 2025.5. Since its unlikely anyone was calling `run_immediately` with `False` as it was only ever in the `event` helper in core prior to the 2024.5 dev cycle, the default of `True` will always be used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


needs 
- [x] https://github.com/home-assistant/core/pull/115165 
- [x] tests to make sure frame is logged
- [x] ~~blog post -- probably not since its unlikely to be used outside of core and the solution is to remove the kwarg~~