### PR TITLE
Add dataclass to store AdGuard data

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
@@ -24,7 +26,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_FORCE,
-    DATA_ADGUARD_CLIENT,
     DOMAIN,
     SERVICE_ADD_URL,
     SERVICE_DISABLE_URL,
@@ -44,6 +45,14 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
 
 
+@dataclass
+class AdGuardData:
+    """Adguard data type."""
+
+    client: AdGuardHome
+    version: str | None = None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up AdGuard Home from a config entry."""
     session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
@@ -57,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session=session,
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {DATA_ADGUARD_CLIENT: adguard}
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = AdGuardData(adguard)
 
     try:
         await adguard.version()

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -50,7 +50,7 @@ class AdGuardData:
     """Adguard data type."""
 
     client: AdGuardHome
-    version: str | None = None
+    version: str
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -66,12 +66,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session=session,
     )
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = AdGuardData(adguard)
-
     try:
-        await adguard.version()
+        version = await adguard.version()
     except AdGuardHomeConnectionError as exception:
         raise ConfigEntryNotReady from exception
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = AdGuardData(adguard, version)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/adguard/const.py
+++ b/homeassistant/components/adguard/const.py
@@ -6,9 +6,6 @@ DOMAIN = "adguard"
 
 LOGGER = logging.getLogger(__package__)
 
-DATA_ADGUARD_CLIENT = "adguard_client"
-DATA_ADGUARD_VERSION = "adguard_version"
-
 CONF_FORCE = "force"
 
 SERVICE_ADD_URL = "add_url"

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from adguardhome import AdGuardHome, AdGuardHomeError
+from adguardhome import AdGuardHomeError
 
 from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
-from .const import DATA_ADGUARD_VERSION, DOMAIN, LOGGER
+from . import AdGuardData
+from .const import DOMAIN, LOGGER
 
 
 class AdGuardHomeEntity(Entity):
@@ -19,12 +20,13 @@ class AdGuardHomeEntity(Entity):
 
     def __init__(
         self,
-        adguard: AdGuardHome,
+        data: AdGuardData,
         entry: ConfigEntry,
     ) -> None:
         """Initialize the AdGuard Home entity."""
         self._entry = entry
-        self.adguard = adguard
+        self.data = data
+        self.adguard = data.client
 
     async def async_update(self) -> None:
         """Update AdGuard Home entity."""
@@ -68,8 +70,6 @@ class AdGuardHomeEntity(Entity):
             },
             manufacturer="AdGuard Team",
             name="AdGuard Home",
-            sw_version=self.hass.data[DOMAIN][self._entry.entry_id].get(
-                DATA_ADGUARD_VERSION
-            ),
+            sw_version=self.data.version,
             configuration_url=config_url,
         )

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -16,7 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN
+from . import AdGuardData
+from .const import DOMAIN
 from .entity import AdGuardHomeEntity
 
 SCAN_INTERVAL = timedelta(seconds=300)
@@ -89,17 +90,17 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home sensor based on a config entry."""
-    adguard = hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_CLIENT]
+    data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
 
     try:
-        version = await adguard.version()
+        version = await data.client.version()
     except AdGuardHomeConnectionError as exception:
         raise PlatformNotReady from exception
 
-    hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_VERSION] = version
+    data.version = version
 
     async_add_entities(
-        [AdGuardHomeSensor(adguard, entry, description) for description in SENSORS],
+        [AdGuardHomeSensor(data, entry, description) for description in SENSORS],
         True,
     )
 
@@ -111,18 +112,18 @@ class AdGuardHomeSensor(AdGuardHomeEntity, SensorEntity):
 
     def __init__(
         self,
-        adguard: AdGuardHome,
+        data: AdGuardData,
         entry: ConfigEntry,
         description: AdGuardHomeEntityDescription,
     ) -> None:
         """Initialize AdGuard Home sensor."""
-        super().__init__(adguard, entry)
+        super().__init__(data, entry)
         self.entity_description = description
         self._attr_unique_id = "_".join(
             [
                 DOMAIN,
-                adguard.host,
-                str(adguard.port),
+                self.adguard.host,
+                str(self.adguard.port),
                 "sensor",
                 description.key,
             ]

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -7,13 +7,12 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
-from adguardhome import AdGuardHome, AdGuardHomeConnectionError
+from adguardhome import AdGuardHome
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AdGuardData
@@ -91,13 +90,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up AdGuard Home sensor based on a config entry."""
     data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
-
-    try:
-        version = await data.client.version()
-    except AdGuardHomeConnectionError as exception:
-        raise PlatformNotReady from exception
-
-    data.version = version
 
     async_add_entities(
         [AdGuardHomeSensor(data, entry, description) for description in SENSORS],

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -15,7 +15,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_ADGUARD_CLIENT, DATA_ADGUARD_VERSION, DOMAIN, LOGGER
+from . import AdGuardData
+from .const import DOMAIN, LOGGER
 from .entity import AdGuardHomeEntity
 
 SCAN_INTERVAL = timedelta(seconds=10)
@@ -83,17 +84,17 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
-    adguard = hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_CLIENT]
+    data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
 
     try:
-        version = await adguard.version()
+        version = await data.client.version()
     except AdGuardHomeConnectionError as exception:
         raise PlatformNotReady from exception
 
-    hass.data[DOMAIN][entry.entry_id][DATA_ADGUARD_VERSION] = version
+    data.version = version
 
     async_add_entities(
-        [AdGuardHomeSwitch(adguard, entry, description) for description in SWITCHES],
+        [AdGuardHomeSwitch(data, entry, description) for description in SWITCHES],
         True,
     )
 
@@ -105,15 +106,21 @@ class AdGuardHomeSwitch(AdGuardHomeEntity, SwitchEntity):
 
     def __init__(
         self,
-        adguard: AdGuardHome,
+        data: AdGuardData,
         entry: ConfigEntry,
         description: AdGuardHomeSwitchEntityDescription,
     ) -> None:
         """Initialize AdGuard Home switch."""
-        super().__init__(adguard, entry)
+        super().__init__(data, entry)
         self.entity_description = description
         self._attr_unique_id = "_".join(
-            [DOMAIN, adguard.host, str(adguard.port), "switch", description.key]
+            [
+                DOMAIN,
+                self.adguard.host,
+                str(self.adguard.port),
+                "switch",
+                description.key,
+            ]
         )
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -7,12 +7,11 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any
 
-from adguardhome import AdGuardHome, AdGuardHomeConnectionError, AdGuardHomeError
+from adguardhome import AdGuardHome, AdGuardHomeError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import AdGuardData
@@ -85,13 +84,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
     data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
-
-    try:
-        version = await data.client.version()
-    except AdGuardHomeConnectionError as exception:
-        raise PlatformNotReady from exception
-
-    data.version = version
 
     async_add_entities(
         [AdGuardHomeSwitch(data, entry, description) for description in SWITCHES],


### PR DESCRIPTION
## Proposed change
Extracted from #103844 to be able to highlight the actual changes.
This PR adds a dedicated dataclass to store the AdGuard data instead of a simple (untyped) dict.

_This will also help to visualize the difference with the proposed alternative of storing the data inside the ConfigEntry instead._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
