### PR TITLE
Add Notify entity for Bring

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -158,6 +158,7 @@ omit =
     homeassistant/components/braviatv/media_player.py
     homeassistant/components/braviatv/remote.py
     homeassistant/components/bring/coordinator.py
+    homeassistant/components/bring/notify.py
     homeassistant/components/bring/todo.py
     homeassistant/components/broadlink/climate.py
     homeassistant/components/broadlink/light.py

--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from .const import DOMAIN
 from .coordinator import BringDataUpdateCoordinator
 
-PLATFORMS: list[Platform] = [Platform.TODO]
+PLATFORMS: list[Platform] = [Platform.NOTIFY, Platform.TODO]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -1,3 +1,12 @@
 """Constants for the Bring! integration."""
 
+from typing import Final
+
 DOMAIN = "bring"
+
+ATTR_SENDER: Final = "sender"
+ATTR_ITEM_NAME: Final = "item_name"
+ATTR_NOTIFICATION_TYPE: Final = "notification_type"
+ATTR_LIST: Final = "bring_list"
+
+SERVICE_PUSH_NOTIFICATION = "push_notification"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -4,7 +4,7 @@ from typing import Final
 
 DOMAIN = "bring"
 
-ATTR_ITEM_NAME: Final = "message"
+ATTR_ITEM_NAME: Final = "item"
 ATTR_NOTIFICATION_TYPE: Final = "notification_type"
 
 SERVICE_PUSH_NOTIFICATION: Final = "push_notification"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -4,8 +4,10 @@ from typing import Final
 
 DOMAIN = "bring"
 
-ATTR_SENDER: Final = "sender"
-ATTR_ITEM_NAME: Final = "item_name"
+ATTR_ITEM_NAME: Final = "message"
 ATTR_NOTIFICATION_TYPE: Final = "notification_type"
 
-SERVICE_PUSH_NOTIFICATION = "push_notification"
+SERVICE_PUSH_NOTIFICATION: Final = "push_notification"
+
+MANUFACTURER: Final = "Bring! Labs AG"
+SERVICE_NAME: Final = "Bring!"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -7,6 +7,5 @@ DOMAIN = "bring"
 ATTR_SENDER: Final = "sender"
 ATTR_ITEM_NAME: Final = "item_name"
 ATTR_NOTIFICATION_TYPE: Final = "notification_type"
-ATTR_LIST: Final = "bring_list"
 
 SERVICE_PUSH_NOTIFICATION = "push_notification"

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -5,7 +5,7 @@ from typing import Final
 DOMAIN = "bring"
 
 ATTR_ITEM_NAME: Final = "item"
-ATTR_NOTIFICATION_TYPE: Final = "notification_type"
+ATTR_NOTIFICATION_TYPE: Final = "message"
 
 SERVICE_PUSH_NOTIFICATION: Final = "push_notification"
 

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -5,5 +5,8 @@
         "default": "mdi:cart"
       }
     }
+  },
+  "services": {
+    "push_notification": "mdi:message-alert"
   }
 }

--- a/homeassistant/components/bring/icons.json
+++ b/homeassistant/components/bring/icons.json
@@ -7,6 +7,6 @@
     }
   },
   "services": {
-    "push_notification": "mdi:message-alert"
+    "send_message": "mdi:cellphone-message"
   }
 }

--- a/homeassistant/components/bring/notify.py
+++ b/homeassistant/components/bring/notify.py
@@ -1,0 +1,112 @@
+"""Notify platform for the Bring! integration."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from bring_api.exceptions import BringRequestException
+from bring_api.types import BringNotificationType
+import voluptuous as vol
+
+from homeassistant.components.notify import NotifyEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.helpers.config_validation import make_entity_service_schema
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import DOMAIN
+from .const import ATTR_ITEM_NAME, ATTR_NOTIFICATION_TYPE, MANUFACTURER, SERVICE_NAME
+from .coordinator import BringData, BringDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Bring notify entity platform."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    async_add_entities(
+        BringNotify(coordinator, bring_list=bring_list, entry=config_entry)
+        for bring_list in coordinator.data.values()
+    )
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        "send_message",
+        make_entity_service_schema(
+            {
+                vol.Required(ATTR_NOTIFICATION_TYPE): vol.All(
+                    vol.Upper, cv.enum(BringNotificationType)
+                ),
+                vol.Optional(ATTR_ITEM_NAME): cv.string,
+            }
+        ),
+        "async_send_bring_message",
+    )
+
+
+class BringNotify(NotifyEntity):
+    """Representation of a Bring notify entity."""
+
+    _attr_has_entity_name = False
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: BringDataUpdateCoordinator,
+        bring_list: BringData,
+        entry: ConfigEntry,
+    ) -> None:
+        """Initialize the Notify entity."""
+        if TYPE_CHECKING:
+            assert entry.unique_id
+
+        self.coordinator = coordinator
+        self._list_uuid = bring_list["listUuid"]
+        self._attr_name = bring_list["name"]
+
+        self._attr_unique_id = f"{entry.unique_id}_{self._list_uuid}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, entry.unique_id)},
+            manufacturer=MANUFACTURER,
+            model=SERVICE_NAME,
+        )
+
+    async def async_send_message(self, message: str) -> None:
+        """Implement for base class.
+
+        Cannot be overridden with custom fields,
+        so calling async_send_bring_message instead.
+        """
+
+    async def async_send_bring_message(
+        self,
+        *,
+        message: str | None = None,
+        notification_type: BringNotificationType,
+    ) -> None:
+        """Send a push notification to members of a To-Do list."""
+
+        try:
+            await self.coordinator.bring.notify(
+                self._list_uuid, notification_type, message
+            )
+        except BringRequestException as e:
+            raise HomeAssistantError(
+                "Unable to send push notification for bring"
+            ) from e
+        except ValueError as e:
+            raise HomeAssistantError(
+                "Item name is required for Breaking news notification"
+            ) from e
+        else:
+            await super()._async_send_message(message=message or "item_name")

--- a/homeassistant/components/bring/notify.py
+++ b/homeassistant/components/bring/notify.py
@@ -91,14 +91,14 @@ class BringNotify(NotifyEntity):
     async def async_send_bring_message(
         self,
         *,
-        message: str | None = None,
+        item: str | None = None,
         notification_type: BringNotificationType,
     ) -> None:
         """Send a push notification to members of a To-Do list."""
 
         try:
             await self.coordinator.bring.notify(
-                self._list_uuid, notification_type, message
+                self._list_uuid, notification_type, item
             )
         except BringRequestException as e:
             raise HomeAssistantError(
@@ -109,4 +109,4 @@ class BringNotify(NotifyEntity):
                 "Item name is required for Breaking news notification"
             ) from e
         else:
-            await super()._async_send_message(message=message or "item_name")
+            await super()._async_send_message(message="None")

--- a/homeassistant/components/bring/notify.py
+++ b/homeassistant/components/bring/notify.py
@@ -89,12 +89,18 @@ class BringNotify(NotifyEntity):
         )
 
     async def async_send_message(self, message: str) -> None:
-        """Send a push notification to members of a To-Do list."""
+        """Send a push notification to members of a shared bring list."""
         try:
             await self.async_send_bring_message(message=BringNotificationType[message])
         except KeyError as e:
             raise ServiceValidationError(
-                f"Message must contain one of {", ".join(x.value for x in BringNotificationType)}"
+                translation_domain=DOMAIN,
+                translation_key="notify_invalid_message_type",
+                translation_placeholders={
+                    "notification_types": ", ".join(
+                        x.value for x in BringNotificationType
+                    ),
+                },
             ) from e
 
     async def async_send_bring_message(
@@ -102,15 +108,17 @@ class BringNotify(NotifyEntity):
         message: BringNotificationType,
         item: str | None = None,
     ) -> None:
-        """Send a push notification to members of a To-Do list."""
+        """Send a push notification to members of a shared bring list."""
 
         try:
             await self.coordinator.bring.notify(self._list_uuid, message, item)
         except BringRequestException as e:
             raise HomeAssistantError(
-                "Unable to send push notification for bring"
+                translation_domain=DOMAIN,
+                translation_key="notify_request_failed",
             ) from e
         except ValueError as e:
             raise ServiceValidationError(
-                "Item name is required for Breaking news notification"
+                translation_domain=DOMAIN,
+                translation_key="notify_missing_argument_item",
             ) from e

--- a/homeassistant/components/bring/notify.py
+++ b/homeassistant/components/bring/notify.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant.components.notify import NotifyEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.config_validation import make_entity_service_schema
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
@@ -93,7 +93,7 @@ class BringNotify(NotifyEntity):
         try:
             await self.async_send_bring_message(message=BringNotificationType[message])
         except KeyError as e:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 f"Message must contain one of {", ".join(x.value for x in BringNotificationType)}"
             ) from e
 
@@ -111,6 +111,6 @@ class BringNotify(NotifyEntity):
                 "Unable to send push notification for bring"
             ) from e
         except ValueError as e:
-            raise HomeAssistantError(
+            raise ServiceValidationError(
                 "Item name is required for Breaking news notification"
             ) from e

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,0 +1,26 @@
+push_notification:
+  fields:
+    bring_list:
+      required: true
+      example: todo.bring_shoppinglist
+      selector:
+        entity:
+          domain: todo
+          integration: bring
+    notification_type:
+      example: going_shopping
+      required: true
+      default: "going_shopping"
+      selector:
+        select:
+          translation_key: "notification_type_selector"
+          options:
+            - "going_shopping"
+            - "changed_list"
+            - "shopping_done"
+            - "urgent_message"
+    item_name:
+      example: Cilantro
+      required: false
+      selector:
+        text:

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -4,7 +4,7 @@ send_message:
       domain: notify
       integration: bring
   fields:
-    notification_type:
+    message:
       example: going_shopping
       required: true
       default: "going_shopping"

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -16,7 +16,7 @@ send_message:
             - "changed_list"
             - "shopping_done"
             - "urgent_message"
-    message:
+    item:
       example: Cilantro
       required: false
       selector:

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,6 +1,6 @@
 push_notification:
   fields:
-    bring_list:
+    entity_id:
       required: true
       example: todo.bring_shoppinglist
       selector:

--- a/homeassistant/components/bring/services.yaml
+++ b/homeassistant/components/bring/services.yaml
@@ -1,12 +1,9 @@
-push_notification:
+send_message:
+  target:
+    entity:
+      domain: notify
+      integration: bring
   fields:
-    entity_id:
-      required: true
-      example: todo.bring_shoppinglist
-      selector:
-        entity:
-          domain: todo
-          integration: bring
     notification_type:
       example: going_shopping
       required: true
@@ -19,7 +16,7 @@ push_notification:
             - "changed_list"
             - "shopping_done"
             - "urgent_message"
-    item_name:
+    message:
       example: Cilantro
       required: false
       selector:

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -22,7 +22,7 @@
       "name": "Notifications",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
-        "bring_list": {
+        "entity_id": {
           "name": "List",
           "description": "Bring! list whose members (except sender) will be notified."
         },

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -16,5 +16,35 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
+  },
+  "services": {
+    "push_notification": {
+      "name": "Notifications",
+      "description": "Send a mobile push notification to members of a shared Bring! list.",
+      "fields": {
+        "bring_list": {
+          "name": "List",
+          "description": "Bring! list whose members (except sender) will be notified."
+        },
+        "notification_type": {
+          "name": "Notification type",
+          "description": "Type of push notification to send to list members."
+        },
+        "item_name": {
+          "name": "Item name (Required if message type 'Breaking news' selected)",
+          "description": "Item Name to include in an urgent message e.g. 'Breaking news - Please get cilantro!'"
+        }
+      }
+    }
+  },
+  "selector": {
+    "notification_type_selector": {
+      "options": {
+        "going_shopping": "I'm going shopping! - Last chance for adjustments",
+        "changed_list": "List changed - Check it out",
+        "shopping_done": "Shopping done - you can relax",
+        "urgent_message": "Breaking news - Please get 'item name' !"
+      }
+    }
   }
 }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -22,7 +22,7 @@
       "name": "[%key:component::notify::services::notify::name%]",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
-        "notification_type": {
+        "message": {
           "name": "Notification type",
           "description": "Type of push notification to send to list members."
         },

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -26,7 +26,7 @@
           "name": "Notification type",
           "description": "Type of push notification to send to list members."
         },
-        "message": {
+        "item": {
           "name": "Item name (Required if message type `Breaking news` selected)",
           "description": "Item Name to include in an urgent message e.g. `Breaking news - Please get cilantro!`"
         }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -42,5 +42,16 @@
         "urgent_message": "Breaking news - Please get `item name` !"
       }
     }
+  },
+  "exceptions": {
+    "notify_missing_argument_item": {
+      "message": "This service requires field item for `Breaking news` notification, please enter a valid value for item"
+    },
+    "notify_request_failed": {
+      "message": "Failed to send push notification for bring"
+    },
+    "notify_invalid_message_type": {
+      "message": "This service requires message to be one of {notification_types}, please enter a valid value for message"
+    }
   }
 }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -18,21 +18,17 @@
     }
   },
   "services": {
-    "push_notification": {
+    "send_message": {
       "name": "[%key:component::notify::services::notify::name%]",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
-        "entity_id": {
-          "name": "List",
-          "description": "Bring! list whose members (except sender) will be notified."
-        },
         "notification_type": {
           "name": "Notification type",
           "description": "Type of push notification to send to list members."
         },
-        "item_name": {
-          "name": "Item name (Required if message type 'Breaking news' selected)",
-          "description": "Item Name to include in an urgent message e.g. 'Breaking news - Please get cilantro!'"
+        "message": {
+          "name": "Item name (Required if message type `Breaking news` selected)",
+          "description": "Item Name to include in an urgent message e.g. `Breaking news - Please get cilantro!`"
         }
       }
     }
@@ -43,7 +39,7 @@
         "going_shopping": "I'm going shopping! - Last chance for adjustments",
         "changed_list": "List changed - Check it out",
         "shopping_done": "Shopping done - you can relax",
-        "urgent_message": "Breaking news - Please get 'item name' !"
+        "urgent_message": "Breaking news - Please get `item name` !"
       }
     }
   }

--- a/homeassistant/components/bring/strings.json
+++ b/homeassistant/components/bring/strings.json
@@ -19,7 +19,7 @@
   },
   "services": {
     "push_notification": {
-      "name": "Notifications",
+      "name": "[%key:component::notify::services::notify::name%]",
       "description": "Send a mobile push notification to members of a shared Bring! list.",
       "fields": {
         "entity_id": {

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -247,9 +247,13 @@ class BringTodoListEntity(
         item_name: str | None = None,
     ) -> None:
         """Send a push notification to members of the To-Do list."""
+        if notification_type is BringNotificationType.URGENT_MESSAGE and not item_name:
+            raise HomeAssistantError(
+                "Item name is required for Breaking news notification"
+            )
         try:
-            await self.coordinator.bring.notifyAsync(
-                self.bring_list["listUuid"], notification_type, item_name or None
+            await self.coordinator.bring.notify(
+                self._list_uuid, notification_type, item_name or None
             )
         except BringRequestException as e:
             raise HomeAssistantError(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is an alternative implementation [(see previous PR)](https://github.com/home-assistant/core/pull/109222) of a notification service for the Bring integration. It is based on the newly introduced Notify entity component 

* https://github.com/home-assistant/core/pull/110950

Documentation PR may also require an update as there are some small differences:

* https://github.com/home-assistant/home-assistant.io/pull/31522

![image](https://github.com/home-assistant/core/assets/4445816/eecabe19-528c-4fa5-8bb4-636b5015abd3)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
