### PR TITLE
Add `_attr` class attributes to TextToSpeechEntity

### DIFF
--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -431,13 +431,13 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
             _ = self.default_language
         except AttributeError as err:
             raise AttributeError(
-                "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
+                "TTS entities must either set the '_attr_default_language' attribute or override the 'default_language' property"
             ) from err
         try:
             _ = self.supported_languages
         except AttributeError as err:
             raise AttributeError(
-                "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
+                "TTS entities must either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
             ) from err
         state = await self.async_get_last_state()
         if (

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -383,6 +383,23 @@ class TextToSpeechEntity(RestoreEntity):
     _attr_supported_options: list[str] | None = None
     _attr_default_options: Mapping[str, Any] | None = None
 
+    @classmethod
+    def __init_subclass__(cls) -> None:
+        if not (
+            hasattr(cls, "_attr_default_language")
+            or type(cls.default_language) is property  # type: ignore[comparison-overlap]
+        ):
+            raise AttributeError(
+                "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+            )
+        if not (
+            hasattr(cls, "_attr_supported_languages")
+            or type(cls.supported_languages) is property  # type: ignore[comparison-overlap]
+        ):
+            raise AttributeError(
+                "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+            )
+
     @property
     @final
     def state(self) -> str | None:

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -385,19 +385,20 @@ class TextToSpeechEntity(RestoreEntity):
 
     @classmethod
     def __init_subclass__(cls) -> None:
+        super().__init_subclass__()
         if not (
             hasattr(cls, "_attr_default_language")
-            or type(cls.default_language) is property  # type: ignore[comparison-overlap]
+            or cls.default_language != TextToSpeechEntity.default_language
         ):
             raise AttributeError(
-                "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+                "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
             )
         if not (
             hasattr(cls, "_attr_supported_languages")
-            or type(cls.supported_languages) is property  # type: ignore[comparison-overlap]
+            or cls.supported_languages != TextToSpeechEntity.supported_languages
         ):
             raise AttributeError(
-                "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+                "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
             )
 
     @property

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from abc import abstractmethod
 import asyncio
 from collections.abc import Mapping
 from datetime import datetime
-from functools import partial
+from functools import cached_property, partial
 import hashlib
 from http import HTTPStatus
 import io
@@ -379,6 +378,11 @@ class TextToSpeechEntity(RestoreEntity):
     _attr_should_poll = False
     __last_tts_loaded: str | None = None
 
+    _attr_default_language: str
+    _attr_supported_languages: list[str]
+    _attr_supported_options: list[str] | None = None
+    _attr_default_options: Mapping[str, Any] | None = None
+
     @property
     @final
     def state(self) -> str | None:
@@ -387,25 +391,25 @@ class TextToSpeechEntity(RestoreEntity):
             return None
         return self.__last_tts_loaded
 
-    @property
-    @abstractmethod
+    @cached_property
     def supported_languages(self) -> list[str]:
         """Return a list of supported languages."""
+        return self._attr_supported_languages
 
-    @property
-    @abstractmethod
+    @cached_property
     def default_language(self) -> str:
         """Return the default language."""
+        return self._attr_default_language
 
-    @property
+    @cached_property
     def supported_options(self) -> list[str] | None:
         """Return a list of supported options like voice, emotions."""
-        return None
+        return self._attr_supported_options
 
-    @property
+    @cached_property
     def default_options(self) -> Mapping[str, Any] | None:
         """Return a mapping with the default options."""
-        return None
+        return self._attr_default_options
 
     @callback
     def async_get_supported_voices(self, language: str) -> list[Voice] | None:

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -427,19 +427,18 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
     async def async_internal_added_to_hass(self) -> None:
         """Call when the entity is added to hass."""
         await super().async_internal_added_to_hass()
-        if not (
-            hasattr(self, "_attr_default_language") or hasattr(self, "default_language")
-        ):
+        try:
+            _ = self.default_language
+        except AttributeError as err:
             raise AttributeError(
                 "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
-            )
-        if not (
-            hasattr(self, "_attr_supported_languages")
-            or hasattr(self, "supported_languages")
-        ):
+            ) from err
+        try:
+            _ = self.supported_languages
+        except AttributeError as err:
             raise AttributeError(
                 "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
-            )
+            ) from err
         state = await self.async_get_last_state()
         if (
             state is not None

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -374,9 +374,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 CACHED_PROPERTIES_WITH_ATTR_ = {
     "default_language",
+    "default_options",
     "supported_languages",
     "supported_options",
-    "default_options",
 }
 
 
@@ -387,9 +387,9 @@ class TextToSpeechEntity(RestoreEntity, cached_properties=CACHED_PROPERTIES_WITH
     __last_tts_loaded: str | None = None
 
     _attr_default_language: str
+    _attr_default_options: Mapping[str, Any] | None = None
     _attr_supported_languages: list[str]
     _attr_supported_options: list[str] | None = None
-    _attr_default_options: Mapping[str, Any] | None = None
 
     @property
     @final

--- a/homeassistant/components/tts/__init__.py
+++ b/homeassistant/components/tts/__init__.py
@@ -391,14 +391,14 @@ class TextToSpeechEntity(RestoreEntity):
             or cls.default_language != TextToSpeechEntity.default_language
         ):
             raise AttributeError(
-                "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
+                "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
             )
         if not (
             hasattr(cls, "_attr_supported_languages")
             or cls.supported_languages != TextToSpeechEntity.supported_languages
         ):
             raise AttributeError(
-                "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
+                "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
             )
 
     @property

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1778,7 +1778,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
+        == "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1788,7 +1788,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
+        == "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1800,7 +1800,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
+        == "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1812,5 +1812,5 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
+        == "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
     )

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -47,15 +47,8 @@ ORIG_WRITE_TAGS = tts.SpeechManager.write_tags
 class DefaultEntity(tts.TextToSpeechEntity):
     """Test entity."""
 
-    @property
-    def supported_languages(self) -> list[str]:
-        """Return a list of supported languages."""
-        return SUPPORT_LANGUAGES
-
-    @property
-    def default_language(self) -> str:
-        """Return the default language."""
-        return DEFAULT_LANG
+    _attr_supported_languages = SUPPORT_LANGUAGES
+    _attr_default_language = DEFAULT_LANG
 
 
 async def test_default_entity_attributes() -> None:
@@ -523,10 +516,7 @@ class MockProviderWithDefaults(MockProvider):
 class MockEntityWithDefaults(MockTTSEntity):
     """Mock entity with default options."""
 
-    @property
-    def default_options(self):
-        """Return a mapping with the default options."""
-        return {"voice": "alex"}
+    _attr_default_options = {"voice": "alex"}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1748,3 +1748,69 @@ async def test_async_convert_audio_error(hass: HomeAssistant) -> None:
     with pytest.raises(RuntimeError):
         # Simulate a bad WAV file
         await tts.async_convert_audio(hass, "wav", bytes(0), "mp3")
+
+
+def test_ttsentity_subclass_properties() -> None:
+    """Test for exceptions when subclasses of the TextToSpeechEntity are missing required properties."""
+
+    class TestClass1(tts.TextToSpeechEntity):
+        _attr_default_language = DEFAULT_LANG
+        _attr_supported_languages = SUPPORT_LANGUAGES
+
+    class TestClass2(tts.TextToSpeechEntity):
+        @property
+        def default_language(self) -> str:
+            return DEFAULT_LANG
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return SUPPORT_LANGUAGES
+
+    assert TestClass1().default_language == DEFAULT_LANG
+    assert TestClass1().supported_languages == SUPPORT_LANGUAGES
+    assert TestClass2().default_language == DEFAULT_LANG
+    assert TestClass2().supported_languages == SUPPORT_LANGUAGES
+
+    with pytest.raises(AttributeError) as exc_info:
+
+        class TestClass3(tts.TextToSpeechEntity):
+            _attr_default_language = DEFAULT_LANG
+
+    assert (
+        str(exc_info.value)
+        == "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+
+        class TestClass4(tts.TextToSpeechEntity):
+            _attr_supported_languages = SUPPORT_LANGUAGES
+
+    assert (
+        str(exc_info.value)
+        == "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+
+        class TestClass5(tts.TextToSpeechEntity):
+            @property
+            def default_language(self) -> str:
+                return DEFAULT_LANG
+
+    assert (
+        str(exc_info.value)
+        == "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+    )
+
+    with pytest.raises(AttributeError) as exc_info:
+
+        class TestClass6(tts.TextToSpeechEntity):
+            @property
+            def supported_languages(self) -> list[str]:
+                return SUPPORT_LANGUAGES
+
+    assert (
+        str(exc_info.value)
+        == "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+    )

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1778,7 +1778,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+        == "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1788,7 +1788,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+        == "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1800,7 +1800,7 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_supported_languages' variable or overwrite the 'supported_languages' property"
+        == "You need to either set the '_attr_supported_languages' attribute or overwrite the 'supported_languages' property"
     )
 
     with pytest.raises(AttributeError) as exc_info:
@@ -1812,5 +1812,5 @@ def test_ttsentity_subclass_properties() -> None:
 
     assert (
         str(exc_info.value)
-        == "You need to either set the '_attr_default_language' variable or overwrite the 'default_language' property"
+        == "You need to either set the '_attr_default_language' attribute or overwrite the 'default_language' property"
     )

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1755,6 +1755,27 @@ async def test_ttsentity_subclass_properties(
 ) -> None:
     """Test for errors when subclasses of the TextToSpeechEntity are missing required properties."""
 
+    class TestClass1(tts.TextToSpeechEntity):
+        _attr_default_language = DEFAULT_LANG
+        _attr_supported_languages = SUPPORT_LANGUAGES
+
+    await mock_config_entry_setup(hass, TestClass1())
+
+    class TestClass2(tts.TextToSpeechEntity):
+        @property
+        def default_language(self) -> str:
+            return DEFAULT_LANG
+
+        @property
+        def supported_languages(self) -> list[str]:
+            return SUPPORT_LANGUAGES
+
+    await mock_config_entry_setup(hass, TestClass2())
+
+    assert all(record.exc_info is None for record in caplog.records)
+
+    caplog.clear()
+
     class TestClass3(tts.TextToSpeechEntity):
         _attr_default_language = DEFAULT_LANG
 

--- a/tests/components/tts/test_init.py
+++ b/tests/components/tts/test_init.py
@@ -1782,7 +1782,7 @@ async def test_ttsentity_subclass_properties(
     await mock_config_entry_setup(hass, TestClass3())
 
     assert (
-        "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
+        "TTS entities must either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
         in [
             str(record.exc_info[1])
             for record in caplog.records
@@ -1797,7 +1797,7 @@ async def test_ttsentity_subclass_properties(
     await mock_config_entry_setup(hass, TestClass4())
 
     assert (
-        "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
+        "TTS entities must either set the '_attr_default_language' attribute or override the 'default_language' property"
         in [
             str(record.exc_info[1])
             for record in caplog.records
@@ -1814,7 +1814,7 @@ async def test_ttsentity_subclass_properties(
     await mock_config_entry_setup(hass, TestClass5())
 
     assert (
-        "You need to either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
+        "TTS entities must either set the '_attr_supported_languages' attribute or override the 'supported_languages' property"
         in [
             str(record.exc_info[1])
             for record in caplog.records
@@ -1831,7 +1831,7 @@ async def test_ttsentity_subclass_properties(
     await mock_config_entry_setup(hass, TestClass6())
 
     assert (
-        "You need to either set the '_attr_default_language' attribute or override the 'default_language' property"
+        "TTS entities must either set the '_attr_default_language' attribute or override the 'default_language' property"
         in [
             str(record.exc_info[1])
             for record in caplog.records


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds `_attr` class variables to the TextToSpeechEntitity, analogous to the other platform entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
