### PR TITLE
Use EventType for remaining registry events

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, TypedDict, cast
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import slugify
 
+from ..util.event_type import EventType
 from . import device_registry as dr, entity_registry as er
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
@@ -20,7 +21,9 @@ from .storage import Store
 from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "area_registry"
-EVENT_AREA_REGISTRY_UPDATED = "area_registry_updated"
+EVENT_AREA_REGISTRY_UPDATED: EventType[EventAreaRegistryUpdatedData] = EventType(
+    "area_registry_updated"
+)
 STORAGE_KEY = "core.area_registry"
 STORAGE_VERSION_MAJOR = 1
 STORAGE_VERSION_MINOR = 6
@@ -219,7 +222,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         self.areas[area.id] = area
         self.async_schedule_save()
         self.hass.bus.async_fire(
-            EVENT_AREA_REGISTRY_UPDATED, {"action": "create", "area_id": area.id}
+            EVENT_AREA_REGISTRY_UPDATED,
+            EventAreaRegistryUpdatedData(action="create", area_id=area.id),
         )
         return area
 
@@ -234,7 +238,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
         del self.areas[area_id]
 
         self.hass.bus.async_fire(
-            EVENT_AREA_REGISTRY_UPDATED, {"action": "remove", "area_id": area_id}
+            EVENT_AREA_REGISTRY_UPDATED,
+            EventAreaRegistryUpdatedData(action="remove", area_id=area_id),
         )
 
         self.async_schedule_save()
@@ -262,7 +267,8 @@ class AreaRegistry(BaseRegistry[AreasRegistryStoreData]):
             picture=picture,
         )
         self.hass.bus.async_fire(
-            EVENT_AREA_REGISTRY_UPDATED, {"action": "update", "area_id": area_id}
+            EVENT_AREA_REGISTRY_UPDATED,
+            EventAreaRegistryUpdatedData(action="update", area_id=area_id),
         )
         return updated
 

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -8,8 +8,8 @@ from typing import Any, Literal, TypedDict, cast
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import slugify
+from homeassistant.util.event_type import EventType
 
-from ..util.event_type import EventType
 from . import device_registry as dr, entity_registry as er
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,

--- a/homeassistant/helpers/category_registry.py
+++ b/homeassistant/helpers/category_registry.py
@@ -8,9 +8,9 @@ from dataclasses import dataclass, field
 from typing import Literal, TypedDict, cast
 
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.util.event_type import EventType
 from homeassistant.util.ulid import ulid_now
 
-from ..util.event_type import EventType
 from .registry import BaseRegistry
 from .storage import Store
 from .typing import UNDEFINED, UndefinedType

--- a/homeassistant/helpers/category_registry.py
+++ b/homeassistant/helpers/category_registry.py
@@ -10,12 +10,15 @@ from typing import Literal, TypedDict, cast
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util.ulid import ulid_now
 
+from ..util.event_type import EventType
 from .registry import BaseRegistry
 from .storage import Store
 from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "category_registry"
-EVENT_CATEGORY_REGISTRY_UPDATED = "category_registry_updated"
+EVENT_CATEGORY_REGISTRY_UPDATED: EventType[EventCategoryRegistryUpdatedData] = (
+    EventType("category_registry_updated")
+)
 STORAGE_KEY = "core.category_registry"
 STORAGE_VERSION_MAJOR = 1
 

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -10,6 +10,7 @@ from typing import Literal, TypedDict, cast
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
 
+from ..util.event_type import EventType
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
     NormalizedNameBaseRegistryItems,
@@ -20,7 +21,9 @@ from .storage import Store
 from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "floor_registry"
-EVENT_FLOOR_REGISTRY_UPDATED = "floor_registry_updated"
+EVENT_FLOOR_REGISTRY_UPDATED: EventType[EventFloorRegistryUpdatedData] = EventType(
+    "floor_registry_updated"
+)
 STORAGE_KEY = "core.floor_registry"
 STORAGE_VERSION_MAJOR = 1
 

--- a/homeassistant/helpers/floor_registry.py
+++ b/homeassistant/helpers/floor_registry.py
@@ -9,8 +9,8 @@ from typing import Literal, TypedDict, cast
 
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
+from homeassistant.util.event_type import EventType
 
-from ..util.event_type import EventType
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
     NormalizedNameBaseRegistryItems,

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -9,8 +9,8 @@ from typing import Literal, TypedDict, cast
 
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
+from homeassistant.util.event_type import EventType
 
-from ..util.event_type import EventType
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
     NormalizedNameBaseRegistryItems,

--- a/homeassistant/helpers/label_registry.py
+++ b/homeassistant/helpers/label_registry.py
@@ -10,6 +10,7 @@ from typing import Literal, TypedDict, cast
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util import slugify
 
+from ..util.event_type import EventType
 from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryEntry,
     NormalizedNameBaseRegistryItems,
@@ -20,7 +21,9 @@ from .storage import Store
 from .typing import UNDEFINED, UndefinedType
 
 DATA_REGISTRY = "label_registry"
-EVENT_LABEL_REGISTRY_UPDATED = "label_registry_updated"
+EVENT_LABEL_REGISTRY_UPDATED: EventType[EventLabelRegistryUpdatedData] = EventType(
+    "label_registry_updated"
+)
 STORAGE_KEY = "core.label_registry"
 STORAGE_VERSION_MAJOR = 1
 


### PR DESCRIPTION
## Proposed change
Use `EventType` introduced in #114906.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
