### PR TITLE
Deprecate modbus:restart service

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -239,14 +239,10 @@ async def async_modbus_setup(
             hass,
             DOMAIN,
             "deprecated_restart",
-            breaks_in_ha_version="2024.10.0",
+            breaks_in_ha_version="2024.11.0",
             is_fixable=False,
             severity=IssueSeverity.WARNING,
             translation_key="deprecated_restart",
-            translation_placeholders={
-                "integration": DOMAIN,
-                "url": "https://www.home-assistant.io/integrations/modbus",
-            },
         )
         _LOGGER.warning(
             "`modbus:restart`: is deprecated and will be removed in version 2024.10"

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -34,6 +34,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType
 
@@ -234,6 +235,22 @@ async def async_modbus_setup(
 
     async def async_restart_hub(service: ServiceCall) -> None:
         """Restart Modbus hub."""
+        async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_restart",
+            breaks_in_ha_version="2024.10.0",
+            is_fixable=False,
+            severity=IssueSeverity.WARNING,
+            translation_key="deprecated_restart",
+            translation_placeholders={
+                "integration": DOMAIN,
+                "url": "https://www.home-assistant.io/integrations/modbus",
+            },
+        )
+        _LOGGER.warning(
+            "`modbus:restart`: is deprecated and will be removed in version 2024.10"
+        )
         async_dispatcher_send(hass, SIGNAL_START_ENTITY)
         hub = hub_collect[service.data[ATTR_HUB]]
         await hub.async_restart()

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -245,7 +245,7 @@ async def async_modbus_setup(
             translation_key="deprecated_restart",
         )
         _LOGGER.warning(
-            "`modbus:restart`: is deprecated and will be removed in version 2024.10"
+            "`modbus.restart`: is deprecated and will be removed in version 2024.11"
         )
         async_dispatcher_send(hass, SIGNAL_START_ENTITY)
         hub = hub_collect[service.data[ATTR_HUB]]

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -99,7 +99,7 @@
       "description": "Please add at least one entity to Modbus {sub_1} in your configuration.yaml file and restart Home Assistant to fix this issue."
     },
     "deprecated_restart": {
-      "title": "`modbus.restart` is obsolete and is being removed",
+      "title": "`modbus.restart` is being removed",
       "description": "Please use core function reload yaml (developer entry in UI) instead of modbus.restart."
     }
   }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -97,6 +97,10 @@
     "no_entities": {
       "title": "Modbus {sub_1} contain no entities, entry not loaded.",
       "description": "Please add at least one entity to Modbus {sub_1} in your configuration.yaml file and restart Home Assistant to fix this issue."
+    },
+    "deprecated_restart": {
+      "title": "`modbus:restart` is obsolete and is being removed",
+      "description": "Please use core function reload yaml (developer entry in UI) instead of modbus:restart."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -99,7 +99,7 @@
       "description": "Please add at least one entity to Modbus {sub_1} in your configuration.yaml file and restart Home Assistant to fix this issue."
     },
     "deprecated_restart": {
-      "title": "`modbus:restart` is obsolete and is being removed",
+      "title": "`modbus.restart` is obsolete and is being removed",
       "description": "Please use core function reload yaml (developer entry in UI) instead of modbus:restart."
     }
   }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -100,7 +100,7 @@
     },
     "deprecated_restart": {
       "title": "`modbus.restart` is being removed",
-      "description": "Please use core function reload yaml (developer entry in UI) instead of modbus.restart."
+      "description": "Please use reload yaml via the developer tools in the UI instead of via the `modbus.restart` service."
     }
   }
 }

--- a/homeassistant/components/modbus/strings.json
+++ b/homeassistant/components/modbus/strings.json
@@ -100,7 +100,7 @@
     },
     "deprecated_restart": {
       "title": "`modbus.restart` is obsolete and is being removed",
-      "description": "Please use core function reload yaml (developer entry in UI) instead of modbus:restart."
+      "description": "Please use core function reload yaml (developer entry in UI) instead of modbus.restart."
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
modbus:restart service is obsolete and will be removed in 2024.11, this PR creates an issue to warn end-users that use this service.

modbus:restart do not reload the yaml, nor does it reset the library (since there are no reconfiguration), this can lead to dangling tasks in the library.

The core function to reload yaml (developer entry in the UI) is much cleaner and provides the same functionality.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
