### PR TITLE
Unignore Ruff UP006, UP007

### DIFF
--- a/homeassistant/components/aprilaire/coordinator.py
+++ b/homeassistant/components/aprilaire/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import logging
-from typing import Any, Optional
+from typing import Any
 
 import pyaprilaire.client
 from pyaprilaire.const import MODELS, Attribute, FunctionalDomain
@@ -155,7 +155,7 @@ class AprilaireCoordinator(BaseDataUpdateCoordinatorProtocol):
 
         return self.create_device_name(self.data)
 
-    def create_device_name(self, data: Optional[dict[str, Any]]) -> str:
+    def create_device_name(self, data: dict[str, Any] | None) -> str:
         """Create the name of the thermostat."""
 
         name = data.get(Attribute.NAME) if data else None

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from contextlib import AsyncExitStack
 from datetime import timedelta
 import logging
-from typing import Optional
 
 from aiohttp import CookieJar
 from tesla_powerwall import (
@@ -244,7 +243,7 @@ async def _call_base_info(power_wall: Powerwall, host: str) -> PowerwallBaseInfo
     )
 
 
-async def get_backup_reserve_percentage(power_wall: Powerwall) -> Optional[float]:
+async def get_backup_reserve_percentage(power_wall: Powerwall) -> float | None:
     """Return the backup reserve percentage."""
     try:
         return await power_wall.get_backup_reserve_percentage()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -760,8 +760,6 @@ ignore = [
     "SIM115", # Use context handler for opening files
     "TRY003", # Avoid specifying long messages outside the exception class
     "TRY400", # Use `logging.exception` instead of `logging.error`
-    "UP006", # keep type annotation style as is
-    "UP007", # keep type annotation style as is
     # Ignored due to performance: https://github.com/charliermarsh/ruff/issues/2923
     "UP038", # Use `X | Y` in `isinstance` call instead of `(X, Y)`
     # Ignored due to incompatible with mypy: https://github.com/python/mypy/issues/15238

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Union
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from crownstone_cloud.cloud_models.spheres import Spheres
@@ -31,7 +30,7 @@ from homeassistant.data_entry_flow import FlowResultType
 
 from tests.common import MockConfigEntry
 
-MockFixture = Generator[Union[MagicMock, AsyncMock], None, None]
+MockFixture = Generator[MagicMock | AsyncMock, None, None]
 
 
 @pytest.fixture(name="crownstone_setup")

--- a/tests/components/dlna_dms/test_dms_device_source.py
+++ b/tests/components/dlna_dms/test_dms_device_source.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Final, Union
+from typing import Final
 from unittest.mock import ANY, Mock, call
 
 from async_upnp_client.exceptions import UpnpActionError, UpnpConnectionError, UpnpError
@@ -38,7 +38,7 @@ pytestmark = [
 ]
 
 
-BrowseResultList = list[Union[didl_lite.DidlObject, didl_lite.Descriptor]]
+BrowseResultList = list[didl_lite.DidlObject | didl_lite.Descriptor]
 
 
 async def async_resolve_media(

--- a/tests/components/fints/test_client.py
+++ b/tests/components/fints/test_client.py
@@ -1,7 +1,5 @@
 """Tests for the FinTS client."""
 
-from typing import Optional
-
 from fints.client import BankIdentifier, FinTSOperations
 import pytest
 
@@ -51,10 +49,10 @@ BANK_INFORMATION = {
     ],
 )
 async def test_account_type(
-    account_number: Optional[str],
-    iban: Optional[str],
+    account_number: str | None,
+    iban: str | None,
     product_name: str,
-    account_type: Optional[int],
+    account_type: int | None,
     expected_balance_result: bool,
     expected_holdings_result: bool,
 ) -> None:

--- a/tests/components/seventeentrack/conftest.py
+++ b/tests/components/seventeentrack/conftest.py
@@ -1,7 +1,6 @@
 """Configuration for 17Track tests."""
 
 from collections.abc import Generator
-from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 from py17track.package import Package
@@ -129,7 +128,7 @@ def mock_seventeentrack():
 def get_package(
     tracking_number: str = "456",
     destination_country: int = 206,
-    friendly_name: Optional[str] = "friendly name 1",
+    friendly_name: str | None = "friendly name 1",
     info_text: str = "info text 1",
     location: str = "location 1",
     timestamp: str = "2020-08-10 10:32",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This unignores the following rules:
UP006: Use PEP585 annotations (`list[]` instead of the old `typing.List[]` etc.)
UP007: Use PEP604 annotations (`X | Y` instead of `Union[X, Y]` etc.)

Because there are only so few usages of the old styles left, I think we can just unignore the rules and fix the last 8 occurrences.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
