### PR TITLE
Keep track of top level components

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2742,7 +2742,7 @@ class Config:
         # and should not be modified directly
         self.top_level_components: set[str] = set()
 
-        # List of loaded components
+        # Set of loaded components
         self.components: _ComponentSet = _ComponentSet(self.top_level_components)
 
         # API (HTTP) server configuration

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2697,6 +2697,7 @@ class _ComponentSet(set[str]):
         """Remove a component from the store."""
         if "." in component:
             raise ValueError("_ComponentSet does not support removing sub-components")
+        self._top_level_components.remove(component)
         return super().remove(component)
 
     def discard(self, component: str) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2737,7 +2737,7 @@ class Config:
         # List of packages to skip when installing requirements on startup
         self.skip_pip_packages: list[str] = []
 
-        # List of loaded top level components
+        # Set of loaded top level components
         # This set is updated by _ComponentSet
         # and should not be modified directly
         self.top_level_components: set[str] = set()

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2670,6 +2670,40 @@ class ServiceRegistry:
         return await self._hass.async_add_executor_job(target, service_call)
 
 
+class _ComponentSet(set[str]):
+    """Set of loaded components.
+
+    This set contains both top level components and platforms.
+
+    Examples:
+    `light`, `switch`, `hue`, `mjpeg.camera`, `universal.media_player`,
+    `homeassistant.scene`
+
+    The top level components set only contains the top level components.
+
+    """
+
+    def __init__(self, top_level_components: set[str]) -> None:
+        """Initialize the component set."""
+        self._top_level_components = top_level_components
+
+    def add(self, component: str) -> None:
+        """Add a component to the store."""
+        if "." not in component:
+            self._top_level_components.add(component)
+        return super().add(component)
+
+    def remove(self, component: str) -> None:
+        """Remove a component from the store."""
+        if "." in component:
+            raise ValueError("_ComponentSet does not support removing sub-components")
+        return super().remove(component)
+
+    def discard(self, component: str) -> None:
+        """Remove a component from the store."""
+        raise NotImplementedError("_ComponentSet does not support discard, use remove")
+
+
 class Config:
     """Configuration settings for Home Assistant."""
 
@@ -2702,8 +2736,13 @@ class Config:
         # List of packages to skip when installing requirements on startup
         self.skip_pip_packages: list[str] = []
 
+        # List of loaded top level components
+        # This set is updated by _ComponentSet
+        # and should not be modified directly
+        self.top_level_components: set[str] = set()
+
         # List of loaded components
-        self.components: set[str] = set()
+        self.components: _ComponentSet = _ComponentSet(self.top_level_components)
 
         # API (HTTP) server configuration
         self.api: ApiConfig | None = None

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -26,11 +26,9 @@ def _component_icons_path(component: str, integration: Integration) -> str | Non
     Ex: components/hue/icons.json
     If component is just a single file, will return None.
     """
-    domain = component.rpartition(".")[-1]
-
     # If it's a component that is just one file, we don't support icons
     # Example custom_components/my_component.py
-    if integration.file_path.name != domain:
+    if integration.file_path.name != component:
         return None
 
     return str(integration.file_path / "icons.json")
@@ -54,12 +52,11 @@ async def _async_get_component_icons(
 
     # Determine files to load
     files_to_load = {}
-    for loaded in components:
-        domain = loaded.rpartition(".")[-1]
-        if (path := _component_icons_path(loaded, integrations[domain])) is None:
-            icons[loaded] = {}
+    for comp in components:
+        if (path := _component_icons_path(comp, integrations[comp])) is None:
+            icons[comp] = {}
         else:
-            files_to_load[loaded] = path
+            files_to_load[comp] = path
 
     # Load files
     if files_to_load and (
@@ -108,8 +105,7 @@ class _IconsCache:
         _LOGGER.debug("Cache miss for: %s", components)
 
         integrations: dict[str, Integration] = {}
-        domains = {loaded.rpartition(".")[-1] for loaded in components}
-        ints_or_excs = await async_get_integrations(self._hass, domains)
+        ints_or_excs = await async_get_integrations(self._hass, components)
         for domain, int_or_exc in ints_or_excs.items():
             if isinstance(int_or_exc, Exception):
                 raise int_or_exc

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-def _component_icons_path(component: str, integration: Integration) -> pathlib.Path:
+def _component_icons_path(integration: Integration) -> pathlib.Path:
     """Return the icons json file location for a component.
 
     Ex: components/hue/icons.json
@@ -50,7 +50,7 @@ async def _async_get_component_icons(
 
     # Determine files to load
     files_to_load = {
-        comp: _component_icons_path(comp, integrations[comp]) for comp in components
+        comp: _component_icons_path(integrations[comp]) for comp in components
     }
 
     # Load files
@@ -118,11 +118,9 @@ class _IconsCache:
         icons: dict[str, dict[str, Any]],
     ) -> None:
         """Extract resources into the cache."""
-        categories: set[str] = set()
-
-        for resource in icons.values():
-            categories.update(resource)
-
+        categories = {
+            category for component in icons.values() for category in component
+        }
         for category in categories:
             self._cache.setdefault(category, {}).update(
                 build_resources(icons, components, category)

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -151,9 +151,7 @@ async def async_get_icons(
     if integrations:
         components = set(integrations)
     else:
-        components = {
-            component for component in hass.config.components if "." not in component
-        }
+        components = hass.config.top_level_components
 
     if ICON_CACHE in hass.data:
         cache: _IconsCache = hass.data[ICON_CACHE]

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -25,7 +25,6 @@ def _component_icons_path(integration: Integration) -> pathlib.Path:
     """Return the icons json file location for a component.
 
     Ex: components/hue/icons.json
-    If component is just a single file, will return None.
     """
     return integration.file_path / "icons.json"
 
@@ -54,10 +53,10 @@ async def _async_get_component_icons(
     }
 
     # Load files
-    if files_to_load and (
-        load_icons_job := hass.async_add_executor_job(_load_icons_files, files_to_load)
-    ):
-        icons |= await load_icons_job
+    if files_to_load:
+        icons.update(
+            await hass.async_add_executor_job(_load_icons_files, files_to_load)
+        )
 
     return icons
 

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -174,7 +174,7 @@ async def async_process_integration_platforms(
         integration_platforms = hass.data[DATA_INTEGRATION_PLATFORMS]
 
     async_register_preload_platform(hass, platform_name)
-    top_level_components = {comp for comp in hass.config.components if "." not in comp}
+    top_level_components = hass.config.top_level_components
     process_job = HassJob(
         catch_log_exception(
             process_platform,

--- a/homeassistant/helpers/integration_platform.py
+++ b/homeassistant/helpers/integration_platform.py
@@ -174,7 +174,7 @@ async def async_process_integration_platforms(
         integration_platforms = hass.data[DATA_INTEGRATION_PLATFORMS]
 
     async_register_preload_platform(hass, platform_name)
-    top_level_components = hass.config.top_level_components
+    top_level_components = hass.config.top_level_components.copy()
     process_job = HassJob(
         catch_log_exception(
             process_platform,

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -345,7 +345,7 @@ async def async_get_translations(
     elif integrations is not None:
         components = set(integrations)
     else:
-        components = {comp for comp in hass.config.components if "." not in comp}
+        components = hass.config.top_level_components
 
     return await _async_get_translations_cache(hass).async_fetch(
         language, category, components
@@ -364,11 +364,7 @@ def async_get_cached_translations(
     If integration is specified, return translations for it.
     Otherwise, default to all loaded integrations.
     """
-    if integration is not None:
-        components = {integration}
-    else:
-        components = {comp for comp in hass.config.components if "." not in comp}
-
+    components = {integration} if integration else hass.config.top_level_components
     return _async_get_translations_cache(hass).get_cached(
         language, category, components
     )

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -212,8 +212,7 @@ class _TranslationCache:
         languages = [LOCALE_EN] if language == LOCALE_EN else [LOCALE_EN, language]
 
         integrations: dict[str, Integration] = {}
-        domains = {loaded.partition(".")[0] for loaded in components}
-        ints_or_excs = await async_get_integrations(self.hass, domains)
+        ints_or_excs = await async_get_integrations(self.hass, components)
         for domain, int_or_exc in ints_or_excs.items():
             if isinstance(int_or_exc, Exception):
                 _LOGGER.warning(

--- a/tests/helpers/test_icon.py
+++ b/tests/helpers/test_icon.py
@@ -106,8 +106,8 @@ async def test_get_icons(hass: HomeAssistant) -> None:
     # Ensure icons file for platform isn't loaded, as that isn't supported
     icons = await icon.async_get_icons(hass, "entity")
     assert icons == {}
-    icons = await icon.async_get_icons(hass, "entity", ["test.switch"])
-    assert icons == {}
+    with pytest.raises(ValueError, match="test.switch"):
+        await icon.async_get_icons(hass, "entity", ["test.switch"])
 
     # Load up an custom integration
     hass.config.components.add("test_package")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3411,3 +3411,20 @@ async def test_async_listen_with_run_immediately_deprecated(
         f"Detected code that calls `{method}` with run_immediately, which is "
         "deprecated and will be removed in Home Assistant 2025.5."
     ) in caplog.text
+
+
+async def test_top_level_components(hass: HomeAssistant) -> None:
+    """Test top level components."""
+    hass.config.components.add("homeassistant")
+    assert hass.config.components == {"homeassistant"}
+    assert hass.config.top_level_components == {"homeassistant"}
+    hass.config.components.add("homeassistant.scene")
+    assert hass.config.components == {"homeassistant", "homeassistant.scene"}
+    assert hass.config.top_level_components == {"homeassistant"}
+    hass.config.components.remove("homeassistant")
+    assert hass.config.components == {"homeassistant.scene"}
+    assert hass.config.top_level_components == set()
+    with pytest.raises(ValueError):
+        hass.config.components.remove("homeassistant.scene")
+    with pytest.raises(NotImplementedError):
+        hass.config.components.discard("homeassistant")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3414,7 +3414,7 @@ async def test_async_listen_with_run_immediately_deprecated(
 
 
 async def test_top_level_components(hass: HomeAssistant) -> None:
-    """Test top level components."""
+    """Test top level components are updated when components change."""
     hass.config.components.add("homeassistant")
     assert hass.config.components == {"homeassistant"}
     assert hass.config.top_level_components == {"homeassistant"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently we have to do a set comp for icons, translations, and integration platforms every time to split the top level components from the platforms in `hass.config.components`. Keep track of the top level components in a separate set `hass.config.top_level_components` so we avoid having to do the setcomp every time. This allows us to remove a lot of code in the translations and icon helpers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
