### PR TITLE
Fix zha test by tweaking the log level

### DIFF
--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -81,7 +81,7 @@ async def probe_silabs_firmware_type(device: str) -> ApplicationType | None:
     try:
         await flasher.probe_app_type()
     except Exception:  # pylint: disable=broad-except
-        _LOGGER.exception("Failed to probe application type")
+        _LOGGER.debug("Failed to probe application type", exc_info=True)
 
     return flasher.app_type
 

--- a/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
+++ b/homeassistant/components/zha/repairs/wrong_silabs_firmware.py
@@ -81,7 +81,7 @@ async def probe_silabs_firmware_type(device: str) -> ApplicationType | None:
     try:
         await flasher.probe_app_type()
     except Exception:  # pylint: disable=broad-except
-        _LOGGER.debug("Failed to probe application type", exc_info=True)
+        _LOGGER.exception("Failed to probe application type")
 
     return flasher.app_type
 

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -265,7 +265,9 @@ async def test_no_warn_on_socket(hass: HomeAssistant) -> None:
     mock_probe.assert_not_called()
 
 
-async def test_probe_failure_exception_handling(caplog) -> None:
+async def test_probe_failure_exception_handling(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that probe failures are handled gracefully."""
     with (
         patch(

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -1,5 +1,6 @@
 """Test ZHA repairs."""
 
+import asyncio
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
@@ -277,6 +278,7 @@ async def test_probe_failure_exception_handling(
         caplog.at_level(logging.DEBUG),
     ):
         await probe_silabs_firmware_type("/dev/ttyZigbee")
+        await asyncio.sleep(0)
 
     mock_probe_app_type.assert_awaited()
     assert "Failed to probe application type" in caplog.text

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -1,6 +1,5 @@
 """Test ZHA repairs."""
 
-import asyncio
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
@@ -267,18 +266,19 @@ async def test_no_warn_on_socket(hass: HomeAssistant) -> None:
 
 
 async def test_probe_failure_exception_handling(
+    hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that probe failures are handled gracefully."""
     with (
+        caplog.at_level(logging.DEBUG),
         patch(
             "homeassistant.components.zha.repairs.wrong_silabs_firmware.Flasher.probe_app_type",
             side_effect=RuntimeError(),
         ) as mock_probe_app_type,
-        caplog.at_level(logging.DEBUG),
     ):
         await probe_silabs_firmware_type("/dev/ttyZigbee")
-        await asyncio.sleep(0)
+        await hass.async_block_till_done()
 
     mock_probe_app_type.assert_awaited()
     assert "Failed to probe application type" in caplog.text

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from http import HTTPStatus
-import logging
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -265,20 +264,17 @@ async def test_no_warn_on_socket(hass: HomeAssistant) -> None:
     mock_probe.assert_not_called()
 
 
-async def test_probe_failure_exception_handling(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+async def test_probe_failure_exception_handling() -> None:
     """Test that probe failures are handled gracefully."""
     with (
         patch(
             "homeassistant.components.zha.repairs.wrong_silabs_firmware.Flasher.probe_app_type",
             side_effect=RuntimeError(),
-        ),
-        caplog.at_level(logging.DEBUG),
+        ) as mock_probe_app_type,
     ):
         await probe_silabs_firmware_type("/dev/ttyZigbee")
 
-    assert "Failed to probe application type" in caplog.text
+    mock_probe_app_type.assert_awaited()
 
 
 async def test_inconsistent_settings_keep_new(

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -1,6 +1,5 @@
 """Test ZHA repairs."""
 
-import asyncio
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
@@ -270,6 +269,11 @@ async def test_probe_failure_exception_handling(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that probe failures are handled gracefully."""
+    logger = logging.getLogger(
+        "homeassistant.components.zha.repairs.wrong_silabs_firmware"
+    )
+    orig_level = logger.level
+
     with (
         caplog.at_level(logging.DEBUG),
         patch(
@@ -277,11 +281,12 @@ async def test_probe_failure_exception_handling(
             side_effect=RuntimeError(),
         ) as mock_probe_app_type,
     ):
+        logger.setLevel(logging.DEBUG)
         await probe_silabs_firmware_type("/dev/ttyZigbee")
-        await asyncio.sleep(0)
+        logger.setLevel(orig_level)
 
-        mock_probe_app_type.assert_awaited()
-        assert "Failed to probe application type" in caplog.text
+    mock_probe_app_type.assert_awaited()
+    assert "Failed to probe application type" in caplog.text
 
 
 async def test_inconsistent_settings_keep_new(

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -1,5 +1,6 @@
 """Test ZHA repairs."""
 
+import asyncio
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
@@ -266,7 +267,6 @@ async def test_no_warn_on_socket(hass: HomeAssistant) -> None:
 
 
 async def test_probe_failure_exception_handling(
-    hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that probe failures are handled gracefully."""
@@ -278,10 +278,10 @@ async def test_probe_failure_exception_handling(
         ) as mock_probe_app_type,
     ):
         await probe_silabs_firmware_type("/dev/ttyZigbee")
-        await hass.async_block_till_done()
+        await asyncio.sleep(0)
 
-    mock_probe_app_type.assert_awaited()
-    assert "Failed to probe application type" in caplog.text
+        mock_probe_app_type.assert_awaited()
+        assert "Failed to probe application type" in caplog.text
 
 
 async def test_inconsistent_settings_keep_new(

--- a/tests/components/zha/test_repairs.py
+++ b/tests/components/zha/test_repairs.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from http import HTTPStatus
+import logging
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -264,17 +265,21 @@ async def test_no_warn_on_socket(hass: HomeAssistant) -> None:
     mock_probe.assert_not_called()
 
 
-async def test_probe_failure_exception_handling() -> None:
+async def test_probe_failure_exception_handling(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """Test that probe failures are handled gracefully."""
     with (
         patch(
             "homeassistant.components.zha.repairs.wrong_silabs_firmware.Flasher.probe_app_type",
             side_effect=RuntimeError(),
         ) as mock_probe_app_type,
+        caplog.at_level(logging.DEBUG),
     ):
         await probe_silabs_firmware_type("/dev/ttyZigbee")
 
     mock_probe_app_type.assert_awaited()
+    assert "Failed to probe application type" in caplog.text
 
 
 async def test_inconsistent_settings_keep_new(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`test_probe_failure_exception_handling` failed multiple times:
https://github.com/home-assistant/core/actions/runs/8633392085/job/23671932070?pr=110950

Possible the asserting on debug log is an issue because the test used to lean on the debug level being set to DEBUG by another test. This PR set the log level to debug temporary to ensure the test passes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
