### PR TITLE
Move Alexa entity id generation into abstract config class

### DIFF
--- a/homeassistant/components/alexa/config.py
+++ b/homeassistant/components/alexa/config.py
@@ -13,6 +13,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.storage import Store
 
 from .const import DOMAIN
+from .entities import TRANSLATION_TABLE
 from .state_report import async_enable_proactive_mode
 
 STORE_AUTHORIZED = "authorized"
@@ -100,6 +101,10 @@ class AbstractConfig(ABC):
     def should_expose(self, entity_id: str) -> bool:
         """If an entity should be exposed."""
         return False
+
+    def generate_alexa_id(self, entity_id: str) -> str:
+        """Return the alexa ID for an entity ID."""
+        return entity_id.replace(".", "#").translate(TRANSLATION_TABLE)
 
     @callback
     def async_invalidate_access_token(self) -> None:

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -259,11 +259,6 @@ class DisplayCategory:
     WEARABLE = "WEARABLE"
 
 
-def generate_alexa_id(entity_id: str) -> str:
-    """Return the alexa ID for an entity ID."""
-    return entity_id.replace(".", "#").translate(TRANSLATION_TABLE)
-
-
 class AlexaEntity:
     """An adaptation of an entity, expressed in Alexa's terms.
 
@@ -298,7 +293,7 @@ class AlexaEntity:
 
     def alexa_id(self) -> str:
         """Return the Alexa API entity id."""
-        return generate_alexa_id(self.entity.entity_id)
+        return self.config.generate_alexa_id(self.entity.entity_id)
 
     def display_categories(self) -> list[str] | None:
         """Return a list of display categories."""

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -41,7 +41,7 @@ from .const import (
     Cause,
 )
 from .diagnostics import async_redact_auth_data
-from .entities import ENTITY_ADAPTERS, AlexaEntity, generate_alexa_id
+from .entities import ENTITY_ADAPTERS, AlexaEntity
 from .errors import AlexaInvalidEndpointError, NoTokenAvailable, RequireRelink
 
 if TYPE_CHECKING:
@@ -492,7 +492,7 @@ async def async_send_delete_message(
         if domain not in ENTITY_ADAPTERS:
             continue
 
-        endpoints.append({"endpointId": generate_alexa_id(entity_id)})
+        endpoints.append({"endpointId": config.generate_alexa_id(entity_id)})
 
     payload: dict[str, Any] = {
         "endpoints": endpoints,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes it possible to change the ID schema in implementations.

I am currently working on an Alexa integration using the Alexa Voice Service (AVS) SDK which makes exposing Home Assistant to the internet and running a skill on AWS Lambda obsolete. Instead Home Assistant will directly connect to AVS servers and provide a backchannel for connected Smart Home endpoints. I already have a fully functioning prototype running locally, but need this change in core as a basis for the new integration based upon the `AbstractConfig` class.

Detail background for this change: AVS needs connected Smart Home endpoints (e.g. Home Assistant Devices/Entities) to follow a specific ID schema, like this: `{client-id}::{product-id}::{device-serial-number}-{entity-id}`.

This doesn't break existing behavior, code or integrations. It just makes it possible to overwrite this function. Therefore, I am looking forward to get this merged, thank you!

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] **Preparation for** New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
