### PR TITLE
Add json_attributes_path configuration for command_line sensor

### DIFF
--- a/homeassistant/components/command_line/__init__.py
+++ b/homeassistant/components/command_line/__init__.py
@@ -59,12 +59,17 @@ from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.trigger_template_entity import CONF_AVAILABILITY
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_COMMAND_TIMEOUT, DEFAULT_TIMEOUT, DOMAIN
+from .const import (
+    CONF_COMMAND_TIMEOUT,
+    CONF_JSON_ATTRIBUTES,
+    CONF_JSON_ATTRIBUTES_PATH,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
 
 BINARY_SENSOR_DEFAULT_NAME = "Binary Command Sensor"
 DEFAULT_PAYLOAD_ON = "ON"
 DEFAULT_PAYLOAD_OFF = "OFF"
-CONF_JSON_ATTRIBUTES = "json_attributes"
 SENSOR_DEFAULT_NAME = "Command Sensor"
 CONF_NOTIFIERS = "notifiers"
 
@@ -123,6 +128,7 @@ SENSOR_SCHEMA = vol.Schema(
         vol.Required(CONF_COMMAND): cv.string,
         vol.Optional(CONF_COMMAND_TIMEOUT, default=DEFAULT_TIMEOUT): cv.positive_int,
         vol.Optional(CONF_JSON_ATTRIBUTES): cv.ensure_list_csv,
+        vol.Optional(CONF_JSON_ATTRIBUTES_PATH): cv.string,
         vol.Optional(CONF_NAME, default=SENSOR_DEFAULT_NAME): cv.string,
         vol.Optional(CONF_ICON): cv.template,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,

--- a/homeassistant/components/command_line/const.py
+++ b/homeassistant/components/command_line/const.py
@@ -7,6 +7,8 @@ from homeassistant.const import Platform
 LOGGER = logging.getLogger(__package__)
 
 CONF_COMMAND_TIMEOUT = "command_timeout"
+CONF_JSON_ATTRIBUTES = "json_attributes"
+CONF_JSON_ATTRIBUTES_PATH = "json_attributes_path"
 DEFAULT_TIMEOUT = 15
 DOMAIN = "command_line"
 PLATFORMS = [

--- a/homeassistant/components/command_line/manifest.json
+++ b/homeassistant/components/command_line/manifest.json
@@ -3,5 +3,6 @@
   "name": "Command Line",
   "codeowners": ["@gjohansson-ST"],
   "documentation": "https://www.home-assistant.io/integrations/command_line",
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "requirements": ["jsonpath==0.82.2"]
 }

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -8,6 +8,8 @@ from datetime import datetime, timedelta
 import json
 from typing import Any, cast
 
+from jsonpath import jsonpath
+
 from homeassistant.components.sensor import CONF_STATE_CLASS, SensorDeviceClass
 from homeassistant.components.sensor.helpers import async_parse_date_datetime
 from homeassistant.const import (
@@ -33,10 +35,13 @@ from homeassistant.helpers.trigger_template_entity import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import dt as dt_util
 
-from .const import CONF_COMMAND_TIMEOUT, LOGGER
+from .const import (
+    CONF_COMMAND_TIMEOUT,
+    CONF_JSON_ATTRIBUTES,
+    CONF_JSON_ATTRIBUTES_PATH,
+    LOGGER,
+)
 from .utils import async_check_output_or_log
-
-CONF_JSON_ATTRIBUTES = "json_attributes"
 
 DEFAULT_NAME = "Command Sensor"
 
@@ -71,6 +76,7 @@ async def async_setup_platform(
     if value_template is not None:
         value_template.hass = hass
     json_attributes: list[str] | None = sensor_config.get(CONF_JSON_ATTRIBUTES)
+    json_attributes_path: str | None = config.get(CONF_JSON_ATTRIBUTES_PATH)
     scan_interval: timedelta = sensor_config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     data = CommandSensorData(hass, command, command_timeout)
 
@@ -87,6 +93,7 @@ async def async_setup_platform(
                 trigger_entity_config,
                 value_template,
                 json_attributes,
+                json_attributes_path,
                 scan_interval,
             )
         ]
@@ -104,6 +111,7 @@ class CommandSensor(ManualTriggerSensorEntity):
         config: ConfigType,
         value_template: Template | None,
         json_attributes: list[str] | None,
+        json_attributes_path: str | None,
         scan_interval: timedelta,
     ) -> None:
         """Initialize the sensor."""
@@ -111,6 +119,7 @@ class CommandSensor(ManualTriggerSensorEntity):
         self.data = data
         self._attr_extra_state_attributes: dict[str, Any] = {}
         self._json_attributes = json_attributes
+        self._json_attributes_path = json_attributes_path
         self._attr_native_value = None
         self._value_template = value_template
         self._scan_interval = scan_interval
@@ -161,6 +170,13 @@ class CommandSensor(ManualTriggerSensorEntity):
             if value:
                 try:
                     json_dict = json.loads(value)
+                    if self._json_attributes_path is not None:
+                        json_dict = jsonpath(json_dict, self._json_attributes_path)
+                    # jsonpath will always store the result in json_dict[0]
+                    # so the next line happens to work exactly as needed to
+                    # find the result
+                    if isinstance(json_dict, list):
+                        json_dict = json_dict[0]
                     if isinstance(json_dict, Mapping):
                         self._attr_extra_state_attributes = {
                             k: json_dict[k]

--- a/homeassistant/components/command_line/sensor.py
+++ b/homeassistant/components/command_line/sensor.py
@@ -76,7 +76,7 @@ async def async_setup_platform(
     if value_template is not None:
         value_template.hass = hass
     json_attributes: list[str] | None = sensor_config.get(CONF_JSON_ATTRIBUTES)
-    json_attributes_path: str | None = config.get(CONF_JSON_ATTRIBUTES_PATH)
+    json_attributes_path: str | None = sensor_config.get(CONF_JSON_ATTRIBUTES_PATH)
     scan_interval: timedelta = sensor_config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
     data = CommandSensorData(hass, command, command_timeout)
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1172,6 +1172,7 @@ jaraco.functools==3.9.0
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2
 
+# homeassistant.components.command_line
 # homeassistant.components.rest
 jsonpath==0.82.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -950,6 +950,7 @@ jaraco.functools==3.9.0
 # homeassistant.components.jellyfin
 jellyfin-apiclient-python==1.9.2
 
+# homeassistant.components.command_line
 # homeassistant.components.rest
 jsonpath==0.82.2
 

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -475,6 +475,46 @@ async def test_update_with_unnecessary_json_attrs(
                 {
                     "sensor": {
                         "name": "Test",
+                        "command": 'echo \
+                            {\
+                                \\"top_level\\": {\
+                                    \\"second_level\\": {\
+                                        \\"key\\": \\"some_json_value\\",\
+                                        \\"another_key\\": \\"another_json_value\\",\
+                                        \\"key_three\\": \\"value_three\\"\
+                                    }\
+                                }\
+                            }',
+                        "json_attributes": ["key", "another_key", "key_three"],
+                        "json_attributes_path": "$.top_level.second_level",
+                    }
+                }
+            ]
+        }
+    ],
+)
+async def test_update_with_json_attrs_with_json_attrs_path(
+    hass: HomeAssistant, load_yaml_integration: None
+) -> None:
+    """Test using json_attributes_path to select a different part of the json object as root."""
+
+    entity_state = hass.states.get("sensor.test")
+    assert entity_state
+    assert entity_state.attributes["key"] == "some_json_value"
+    assert entity_state.attributes["another_key"] == "another_json_value"
+    assert entity_state.attributes["key_three"] == "value_three"
+    assert "top_level" not in entity_state.attributes
+    assert "second_level" not in entity_state.attributes
+
+
+@pytest.mark.parametrize(
+    "get_config",
+    [
+        {
+            "command_line": [
+                {
+                    "sensor": {
+                        "name": "Test",
                         "unique_id": "unique",
                         "command": "echo 0",
                     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
This change adds `json_attributes_path` configuration parameter to the command_line sensor integration bringing it up to parity of the available JSON matching capability of the REST sensor. This parameter uses [jsonpath](https://pypi.org/project/jsonpath/) to select an object from somewhere other than the first level to be considered the root dictionary for the attributes specified in `json_attributes`. The implementation used here is the exact same as is used in the REST sensor. This PR implements the same change that was proposed in #57801 but in a way that is compliant with [ADR-0007](https://github.com/home-assistant/architecture/blob/master/adr/0007-integration-config-yaml-structure.md).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32241

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
