### PR TITLE
Platinum quality on Teslemetry 

### DIFF
--- a/homeassistant/components/teslemetry/binary_sensor.py
+++ b/homeassistant/components/teslemetry/binary_sensor.py
@@ -26,6 +26,8 @@ from .entity import (
 )
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TeslemetryBinarySensorEntityDescription(BinarySensorEntityDescription):

--- a/homeassistant/components/teslemetry/button.py
+++ b/homeassistant/components/teslemetry/button.py
@@ -17,6 +17,8 @@ from .entity import TeslemetryVehicleEntity
 from .helpers import handle_vehicle_command
 from .models import TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TeslemetryButtonEntityDescription(ButtonEntityDescription):

--- a/homeassistant/components/teslemetry/climate.py
+++ b/homeassistant/components/teslemetry/climate.py
@@ -32,6 +32,8 @@ from .models import TeslemetryVehicleData
 DEFAULT_MIN_TEMP = 15
 DEFAULT_MAX_TEMP = 28
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/teslemetry/cover.py
+++ b/homeassistant/components/teslemetry/cover.py
@@ -23,6 +23,8 @@ from .models import TeslemetryVehicleData
 OPEN = 1
 CLOSED = 0
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/teslemetry/device_tracker.py
+++ b/homeassistant/components/teslemetry/device_tracker.py
@@ -11,6 +11,8 @@ from . import TeslemetryConfigEntry
 from .entity import TeslemetryVehicleEntity
 from .models import TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/teslemetry/lock.py
+++ b/homeassistant/components/teslemetry/lock.py
@@ -19,6 +19,8 @@ from .models import TeslemetryVehicleData
 
 ENGAGED = "Engaged"
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -1,11 +1,11 @@
 {
-    "domain": "teslemetry",
-    "name": "Teslemetry",
-    "codeowners": ["@Bre77"],
-    "config_flow": true,
-    "documentation": "https://www.home-assistant.io/integrations/teslemetry",
-    "iot_class": "cloud_polling",
-    "loggers": ["tesla-fleet-api"],
-    "quality_scale": "platinum",
-    "requirements": ["tesla-fleet-api==0.6.1"]
+  "domain": "teslemetry",
+  "name": "Teslemetry",
+  "codeowners": ["@Bre77"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/teslemetry",
+  "iot_class": "cloud_polling",
+  "loggers": ["tesla-fleet-api"],
+  "quality_scale": "platinum",
+  "requirements": ["tesla-fleet-api==0.6.1"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -1,10 +1,11 @@
 {
-  "domain": "teslemetry",
-  "name": "Teslemetry",
-  "codeowners": ["@Bre77"],
-  "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/teslemetry",
-  "iot_class": "cloud_polling",
-  "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.6.1"]
+    "domain": "teslemetry",
+    "name": "Teslemetry",
+    "codeowners": ["@Bre77"],
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/integrations/teslemetry",
+    "iot_class": "cloud_polling",
+    "loggers": ["tesla-fleet-api"],
+    "quality_scale": "platinum",
+    "requirements": ["tesla-fleet-api==0.6.1"]
 }

--- a/homeassistant/components/teslemetry/media_player.py
+++ b/homeassistant/components/teslemetry/media_player.py
@@ -27,6 +27,8 @@ STATES = {
 VOLUME_MAX = 11.0
 VOLUME_STEP = 1.0 / 3
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/teslemetry/number.py
+++ b/homeassistant/components/teslemetry/number.py
@@ -26,6 +26,8 @@ from .entity import TeslemetryEnergyInfoEntity, TeslemetryVehicleEntity
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TeslemetryNumberVehicleEntityDescription(NumberEntityDescription):

--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -22,6 +22,8 @@ LOW = "low"
 MEDIUM = "medium"
 HIGH = "high"
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class SeatHeaterDescription(SelectEntityDescription):

--- a/homeassistant/components/teslemetry/sensor.py
+++ b/homeassistant/components/teslemetry/sensor.py
@@ -42,6 +42,8 @@ from .entity import (
 )
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 CHARGE_STATES = {
     "Starting": "starting",
     "Charging": "charging",

--- a/homeassistant/components/teslemetry/switch.py
+++ b/homeassistant/components/teslemetry/switch.py
@@ -22,6 +22,8 @@ from .entity import TeslemetryEnergyInfoEntity, TeslemetryVehicleEntity
 from .helpers import handle_command, handle_vehicle_command
 from .models import TeslemetryEnergyData, TeslemetryVehicleData
 
+PARALLEL_UPDATES = 0
+
 
 @dataclass(frozen=True, kw_only=True)
 class TeslemetrySwitchEntityDescription(SwitchEntityDescription):

--- a/homeassistant/components/teslemetry/update.py
+++ b/homeassistant/components/teslemetry/update.py
@@ -21,6 +21,8 @@ INSTALLING = "installing"
 WIFI_WAIT = "downloading_wifi_wait"
 SCHEDULED = "scheduled"
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates Teslemetry to Platinum quality

Silver
- [x] Satisfying all No score level requirements
- [x] Connection/configuration is handled via a component - Update Coordinator
- [ ] Set an appropriate SCAN_INTERVAL (if a polling integration) - N/A
- [ ] Raise PlatformNotReady if unable to connect during platform setup (if appropriate) - N/A
- [x] Handles expiration of auth credentials. Refresh if possible or print correct error and fail setup. If based on a config entry, should trigger a new config entry flow to re-authorize.
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling. Raise ServiceValidationError on invalid user input and raise HomeAssistantError for other failures such as a problem communicating with a device.
- [x] Set available property to False if appropriate
- [x] Entities have unique ID (if available)

Gold
- [x] Configurable via config entries.
- [x] Don't allow configuring already configured device/service (example: no 2 entries for same hub) - https://github.com/home-assistant/core/pull/115616
- [ ] Discoverable (if available) - N/A
- [x] Set unique ID in config flow (if available) - https://github.com/home-assistant/core/pull/115616
- [x] Raise ConfigEntryNotReady if unable to connect during entry setup (if appropriate)
- [x] Entities have device info (if available)
- [x] Tests - 100%
- [x] Full test coverage for the config flow
- [x] Above average test coverage for all integration modules
- [x] Tests for fetching data from the integration and controlling it
- [x] Has a code owner
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass 
- [x] Entities have correct device classes where appropriate
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities 
- [x] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry. - N/A
- [x] When communicating with a device or service, the integration implements the diagnostics platform which redacts sensitive information. (https://github.com/home-assistant/core/pull/115195)

Platinum
- [x] Set appropriate PARALLEL_UPDATES constant
- [x] Support config entry unloading (called when config entry is removed)
- [x] Integration + dependency are async
- [x] Uses aiohttp or httpx and allows passing in websession (if making HTTP requests)
- [x] Handles expired credentials (if appropriate)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33358

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
