### PR TITLE
Add migration logic to assist_pipeline

### DIFF
--- a/homeassistant/components/assist_pipeline/__init__.py
+++ b/homeassistant/components/assist_pipeline/__init__.py
@@ -31,6 +31,8 @@ from .pipeline import (
     async_create_default_pipeline,
     async_get_pipeline,
     async_get_pipelines,
+    async_migrate_engine,
+    async_run_migrations,
     async_setup_pipeline_store,
     async_update_pipeline,
 )
@@ -40,6 +42,7 @@ __all__ = (
     "DOMAIN",
     "async_create_default_pipeline",
     "async_get_pipelines",
+    "async_migrate_engine",
     "async_setup",
     "async_pipeline_from_audio_stream",
     "async_update_pipeline",
@@ -72,6 +75,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     hass.data[DATA_LAST_WAKE_UP] = {}
 
     await async_setup_pipeline_store(hass)
+    await async_run_migrations(hass)
     async_register_websocket_api(hass)
 
     return True

--- a/homeassistant/components/assist_pipeline/const.py
+++ b/homeassistant/components/assist_pipeline/const.py
@@ -3,6 +3,7 @@
 DOMAIN = "assist_pipeline"
 
 DATA_CONFIG = f"{DOMAIN}.config"
+DATA_MIGRATIONS = f"{DOMAIN}_migrations"
 
 DEFAULT_PIPELINE_TIMEOUT = 60 * 5  # seconds
 

--- a/homeassistant/components/assist_pipeline/pipeline.py
+++ b/homeassistant/components/assist_pipeline/pipeline.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from queue import Empty, Queue
 from threading import Thread
 import time
-from typing import TYPE_CHECKING, Any, Final, cast
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 import wave
 
 import voluptuous as vol
@@ -56,6 +56,7 @@ from .const import (
     CONF_DEBUG_RECORDING_DIR,
     DATA_CONFIG,
     DATA_LAST_WAKE_UP,
+    DATA_MIGRATIONS,
     DOMAIN,
     WAKE_WORD_COOLDOWN,
 )
@@ -376,10 +377,6 @@ class Pipeline:
         This function was added in HA Core 2023.10, previous versions will raise
         if there are unexpected items in the serialized data.
         """
-        # Migrate to new value for conversation agent
-        if data["conversation_engine"] == conversation.OLD_HOME_ASSISTANT_AGENT:
-            data["conversation_engine"] = conversation.HOME_ASSISTANT_AGENT
-
         return cls(
             conversation_engine=data["conversation_engine"],
             conversation_language=data["conversation_language"],
@@ -1818,3 +1815,47 @@ async def async_setup_pipeline_store(hass: HomeAssistant) -> PipelineData:
         PIPELINE_FIELDS,
     ).async_setup(hass)
     return PipelineData(pipeline_store)
+
+
+@callback
+def async_migrate_engine(
+    hass: HomeAssistant,
+    engine_type: Literal["conversation", "stt", "tts", "wake_word"],
+    old_value: str,
+    new_value: str,
+) -> None:
+    """Register a migration of an engine used in pipelines."""
+    hass.data.setdefault(DATA_MIGRATIONS, {})[engine_type] = (old_value, new_value)
+
+    # Run migrations when config is already loaded
+    if DATA_CONFIG in hass.data:
+        hass.async_create_background_task(
+            async_run_migrations(hass), "assist_pipeline_migration", eager_start=True
+        )
+
+
+async def async_run_migrations(hass: HomeAssistant) -> None:
+    """Run pipeline migrations."""
+    if not (migrations := hass.data.get(DATA_MIGRATIONS)):
+        return
+
+    engine_attr = {
+        "conversation": "conversation_engine",
+        "stt": "stt_engine",
+        "tts": "tts_engine",
+        "wake_word": "wake_word_entity",
+    }
+
+    updates = []
+
+    for pipeline in async_get_pipelines(hass):
+        attr_updates = {}
+        for engine_type, (old_value, new_value) in migrations.items():
+            if getattr(pipeline, engine_attr[engine_type]) == old_value:
+                attr_updates[engine_attr[engine_type]] = new_value
+
+        if attr_updates:
+            updates.append((pipeline, attr_updates))
+
+    for pipeline, attr_updates in updates:
+        await async_update_pipeline(hass, pipeline, **attr_updates)

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -5,7 +5,6 @@
   "dependencies": ["http", "intent"],
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
-  "iot_class": "local_push",
   "quality_scale": "internal",
   "requirements": ["hassil==1.6.1", "home-assistant-intents==2024.4.3"]
 }

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -44,6 +44,7 @@ class Platform(StrEnum):
     CALENDAR = "calendar"
     CAMERA = "camera"
     CLIMATE = "climate"
+    CONVERSATION = "conversation"
     COVER = "cover"
     DATE = "date"
     DATETIME = "datetime"

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -156,6 +156,8 @@ IGNORE_VIOLATIONS = {
     ("websocket_api", "lovelace"),
     ("websocket_api", "shopping_list"),
     "logbook",
+    # Temporary needed for migration until 2024.10
+    ("conversation", "assist_pipeline"),
 }
 
 

--- a/tests/components/assist_pipeline/test_pipeline.py
+++ b/tests/components/assist_pipeline/test_pipeline.py
@@ -19,6 +19,7 @@ from homeassistant.components.assist_pipeline.pipeline import (
     async_create_default_pipeline,
     async_get_pipeline,
     async_get_pipelines,
+    async_migrate_engine,
     async_update_pipeline,
 )
 from homeassistant.core import HomeAssistant
@@ -118,6 +119,12 @@ async def test_loading_pipelines_from_storage(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
     """Test loading stored pipelines on start."""
+    async_migrate_engine(
+        hass,
+        "conversation",
+        conversation.OLD_HOME_ASSISTANT_AGENT,
+        conversation.HOME_ASSISTANT_AGENT,
+    )
     id_1 = "01GX8ZWBAQYWNB1XV3EXEZ75DY"
     hass_storage[STORAGE_KEY] = {
         "version": STORAGE_VERSION,
@@ -614,3 +621,41 @@ async def test_update_pipeline(
         "wake_word_entity": "wake_work.test_1",
         "wake_word_id": "wake_word_id_1",
     }
+
+
+async def test_migrate_after_load(
+    hass: HomeAssistant, init_supporting_components
+) -> None:
+    """Test migrating an engine after done loading."""
+    assert await async_setup_component(hass, "assist_pipeline", {})
+
+    pipeline_data: PipelineData = hass.data[DOMAIN]
+    store = pipeline_data.pipeline_store
+    assert len(store.data) == 1
+
+    assert (
+        await async_create_default_pipeline(
+            hass,
+            stt_engine_id="bla",
+            tts_engine_id="bla",
+            pipeline_name="Bla pipeline",
+        )
+        is None
+    )
+    pipeline = await async_create_default_pipeline(
+        hass,
+        stt_engine_id="test",
+        tts_engine_id="test",
+        pipeline_name="Test pipeline",
+    )
+    assert pipeline is not None
+
+    async_migrate_engine(hass, "stt", "test", "stt.test")
+    async_migrate_engine(hass, "tts", "test", "tts.test")
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    pipeline_updated = async_get_pipeline(hass, pipeline.id)
+
+    assert pipeline_updated.stt_engine == "stt.test"
+    assert pipeline_updated.tts_engine == "tts.test"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extracted from #114942

Add logic to Assist Pipeline to make it easier to migrate engines. Will be used to migrate all integrations with conversation platforms to use conversation entities.

Because we do not always know the load order, migrations can be registered before and after assist_pipeline is set up. 

This logic can be removed in 2024.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
