### PR TITLE
Revert "Freeze timezone in bmw_connected_drive tests (#113533)"

### DIFF
--- a/tests/components/bmw_connected_drive/test_diagnostics.py
+++ b/tests/components/bmw_connected_drive/test_diagnostics.py
@@ -1,6 +1,8 @@
 """Test BMW diagnostics."""
 
 import datetime
+import os
+import time
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -18,7 +20,7 @@ from tests.components.diagnostics import (
 from tests.typing import ClientSessionGenerator
 
 
-@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_config_entry_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -26,6 +28,10 @@ async def test_config_entry_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test config entry diagnostics."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
 
     mock_config_entry = await setup_mocked_integration(hass)
 
@@ -36,7 +42,7 @@ async def test_config_entry_diagnostics(
     assert diagnostics == snapshot
 
 
-@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_device_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -45,6 +51,10 @@ async def test_device_diagnostics(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device diagnostics."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
 
     mock_config_entry = await setup_mocked_integration(hass)
 
@@ -60,7 +70,7 @@ async def test_device_diagnostics(
     assert diagnostics == snapshot
 
 
-@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11, tzinfo=datetime.UTC))
+@pytest.mark.freeze_time(datetime.datetime(2022, 7, 10, 11))
 async def test_device_diagnostics_vehicle_not_found(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -69,6 +79,10 @@ async def test_device_diagnostics_vehicle_not_found(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device diagnostics when the vehicle cannot be found."""
+
+    # Make sure that local timezone for test is UTC
+    os.environ["TZ"] = "UTC"
+    time.tzset()
 
     mock_config_entry = await setup_mocked_integration(hass)
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This reverts #113533.

While the implemented solution looks better, I am unable to get it working in my local environment in CE(S)T. Diff of the updated snapshot against `dev` branch:

```diff
--- a/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
+++ b/tests/components/bmw_connected_drive/snapshots/test_diagnostics.ambr
@@ -141,13 +141,13 @@
         }),
         'climate': dict({
           'account_timezone': dict({
-            '_dst_offset': '0:00:00',
-            '_dst_saved': '0:00:00',
-            '_hasdst': False,
-            '_std_offset': '0:00:00',
+            '_dst_offset': '2:00:00',
+            '_dst_saved': '1:00:00',
+            '_hasdst': True,
+            '_std_offset': '1:00:00',
             '_tznames': list([
-              'UTC',
-              'UTC',
+              'CET',
+              'CEST',
             ]),
           }),
           'activity': 'INACTIVE',
```

There seem to be long-standing issues in freezegun for exactly this issue: https://github.com/spulec/freezegun/issues/299.

CC @Thomas55555 @gjohansson-ST @emontnemery as you all looked into timezones here or other PRs.

If you have any suggestions (or the existing code works for you when your host is a non-UTC system), I'd be happy to try it out as well.

Using Ubuntu 22.04 (WSL) with 3.12.2 and latest HA dev.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
