### PR TITLE
Use EventType for system events

### DIFF
--- a/homeassistant/components/api/__init__.py
+++ b/homeassistant/components/api/__init__.py
@@ -49,6 +49,7 @@ from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.json import json_dumps, json_fragment
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.event_type import EventType
 from homeassistant.util.json import json_loads
 
 _LOGGER = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ class APIEventStream(HomeAssistantView):
         stop_obj = object()
         to_write: asyncio.Queue[object | str] = asyncio.Queue()
 
-        restrict: list[str] | None = None
+        restrict: list[EventType[Any] | str] | None = None
         if restrict_str := request.query.get("restrict"):
             restrict = [*restrict_str.split(","), EVENT_HOMEASSISTANT_STOP]
 

--- a/homeassistant/components/homeassistant/logbook.py
+++ b/homeassistant/components/homeassistant/logbook.py
@@ -12,6 +12,7 @@ from homeassistant.components.logbook import (
 )
 from homeassistant.const import EVENT_HOMEASSISTANT_START, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.typing import NoEventData
 from homeassistant.util.event_type import EventType
 
 from . import DOMAIN
@@ -25,12 +26,14 @@ EVENT_TO_NAME: dict[EventType[Any] | str, str] = {
 @callback
 def async_describe_events(
     hass: HomeAssistant,
-    async_describe_event: Callable[[str, str, Callable[[Event], dict[str, str]]], None],
+    async_describe_event: Callable[
+        [str, EventType[NoEventData] | str, Callable[[Event], dict[str, str]]], None
+    ],
 ) -> None:
     """Describe logbook events."""
 
     @callback
-    def async_describe_hass_event(event: Event) -> dict[str, str]:
+    def async_describe_hass_event(event: Event[NoEventData]) -> dict[str, str]:
         """Describe homeassistant logbook event."""
         return {
             LOGBOOK_ENTRY_NAME: "Home Assistant",

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -18,6 +18,7 @@ from .util.signal_type import SignalType
 
 if TYPE_CHECKING:
     from .core import EventStateChangedData
+    from .helpers.typing import NoEventData
 
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
@@ -301,11 +302,13 @@ CONF_ZONE: Final = "zone"
 EVENT_CALL_SERVICE: Final = "call_service"
 EVENT_COMPONENT_LOADED: Final = "component_loaded"
 EVENT_CORE_CONFIG_UPDATE: Final = "core_config_updated"
-EVENT_HOMEASSISTANT_CLOSE: Final = "homeassistant_close"
-EVENT_HOMEASSISTANT_START: Final = "homeassistant_start"
-EVENT_HOMEASSISTANT_STARTED: Final = "homeassistant_started"
-EVENT_HOMEASSISTANT_STOP: Final = "homeassistant_stop"
-EVENT_HOMEASSISTANT_FINAL_WRITE: Final = "homeassistant_final_write"
+EVENT_HOMEASSISTANT_CLOSE: EventType[NoEventData] = EventType("homeassistant_close")
+EVENT_HOMEASSISTANT_START: EventType[NoEventData] = EventType("homeassistant_start")
+EVENT_HOMEASSISTANT_STARTED: EventType[NoEventData] = EventType("homeassistant_started")
+EVENT_HOMEASSISTANT_STOP: EventType[NoEventData] = EventType("homeassistant_stop")
+EVENT_HOMEASSISTANT_FINAL_WRITE: EventType[NoEventData] = EventType(
+    "homeassistant_final_write"
+)
 EVENT_LOGBOOK_ENTRY: Final = "logbook_entry"
 EVENT_LOGGING_CHANGED: Final = "logging_changed"
 EVENT_SERVICE_REGISTERED: Final = "service_registered"

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -14,13 +14,16 @@ from homeassistant.core import (
     HomeAssistant,
     callback,
 )
+from homeassistant.util.event_type import EventType
+
+from .typing import NoEventData
 
 
 @callback
 def _async_at_core_state(
     hass: HomeAssistant,
     at_start_cb: Callable[[HomeAssistant], Coroutine[Any, Any, None] | None],
-    event_type: str,
+    event_type: EventType[NoEventData],
     check_state: Callable[[HomeAssistant], bool],
 ) -> CALLBACK_TYPE:
     """Execute a job at_start_cb when Home Assistant has the wanted state.

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from enum import Enum
 from functools import partial
-from typing import Any
+from typing import Any, Never
 
 import homeassistant.core
 
@@ -20,6 +20,7 @@ DiscoveryInfoType = dict[str, Any]
 ServiceDataType = dict[str, Any]
 StateType = str | int | float | None
 TemplateVarsType = Mapping[str, Any] | None
+NoEventData = Mapping[str, Never]
 
 # Custom type for recorder Queries
 QueryType = Any


### PR DESCRIPTION
## Proposed change
Use `EventType` introduced in #114906.

This PR adds a new type alias `NoEventData = Mapping[str, Never]` which should be used when an Event doesn't contain any data / only an empty dict.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
