### PR TITLE
For new installs make enphase_envoy phase entities default disabled

### DIFF
--- a/homeassistant/components/enphase_envoy/sensor.py
+++ b/homeassistant/components/enphase_envoy/sensor.py
@@ -146,6 +146,7 @@ PRODUCTION_PHASE_SENSORS = {
             sensor,
             key=f"{sensor.key}_l{phase + 1}",
             translation_key=f"{sensor.translation_key}_phase",
+            entity_registry_enabled_default=False,
             on_phase=on_phase,
             translation_placeholders={"phase_name": f"l{phase + 1}"},
         )
@@ -216,6 +217,7 @@ CONSUMPTION_PHASE_SENSORS = {
             sensor,
             key=f"{sensor.key}_l{phase + 1}",
             translation_key=f"{sensor.translation_key}_phase",
+            entity_registry_enabled_default=False,
             on_phase=on_phase,
             translation_placeholders={"phase_name": f"l{phase + 1}"},
         )

--- a/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_diagnostics.ambr
@@ -475,7 +475,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l1',
@@ -486,9 +486,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -503,17 +500,7 @@
               'unique_id': '<<envoyserial>>_production_l1',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power production l1',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l1',
-              'state': '1.234',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -527,7 +514,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l1',
@@ -538,9 +525,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -555,17 +539,7 @@
               'unique_id': '<<envoyserial>>_daily_production_l1',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production today l1',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l1',
-              'state': '1.233',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -577,7 +551,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l1',
@@ -588,9 +562,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -605,16 +576,7 @@
               'unique_id': '<<envoyserial>>_seven_days_production_l1',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production last seven days l1',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l1',
-              'state': '1.231',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -628,7 +590,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l1',
@@ -639,9 +601,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -656,17 +615,7 @@
               'unique_id': '<<envoyserial>>_lifetime_production_l1',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy production l1',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l1',
-              'state': '0.001232',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -680,7 +629,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l2',
@@ -691,9 +640,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -708,17 +654,7 @@
               'unique_id': '<<envoyserial>>_production_l2',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power production l2',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l2',
-              'state': '2.234',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -732,7 +668,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l2',
@@ -743,9 +679,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -760,17 +693,7 @@
               'unique_id': '<<envoyserial>>_daily_production_l2',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production today l2',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l2',
-              'state': '2.233',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -782,7 +705,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l2',
@@ -793,9 +716,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -810,16 +730,7 @@
               'unique_id': '<<envoyserial>>_seven_days_production_l2',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production last seven days l2',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l2',
-              'state': '2.231',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -833,7 +744,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l2',
@@ -844,9 +755,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -861,17 +769,7 @@
               'unique_id': '<<envoyserial>>_lifetime_production_l2',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy production l2',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l2',
-              'state': '0.002232',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -885,7 +783,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l3',
@@ -896,9 +794,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -913,17 +808,7 @@
               'unique_id': '<<envoyserial>>_production_l3',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power production l3',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_production_l3',
-              'state': '3.234',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -937,7 +822,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l3',
@@ -948,9 +833,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -965,17 +847,7 @@
               'unique_id': '<<envoyserial>>_daily_production_l3',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production today l3',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_today_l3',
-              'state': '3.233',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -987,7 +859,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l3',
@@ -998,9 +870,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1015,16 +884,7 @@
               'unique_id': '<<envoyserial>>_seven_days_production_l3',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy production last seven days l3',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_production_last_seven_days_l3',
-              'state': '3.231',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1038,7 +898,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l3',
@@ -1049,9 +909,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -1066,17 +923,7 @@
               'unique_id': '<<envoyserial>>_lifetime_production_l3',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy production l3',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_production_l3',
-              'state': '0.003232',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1090,7 +937,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l1',
@@ -1101,9 +948,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -1118,17 +962,7 @@
               'unique_id': '<<envoyserial>>_consumption_l1',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power consumption l1',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l1',
-              'state': '1.324',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1142,7 +976,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l1',
@@ -1153,9 +987,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1170,17 +1001,7 @@
               'unique_id': '<<envoyserial>>_daily_consumption_l1',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption today l1',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l1',
-              'state': '1.323',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1192,7 +1013,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l1',
@@ -1203,9 +1024,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1220,16 +1038,7 @@
               'unique_id': '<<envoyserial>>_seven_days_consumption_l1',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption last seven days l1',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l1',
-              'state': '1.321',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1243,7 +1052,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l1',
@@ -1254,9 +1063,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -1271,17 +1077,7 @@
               'unique_id': '<<envoyserial>>_lifetime_consumption_l1',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy consumption l1',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l1',
-              'state': '0.001322',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1295,7 +1091,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l2',
@@ -1306,9 +1102,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -1323,17 +1116,7 @@
               'unique_id': '<<envoyserial>>_consumption_l2',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power consumption l2',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l2',
-              'state': '2.324',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1347,7 +1130,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l2',
@@ -1358,9 +1141,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1375,17 +1155,7 @@
               'unique_id': '<<envoyserial>>_daily_consumption_l2',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption today l2',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l2',
-              'state': '2.323',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1397,7 +1167,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l2',
@@ -1408,9 +1178,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1425,16 +1192,7 @@
               'unique_id': '<<envoyserial>>_seven_days_consumption_l2',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption last seven days l2',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l2',
-              'state': '2.321',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1448,7 +1206,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l2',
@@ -1459,9 +1217,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -1476,17 +1231,7 @@
               'unique_id': '<<envoyserial>>_lifetime_consumption_l2',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy consumption l2',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l2',
-              'state': '0.002322',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1500,7 +1245,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l3',
@@ -1511,9 +1256,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kW',
                 }),
@@ -1528,17 +1270,7 @@
               'unique_id': '<<envoyserial>>_consumption_l3',
               'unit_of_measurement': 'kW',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'power',
-                'friendly_name': 'Envoy <<envoyserial>> Current power consumption l3',
-                'icon': 'mdi:flash',
-                'state_class': 'measurement',
-                'unit_of_measurement': 'kW',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_current_power_consumption_l3',
-              'state': '3.324',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1552,7 +1284,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l3',
@@ -1563,9 +1295,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 2,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1580,17 +1309,7 @@
               'unique_id': '<<envoyserial>>_daily_consumption_l3',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption today l3',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_today_l3',
-              'state': '3.323',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1602,7 +1321,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l3',
@@ -1613,9 +1332,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 1,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'kWh',
                 }),
@@ -1630,16 +1346,7 @@
               'unique_id': '<<envoyserial>>_seven_days_consumption_l3',
               'unit_of_measurement': 'kWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Energy consumption last seven days l3',
-                'icon': 'mdi:flash',
-                'unit_of_measurement': 'kWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_energy_consumption_last_seven_days_l3',
-              'state': '3.321',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({
@@ -1653,7 +1360,7 @@
               }),
               'config_entry_id': '45a36e55aaddb2007c5f6602e0c38e72',
               'device_class': None,
-              'disabled_by': None,
+              'disabled_by': 'integration',
               'domain': 'sensor',
               'entity_category': None,
               'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l3',
@@ -1664,9 +1371,6 @@
               ]),
               'name': None,
               'options': dict({
-                'sensor': dict({
-                  'suggested_display_precision': 3,
-                }),
                 'sensor.private': dict({
                   'suggested_unit_of_measurement': 'MWh',
                 }),
@@ -1681,17 +1385,7 @@
               'unique_id': '<<envoyserial>>_lifetime_consumption_l3',
               'unit_of_measurement': 'MWh',
             }),
-            'state': dict({
-              'attributes': dict({
-                'device_class': 'energy',
-                'friendly_name': 'Envoy <<envoyserial>> Lifetime energy consumption l3',
-                'icon': 'mdi:flash',
-                'state_class': 'total_increasing',
-                'unit_of_measurement': 'MWh',
-              }),
-              'entity_id': 'sensor.envoy_<<envoyserial>>_lifetime_energy_consumption_l3',
-              'state': '0.003322',
-            }),
+            'state': None,
           }),
           dict({
             'entity': dict({

--- a/tests/components/enphase_envoy/snapshots/test_sensor.ambr
+++ b/tests/components/enphase_envoy/snapshots/test_sensor.ambr
@@ -319,7 +319,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_production_l1',
@@ -331,9 +331,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -358,7 +355,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_today_l1',
@@ -370,9 +367,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -395,7 +389,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l1',
@@ -407,9 +401,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -434,7 +425,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l1',
@@ -446,9 +437,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -473,7 +461,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_production_l2',
@@ -485,9 +473,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -512,7 +497,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_today_l2',
@@ -524,9 +509,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -549,7 +531,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l2',
@@ -561,9 +543,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -588,7 +567,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l2',
@@ -600,9 +579,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -627,7 +603,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_production_l3',
@@ -639,9 +615,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -666,7 +639,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_today_l3',
@@ -678,9 +651,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -703,7 +673,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l3',
@@ -715,9 +685,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -742,7 +709,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l3',
@@ -754,9 +721,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -781,7 +745,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_consumption_l1',
@@ -793,9 +757,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -820,7 +781,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_today_l1',
@@ -832,9 +793,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -857,7 +815,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l1',
@@ -869,9 +827,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -896,7 +851,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l1',
@@ -908,9 +863,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -935,7 +887,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_consumption_l2',
@@ -947,9 +899,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -974,7 +923,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_today_l2',
@@ -986,9 +935,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -1011,7 +957,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l2',
@@ -1023,9 +969,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -1050,7 +993,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l2',
@@ -1062,9 +1005,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -1089,7 +1029,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_current_power_consumption_l3',
@@ -1101,9 +1041,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
         }),
@@ -1128,7 +1065,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_today_l3',
@@ -1140,9 +1077,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 2,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -1165,7 +1099,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l3',
@@ -1177,9 +1111,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 1,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
         }),
@@ -1204,7 +1135,7 @@
       'config_entry_id': <ANY>,
       'device_class': None,
       'device_id': <ANY>,
-      'disabled_by': None,
+      'disabled_by': <RegistryEntryDisabler.INTEGRATION: 'integration'>,
       'domain': 'sensor',
       'entity_category': None,
       'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l3',
@@ -1216,9 +1147,6 @@
       }),
       'name': None,
       'options': dict({
-        'sensor': dict({
-          'suggested_display_precision': 3,
-        }),
         'sensor.private': dict({
           'suggested_unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
         }),
@@ -3487,55 +3415,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_consumption_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power consumption l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_consumption_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.324',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_consumption_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power consumption l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_consumption_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.324',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_consumption_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power consumption l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_consumption_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.324',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_production-state]
   StateSnapshot({
@@ -3555,55 +3441,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_production_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power production l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_production_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.234',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_production_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power production l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_production_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.234',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_current_power_production_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'power',
-      'friendly_name': 'Envoy 1234 Current power production l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-      'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_current_power_production_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.234',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_last_seven_days-state]
   StateSnapshot({
@@ -3622,52 +3466,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_last_seven_days_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption last seven days l1',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.321',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_last_seven_days_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption last seven days l2',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.321',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_last_seven_days_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption last seven days l3',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_last_seven_days_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.321',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_today-state]
   StateSnapshot({
@@ -3687,55 +3492,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_today_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption today l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_today_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.323',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_today_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption today l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_today_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.323',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_consumption_today_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy consumption today l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_consumption_today_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.323',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_last_seven_days-state]
   StateSnapshot({
@@ -3754,52 +3517,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_last_seven_days_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production last seven days l1',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.231',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_last_seven_days_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production last seven days l2',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.231',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_last_seven_days_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production last seven days l3',
-      'icon': 'mdi:flash',
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_last_seven_days_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.231',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_today-state]
   StateSnapshot({
@@ -3819,55 +3543,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_today_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production today l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_today_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '1.233',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_today_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production today l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_today_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2.233',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_energy_production_today_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Energy production today l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_energy_production_today_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '3.233',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_frequency_net_consumption_ct-state]
   None
@@ -3951,55 +3633,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_consumption_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy consumption l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.001322',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_consumption_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy consumption l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.002322',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_consumption_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy consumption l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_consumption_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.003322',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_production-state]
   StateSnapshot({
@@ -4019,55 +3659,13 @@
   })
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_production_l1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy production l1',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.001232',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_production_l2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy production l2',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.002232',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_energy_production_l3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Envoy 1234 Lifetime energy production l3',
-      'icon': 'mdi:flash',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      'unit_of_measurement': <UnitOfEnergy.MEGA_WATT_HOUR: 'MWh'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.envoy_1234_lifetime_energy_production_l3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.003232',
-  })
+  None
 # ---
 # name: test_sensor[sensor.envoy_1234_lifetime_net_energy_consumption-state]
   StateSnapshot({


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently, the enphase_envoy integration adds phase entities for production and consumption when detecting a multi-phase setup. A future dependency update for pyenphase will fix an issue with phase data reporting for newer envoy firmware. As a result all existing implementations with firmware >= Envoy 7.6.x may suddenly get these currently missing phase entities added to the HA configuration. This is an unexpected, uncontrolled and maybe undesired impact on history and state logging.

This PR will set all phase sensor entities to `entity_registry_enabled_default=False` to prevent this from happening. Users then may choose to enable these or not. The change has no impact on existing implementations with detected phase entities, as these are already enabled and remain so. For existing implementations without the `currently missing` phase entities, the newly discovered phase entities will be available in disabled mode. For all new implementations all phases entities will be available in disabled mode. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/114862
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
