### PR TITLE
Add sweep_frequency service

### DIFF
--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -90,6 +90,9 @@ _DEPRECATED_SUPPORT_DELETE_COMMAND = DeprecatedConstantEnum(
 _DEPRECATED_SUPPORT_ACTIVITY = DeprecatedConstantEnum(
     RemoteEntityFeature.ACTIVITY, "2025.1"
 )
+_DEPRECATED_SUPPORT_SWEEP_FREQUENCY = DeprecatedConstantEnum(
+    RemoteEntityFeature.SWEEP_FREQUENCY, "2025.1"
+)
 
 
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -275,7 +275,9 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
 
     async def async_sweep_frequency(self, **kwargs: Any) -> None:
         """Sweep remote control frequency."""
-        await self.hass.async_add_executor_job(ft.partial(self.sweep_frequency, **kwargs))
+        await self.hass.async_add_executor_job(
+            ft.partial(self.sweep_frequency, **kwargs)
+        )
 
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -48,6 +48,7 @@ ATTR_DEVICE = "device"
 ATTR_NUM_REPEATS = "num_repeats"
 ATTR_DELAY_SECS = "delay_secs"
 ATTR_HOLD_SECS = "hold_secs"
+ATTR_FREQUENCY = "frequency"
 ATTR_ALTERNATIVE = "alternative"
 ATTR_TIMEOUT = "timeout"
 
@@ -61,6 +62,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 SERVICE_SEND_COMMAND = "send_command"
 SERVICE_LEARN_COMMAND = "learn_command"
 SERVICE_DELETE_COMMAND = "delete_command"
+SERVICE_SWEEP_FREQUENCY = "sweep_frequency"
 SERVICE_SYNC = "sync"
 
 DEFAULT_NUM_REPEATS = 1
@@ -74,6 +76,7 @@ class RemoteEntityFeature(IntFlag):
     LEARN_COMMAND = 1
     DELETE_COMMAND = 2
     ACTIVITY = 4
+    SWEEP_FREQUENCY = 8
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
@@ -139,6 +142,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Optional(ATTR_DEVICE): cv.string,
             vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(ATTR_COMMAND_TYPE): cv.string,
+            vol.Optional(ATTR_FREQUENCY): cv.positive_float,
             vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
             vol.Optional(ATTR_TIMEOUT): cv.positive_int,
         },
@@ -152,6 +156,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Optional(ATTR_DEVICE): cv.string,
         },
         "async_delete_command",
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SWEEP_FREQUENCY,
+        {
+            vol.Optional(ATTR_DEVICE): cv.string,
+            vol.Optional(ATTR_TIMEOUT): cv.positive_int,
+        },
+        "async_sweep_frequency",
     )
 
     return True
@@ -255,6 +268,14 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
         await self.hass.async_add_executor_job(
             ft.partial(self.delete_command, **kwargs)
         )
+
+    def sweep_frequency(self, **kwargs: Any) -> None:
+        """Sweep remote control frequency."""
+        raise NotImplementedError
+
+    async def async_sweep_frequency(self, **kwargs: Any) -> None:
+        """Sweep remote control frequency."""
+        await self.hass.async_add_executor_job(ft.partial(self.sweep_frequency, **kwargs))
 
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/components/remote/icons.json
+++ b/homeassistant/components/remote/icons.json
@@ -11,6 +11,7 @@
     "delete_command": "mdi:delete",
     "learn_command": "mdi:school",
     "send_command": "mdi:remote",
+    "sweep_frequency": "mdi:sine-wave",
     "toggle": "mdi:remote",
     "turn_off": "mdi:remote-off",
     "turn_on": "mdi:remote"

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -84,6 +84,7 @@ learn_command:
       selector:
         number:
           min: 0
+          max: 3072
           step: 0.01
           unit_of_measurement: MHz
     alternative:

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -80,6 +80,12 @@ learn_command:
           options:
             - "ir"
             - "rf"
+    frequency:
+      selector:
+        number:
+          min: 0
+          step: 0.01
+          unit_of_measurement: MHz
     alternative:
       selector:
         boolean:
@@ -105,3 +111,20 @@ delete_command:
       example: "Mute"
       selector:
         object:
+
+sweep_frequency:
+  target:
+    entity:
+      domain: remote
+  fields:
+    device:
+      example: "television"
+      selector:
+        text:
+    timeout:
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 5
+          unit_of_measurement: seconds

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -86,6 +86,10 @@
           "name": "Command type",
           "description": "The type of command to be learned."
         },
+        "frequency": {
+          "name": "Frequency",
+          "description": "Frequency of the command to be learned."
+        },
         "alternative": {
           "name": "Alternative",
           "description": "If code must be stored as an alternative. This is useful for discrete codes. Discrete codes are used for toggles that only perform one function. For example, a code to only turn a device on. If it is on already, sending the code won't change the state."

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -109,6 +109,20 @@
           "description": "The single command or the list of commands to be deleted."
         }
       }
+    },
+    "sweep_frequency": {
+      "name": "Sweep frequency",
+      "description": "Detects the frequency of a remote control.",
+      "fields": {
+        "device": {
+          "name": "Device",
+          "description": "Device ID to detect frequency from."
+        },
+        "timeout": {
+          "name": "Timeout",
+          "description": "Timeout for the frequency to be found."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the process of scanning commands from radio frequency remote controls, it's essential to first scan the frequency. Currently, both tasks are managed by the same service (learn_command), which presents usability challenges for learning RF commands due to the following reasons:

- Users are required to scan the frequency repeatedly for each learned command, instead of performing it just once initially.
- Users must stay alert to notifications indicating when to initiate a long click (to sweep frequency) followed by a short click (to learn the command).

A preferable approach involves separating these tasks into distinct services — one dedicated to identifying the frequency and another to learn the commands themselves. This PR addresses this issue by creating a separate service for frequency scanning and introducing a "frequency" attribute to the command learning service.

Depends on: https://github.com/home-assistant/architecture/discussions/1076

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
