### PR TITLE
Enable Ruff PYI041

### DIFF
--- a/homeassistant/auth/jwt_wrapper.py
+++ b/homeassistant/auth/jwt_wrapper.py
@@ -78,7 +78,7 @@ class _PyJWTWithVerify(PyJWT):
         key: str,
         algorithms: list[str],
         issuer: str | None = None,
-        leeway: int | float | timedelta = 0,
+        leeway: float | timedelta = 0,
         options: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Verify a JWT's signature and claims."""

--- a/homeassistant/components/alexa/resources.py
+++ b/homeassistant/components/alexa/resources.py
@@ -291,9 +291,9 @@ class AlexaPresetResource(AlexaCapabilityResource):
     def __init__(
         self,
         labels: list[str],
-        min_value: int | float,
-        max_value: int | float,
-        precision: int | float,
+        min_value: float,
+        max_value: float,
+        precision: float,
         unit: str | None = None,
     ) -> None:
         """Initialize an Alexa presetResource."""
@@ -306,7 +306,7 @@ class AlexaPresetResource(AlexaCapabilityResource):
         if unit in AlexaGlobalCatalog.__dict__.values():
             self._unit_of_measure = unit
 
-    def add_preset(self, value: int | float, labels: list[str]) -> None:
+    def add_preset(self, value: float, labels: list[str]) -> None:
         """Add preset to configuration presets array."""
         self._presets.append({"value": value, "labels": labels})
 
@@ -405,7 +405,7 @@ class AlexaSemantics:
         )
 
     def add_states_to_range(
-        self, states: list[str], min_value: int | float, max_value: int | float
+        self, states: list[str], min_value: float, max_value: float
     ) -> None:
         """Add StatesToRange stateMappings."""
         self._add_state_mapping(

--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -149,7 +149,7 @@ class DemoSensor(SensorEntity):
         self,
         unique_id: str,
         device_name: str | None,
-        state: float | int | str | None,
+        state: float | str | None,
         device_class: SensorDeviceClass,
         state_class: SensorStateClass | None,
         unit_of_measurement: str | None,

--- a/homeassistant/components/homekit/type_thermostats.py
+++ b/homeassistant/components/homekit/type_thermostats.py
@@ -411,10 +411,10 @@ class Thermostat(HomeAccessory):
         params = {ATTR_ENTITY_ID: self.entity_id, ATTR_FAN_MODE: mode}
         self.async_call_service(DOMAIN_CLIMATE, SERVICE_SET_FAN_MODE, params)
 
-    def _temperature_to_homekit(self, temp: float | int) -> float:
+    def _temperature_to_homekit(self, temp: float) -> float:
         return temperature_to_homekit(temp, self._unit)
 
-    def _temperature_to_states(self, temp: float | int) -> float:
+    def _temperature_to_states(self, temp: float) -> float:
         return temperature_to_states(temp, self._unit)
 
     def _set_chars(self, char_values: dict[str, Any]) -> None:

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -401,14 +401,14 @@ def cleanup_name_for_homekit(name: str | None) -> str:
     return name.translate(HOMEKIT_CHAR_TRANSLATIONS)[:MAX_NAME_LENGTH]
 
 
-def temperature_to_homekit(temperature: float | int, unit: str) -> float:
+def temperature_to_homekit(temperature: float, unit: str) -> float:
     """Convert temperature to Celsius for HomeKit."""
     return round(
         TemperatureConverter.convert(temperature, unit, UnitOfTemperature.CELSIUS), 1
     )
 
 
-def temperature_to_states(temperature: float | int, unit: str) -> float:
+def temperature_to_states(temperature: float, unit: str) -> float:
     """Convert temperature back from Celsius to Home Assistant unit."""
     return (
         round(

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -431,7 +431,7 @@ def _categorize_programs(isy_data: IsyData, programs: Programs) -> None:
 
 
 def convert_isy_value_to_hass(
-    value: int | float | None,
+    value: float | None,
     uom: str | None,
     precision: int | str,
     fallback_precision: int | None = None,

--- a/homeassistant/components/modbus/base_platform.py
+++ b/homeassistant/components/modbus/base_platform.py
@@ -202,7 +202,7 @@ class BaseStructPlatform(BasePlatform, RestoreEntity):
             registers.reverse()
         return registers
 
-    def __process_raw_value(self, entry: float | int | str | bytes) -> str | None:
+    def __process_raw_value(self, entry: float | str | bytes) -> str | None:
         """Process value from sensor with NaN handling, scaling, offset, min/max etc."""
         if self._nan_value and entry in (self._nan_value, -self._nan_value):
             return None

--- a/homeassistant/components/nibe_heatpump/coordinator.py
+++ b/homeassistant/components/nibe_heatpump/coordinator.py
@@ -136,7 +136,7 @@ class Coordinator(ContextCoordinator[dict[int, CoilData], int]):
             return float(value)  # type: ignore[arg-type]
         return None
 
-    async def async_write_coil(self, coil: Coil, value: int | float | str) -> None:
+    async def async_write_coil(self, coil: Coil, value: float | str) -> None:
         """Write coil and update state."""
         data = CoilData(coil, value)
         await self.connection.write_coil(data)
@@ -224,7 +224,7 @@ class CoilEntity(CoordinatorEntity[Coordinator]):
     def _async_read_coil(self, data: CoilData):
         """Update state of entity based on coil data."""
 
-    async def _async_write_coil(self, value: int | float | str):
+    async def _async_write_coil(self, value: float | str):
         """Write coil and update state."""
         await self.coordinator.async_write_coil(self._coil, value)
 

--- a/homeassistant/components/number/significant_change.py
+++ b/homeassistant/components/number/significant_change.py
@@ -21,10 +21,10 @@ from .const import NumberDeviceClass
 
 
 def _absolute_and_relative_change(
-    old_state: int | float | None,
-    new_state: int | float | None,
-    absolute_change: int | float,
-    percentage_change: int | float,
+    old_state: float | None,
+    new_state: float | None,
+    absolute_change: float,
+    percentage_change: float,
 ) -> bool:
     return check_absolute_change(
         old_state, new_state, absolute_change

--- a/homeassistant/components/sensor/significant_change.py
+++ b/homeassistant/components/sensor/significant_change.py
@@ -20,10 +20,10 @@ from . import SensorDeviceClass
 
 
 def _absolute_and_relative_change(
-    old_state: int | float | None,
-    new_state: int | float | None,
-    absolute_change: int | float,
-    percentage_change: int | float,
+    old_state: float | None,
+    new_state: float | None,
+    absolute_change: float,
+    percentage_change: float,
 ) -> bool:
     return check_absolute_change(
         old_state, new_state, absolute_change

--- a/homeassistant/components/sonos/diagnostics.py
+++ b/homeassistant/components/sonos/diagnostics.py
@@ -113,7 +113,7 @@ async def async_generate_speaker_info(
     payload: dict[str, Any] = {}
 
     def get_contents(
-        item: int | float | str | dict[str, Any],
+        item: float | str | dict[str, Any],
     ) -> int | float | str | dict[str, Any]:
         if isinstance(item, (int, float, str)):
             return item

--- a/homeassistant/components/tomorrowio/sensor.py
+++ b/homeassistant/components/tomorrowio/sensor.py
@@ -100,7 +100,7 @@ class TomorrowioSensorEntityDescription(SensorEntityDescription):
 
 # From https://cfpub.epa.gov/ncer_abstracts/index.cfm/fuseaction/display.files/fileID/14285
 # x ug/m^3 = y ppb * molecular weight / 24.45
-def convert_ppb_to_ugm3(molecular_weight: int | float) -> Callable[[float], float]:
+def convert_ppb_to_ugm3(molecular_weight: float) -> Callable[[float], float]:
     """Return function to convert ppb to ug/m^3."""
     return lambda x: (x * molecular_weight) / 24.45
 
@@ -339,7 +339,7 @@ async def async_setup_entry(
 
 
 def handle_conversion(
-    value: float | int, conversion: Callable[[float], float] | float
+    value: float, conversion: Callable[[float], float] | float
 ) -> float:
     """Handle conversion of a value based on conversion type."""
     if callable(conversion):

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -228,7 +228,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         await self.device.set_hsv(hue, sat, brightness, transition=transition)
 
     async def _async_set_color_temp(
-        self, color_temp: float | int, brightness: int | None, transition: int | None
+        self, color_temp: float, brightness: int | None, transition: int | None
     ) -> None:
         device = self.device
         valid_temperature_range = device.valid_temperature_range

--- a/homeassistant/components/tuya/base.py
+++ b/homeassistant/components/tuya/base.py
@@ -45,19 +45,19 @@ class IntegerTypeData:
         """Return the step scaled."""
         return self.step / (10**self.scale)
 
-    def scale_value(self, value: float | int) -> float:
+    def scale_value(self, value: float) -> float:
         """Scale a value."""
         return value / (10**self.scale)
 
-    def scale_value_back(self, value: float | int) -> int:
+    def scale_value_back(self, value: float) -> int:
         """Return raw value for scaled."""
         return int(value * (10**self.scale))
 
     def remap_value_to(
         self,
         value: float,
-        to_min: float | int = 0,
-        to_max: float | int = 255,
+        to_min: float = 0,
+        to_max: float = 255,
         reverse: bool = False,
     ) -> float:
         """Remap a value from this range to a new range."""
@@ -66,8 +66,8 @@ class IntegerTypeData:
     def remap_value_from(
         self,
         value: float,
-        from_min: float | int = 0,
-        from_max: float | int = 255,
+        from_min: float = 0,
+        from_max: float = 255,
         reverse: bool = False,
     ) -> float:
         """Remap a value from its current range to this range."""

--- a/homeassistant/components/tuya/util.py
+++ b/homeassistant/components/tuya/util.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 
 def remap_value(
-    value: float | int,
-    from_min: float | int = 0,
-    from_max: float | int = 255,
-    to_min: float | int = 0,
-    to_max: float | int = 255,
+    value: float,
+    from_min: float = 0,
+    from_max: float = 255,
+    to_min: float = 0,
+    to_max: float = 255,
     reverse: bool = False,
 ) -> float:
     """Remap a value from its current range, to a new range."""

--- a/homeassistant/components/weather/significant_change.py
+++ b/homeassistant/components/weather/significant_change.py
@@ -64,7 +64,7 @@ VALID_CARDINAL_DIRECTIONS: list[str] = [
 ]
 
 
-def _cardinal_to_degrees(value: str | int | float | None) -> int | float | None:
+def _cardinal_to_degrees(value: str | float | None) -> int | float | None:
     """Translate a cardinal direction into azimuth angle (degrees)."""
     if not isinstance(value, str):
         return value

--- a/homeassistant/helpers/significant_change.py
+++ b/homeassistant/helpers/significant_change.py
@@ -99,9 +99,9 @@ def either_one_none(val1: Any | None, val2: Any | None) -> bool:
 
 
 def _check_numeric_change(
-    old_state: int | float | None,
-    new_state: int | float | None,
-    change: int | float,
+    old_state: float | None,
+    new_state: float | None,
+    change: float,
     metric: Callable[[int | float, int | float], int | float],
 ) -> bool:
     """Check if two numeric values have changed."""
@@ -121,9 +121,9 @@ def _check_numeric_change(
 
 
 def check_absolute_change(
-    val1: int | float | None,
-    val2: int | float | None,
-    change: int | float,
+    val1: float | None,
+    val2: float | None,
+    change: float,
 ) -> bool:
     """Check if two numeric values have changed."""
     return _check_numeric_change(
@@ -132,13 +132,13 @@ def check_absolute_change(
 
 
 def check_percentage_change(
-    old_state: int | float | None,
-    new_state: int | float | None,
-    change: int | float,
+    old_state: float | None,
+    new_state: float | None,
+    change: float,
 ) -> bool:
     """Check if two numeric values have changed."""
 
-    def percentage_change(old_state: int | float, new_state: int | float) -> float:
+    def percentage_change(old_state: float, new_state: float) -> float:
         if old_state == new_state:
             return 0
         try:
@@ -149,7 +149,7 @@ def check_percentage_change(
     return _check_numeric_change(old_state, new_state, change, percentage_change)
 
 
-def check_valid_float(value: str | int | float) -> bool:
+def check_valid_float(value: str | float) -> bool:
     """Check if given value is a valid float."""
     try:
         float(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -723,7 +723,6 @@ ignore = [
     "PT019",
     "PYI024", # Use typing.NamedTuple instead of collections.namedtuple
     "PYI036",
-    "PYI041",
     "RET503",
     "RET502",
     "RET501",

--- a/tests/components/coolmaster/conftest.py
+++ b/tests/components/coolmaster/conftest.py
@@ -64,7 +64,7 @@ class CoolMasterNetUnitMock:
         self._attributes["mode"] = value
         return CoolMasterNetUnitMock(self.unit_id, self._attributes)
 
-    async def set_thermostat(self, value: int | float) -> CoolMasterNetUnitMock:
+    async def set_thermostat(self, value: float) -> CoolMasterNetUnitMock:
         """Set the target temperature."""
         self._attributes["thermostat"] = value
         return CoolMasterNetUnitMock(self.unit_id, self._attributes)

--- a/tests/components/nibe_heatpump/__init__.py
+++ b/tests/components/nibe_heatpump/__init__.py
@@ -50,7 +50,7 @@ class MockConnection(Connection):
     async def verify_connectivity(self):
         """Verify that we have functioning communication."""
 
-    def mock_coil_update(self, coil_id: int, value: int | float | str | None):
+    def mock_coil_update(self, coil_id: int, value: float | str | None):
         """Trigger an out of band coil update."""
         coil = self.heatpump.get_coil_by_address(coil_id)
         self.coils[coil_id] = value

--- a/tests/components/sensor/test_init.py
+++ b/tests/components/sensor/test_init.py
@@ -2630,7 +2630,7 @@ async def test_suggested_unit_guard_valid_unit(
     native_unit: str,
     native_value: int,
     suggested_unit: str,
-    expect_value: float | int,
+    expect_value: float,
 ) -> None:
     """Test suggested_unit_of_measurement guard.
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1176,7 +1176,7 @@ def test_as_datetime(hass: HomeAssistant, input) -> None:
 )
 def test_as_datetime_from_timestamp(
     hass: HomeAssistant,
-    input: int | float,
+    input: float,
     output: str,
 ) -> None:
     """Test converting a UNIX timestamp to a date object."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This enables the Ruff rule PYI041: Use `float` instead of `int | float` in argument annotations.

The Python typing spec contains that in argument type annotations, `int` is automatically included when using `float`, so `int | float` is redundant.
https://typing.readthedocs.io/en/latest/spec/special-types.html#special-cases-for-float-and-complex

I don't have a problem either if we would say to ignore this rule because it may be more confusing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
