### PR TITLE
Only calculate the tplink emeter values once per update cycle

### DIFF
--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfPower,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import legacy_device_id
@@ -171,8 +171,17 @@ class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
             else:
                 assert description.device_class
                 self._attr_translation_key = f"{description.device_class.value}_child"
+        self._async_update_attrs()
 
-    @property
-    def native_value(self) -> float | None:
-        """Return the sensors state."""
-        return async_emeter_from_device(self.device, self.entity_description)
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_native_value = async_emeter_from_device(
+            self.device, self.entity_description
+        )
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The sensor platform has to read the native_value multiple times during the state write cycle which means the integration calculated the value multiple times. Switch to using `_attr_native_value` to ensure the calculations in the library are only done once per state write. While the multiple calls are usually not a problem for most integrations, `tplink` does an expensive calculation in the library each time.

To demonstrate this issue,
+        _LOGGER.warning("Fetch name value for %s", self.entity_id)
was added to `def native_value`:
```
2024-04-14 06:58:52.506 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_current_consumption
2024-04-14 06:58:52.506 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_total_consumption
2024-04-14 06:58:52.507 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_today_s_consumption
2024-04-14 06:58:52.507 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_voltage
2024-04-14 06:58:52.508 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_current
2024-04-14 06:58:52.509 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_current_consumption
2024-04-14 06:58:52.510 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_total_consumption
2024-04-14 06:58:52.510 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_today_s_consumption
2024-04-14 06:58:52.510 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_voltage
2024-04-14 06:58:52.510 WARNING (MainThread) [homeassistant.components.tplink.sensor] Fetch name value for sensor.kasa_smart_plug_542b_0_kasa_smart_plug_542b_0_current
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
