### PR TITLE
Create base class for Rachio smart hose timer entities

### DIFF
--- a/homeassistant/components/rachio/device.py
+++ b/homeassistant/components/rachio/device.py
@@ -350,11 +350,9 @@ class RachioBaseStation:
     def __init__(
         self, rachio: Rachio, data: dict[str, Any], coordinator: RachioUpdateCoordinator
     ) -> None:
-        """Initialize a hose time base station."""
+        """Initialize a smart hose timer base station."""
         self.rachio = rachio
         self._id = data[KEY_ID]
-        self.serial_number = data[KEY_SERIAL_NUMBER]
-        self.mac_address = data[KEY_MAC_ADDRESS]
         self.coordinator = coordinator
 
     def start_watering(self, valve_id: str, duration: int) -> None:

--- a/homeassistant/components/rachio/entity.py
+++ b/homeassistant/components/rachio/entity.py
@@ -51,13 +51,13 @@ class RachioDevice(Entity):
         )
 
 
-class RachioHoseTimerDevice(CoordinatorEntity[RachioUpdateCoordinator]):
-    """Base class for smart hose timer devices."""
+class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
+    """Base class for smart hose timer entities."""
 
     _attr_has_entity_name = True
 
     def __init__(self, data, coordinator: RachioUpdateCoordinator) -> None:
-        """Initialize a Rachio smart hose timer device."""
+        """Initialize a Rachio smart hose timer entity."""
         super().__init__(coordinator)
         self.id = data[KEY_ID]
         self._name = data[KEY_NAME]
@@ -73,7 +73,7 @@ class RachioHoseTimerDevice(CoordinatorEntity[RachioUpdateCoordinator]):
 
     @property
     def available(self) -> bool:
-        """Return if the device is available."""
+        """Return if the entity is available."""
         return (
             super().available
             and self.coordinator.data[self.id][KEY_STATE][KEY_REPORTED_STATE][

--- a/homeassistant/components/rachio/entity.py
+++ b/homeassistant/components/rachio/entity.py
@@ -13,7 +13,6 @@ from .const import (
     DOMAIN,
     KEY_CONNECTED,
     KEY_ID,
-    KEY_MAC_ADDRESS,
     KEY_NAME,
     KEY_REPORTED_STATE,
     KEY_STATE,
@@ -61,7 +60,6 @@ class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
         super().__init__(coordinator)
         self.id = data[KEY_ID]
         self._name = data[KEY_NAME]
-        self._mac = coordinator.base_station[KEY_MAC_ADDRESS]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.id)},
             model="Smart Hose Timer",

--- a/homeassistant/components/rachio/entity.py
+++ b/homeassistant/components/rachio/entity.py
@@ -1,6 +1,7 @@
 """Adapter to wrap the rachiopy api for home assistant."""
 
 from abc import abstractmethod
+from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -55,7 +56,9 @@ class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
 
     _attr_has_entity_name = True
 
-    def __init__(self, data, coordinator: RachioUpdateCoordinator) -> None:
+    def __init__(
+        self, data: dict[str, Any], coordinator: RachioUpdateCoordinator
+    ) -> None:
         """Initialize a Rachio smart hose timer entity."""
         super().__init__(coordinator)
         self.id = data[KEY_ID]

--- a/homeassistant/components/rachio/entity.py
+++ b/homeassistant/components/rachio/entity.py
@@ -64,7 +64,6 @@ class RachioHoseTimerEntity(CoordinatorEntity[RachioUpdateCoordinator]):
         self._mac = coordinator.base_station[KEY_MAC_ADDRESS]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.id)},
-            connections={(dr.CONNECTION_NETWORK_MAC, self._mac)},
             model="Smart Hose Timer",
             name=self._name,
             manufacturer=DEFAULT_NAME,

--- a/homeassistant/components/rachio/switch.py
+++ b/homeassistant/components/rachio/switch.py
@@ -13,25 +13,17 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_ID
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import (
-    config_validation as cv,
-    device_registry as dr,
-    entity_platform,
-)
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util.dt import as_timestamp, now, parse_datetime, utc_from_timestamp
 
 from .const import (
     CONF_MANUAL_RUN_MINS,
     DEFAULT_MANUAL_RUN_MINS,
-    DEFAULT_NAME,
     DOMAIN as DOMAIN_RACHIO,
-    KEY_CONNECTED,
     KEY_CURRENT_STATUS,
     KEY_CUSTOM_CROP,
     KEY_CUSTOM_SHADE,
@@ -67,9 +59,8 @@ from .const import (
     SLOPE_SLIGHT,
     SLOPE_STEEP,
 )
-from .coordinator import RachioUpdateCoordinator
 from .device import RachioPerson
-from .entity import RachioDevice
+from .entity import RachioDevice, RachioHoseTimerDevice
 from .webhooks import (
     SUBTYPE_RAIN_DELAY_OFF,
     SUBTYPE_RAIN_DELAY_ON,
@@ -546,39 +537,19 @@ class RachioSchedule(RachioSwitch):
         )
 
 
-class RachioValve(CoordinatorEntity[RachioUpdateCoordinator], SwitchEntity):
+class RachioValve(RachioHoseTimerDevice, SwitchEntity):
     """Representation of one smart hose timer valve."""
 
-    def __init__(
-        self, person, base, data, coordinator: RachioUpdateCoordinator
-    ) -> None:
+    _attr_name = None
+
+    def __init__(self, person, base, data, coordinator) -> None:
         """Initialize a new smart hose valve."""
-        super().__init__(coordinator)
+        super().__init__(data, coordinator)
         self._person = person
         self._base = base
-        self.id = data[KEY_ID]
-        self._attr_name = data[KEY_NAME]
         self._attr_unique_id = f"{self.id}-valve"
         self._static_attrs = data[KEY_STATE][KEY_REPORTED_STATE]
         self._attr_is_on = KEY_CURRENT_STATUS in self._static_attrs
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (
-                    DOMAIN_RACHIO,
-                    self.id,
-                )
-            },
-            connections={(dr.CONNECTION_NETWORK_MAC, self._base.mac_address)},
-            manufacturer=DEFAULT_NAME,
-            model="Smart Hose Timer",
-            name=self._attr_name,
-            configuration_url="https://app.rach.io",
-        )
-
-    @property
-    def available(self) -> bool:
-        """Return if the valve is available."""
-        return super().available and self._static_attrs[KEY_CONNECTED]
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn on this valve."""
@@ -594,20 +565,19 @@ class RachioValve(CoordinatorEntity[RachioUpdateCoordinator], SwitchEntity):
         self._base.start_watering(self.id, manual_run_time.seconds)
         self._attr_is_on = True
         self.schedule_update_ha_state(force_refresh=True)
-        _LOGGER.debug("Starting valve %s for %s", self.name, str(manual_run_time))
+        _LOGGER.debug("Starting valve %s for %s", self._name, str(manual_run_time))
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn off this valve."""
         self._base.stop_watering(self.id)
         self._attr_is_on = False
         self.schedule_update_ha_state(force_refresh=True)
-        _LOGGER.debug("Stopping watering on valve %s", self.name)
+        _LOGGER.debug("Stopping watering on valve %s", self._name)
 
     @callback
-    def _handle_coordinator_update(self) -> None:
+    def _update_attr(self) -> None:
         """Handle updated coordinator data."""
         data = self.coordinator.data[self.id]
 
         self._static_attrs = data[KEY_STATE][KEY_REPORTED_STATE]
         self._attr_is_on = KEY_CURRENT_STATUS in self._static_attrs
-        super()._handle_coordinator_update()

--- a/homeassistant/components/rachio/switch.py
+++ b/homeassistant/components/rachio/switch.py
@@ -60,7 +60,7 @@ from .const import (
     SLOPE_STEEP,
 )
 from .device import RachioPerson
-from .entity import RachioDevice, RachioHoseTimerDevice
+from .entity import RachioDevice, RachioHoseTimerEntity
 from .webhooks import (
     SUBTYPE_RAIN_DELAY_OFF,
     SUBTYPE_RAIN_DELAY_ON,
@@ -537,7 +537,7 @@ class RachioSchedule(RachioSwitch):
         )
 
 
-class RachioValve(RachioHoseTimerDevice, SwitchEntity):
+class RachioValve(RachioHoseTimerEntity, SwitchEntity):
     """Representation of one smart hose timer valve."""
 
     _attr_name = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create a base class for smart hose timer entities. Will be used further for adding binary sensor(s) in a future PR.

Also remove connections from device info. This was problematic when multiple timers are connected to a single base station, because they share the MAC of the base station but should be treated as separate devices. 

Updates entity naming for the switch.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
