### PR TITLE
Fix race stopping scripts

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1046,13 +1046,14 @@ class _ScriptRun:
         If timeout is set, a timeout future and handle will be created
         and will be added to the list of futures.
         """
-        if timeout:
-            timeout_future = self._hass.loop.create_future()
-            timeout_handle = self._hass.loop.call_later(
-                timeout, _set_result_unless_done, timeout_future
-            )
-            return [timeout_future], timeout_handle, timeout_future
-        return [], None, None
+        if not timeout:
+            return [], None, None
+        loop = self._hass.loop
+        timeout_future = loop.create_future()
+        timeout_handle = loop.call_later(
+            timeout, _set_result_unless_done, timeout_future
+        )
+        return [timeout_future], timeout_handle, timeout_future
 
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1118,7 +1118,10 @@ class _ScriptRun:
         unsub: Callable[[], None],
     ) -> None:
         try:
-            await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
+            if len(futures) == 1:
+                await futures[0]
+            else:
+                await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_future and timeout_future.done():
                 self._variables["wait"]["remaining"] = 0.0
                 if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -75,6 +75,7 @@ from homeassistant.core import (
     HassJob,
     HomeAssistant,
     ServiceResponse,
+    State,
     SupportsResponse,
     callback,
 )
@@ -657,8 +658,10 @@ class _ScriptRun:
         done = self._hass.loop.create_future()
         futures.append(done)
 
-        @callback
-        def async_script_wait(entity_id, from_s, to_s):
+        @callback  # type: ignore[misc]
+        def async_script_wait(
+            entity_id: str, from_s: State | None, to_s: State | None
+        ) -> None:
             """Handle script after template condition is true."""
             self._async_set_remaining_time_var(timeout_handle)
             self._variables["wait"]["completed"] = True

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1044,16 +1044,13 @@ class _ScriptRun:
         If timeout is set, a timeout future and handle will be created
         and will be added to the list of futures.
         """
-        timeout_handle: asyncio.TimerHandle | None = None
-        timeout_future: asyncio.Future[None] | None = None
-        futures: list[asyncio.Future[None]] = []
         if timeout:
             timeout_future = self._hass.loop.create_future()
             timeout_handle = self._hass.loop.call_later(
                 timeout, _set_result_unless_done, timeout_future
             )
-            futures.append(timeout_future)
-        return futures, timeout_handle, timeout_future
+            return [timeout_future], timeout_handle, timeout_future
+        return [], None, None
 
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1255,7 +1255,7 @@ async def _async_stop_scripts_after_shutdown(
         _LOGGER.warning("Stopping scripts running too long after shutdown: %s", names)
         await asyncio.gather(
             *(
-                script["instance"].async_stop(update_state=False)
+                create_eager_task(script["instance"].async_stop(update_state=False))
                 for script in running_scripts
             )
         )
@@ -1274,7 +1274,10 @@ async def _async_stop_scripts_at_shutdown(hass: HomeAssistant, event: Event) -> 
         names = ", ".join([script["instance"].name for script in running_scripts])
         _LOGGER.debug("Stopping scripts running at shutdown: %s", names)
         await asyncio.gather(
-            *(script["instance"].async_stop() for script in running_scripts)
+            *(
+                create_eager_task(script["instance"].async_stop())
+                for script in running_scripts
+            )
         )
 
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -226,9 +226,11 @@ async def trace_action(
                 hass, SCRIPT_DEBUG_CONTINUE_ALL, async_continue_stop
             )
 
-            await asyncio.wait([stop, done], return_when=asyncio.FIRST_COMPLETED)
-            remove_signal1()
-            remove_signal2()
+            try:
+                await done
+            finally:
+                remove_signal1()
+                remove_signal2()
 
     try:
         yield trace_element

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1105,12 +1105,13 @@ class _ScriptRun:
         timeout_future: asyncio.Future[None] | None,
     ) -> None:
         await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
-        if timeout_future and timeout_future.done():
-            self._variables["wait"]["remaining"] = 0.0
-            if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
-                self._log(_TIMEOUT_MSG)
-                trace_set_result(wait=self._variables["wait"], timeout=True)
-                raise _AbortScript from TimeoutError()
+        if not timeout_future or not timeout_future.done():
+            return
+        self._variables["wait"]["remaining"] = 0.0
+        if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
+            self._log(_TIMEOUT_MSG)
+            trace_set_result(wait=self._variables["wait"], timeout=True)
+            raise _AbortScript from TimeoutError()
 
     async def _async_variables_step(self):
         """Set a variable value."""

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1061,7 +1061,7 @@ class _ScriptRun:
         """
         timeout_handle: asyncio.TimerHandle | None = None
         timeout_future: asyncio.Future[None] | None = None
-        futures: list[asyncio.Future[None]] = [self._stop]
+        futures: list[asyncio.Future[None]] = []
         if timeout:
             timeout_future = self._hass.loop.create_future()
             timeout_handle = self._hass.loop.call_later(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1102,10 +1102,7 @@ class _ScriptRun:
         timeout_future: asyncio.Future[None] | None,
     ) -> None:
         try:
-            if len(futures) == 1:
-                await futures[0]
-            else:
-                await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
+            await asyncio.wait(futures, return_when=asyncio.FIRST_COMPLETED)
             if timeout_future and timeout_future.done():
                 self._variables["wait"]["remaining"] = 0.0
                 if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -444,13 +444,11 @@ class _ScriptRun:
 
         try:
             self._log("Running %s", self._script.running_description)
-            for self._step, self._action in enumerate(self._script.sequence):
-                if self._stop.done():
-                    script_execution_set("cancelled")
-                    break
-                await self._async_step(log_exceptions=False)
-            else:
-                script_execution_set("finished")
+            async with async_interrupt.interrupt(self._stop, ScriptStoppedError, None):
+                for self._step, self._action in enumerate(self._script.sequence):
+                    await self._async_step(log_exceptions=False)
+        except ScriptStoppedError:
+            script_execution_set("cancelled")
         except _AbortScript:
             script_execution_set("aborted")
             # Let the _AbortScript bubble up if this is a sub-script
@@ -470,6 +468,8 @@ class _ScriptRun:
         except Exception:
             script_execution_set("error")
             raise
+        else:
+            script_execution_set("cancelled" if self._stop.done() else "finished")
         finally:
             # Pop the script from the script execution stack
             script_stack.pop()
@@ -1695,6 +1695,9 @@ class Script:
             # return false after the other script runs were stopped until our task
             # resumes running.
             self._log("Restarting")
+            # Important: yield to the event loop to allow the script to start in case
+            # the script is restarting itself.
+            await asyncio.sleep(0)
             await self.async_stop(update_state=False, spare=run)
 
         if started_action:
@@ -1724,11 +1727,13 @@ class Script:
         # asyncio.shield as asyncio.shield yields to the event loop, which would cause
         # us to wait for script runs added after the call to async_stop.
         aws = [
-            asyncio.create_task(run.async_stop()) for run in self._runs if run != spare
+            create_eager_task(run.async_stop()) for run in self._runs if run != spare
         ]
         if not aws:
             return
-        await asyncio.shield(self._async_stop(aws, update_state, spare))
+        await asyncio.shield(
+            create_eager_task(self._async_stop(aws, update_state, spare))
+        )
 
     async def _async_get_condition(self, config):
         if isinstance(config, template.Template):

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1069,7 +1069,8 @@ async def test_wait_basic_times_out(hass: HomeAssistant, action_type) -> None:
                         "variables": {"wait": {"completed": False, "remaining": None}},
                     }
                 ],
-            }
+            },
+            "cancelled",
         )
     else:
         assert_action_trace(
@@ -1080,7 +1081,8 @@ async def test_wait_basic_times_out(hass: HomeAssistant, action_type) -> None:
                         "variables": {"wait": {"remaining": None, "trigger": None}},
                     }
                 ],
-            }
+            },
+            "cancelled",
         )
 
 
@@ -1484,7 +1486,8 @@ async def test_wait_template_with_utcnow_no_match(hass: HomeAssistant) -> None:
                     "variables": {"wait": {"completed": False, "remaining": None}},
                 }
             ],
-        }
+        },
+        "cancelled",
     )
 
 
@@ -4713,7 +4716,7 @@ async def test_shutdown_at(
     expected_trace = {
         "0": [{"result": {"delay": 120.0, "done": False}}],
     }
-    assert_action_trace(expected_trace)
+    assert_action_trace(expected_trace, "cancelled")
 
 
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])
@@ -4752,7 +4755,7 @@ async def test_shutdown_after(
     expected_trace = {
         "0": [{"result": {"delay": 120.0, "done": False}}],
     }
-    assert_action_trace(expected_trace)
+    assert_action_trace(expected_trace, "cancelled")
 
 
 @pytest.mark.parametrize("wait_for_stop_scripts_after_shutdown", [True])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While debugging #115305, it was discovered that sometimes a script would not be stopped soon enough because there was still a wait of one event loop because the stop was not using an eager task. Additionally, there was a race where the stop future could get set but the step would still process because it was not checked until the next step started.

Switch to using `async_interrupt` and an eager task to eliminate the race

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
