### PR TITLE
Add device info to to-do entities in Bring integration

### DIFF
--- a/homeassistant/components/bring/config_flow.py
+++ b/homeassistant/components/bring/config_flow.py
@@ -53,8 +53,7 @@ class BringConfigFlow(ConfigFlow, domain=DOMAIN):
             bring = Bring(session, user_input[CONF_EMAIL], user_input[CONF_PASSWORD])
 
             try:
-                await bring.login()
-                await bring.load_lists()
+                resp = await bring.login()
             except BringRequestException:
                 errors["base"] = "cannot_connect"
             except BringAuthException:
@@ -65,9 +64,8 @@ class BringConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 await self.async_set_unique_id(bring.uuid)
                 self._abort_if_unique_id_configured()
-                return self.async_create_entry(
-                    title=user_input[CONF_EMAIL], data=user_input
-                )
+                title = resp["name"] if resp["name"] != "" else user_input[CONF_EMAIL]
+                return self.async_create_entry(title=title, data=user_input)
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors

--- a/homeassistant/components/bring/const.py
+++ b/homeassistant/components/bring/const.py
@@ -9,3 +9,7 @@ ATTR_ITEM_NAME: Final = "item"
 ATTR_NOTIFICATION_TYPE: Final = "message"
 
 SERVICE_PUSH_NOTIFICATION = "send_message"
+
+MANUFACTURER: Final = "Bring! Labs AG"
+SERVICE_NAME: Final = "Bring!"
+SERVICE_URL: Final = "https://web.getbring.com/"

--- a/homeassistant/components/bring/todo.py
+++ b/homeassistant/components/bring/todo.py
@@ -20,6 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.config_validation import make_entity_service_schema
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -27,7 +28,10 @@ from .const import (
     ATTR_ITEM_NAME,
     ATTR_NOTIFICATION_TYPE,
     DOMAIN,
+    MANUFACTURER,
+    SERVICE_NAME,
     SERVICE_PUSH_NOTIFICATION,
+    SERVICE_URL,
 )
 from .coordinator import BringData, BringDataUpdateCoordinator
 
@@ -95,6 +99,14 @@ class BringTodoListEntity(
         self._list_uuid = bring_list["listUuid"]
         self._attr_name = bring_list["name"]
         self._attr_unique_id = f"{unique_id}_{self._list_uuid}"
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            manufacturer=MANUFACTURER,
+            model=SERVICE_NAME,
+            name=SERVICE_NAME,
+            configuration_url=SERVICE_URL,
+            identifiers={(DOMAIN, unique_id)},
+        )
 
     @property
     def todo_items(self) -> list[TodoItem]:

--- a/tests/components/bring/conftest.py
+++ b/tests/components/bring/conftest.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
+from bring_api.types import BringAuthResponse
 import pytest
 
 from homeassistant.components.bring import DOMAIN
@@ -40,7 +41,18 @@ def mock_bring_client() -> Generator[AsyncMock, None, None]:
     ):
         client = mock_client.return_value
         client.uuid = UUID
-        client.login.return_value = True
+        client.login.return_value = BringAuthResponse(
+            uuid=UUID,
+            publicUuid=UUID,
+            email=EMAIL,
+            name="",
+            photoPath="",
+            bringListUUID=UUID,
+            access_token="",
+            refresh_token="",
+            token_type="",
+            expires_in=20,
+        )
         client.load_lists.return_value = {"lists": []}
         yield client
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `DeviceInfo` to entities. Entities will then be shown grouped under a service entry and some additional info about the manufacturer. 
As `name` is set in the device info this will change the behaviour for creation of new entities, `bring_` will be prepended to the list names. 

Additionally a small cosmetic change, when the config entry is created the name from the bring profile is used as title, only if it is empty, it falls back to the email. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
