### PR TITLE
Skip processing websocket_api schema if it has no arguments

### DIFF
--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -221,7 +221,12 @@ class ActiveConnection:
         handler, schema = handler_schema
 
         try:
-            handler(self.hass, self, msg if schema is False else schema(msg))
+            if schema is False:
+                if len(msg) > 2:
+                    raise vol.Invalid("Message has unexpected keys")
+                handler(self.hass, self, msg)
+            else:
+                handler(self.hass, self, schema(msg))
         except Exception as err:  # pylint: disable=broad-except
             self.async_handle_exception(msg, err)
 

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Hashable
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from aiohttp import web
 import voluptuous as vol
@@ -65,9 +65,9 @@ class ActiveConnection:
         self.last_id = 0
         self.can_coalesce = False
         self.supported_features: dict[str, float] = {}
-        self.handlers: dict[str, tuple[MessageHandler, vol.Schema]] = self.hass.data[
-            const.DOMAIN
-        ]
+        self.handlers: dict[str, tuple[MessageHandler, vol.Schema | Literal[False]]] = (
+            self.hass.data[const.DOMAIN]
+        )
         self.binary_handlers: list[BinaryHandler | None] = []
         current_connection.set(self)
 
@@ -185,6 +185,7 @@ class ActiveConnection:
             or (
                 not (cur_id := msg.get("id"))
                 or type(cur_id) is not int  # noqa: E721
+                or cur_id < 0
                 or not (type_ := msg.get("type"))
                 or type(type_) is not str  # noqa: E721
             )
@@ -220,7 +221,7 @@ class ActiveConnection:
         handler, schema = handler_schema
 
         try:
-            handler(self.hass, self, schema(msg))
+            handler(self.hass, self, msg if schema is False else schema(msg))
         except Exception as err:  # pylint: disable=broad-except
             self.async_handle_exception(msg, err)
 

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -221,12 +221,7 @@ class ActiveConnection:
         handler, schema = handler_schema
 
         try:
-            if schema is False:
-                if len(msg) > 2:
-                    raise vol.Invalid("Message has unexpected keys")
-                handler(self.hass, self, msg)
-            else:
-                handler(self.hass, self, schema(msg))
+            handler(self.hass, self, msg if schema is False else schema(msg))
         except Exception as err:  # pylint: disable=broad-except
             self.async_handle_exception(msg, err)
 

--- a/homeassistant/components/websocket_api/connection.py
+++ b/homeassistant/components/websocket_api/connection.py
@@ -223,7 +223,7 @@ class ActiveConnection:
         try:
             if schema is False:
                 if len(msg) > 2:
-                    raise vol.Invalid("Message has unexpected keys")
+                    raise vol.Invalid("extra keys not allowed")
                 handler(self.hass, self, msg)
             else:
                 handler(self.hass, self, schema(msg))

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -135,7 +135,7 @@ async def test_async_response_request_context(
     assert not msg["success"]
     assert msg["error"]["code"] == "invalid_format"
     assert msg["error"]["message"] == (
-        "Message has unexpected keys. "
+        "extra keys not allowed. "
         "Got {'id': 10, 'type': 'test-get-request', 'not_valid': 'dog'}"
     )
 

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -122,6 +122,23 @@ async def test_async_response_request_context(
     assert msg["error"]["code"] == "invalid_format"
     assert msg["error"]["message"] == "Message incorrectly formatted."
 
+    await websocket_client.send_json(
+        {
+            "id": 10,
+            "type": "test-get-request",
+            "not_valid": "dog",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 10
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_format"
+    assert msg["error"]["message"] == (
+        "Message has unexpected keys. "
+        "Got {'id': 10, 'type': 'test-get-request', 'not_valid': 'dog'}"
+    )
+
 
 async def test_supervisor_only(hass: HomeAssistant, websocket_client) -> None:
     """Test that only the Supervisor can make requests."""

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -130,12 +130,14 @@ async def test_async_response_request_context(
         }
     )
 
-    # Extra keys in message are allowed and ignored
-    # to match the default of ALLOW_EXTRA
     msg = await websocket_client.receive_json()
     assert msg["id"] == 10
-    assert msg["success"]
-    assert msg["result"] == "/api/websocket"
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_format"
+    assert msg["error"]["message"] == (
+        "Message has unexpected keys. "
+        "Got {'id': 10, 'type': 'test-get-request', 'not_valid': 'dog'}"
+    )
 
 
 async def test_supervisor_only(hass: HomeAssistant, websocket_client) -> None:

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -130,14 +130,12 @@ async def test_async_response_request_context(
         }
     )
 
+    # Extra keys in message are allowed and ignored
+    # to match the default of ALLOW_EXTRA
     msg = await websocket_client.receive_json()
     assert msg["id"] == 10
-    assert not msg["success"]
-    assert msg["error"]["code"] == "invalid_format"
-    assert msg["error"]["message"] == (
-        "Message has unexpected keys. "
-        "Got {'id': 10, 'type': 'test-get-request', 'not_valid': 'dog'}"
-    )
+    assert msg["success"]
+    assert msg["result"] == "/api/websocket"
 
 
 async def test_supervisor_only(hass: HomeAssistant, websocket_client) -> None:

--- a/tests/components/websocket_api/test_decorators.py
+++ b/tests/components/websocket_api/test_decorators.py
@@ -1,5 +1,7 @@
 """Test decorators."""
 
+import voluptuous as vol
+
 from homeassistant.components import http, websocket_api
 from homeassistant.core import HomeAssistant
 
@@ -31,9 +33,16 @@ async def test_async_response_request_context(
     def get_request(hass, connection, msg):
         handle_request(http.current_request.get(), connection, msg)
 
+    @websocket_api.websocket_command(
+        {"type": "test-get-request-with-arg", vol.Required("arg"): str}
+    )
+    def get_with_arg_request(hass, connection, msg):
+        handle_request(http.current_request.get(), connection, msg)
+
     websocket_api.async_register_command(hass, executor_get_request)
     websocket_api.async_register_command(hass, async_get_request)
     websocket_api.async_register_command(hass, get_request)
+    websocket_api.async_register_command(hass, get_with_arg_request)
 
     await websocket_client.send_json(
         {
@@ -70,6 +79,48 @@ async def test_async_response_request_context(
     assert msg["id"] == 7
     assert not msg["success"]
     assert msg["error"]["code"] == "not_found"
+
+    await websocket_client.send_json(
+        {
+            "id": 8,
+            "type": "test-get-request-with-arg",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 8
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_format"
+    assert (
+        msg["error"]["message"] == "required key not provided @ data['arg']. Got None"
+    )
+
+    await websocket_client.send_json(
+        {
+            "id": 9,
+            "type": "test-get-request-with-arg",
+            "arg": "dog",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 9
+    assert msg["success"]
+    assert msg["result"] == "/api/websocket"
+
+    await websocket_client.send_json(
+        {
+            "id": -1,
+            "type": "test-get-request-with-arg",
+            "arg": "dog",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == -1
+    assert not msg["success"]
+    assert msg["error"]["code"] == "invalid_format"
+    assert msg["error"]["message"] == "Message incorrectly formatted."
 
 
 async def test_supervisor_only(hass: HomeAssistant, websocket_client) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
~40% of the websocket commands on first connection have no arguments and only pass `type`. 

We can skip processing the schema for these cases as processing the schema represents ~18% of the run time of some
of many of the simple requests as `async_handle` already validates `type` and `id`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
