### PR TITLE
Ignore coverage for aiohttp_resolver backport helper

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,12 +6,12 @@
 source = homeassistant
 omit =
     homeassistant/__main__.py
-    homeassistant/helpers/signal.py
     homeassistant/helpers/backports/aiohttp_resolver.py
+    homeassistant/helpers/signal.py
     homeassistant/scripts/__init__.py
+    homeassistant/scripts/benchmark/__init__.py
     homeassistant/scripts/check_config.py
     homeassistant/scripts/ensure_config.py
-    homeassistant/scripts/benchmark/__init__.py
     homeassistant/scripts/macos/__init__.py
 
     # omit pieces of code that rely on external devices being present

--- a/.coveragerc
+++ b/.coveragerc
@@ -7,6 +7,7 @@ source = homeassistant
 omit =
     homeassistant/__main__.py
     homeassistant/helpers/signal.py
+    homeassistant/helpers/backports/aiohttp_resolver.py
     homeassistant/scripts/__init__.py
     homeassistant/scripts/check_config.py
     homeassistant/scripts/ensure_config.py

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -29,6 +29,7 @@ source = homeassistant
 omit =
     homeassistant/__main__.py
     homeassistant/helpers/signal.py
+    homeassistant/helpers/backports/aiohttp_resolver.py
     homeassistant/scripts/__init__.py
     homeassistant/scripts/check_config.py
     homeassistant/scripts/ensure_config.py

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -160,8 +160,8 @@ def generate(integrations: dict[str, Integration], config: Config) -> None:
             elif section == "components" and line != "\n":
                 components.append(line)
 
-    assert(core, "core should be a non-empty list")
-    assert(components, "components should be a non-empty list")
+    assert core, "core should be a non-empty list"
+    assert components, "components should be a non-empty list"
     content = (
         f"{CORE_PREFIX}{"".join(sorted(core))}\n"
         f"{COMPONENTS_PREFIX}{"".join(sorted(components))}\n"

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -160,7 +160,11 @@ def generate(integrations: dict[str, Integration], config: Config) -> None:
             elif section == "components" and line != "\n":
                 components.append(line)
 
-    content = f"{CORE_PREFIX}{"".join(sorted(core))}\n{COMPONENTS_PREFIX}{"".join(sorted(components))}\n\n{SUFFIX}"
+    content = (
+        f"{CORE_PREFIX}{"".join(sorted(core))}\n"
+        f"{COMPONENTS_PREFIX}{"".join(sorted(components))}\n"
+        f"\n{SUFFIX}"
+    )
 
     with coverage_path.open("w") as fp:
         fp.write(content)

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -160,6 +160,8 @@ def generate(integrations: dict[str, Integration], config: Config) -> None:
             elif section == "components" and line != "\n":
                 components.append(line)
 
+    assert(core, "core should be a non-empty list")
+    assert(components, "components should be a non-empty list")
     content = (
         f"{CORE_PREFIX}{"".join(sorted(core))}\n"
         f"{COMPONENTS_PREFIX}{"".join(sorted(components))}\n"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on #115017 and #115044

Adjusted hassfest coverage script to ensure `core` items are included in the sorting checks.

Also marked validation failures as fixable since `validate` runs on CI, and `generate` runs only locally

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
