### PR TITLE
Store runtime data inside ConfigEntry

### DIFF
--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from adguardhome import AdGuardHome, AdGuardHomeConnectionError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import (
     CONF_HOST,
     CONF_NAME,
@@ -123,7 +123,13 @@ async def async_unload_entry(
 ) -> bool:
     """Unload AdGuard Home config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if not hass.config_entries.async_entries(DOMAIN):
+    loaded_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
+    if len(loaded_entries) == 1:
+        # This is the last loaded instance of AdGuard, deregister any services
         hass.services.async_remove(DOMAIN, SERVICE_ADD_URL)
         hass.services.async_remove(DOMAIN, SERVICE_REMOVE_URL)
         hass.services.async_remove(DOMAIN, SERVICE_ENABLE_URL)

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -73,7 +73,7 @@ async def async_setup_entry(
     except AdGuardHomeConnectionError as exception:
         raise ConfigEntryNotReady from exception
 
-    entry.shared_data = AdGuardData(adguard, version)
+    entry.runtime_data = AdGuardData(adguard, version)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -74,10 +74,6 @@ async def async_setup_entry(
         raise ConfigEntryNotReady from exception
 
     entry.shared_data = AdGuardData(adguard, version)
-    if hass.data.get(DOMAIN) is None:
-        hass.data[DOMAIN] = 1
-    else:
-        hass.data[DOMAIN] += 1
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -127,9 +123,7 @@ async def async_unload_entry(
 ) -> bool:
     """Unload AdGuard Home config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN] -= 1
-    if hass.data[DOMAIN] == 0:
+    if not hass.config_entries.async_entries(DOMAIN):
         hass.services.async_remove(DOMAIN, SERVICE_ADD_URL)
         hass.services.async_remove(DOMAIN, SERVICE_REMOVE_URL)
         hass.services.async_remove(DOMAIN, SERVICE_ENABLE_URL)

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -43,6 +43,7 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
+AdGuardConfigEntry = ConfigEntry["AdGuardData"]
 
 
 @dataclass
@@ -53,9 +54,7 @@ class AdGuardData:
     version: str
 
 
-async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry[AdGuardData]
-) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> bool:
     """Set up AdGuard Home from a config entry."""
     session = async_get_clientsession(hass, entry.data[CONF_VERIFY_SSL])
     adguard = AdGuardHome(
@@ -118,9 +117,7 @@ async def async_setup_entry(
     return True
 
 
-async def async_unload_entry(
-    hass: HomeAssistant, entry: ConfigEntry[AdGuardData]
-) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: AdGuardConfigEntry) -> bool:
     """Unload AdGuard Home config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     loaded_entries = [

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -135,6 +135,5 @@ async def async_unload_entry(
         hass.services.async_remove(DOMAIN, SERVICE_ENABLE_URL)
         hass.services.async_remove(DOMAIN, SERVICE_DISABLE_URL)
         hass.services.async_remove(DOMAIN, SERVICE_REFRESH)
-        del hass.data[DOMAIN]
 
     return unload_ok

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from adguardhome import AdGuardHomeError
 
-from homeassistant.config_entries import SOURCE_HASSIO, ConfigEntry
+from homeassistant.config_entries import SOURCE_HASSIO
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
-from . import AdGuardData
+from . import AdGuardConfigEntry, AdGuardData
 from .const import DOMAIN, LOGGER
 
 
@@ -21,7 +21,7 @@ class AdGuardHomeEntity(Entity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry[AdGuardData],
+        entry: AdGuardConfigEntry,
     ) -> None:
         """Initialize the AdGuard Home entity."""
         self._entry = entry

--- a/homeassistant/components/adguard/entity.py
+++ b/homeassistant/components/adguard/entity.py
@@ -21,7 +21,7 @@ class AdGuardHomeEntity(Entity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry,
+        entry: ConfigEntry[AdGuardData],
     ) -> None:
         """Initialize the AdGuard Home entity."""
         self._entry = entry

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -85,11 +85,11 @@ SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ConfigEntry[AdGuardData],
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home sensor based on a config entry."""
-    data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.shared_data
 
     async_add_entities(
         [AdGuardHomeSensor(data, entry, description) for description in SENSORS],
@@ -105,7 +105,7 @@ class AdGuardHomeSensor(AdGuardHomeEntity, SensorEntity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry,
+        entry: ConfigEntry[AdGuardData],
         description: AdGuardHomeEntityDescription,
     ) -> None:
         """Initialize AdGuard Home sensor."""

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -89,7 +89,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home sensor based on a config entry."""
-    data = entry.shared_data
+    data = entry.runtime_data
 
     async_add_entities(
         [AdGuardHomeSensor(data, entry, description) for description in SENSORS],

--- a/homeassistant/components/adguard/sensor.py
+++ b/homeassistant/components/adguard/sensor.py
@@ -10,12 +10,11 @@ from typing import Any
 from adguardhome import AdGuardHome
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import AdGuardData
+from . import AdGuardConfigEntry, AdGuardData
 from .const import DOMAIN
 from .entity import AdGuardHomeEntity
 
@@ -85,7 +84,7 @@ SENSORS: tuple[AdGuardHomeEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry[AdGuardData],
+    entry: AdGuardConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home sensor based on a config entry."""
@@ -105,7 +104,7 @@ class AdGuardHomeSensor(AdGuardHomeEntity, SensorEntity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry[AdGuardData],
+        entry: AdGuardConfigEntry,
         description: AdGuardHomeEntityDescription,
     ) -> None:
         """Initialize AdGuard Home sensor."""

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -83,7 +83,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
-    data = entry.shared_data
+    data = entry.runtime_data
 
     async_add_entities(
         [AdGuardHomeSwitch(data, entry, description) for description in SWITCHES],

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -10,11 +10,10 @@ from typing import Any
 from adguardhome import AdGuardHome, AdGuardHomeError
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import AdGuardData
+from . import AdGuardConfigEntry, AdGuardData
 from .const import DOMAIN, LOGGER
 from .entity import AdGuardHomeEntity
 
@@ -79,7 +78,7 @@ SWITCHES: tuple[AdGuardHomeSwitchEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry[AdGuardData],
+    entry: AdGuardConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
@@ -99,7 +98,7 @@ class AdGuardHomeSwitch(AdGuardHomeEntity, SwitchEntity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry[AdGuardData],
+        entry: AdGuardConfigEntry,
         description: AdGuardHomeSwitchEntityDescription,
     ) -> None:
         """Initialize AdGuard Home switch."""

--- a/homeassistant/components/adguard/switch.py
+++ b/homeassistant/components/adguard/switch.py
@@ -79,11 +79,11 @@ SWITCHES: tuple[AdGuardHomeSwitchEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: ConfigEntry[AdGuardData],
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up AdGuard Home switch based on a config entry."""
-    data: AdGuardData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.shared_data
 
     async_add_entities(
         [AdGuardHomeSwitch(data, entry, description) for description in SWITCHES],
@@ -99,7 +99,7 @@ class AdGuardHomeSwitch(AdGuardHomeEntity, SwitchEntity):
     def __init__(
         self,
         data: AdGuardData,
-        entry: ConfigEntry,
+        entry: ConfigEntry[AdGuardData],
         description: AdGuardHomeSwitchEntityDescription,
     ) -> None:
         """Initialize AdGuard Home switch."""

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -275,7 +275,7 @@ class ConfigEntry(Generic[_DataT]):
     domain: str
     title: str
     data: MappingProxyType[str, Any]
-    shared_data: _DataT
+    runtime_data: _DataT
     options: MappingProxyType[str, Any]
     unique_id: str | None
     state: ConfigEntryState

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -21,9 +21,10 @@ from functools import cached_property
 import logging
 from random import randint
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Self, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Generic, Self, cast
 
 from async_interrupt import interrupt
+from typing_extensions import TypeVar
 
 from . import data_entry_flow, loader
 from .components import persistent_notification
@@ -124,6 +125,7 @@ SAVE_DELAY = 1
 
 DISCOVERY_COOLDOWN = 1
 
+_DataT = TypeVar("_DataT", default=Any)
 _R = TypeVar("_R")
 
 
@@ -266,13 +268,14 @@ class ConfigFlowResult(FlowResult, total=False):
     version: int
 
 
-class ConfigEntry:
+class ConfigEntry(Generic[_DataT]):
     """Hold a configuration entry."""
 
     entry_id: str
     domain: str
     title: str
     data: MappingProxyType[str, Any]
+    shared_data: _DataT
     options: MappingProxyType[str, Any]
     unique_id: str | None
     state: ConfigEntryState

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -26,6 +26,7 @@ _PLATFORMS: set[str] = {platform.value for platform in Platform}
 _KNOWN_GENERIC_TYPES: set[str] = {
     "ConfigEntry",
 }
+_KNOWN_GENERIC_TYPES_TUPLE = tuple(_KNOWN_GENERIC_TYPES)
 
 
 class _Special(Enum):
@@ -2980,11 +2981,13 @@ def _is_valid_type(
     ):
         return True
 
-    # Allow subscripts for generic types
+    # Allow subscripts or type aliases for generic types
     if (
         isinstance(node, nodes.Subscript)
         and isinstance(node.value, nodes.Name)
         and node.value.name in _KNOWN_GENERIC_TYPES
+        or isinstance(node, nodes.Name)
+        and node.name.endswith(_KNOWN_GENERIC_TYPES_TUPLE)
     ):
         return True
 

--- a/pylint/plugins/hass_enforce_type_hints.py
+++ b/pylint/plugins/hass_enforce_type_hints.py
@@ -23,6 +23,9 @@ _COMMON_ARGUMENTS: dict[str, list[str]] = {
     "hass": ["HomeAssistant", "HomeAssistant | None"]
 }
 _PLATFORMS: set[str] = {platform.value for platform in Platform}
+_KNOWN_GENERIC_TYPES: set[str] = {
+    "ConfigEntry",
+}
 
 
 class _Special(Enum):
@@ -2974,6 +2977,14 @@ def _is_valid_type(
         and not in_return
         and isinstance(node, nodes.Name)
         and node.name in ("float", "int")
+    ):
+        return True
+
+    # Allow subscripts for generic types
+    if (
+        isinstance(node, nodes.Subscript)
+        and isinstance(node.value, nodes.Name)
+        and node.value.name in _KNOWN_GENERIC_TYPES
     ):
         return True
 


### PR DESCRIPTION
## Proposed change
Suggestion from https://github.com/home-assistant/core/pull/103844#issuecomment-2057092886
Store the integration shared data inside the `ConfigEntry` instead of `hass.dict` and make `ConfigEntry` itself generic to be able to type it.

Some observations
- `ConfigEntry` does already have a `data` attribute which is used to store the data from the config flow. We thus probably need another name. Maybe `shared_data` or `runtime_data`.
- Adding the subscript types everywhere in just one integration is quite cumbersome and it's easy to miss one. This could become an issue in case of a refactoring when the data type is modified. An option might be to use a TypeAlias. There is also no type checking that the provided generic type is correct. _That is in different from the `HassDict` proposal where the type is bound to the key itself which is unlikely to change. I.e. as long as the key is the same, you do get the full type checking._
IIRC this was also one of the arguments against converting `HomeAssistant` to a generic type which I suggested in the past.
- Integrations in general still need / want to know about other config entries from itself. So we either continue to use `hass.data` for that or implement another mechanisms for it.
- _The pylint plugin needs to be updated to either allow subscripts or ignore custom TypeAliases._

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
