### PR TITLE
Fix failing escea test in connection with greeneye_monitor

### DIFF
--- a/tests/components/greeneye_monitor/conftest.py
+++ b/tests/components/greeneye_monitor/conftest.py
@@ -100,15 +100,16 @@ def assert_sensor_registered(
 @pytest.fixture
 def monitors() -> AsyncMock:
     """Provide a mock greeneye.Monitors object that has listeners and can add new monitors."""
-    with patch("greeneye.Monitors", new=AsyncMock) as mock_monitors:
-        add_listeners(mock_monitors)
-        mock_monitors.monitors = {}
+    with patch("greeneye.Monitors", autospec=True) as mock_monitors:
+        mock = mock_monitors.return_value
+        add_listeners(mock)
+        mock.monitors = {}
 
         def add_monitor(monitor: MagicMock) -> None:
             """Add the given mock monitor as a monitor with the given serial number, notifying any listeners on the Monitors object."""
             serial_number = monitor.serial_number
-            mock_monitors.monitors[serial_number] = monitor
-            mock_monitors.notify_all_listeners(monitor)
+            mock.monitors[serial_number] = monitor
+            mock.notify_all_listeners(monitor)
 
-        mock_monitors.add_monitor = add_monitor
-        yield mock_monitors
+        mock.add_monitor = add_monitor
+        yield mock

--- a/tests/components/greeneye_monitor/conftest.py
+++ b/tests/components/greeneye_monitor/conftest.py
@@ -1,5 +1,6 @@
 """Common fixtures for testing greeneye_monitor."""
 
+from collections.abc import Generator
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -98,7 +99,7 @@ def assert_sensor_registered(
 
 
 @pytest.fixture
-def monitors() -> AsyncMock:
+def monitors() -> Generator[AsyncMock, None, None]:
     """Provide a mock greeneye.Monitors object that has listeners and can add new monitors."""
     with patch("greeneye.Monitors", autospec=True) as mock_monitors:
         mock = mock_monitors.return_value


### PR DESCRIPTION
## Proposed change
Running `greeneye_monitor` before the `escea` will fail, found by @joostlek . Local tests succeeds with this now.

```
hass = <HomeAssistant RUNNING>, mock_discovery_service = <AsyncMock name='pescea_discovery_service()' id='4691731776'>

    async def test_not_found(
        hass: HomeAssistant, mock_discovery_service: AsyncMock
    ) -> None:
        """Test not finding any Escea controllers."""
    
        with (
            patch(
                "homeassistant.components.escea.discovery.pescea_discovery_service"
            ) as discovery_service,
            patch("homeassistant.components.escea.config_flow.TIMEOUT_DISCOVERY", 0),
        ):
            discovery_service.return_value = mock_discovery_service
   
            result = await hass.config_entries.flow.async_init(
                DOMAIN, context={"source": config_entries.SOURCE_USER}
            )
    
            # Confirmation form
            assert result["type"] is FlowResultType.FORM
    
            result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
            await hass.async_block_till_done()
    
        assert result["type"] is FlowResultType.ABORT
        assert result["reason"] == "no_devices_found"
>       assert discovery_service.return_value.close.call_count == 1
E       AssertionError: assert 14 == 1
E        +  where 14 = <AsyncMock id='4690550496'>.call_count
E        +    where <AsyncMock id='4690550496'> = <AsyncMock name='pescea_discovery_service()' id='4691731776'>.close
E        +      where <AsyncMock name='pescea_discovery_service()' id='4691731776'> = <MagicMock name='pescea_discovery_service' id='4691048304'>.return_value

tests/components/escea/test_config_flow.py:72: AssertionError
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
