### PR TITLE
Use enum device class in Netatmo wind direction

### DIFF
--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -67,6 +67,17 @@ from .helper import NetatmoArea
 
 _LOGGER = logging.getLogger(__name__)
 
+DIRECTION_OPTIONS = [
+    "n",
+    "ne",
+    "e",
+    "se",
+    "s",
+    "sw",
+    "w",
+    "nw",
+]
+
 
 def process_health(health: StateType) -> str | None:
     """Process health index and return string for display."""
@@ -199,6 +210,9 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
     NetatmoSensorEntityDescription(
         key="windangle",
         netatmo_name="wind_direction",
+        device_class=SensorDeviceClass.ENUM,
+        options=DIRECTION_OPTIONS,
+        value_fn=lambda x: x.lower() if isinstance(x, str) else None,
     ),
     NetatmoSensorEntityDescription(
         key="windangle_value",
@@ -218,6 +232,9 @@ SENSOR_TYPES: tuple[NetatmoSensorEntityDescription, ...] = (
         key="gustangle",
         netatmo_name="gust_direction",
         entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.ENUM,
+        options=DIRECTION_OPTIONS,
+        value_fn=lambda x: x.lower() if isinstance(x, str) else None,
     ),
     NetatmoSensorEntityDescription(
         key="gustangle_value",

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -188,13 +188,13 @@
         "name": "Wind direction",
         "state": {
           "n": "North",
-          "ne": "North-East",
+          "ne": "North-east",
           "e": "East",
-          "se": "South-East",
+          "se": "South-east",
           "s": "South",
-          "sw": "South-West",
+          "sw": "South-west",
           "w": "West",
-          "nw": "North-West"
+          "nw": "North-west"
         }
       },
       "wind_angle": {

--- a/homeassistant/components/netatmo/strings.json
+++ b/homeassistant/components/netatmo/strings.json
@@ -185,13 +185,33 @@
         "name": "Precipitation today"
       },
       "wind_direction": {
-        "name": "Wind direction"
+        "name": "Wind direction",
+        "state": {
+          "n": "North",
+          "ne": "North-East",
+          "e": "East",
+          "se": "South-East",
+          "s": "South",
+          "sw": "South-West",
+          "w": "West",
+          "nw": "North-West"
+        }
       },
       "wind_angle": {
         "name": "Wind angle"
       },
       "gust_direction": {
-        "name": "Gust direction"
+        "name": "Gust direction",
+        "state": {
+          "n": "[%key:component::netatmo::entity::sensor::wind_direction::state::n%]",
+          "ne": "[%key:component::netatmo::entity::sensor::wind_direction::state::ne%]",
+          "e": "[%key:component::netatmo::entity::sensor::wind_direction::state::e%]",
+          "se": "[%key:component::netatmo::entity::sensor::wind_direction::state::se%]",
+          "s": "[%key:component::netatmo::entity::sensor::wind_direction::state::s%]",
+          "sw": "[%key:component::netatmo::entity::sensor::wind_direction::state::sw%]",
+          "w": "[%key:component::netatmo::entity::sensor::wind_direction::state::w%]",
+          "nw": "[%key:component::netatmo::entity::sensor::wind_direction::state::nw%]"
+        }
       },
       "gust_angle": {
         "name": "Gust angle"

--- a/tests/components/netatmo/snapshots/test_sensor.ambr
+++ b/tests/components/netatmo/snapshots/test_sensor.ambr
@@ -6073,7 +6073,18 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'n',
+        'ne',
+        'e',
+        'se',
+        's',
+        'sw',
+        'w',
+        'nw',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -6090,7 +6101,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Gust direction',
     'platform': 'netatmo',
@@ -6105,14 +6116,25 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Villa Garden Gust direction',
+      'options': list([
+        'n',
+        'ne',
+        'e',
+        'se',
+        's',
+        'sw',
+        'w',
+        'nw',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.villa_garden_gust_direction',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'S',
+    'state': 's',
   })
 # ---
 # name: test_entity[sensor.villa_garden_gust_strength-entry]
@@ -6317,7 +6339,18 @@
     'aliases': set({
     }),
     'area_id': None,
-    'capabilities': None,
+    'capabilities': dict({
+      'options': list([
+        'n',
+        'ne',
+        'e',
+        'se',
+        's',
+        'sw',
+        'w',
+        'nw',
+      ]),
+    }),
     'config_entry_id': <ANY>,
     'device_class': None,
     'device_id': <ANY>,
@@ -6334,7 +6367,7 @@
     'name': None,
     'options': dict({
     }),
-    'original_device_class': None,
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
     'original_name': 'Wind direction',
     'platform': 'netatmo',
@@ -6349,14 +6382,25 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by Netatmo',
+      'device_class': 'enum',
       'friendly_name': 'Villa Garden Wind direction',
+      'options': list([
+        'n',
+        'ne',
+        'e',
+        'se',
+        's',
+        'sw',
+        'w',
+        'nw',
+      ]),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.villa_garden_wind_direction',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'SW',
+    'state': 'sw',
   })
 # ---
 # name: test_entity[sensor.villa_garden_wind_speed-entry]

--- a/tests/components/netatmo/test_sensor.py
+++ b/tests/components/netatmo/test_sensor.py
@@ -165,17 +165,17 @@ async def test_process_health(health: int, expected: str) -> None:
         ),
         ("12:34:56:80:c1:ea-sum_rain_1", "villa_rain_rain_last_hour", "0"),
         ("12:34:56:80:c1:ea-sum_rain_24", "villa_rain_rain_today", "6.9"),
-        ("12:34:56:03:1b:e4-windangle", "netatmoindoor_garden_direction", "SW"),
+        ("12:34:56:03:1b:e4-windangle", "netatmoindoor_garden_direction", "sw"),
         (
             "12:34:56:03:1b:e4-windangle_value",
             "netatmoindoor_garden_angle",
             "217",
         ),
-        ("12:34:56:03:1b:e4-gustangle", "mystation_garden_gust_direction", "S"),
+        ("12:34:56:03:1b:e4-gustangle", "mystation_garden_gust_direction", "s"),
         (
             "12:34:56:03:1b:e4-gustangle",
             "netatmoindoor_garden_gust_direction",
-            "S",
+            "s",
         ),
         (
             "12:34:56:03:1b:e4-gustangle_value",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The state of the Netatmo wind and gust direction sensor provided by the weather station now exposes the state in lower case.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use enum device class in Netatmo wind direction

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
