### PR TITLE
Hold the reload lock while attempting config entry setup retry

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1775,7 +1775,7 @@ class ConfigEntries:
         call async_schedule_reload instead of this method since
         it will cancel setup retry before starting this method
         in a task which eliminates a race condition where the
-        setup retry tries can fire during the reload.
+        setup retry can fire during the reload.
 
         If an entry was not loaded, will just load.
         """

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -699,10 +699,19 @@ class ConfigEntry:
         # has started so we do not block shutdown
         if not hass.is_stopping:
             hass.async_create_task(
-                self.async_setup(hass),
+                self._async_setup_retry(hass),
                 f"config entry retry {self.domain} {self.title}",
                 eager_start=True,
             )
+
+    async def _async_setup_retry(self, hass: HomeAssistant) -> None:
+        """Retry setup.
+
+        We hold the reload lock during setup retry to ensure
+        that nothing can reload the entry while we are retrying.
+        """
+        async with self.reload_lock:
+            await self.async_setup(hass)
 
     @callback
     def async_shutdown(self) -> None:
@@ -1762,10 +1771,21 @@ class ConfigEntries:
     async def async_reload(self, entry_id: str) -> bool:
         """Reload an entry.
 
+        When reloading from an integration is is preferable to
+        call async_schedule_reload instead of this method since
+        it will cancel setup retry before starting this method
+        in a task which eliminates a race condition where the
+        setup retry tries can fire during the reload.
+
         If an entry was not loaded, will just load.
         """
         if (entry := self.async_get_entry(entry_id)) is None:
             raise UnknownEntry
+
+        # Cancel the setup retry task before waiting for the
+        # reload lock to reduce the chance of concurrent reload
+        # attempts.
+        entry.async_cancel_retry_setup()
 
         async with entry.reload_lock:
             unload_result = await self.async_unload(entry_id)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1284,6 +1284,48 @@ async def test_setup_does_not_retry_during_shutdown(hass: HomeAssistant) -> None
     assert len(mock_setup_entry.mock_calls) == 1
 
 
+async def test_reload_during_setup_retrying_waits(hass: HomeAssistant) -> None:
+    """Test reloading during setup retry waits."""
+    entry = MockConfigEntry(domain="test")
+    entry.add_to_hass(hass)
+    load_attempts = []
+
+    async def _mock_setup_entry(hass, entry):
+        """Mock setup entry."""
+        await asyncio.sleep(0)
+        load_attempts.append(entry.entry_id)
+        raise ConfigEntryNotReady
+
+    mock_integration(hass, MockModule("test", async_setup_entry=_mock_setup_entry))
+    mock_platform(hass, "test.config_flow", None)
+
+    await hass.async_create_task(
+        hass.config_entries.async_setup(entry.entry_id), eager_start=True
+    )
+    assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
+    await asyncio.sleep(0)
+
+    # Should not raise homeassistant.config_entries.OperationNotAllowed
+    await hass.config_entries.async_reload(entry.entry_id)
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
+    await asyncio.sleep(0)
+
+    # Should not raise homeassistant.config_entries.OperationNotAllowed
+    hass.config_entries.async_schedule_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert load_attempts == [
+        entry.entry_id,
+        entry.entry_id,
+        entry.entry_id,
+        entry.entry_id,
+        entry.entry_id,
+    ]
+
+
 async def test_create_entry_options(
     hass: HomeAssistant, manager: config_entries.ConfigEntries
 ) -> None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -1289,10 +1289,12 @@ async def test_reload_during_setup_retrying_waits(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(domain="test")
     entry.add_to_hass(hass)
     load_attempts = []
+    sleep_duration = 0
 
     async def _mock_setup_entry(hass, entry):
         """Mock setup entry."""
-        await asyncio.sleep(0)
+        nonlocal sleep_duration
+        await asyncio.sleep(sleep_duration)
         load_attempts.append(entry.entry_id)
         raise ConfigEntryNotReady
 
@@ -1304,6 +1306,9 @@ async def test_reload_during_setup_retrying_waits(hass: HomeAssistant) -> None:
     )
     assert entry.state is config_entries.ConfigEntryState.SETUP_RETRY
 
+    # Now make the setup take a while so that the setup retry
+    # will still be in progress when the reload request comes in
+    sleep_duration = 0.1
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
     await asyncio.sleep(0)
 


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
By holding the reload lock we avoid integreations trying to reload during setup retry which cause an OperationNotAllowed

This will fix a lot of cases of `homeassistant.config_entries.OperationNotAllowed: The config entry Mock Title (test) with entry_id 04b499c7397cba6d0632783e9937ef3c cannot be unloaded because it is not in a recoverable state (ConfigEntryState.SETUP_IN_PROGRESS)`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
