### PR TITLE
Fix climate entity creation when Shelly WallDisplay uses external relay as actuator

### DIFF
--- a/homeassistant/components/shelly/climate.py
+++ b/homeassistant/components/shelly/climate.py
@@ -132,7 +132,11 @@ def async_setup_rpc_entry(
     climate_ids = []
     for id_ in climate_key_ids:
         climate_ids.append(id_)
-
+        # There are three configuration scenarios for WallDisplay:
+        # - relay mode (no thermostat)
+        # - thermostat mode using the internal relay as an actuator
+        # - thermostat mode using an external (from another device) relay as
+        #   an actuator
         if is_rpc_thermostat_internal_actuator(coordinator.device.status):
             # Wall Display relay is used as the thermostat actuator,
             # we need to remove a switch entity

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -43,6 +43,7 @@ from .utils import (
     is_block_channel_type_light,
     is_rpc_channel_type_light,
     is_rpc_thermostat_internal_actuator,
+    is_rpc_thermostat_mode,
 )
 
 
@@ -141,8 +142,8 @@ def async_setup_rpc_entry(
             # - thermostat mode using the internal relay as an actuator
             # - thermostat mode using an external (from another device) relay as
             #   an actuator
-            if f"thermostat:{id_}" not in coordinator.device.status:
-                # There is no thermostat in the status, we need to remove a climate
+            if not is_rpc_thermostat_mode(id_, coordinator.device.status):
+                # The device is not in thermostat mode, we need to remove a climate
                 # entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"
                 async_remove_shelly_entity(hass, "climate", unique_id)

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -136,6 +136,11 @@ def async_setup_rpc_entry(
             continue
 
         if coordinator.model == MODEL_WALL_DISPLAY:
+            # There are three configuration scenarios for WallDisplay:
+            # - relay mode (no thermostat)
+            # - thermostat mode using the internal relay as an actuator
+            # - thermostat mode using an external (from another device) relay as
+            #   an actuator
             if f"thermostat:{id_}" not in coordinator.device.status:
                 # There is no thermostat in the status, we need to remove a climate
                 # entity

--- a/homeassistant/components/shelly/switch.py
+++ b/homeassistant/components/shelly/switch.py
@@ -136,12 +136,14 @@ def async_setup_rpc_entry(
             continue
 
         if coordinator.model == MODEL_WALL_DISPLAY:
-            if not is_rpc_thermostat_internal_actuator(coordinator.device.status):
-                # Wall Display relay is not used as the thermostat actuator,
-                # we need to remove a climate entity
+            if f"thermostat:{id_}" not in coordinator.device.status:
+                # There is no thermostat in the status, we need to remove a climate
+                # entity
                 unique_id = f"{coordinator.mac}-thermostat:{id_}"
                 async_remove_shelly_entity(hass, "climate", unique_id)
-            else:
+            elif is_rpc_thermostat_internal_actuator(coordinator.device.status):
+                # The internal relay is an actuator, skip this ID so as not to create
+                # a switch entity
                 continue
 
         switch_ids.append(id_)

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -500,3 +500,8 @@ def async_remove_shelly_rpc_entities(
         if entity_id := entity_reg.async_get_entity_id(domain, DOMAIN, f"{mac}-{key}"):
             LOGGER.debug("Removing entity: %s", entity_id)
             entity_reg.async_remove(entity_id)
+
+
+def is_rpc_thermostat_mode(ident: int, status: dict[str, Any]) -> bool:
+    """Return True if 'thermostat:<IDent>' is present in the status."""
+    return f"thermostat:{ident}" in status

--- a/tests/components/shelly/test_climate.py
+++ b/tests/components/shelly/test_climate.py
@@ -25,7 +25,12 @@ from homeassistant.components.climate import (
 from homeassistant.components.shelly.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -701,6 +706,39 @@ async def test_wall_display_thermostat_mode(
     # the switch entity should be removed
     assert hass.states.get(switch_entity_id) is None
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
+
+    # the climate entity should be created
+    state = hass.states.get(climate_entity_id)
+    assert state
+    assert state.state == HVACMode.HEAT
+    assert len(hass.states.async_entity_ids(CLIMATE_DOMAIN)) == 1
+
+    entry = entity_registry.async_get(climate_entity_id)
+    assert entry
+    assert entry.unique_id == "123456789ABC-thermostat:0"
+
+
+async def test_wall_display_thermostat_mode_external_actuator(
+    hass: HomeAssistant,
+    mock_rpc_device: Mock,
+    entity_registry: EntityRegistry,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test Wall Display in thermostat mode with an external actuator."""
+    climate_entity_id = "climate.test_name"
+    switch_entity_id = "switch.test_switch_0"
+
+    new_status = deepcopy(mock_rpc_device.status)
+    new_status["sys"]["relay_in_thermostat"] = False
+    monkeypatch.setattr(mock_rpc_device, "status", new_status)
+
+    await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)
+
+    # the switch entity should be created
+    state = hass.states.get(switch_entity_id)
+    assert state
+    assert state.state == STATE_ON
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
     # the climate entity should be created
     state = hass.states.get(climate_entity_id)

--- a/tests/components/shelly/test_switch.py
+++ b/tests/components/shelly/test_switch.py
@@ -330,6 +330,7 @@ async def test_wall_display_relay_mode(
 
     new_status = deepcopy(mock_rpc_device.status)
     new_status["sys"]["relay_in_thermostat"] = False
+    new_status.pop("thermostat:0")
     monkeypatch.setattr(mock_rpc_device, "status", new_status)
 
     await init_integration(hass, 2, model=MODEL_WALL_DISPLAY)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes climate entity creation when Shelly WallDisplay uses external relay as actuator.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #115185
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
