### PR TITLE
Set core State last_updated_timestamp when firing state changes

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1744,9 +1744,7 @@ class State:
         if last_updated_timestamp is not None:
             # We round to 6 decimal places to match .timestamp() precision
             # using int() as it is ~4.8x faster than round()
-            self.last_updated_timestamp = (
-                int(last_updated_timestamp * 1000000.0 + 0.5) / 1000000.0
-            )
+            self.last_updated_timestamp = int(last_updated_timestamp * 1e6 + 0.5) / 1e6
         else:
             self.last_updated_timestamp = self.last_updated.timestamp()
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1724,8 +1724,7 @@ class State:
         :param validate_entity_id: Validate the entity_id format.
         :param state_info: Additional state information.
         :param _last_updated_timestamp: Timestamp of last update with
-               6 digits precision and must be created with time.time_ns()
-               / 1000000000. It is only expected to be passed from
+               6 digits precision. It is only expected to be passed from
                core internals to avoid the overhead of creating a new
                timestamp from a datetime object.
         """
@@ -2230,8 +2229,10 @@ class StateMachine:
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6387
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6323
         # datetime objects only have 6 decimal places of precision, and we want
-        # to avoid rounding errors when converting between the two.
-        timestamp = time.time_ns() / 1000000000
+        # to avoid rounding errors when converting between the two so we use
+        # a defined rounding method to ensure the timestamp is always the same
+        # regardless of the platform and python version.
+        timestamp = int(time.time() * 1e6 + 0.5) / 1e6
         now = dt_util.utc_from_timestamp(timestamp)
 
         if same_state and same_attr:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1710,9 +1710,22 @@ class State:
         context: Context | None = None,
         validate_entity_id: bool | None = True,
         state_info: StateInfo | None = None,
-        last_updated_timestamp: float | None = None,
+        _last_updated_timestamp: float | None = None,
     ) -> None:
-        """Initialize a new state."""
+        """Initialize a new state.
+
+        :param entity_id: the entity that is represented.
+        :param state: the state of the entity
+        :param attributes: extra information on entity and state
+        :param last_changed: last time the state was changed.
+        :param last_reported: last time the state was reported.
+        :param last_updated: last time the state or attributes were changed.
+        :param context: Context in which it was created
+        :param validate_entity_id: Validate the entity_id format.
+        :param state_info: Additional state information.
+        :param _last_updated_timestamp: Timestamp of last update with 6 digits precision.
+               must be created with time.time_ns() / 1000000000.
+        """
         state = str(state)
 
         if validate_entity_id and not valid_entity_id(entity_id):
@@ -1742,7 +1755,7 @@ class State:
         # the recorder or websocket_api so we do not need to
         # generate it lazily.
         self.last_updated_timestamp = (
-            last_updated_timestamp or self.last_updated.timestamp()
+            _last_updated_timestamp or self.last_updated.timestamp()
         )
 
     @cached_property
@@ -2213,9 +2226,9 @@ class StateMachine:
         # timestamp implementation:
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6387
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6323
-        timestamp = (
-            time.time_ns() / 1000000000
-        )  # datetime objects only have 6 decimal places of precision
+        # datetime objects only have 6 decimal places of precision, and we want
+        # to avoid rounding errors when converting between the two.
+        timestamp = time.time_ns() / 1000000000
         now = dt_util.utc_from_timestamp(timestamp)
 
         if same_state and same_attr:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1741,12 +1741,9 @@ class State:
         # last_updated_timestamp will nearly always be called by
         # the recorder or websocket_api so we do not need to
         # generate it lazily.
-        if last_updated_timestamp is not None:
-            # We round to 6 decimal places to match .timestamp() precision
-            # using int() as it is ~4.8x faster than round()
-            self.last_updated_timestamp = int(last_updated_timestamp * 1e6 + 0.5) / 1e6
-        else:
-            self.last_updated_timestamp = self.last_updated.timestamp()
+        self.last_updated_timestamp = (
+            last_updated_timestamp or self.last_updated.timestamp()
+        )
 
     @cached_property
     def name(self) -> str:
@@ -2216,7 +2213,9 @@ class StateMachine:
         # timestamp implementation:
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6387
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6323
-        timestamp = time.time()
+        timestamp = (
+            time.time_ns() / 1000000000
+        )  # datetime objects only have 6 decimal places of precision
         now = dt_util.utc_from_timestamp(timestamp)
 
         if same_state and same_attr:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1723,8 +1723,11 @@ class State:
         :param context: Context in which it was created
         :param validate_entity_id: Validate the entity_id format.
         :param state_info: Additional state information.
-        :param _last_updated_timestamp: Timestamp of last update with 6 digits precision.
-               must be created with time.time_ns() / 1000000000.
+        :param _last_updated_timestamp: Timestamp of last update with
+               6 digits precision and must be created with time.time_ns()
+               / 1000000000. It is only expected to be passed from
+               core internals to avoid the overhead of creating a new
+               timestamp from a datetime object.
         """
         state = str(state)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2858,6 +2858,26 @@ def test_state_timestamps() -> None:
     assert state.last_updated_timestamp == now.timestamp()
 
 
+def test_state_timestamp_ends_in_5() -> None:
+    """Test timestamp functions for State."""
+    now = dt_util.utc_from_timestamp(1712718689.0294285)
+    state = ha.State(
+        "light.bedroom",
+        "on",
+        {"brightness": 100},
+        last_changed=now,
+        last_reported=now,
+        last_updated=now,
+        context=ha.Context(id="1234"),
+    )
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+
+
 def test_state_timestamps_with_timestamp_passed() -> None:
     """Test timestamp functions for State."""
     now = dt_util.utcnow()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2903,7 +2903,11 @@ def test_state_timestamps_with_timestamp_passed() -> None:
 
 def test_state_timestamps_rounds_timestamp_passed() -> None:
     """Test timestamp functions for State."""
-    timestamp = time.time()
+    # datetime objects only have 6 decimal places of precision, and we want
+    # to avoid rounding errors when converting between the two so we use
+    # a defined rounding method to ensure the timestamp is always the same
+    # regardless of the platform and python version.
+    timestamp = int(time.time() * 1e6 + 0.5) / 1e6
     now = dt_util.utc_from_timestamp(timestamp)
     state = ha.State(
         "light.bedroom",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2858,6 +2858,49 @@ def test_state_timestamps() -> None:
     assert state.last_updated_timestamp == now.timestamp()
 
 
+def test_state_timestamps_with_timestamp_passed() -> None:
+    """Test timestamp functions for State."""
+    now = dt_util.utcnow()
+    state = ha.State(
+        "light.bedroom",
+        "on",
+        {"brightness": 100},
+        last_changed=now,
+        last_reported=now,
+        last_updated=now,
+        context=ha.Context(id="1234"),
+        last_updated_timestamp=now.timestamp(),
+    )
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+
+
+def test_state_timestamps_rounds_timestamp_passed() -> None:
+    """Test timestamp functions for State."""
+    timestamp = time.time()
+    now = dt_util.utc_from_timestamp(timestamp)
+    state = ha.State(
+        "light.bedroom",
+        "on",
+        {"brightness": 100},
+        last_changed=now,
+        last_reported=now,
+        last_updated=now,
+        context=ha.Context(id="1234"),
+        last_updated_timestamp=timestamp,
+    )
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_changed_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_reported_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+    assert state.last_updated_timestamp == now.timestamp()
+
+
 async def test_state_firing_event_matches_context_id_ulid_time(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2869,6 +2869,7 @@ def test_state_timestamp_ends_in_5() -> None:
         last_reported=now,
         last_updated=now,
         context=ha.Context(id="1234"),
+        last_updated_timestamp=1712718689.0294285,
     )
     assert state.last_changed_timestamp == now.timestamp()
     assert state.last_changed_timestamp == now.timestamp()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2870,7 +2870,7 @@ def test_state_timestamp_conversion() -> None:
         last_reported=now,
         last_updated=now,
         context=ha.Context(id="1234"),
-        last_updated_timestamp=last_updated_timestamp,
+        _last_updated_timestamp=last_updated_timestamp,
     )
     assert state.last_changed_timestamp == now.timestamp()
     assert state.last_changed_timestamp == now.timestamp()
@@ -2891,7 +2891,7 @@ def test_state_timestamps_with_timestamp_passed() -> None:
         last_reported=now,
         last_updated=now,
         context=ha.Context(id="1234"),
-        last_updated_timestamp=now.timestamp(),
+        _last_updated_timestamp=now.timestamp(),
     )
     assert state.last_changed_timestamp == now.timestamp()
     assert state.last_changed_timestamp == now.timestamp()
@@ -2913,7 +2913,7 @@ def test_state_timestamps_rounds_timestamp_passed() -> None:
         last_reported=now,
         last_updated=now,
         context=ha.Context(id="1234"),
-        last_updated_timestamp=timestamp,
+        _last_updated_timestamp=timestamp,
     )
     assert state.last_changed_timestamp == now.timestamp()
     assert state.last_changed_timestamp == now.timestamp()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2858,9 +2858,10 @@ def test_state_timestamps() -> None:
     assert state.last_updated_timestamp == now.timestamp()
 
 
-def test_state_timestamp_ends_in_5() -> None:
+def test_state_timestamp_conversion() -> None:
     """Test timestamp functions for State."""
-    now = dt_util.utc_from_timestamp(1712718689.0294285)
+    last_updated_timestamp = time.time_ns() / 1000000000
+    now = dt_util.utc_from_timestamp(last_updated_timestamp)
     state = ha.State(
         "light.bedroom",
         "on",
@@ -2869,7 +2870,7 @@ def test_state_timestamp_ends_in_5() -> None:
         last_reported=now,
         last_updated=now,
         context=ha.Context(id="1234"),
-        last_updated_timestamp=1712718689.0294285,
+        last_updated_timestamp=last_updated_timestamp,
     )
     assert state.last_changed_timestamp == now.timestamp()
     assert state.last_changed_timestamp == now.timestamp()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`async_fire` already knows the timestamp, pass it to core `State` so it does not have to be converted later as it will always be called for the recorder or `websocket_api`.  This timestamp conversion always shows up on startup profiles because its the most expensive operation in `as_compressed_state`

When I was looking at the recorder conversion in #114911 I realized we mostly had the same value over and over. When looking at a profile of setting states at startup, I realized we already have the timestamp value now so we can avoid the conversion completely.  

I tried to do this in #114999 but gave up on it because `round()` turned out to be slower than `.timestamp()` Than I realized we can pre-round the time to 6 digits so that its always the same regardless of the platform or python version.
```
import timeit

print("time.time() raw",timeit.timeit('time.time()', setup='import time',number=10000000))
print("time_rounded",timeit.timeit('int(time.time() * 1e6 + 0.5)/ 1e6', setup='import time',number=10000000))
print("timestamp",timeit.timeit('now.timestamp()', setup='import datetime; now = datetime.datetime.utcnow()',number=10000000))
```
```
time.time() raw 0.33130800002254546
time_rounded 0.7744000409729779
timestamp 2.2397519160294905
```

The increased cost of time_ns is far less than `.timestamp()`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
