### PR TITLE
Use enum device class in Netatmo health index sensor

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -72,15 +72,12 @@ def process_health(health: StateType) -> str | None:
     """Process health index and return string for display."""
     if not isinstance(health, int):
         return None
-    if health == 0:
-        return "Healthy"
-    if health == 1:
-        return "Fine"
-    if health == 2:
-        return "Fair"
-    if health == 3:
-        return "Poor"
-    return "Unhealthy"
+    return {
+        0: "healthy",
+        1: "fine",
+        2: "fair",
+        3: "poor",
+    }.get(health, "unhealthy")
 
 
 def process_rf(strength: StateType) -> str | None:
@@ -257,6 +254,8 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="health_idx",
         netatmo_name="health_idx",
+        device_class=SensorDeviceClass.ENUM,
+        options=["healthy", "fine", "fair", "poor", "unhealthy"],
         value_fn=process_health,
     ),
     NetatmoSensorEntityDescription(

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -209,7 +209,14 @@
         "name": "Wi-Fi"
       },
       "health_idx": {
-        "name": "Health index"
+        "name": "Health index",
+        "state": {
+          "healthy": "Healthy",
+          "fine": "Fine",
+          "fair": "Fair",
+          "poor": "Poor",
+          "unhealthy": "Unhealthy"
+        }
       }
     }
   }

--- a/tests/components/netatmo/snapshots/test_sensor.ambr
+++ b/tests/components/netatmo/snapshots/test_sensor.ambr
@@ -118,7 +118,15 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -135,7 +143,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Health index',
     'platform': 'netatmo',
@@ -150,16 +158,24 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Baby Bedroom Health index',
       'latitude': 13.377726,
       'longitude': 52.516263,
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.baby_bedroom_health_index',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'Fine',
+    'state': 'fine',
   })
 # ---
 # name: test_entity[sensor.baby_bedroom_humidity-entry]
@@ -638,7 +654,15 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -655,7 +679,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Health index',
     'platform': 'netatmo',
@@ -670,7 +694,15 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Bedroom Health index',
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.bedroom_health_index',
@@ -2845,7 +2877,15 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -2862,7 +2902,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Health index',
     'platform': 'netatmo',
@@ -2877,9 +2917,17 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Kitchen Health index',
       'latitude': 13.377726,
       'longitude': 52.516263,
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.kitchen_health_index',
@@ -3916,7 +3964,15 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -3933,7 +3989,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Health index',
     'platform': 'netatmo',
@@ -3948,9 +4004,17 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Livingroom Health index',
       'latitude': 13.377726,
       'longitude': 52.516263,
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.livingroom_health_index',
@@ -4440,7 +4504,15 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -4457,7 +4529,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Health index',
     'platform': 'netatmo',
@@ -4472,16 +4544,24 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Parents Bedroom Health index',
       'latitude': 13.377726,
       'longitude': 52.516263,
+      'options': list([
+        'healthy',
+        'fine',
+        'fair',
+        'poor',
+        'unhealthy',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.parents_bedroom_health_index',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'Fine',
+    'state': 'fine',
   })
 # ---
 # name: test_entity[sensor.parents_bedroom_humidity-entry]

--- a/tests/components/netatmo/test_sensor.py
+++ b/tests/components/netatmo/test_sensor.py
@@ -136,7 +136,7 @@ async def test_process_rf(strength: int, expected: str) -> None:
 
 @pytest.mark.parametrize(
     ("health", "expected"),
-    [(4, "Unhealthy"), (3, "Poor"), (2, "Fair"), (1, "Fine"), (0, "Healthy")],
+    [(4, "unhealthy"), (3, "poor"), (2, "fair"), (1, "fine"), (0, "healthy")],
 )
 async def test_process_health(health: int, expected: str) -> None:
     """Test health index translation."""
@@ -195,7 +195,7 @@ async def test_process_health(health: int, expected: str) -> None:
         (
             "12:34:56:26:68:92-health_idx",
             "baby_bedroom_health",
-            "Fine",
+            "fine",
         ),
         (
             "12:34:56:26:68:92-wifi_status",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The state of the Netatmo health index sensor provided by the weather station now exposes the state in lower case.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use enum device class in Netatmo health index sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
