### PR TITLE
Unignore Ruff E731

### DIFF
--- a/homeassistant/components/homekit/type_fans.py
+++ b/homeassistant/components/homekit/type_fans.py
@@ -125,11 +125,9 @@ class Fan(HomeAccessory):
                     ),
                 )
 
-                setter_callback = (
-                    lambda value, preset_mode=preset_mode: self.set_preset_mode(
-                        value, preset_mode
-                    )
-                )
+                def setter_callback(value: int, preset_mode: str = preset_mode) -> None:
+                    return self.set_preset_mode(value, preset_mode)
+
                 self.preset_mode_chars[preset_mode] = preset_serv.configure_char(
                     CHAR_ON,
                     value=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -738,7 +738,6 @@ ignore = [
     "D406", # Section name should end with a newline
     "D407", # Section name underlining
     "E501", # line too long
-    "E731", # do not assign a lambda expression, use a def
 
     "PLC1901", # {existing} can be simplified to {replacement} as an empty string is falsey; too many false positives
     "PLR0911", # Too many return statements ({returns} > {max_returns})

--- a/tests/components/screenlogic/test_init.py
+++ b/tests/components/screenlogic/test_init.py
@@ -89,9 +89,9 @@ TEST_MIGRATING_ENTITIES = [
     ),
 ]
 
-MIGRATION_CONNECT = lambda *args, **kwargs: stub_async_connect(
-    DATA_MIN_MIGRATION, *args, **kwargs
-)
+
+def _migration_connect(*args, **kwargs):
+    return stub_async_connect(DATA_MIN_MIGRATION, *args, **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -164,7 +164,7 @@ async def test_async_migrate_entries(
         ),
         patch.multiple(
             ScreenLogicGateway,
-            async_connect=MIGRATION_CONNECT,
+            async_connect=_migration_connect,
             is_connected=True,
             _async_connected_request=DEFAULT,
         ),
@@ -236,7 +236,7 @@ async def test_entity_migration_data(
         ),
         patch.multiple(
             ScreenLogicGateway,
-            async_connect=MIGRATION_CONNECT,
+            async_connect=_migration_connect,
             is_connected=True,
             _async_connected_request=DEFAULT,
         ),
@@ -257,9 +257,9 @@ async def test_platform_setup(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test setup for platforms that define expected data."""
-    stub_connect = lambda *args, **kwargs: stub_async_connect(
-        DATA_MISSING_VALUES_CHEM_CHLOR, *args, **kwargs
-    )
+
+    def stub_connect(*args, **kwargs):
+        return stub_async_connect(DATA_MISSING_VALUES_CHEM_CHLOR, *args, **kwargs)
 
     device_prefix = slugify(MOCK_ADAPTER_NAME)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This unignores the Ruff rule E731: "do not assign a `lambda` expression, use a `def`" and fixes the three violations.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
