### PR TITLE
Reduce scope of diagnostics tests for rtsp_to_webrtc to not depend on global state

### DIFF
--- a/tests/components/rtsp_to_webrtc/test_diagnostics.py
+++ b/tests/components/rtsp_to_webrtc/test_diagnostics.py
@@ -2,8 +2,6 @@
 
 from typing import Any
 
-from freezegun.api import FrozenDateTimeFactory
-
 from homeassistant.core import HomeAssistant
 
 from .conftest import ComponentSetup
@@ -21,13 +19,9 @@ async def test_entry_diagnostics(
     config_entry: MockConfigEntry,
     rtsp_to_webrtc_client: Any,
     setup_integration: ComponentSetup,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test config entry diagnostics."""
     await setup_integration()
 
-    assert await get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
-        "discovery": {"attempt": 1, "web.failure": 1, "webrtc.success": 1},
-        "web": {},
-        "webrtc": {},
-    }
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+    assert "webrtc" in result


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the part of the test that asserts on global counters that would fail if run multiple times. The intent of the test is to verify that diagnostics are working end to end and so its fine to not assert on the lower level counter details of the diagnostics returned by the `rtsp_to_webrtc`.

Old behavior:
```
$ pip3 install pytest-repeat
$ py.test --count=2 tests/components/rtsp_to_webrtc 
...
FAILED tests/components/rtsp_to_webrtc/test_diagnostics.py::test_entry_diagnostics[2-2] - AssertionError: assert {'discovery':... 'webrtc': {}} == {'discovery':... 'webrtc': {}}
...
```

New behavior:
```
$  py.test --count=2 tests/components/rtsp_to_webrtc 
...
      38 passed
```

Reverts #115398 which was not needed.

This test was previously observed as flaky:
- https://github.com/home-assistant/core/pull/115384
- https://github.com/home-assistant/core/pull/115377

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
