### PR TITLE
Migrate device_sun_light_trigger to use async_track_state_change_event

### DIFF
--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -1,6 +1,7 @@
 """Support to turn on lights based on the states."""
 
 from datetime import timedelta
+from functools import partial
 import logging
 
 import voluptuous as vol
@@ -27,11 +28,11 @@ from homeassistant.const import (
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import (
     async_track_point_in_utc_time,
-    async_track_state_change,
+    async_track_state_change_event,
 )
 from homeassistant.helpers.sun import get_astral_event_next, is_up
 from homeassistant.helpers.typing import ConfigType
@@ -195,8 +196,19 @@ async def activate_automation(  # noqa: C901
         schedule_light_turn_on(None)
 
     @callback
-    def check_light_on_dev_state_change(entity, old_state, new_state):
+    def check_light_on_dev_state_change(
+        from_state: str, to_state: str, event: Event[EventStateChangedData]
+    ) -> None:
         """Handle tracked device state changes."""
+        event_data = event.data
+        if (
+            (old_state := event_data["old_state"]) is None
+            or (new_state := event_data["new_state"]) is None
+            or old_state.state != from_state
+            or new_state.state != to_state
+        ):
+            return
+        entity = event_data["entity_id"]
         lights_are_on = any_light_on()
         light_needed = not (lights_are_on or is_up(hass))
 
@@ -237,12 +249,10 @@ async def activate_automation(  # noqa: C901
                     # will all the following then, break.
                     break
 
-    async_track_state_change(
+    async_track_state_change_event(
         hass,
         device_entity_ids,
-        check_light_on_dev_state_change,
-        STATE_NOT_HOME,
-        STATE_HOME,
+        partial(check_light_on_dev_state_change, STATE_NOT_HOME, STATE_HOME),
     )
 
     if disable_turn_off:
@@ -266,12 +276,10 @@ async def activate_automation(  # noqa: C901
             )
         )
 
-    async_track_state_change(
+    async_track_state_change_event(
         hass,
         device_entity_ids,
-        turn_off_lights_when_all_leave,
-        STATE_HOME,
-        STATE_NOT_HOME,
+        partial(turn_off_lights_when_all_leave, STATE_HOME, STATE_NOT_HOME),
     )
 
     return

--- a/homeassistant/components/device_sun_light_trigger/__init__.py
+++ b/homeassistant/components/device_sun_light_trigger/__init__.py
@@ -208,6 +208,7 @@ async def activate_automation(  # noqa: C901
             or new_state.state != to_state
         ):
             return
+
         entity = event_data["entity_id"]
         lights_are_on = any_light_on()
         light_needed = not (lights_are_on or is_up(hass))

--- a/tests/components/device_sun_light_trigger/test_init.py
+++ b/tests/components/device_sun_light_trigger/test_init.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -150,10 +151,22 @@ async def test_lights_turn_on_when_coming_home_after_sun_set(
         hass, device_sun_light_trigger.DOMAIN, {device_sun_light_trigger.DOMAIN: {}}
     )
 
-    hass.states.async_set(f"{DOMAIN}.device_2", STATE_HOME)
-
+    hass.states.async_set(f"{DOMAIN}.device_2", STATE_UNKNOWN)
     await hass.async_block_till_done()
+    assert all(
+        hass.states.get(ent_id).state == STATE_OFF
+        for ent_id in hass.states.async_entity_ids("light")
+    )
 
+    hass.states.async_set(f"{DOMAIN}.device_2", STATE_NOT_HOME)
+    await hass.async_block_till_done()
+    assert all(
+        hass.states.get(ent_id).state == STATE_OFF
+        for ent_id in hass.states.async_entity_ids("light")
+    )
+
+    hass.states.async_set(f"{DOMAIN}.device_2", STATE_HOME)
+    await hass.async_block_till_done()
     assert all(
         hass.states.get(ent_id).state == light.STATE_ON
         for ent_id in hass.states.async_entity_ids("light")


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`async_track_state_change` is legacy and will eventually be deprecated after all core usage is removed. There are only two places left

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
