### PR TITLE
Add sweep_frequency service to Broadlink integration

### DIFF
--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -5,6 +5,7 @@ from base64 import b64encode
 from collections import defaultdict
 from collections.abc import Iterable
 from datetime import timedelta
+from functools import partial
 from itertools import product
 import logging
 from typing import Any
@@ -24,12 +25,14 @@ from homeassistant.components.remote import (
     ATTR_COMMAND_TYPE,
     ATTR_DELAY_SECS,
     ATTR_DEVICE,
+    ATTR_FREQUENCY,
     ATTR_NUM_REPEATS,
     DEFAULT_DELAY_SECS,
     DOMAIN as RM_DOMAIN,
     SERVICE_DELETE_COMMAND,
     SERVICE_LEARN_COMMAND,
     SERVICE_SEND_COMMAND,
+    SERVICE_SWEEP_FREQUENCY,
     RemoteEntity,
     RemoteEntityFeature,
 )
@@ -80,11 +83,16 @@ SERVICE_LEARN_SCHEMA = COMMAND_SCHEMA.extend(
     {
         vol.Required(ATTR_DEVICE): vol.All(cv.string, vol.Length(min=1)),
         vol.Optional(ATTR_COMMAND_TYPE, default=COMMAND_TYPE_IR): vol.In(COMMAND_TYPES),
+        vol.Optional(ATTR_FREQUENCY): cv.positive_float,
         vol.Optional(ATTR_ALTERNATIVE, default=False): cv.boolean,
     }
 )
 
 SERVICE_DELETE_SCHEMA = COMMAND_SCHEMA.extend(
+    {vol.Required(ATTR_DEVICE): vol.All(cv.string, vol.Length(min=1))}
+)
+
+SERVICE_SWEEP_FREQUENCY_SCHEMA = COMMAND_SCHEMA.extend(
     {vol.Required(ATTR_DEVICE): vol.All(cv.string, vol.Length(min=1))}
 )
 
@@ -122,7 +130,9 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
         self._attr_is_on = True
         self._attr_supported_features = (
-            RemoteEntityFeature.LEARN_COMMAND | RemoteEntityFeature.DELETE_COMMAND
+            RemoteEntityFeature.LEARN_COMMAND
+            | RemoteEntityFeature.DELETE_COMMAND
+            | RemoteEntityFeature.SWEEP_FREQUENCY
         )
         self._attr_unique_id = device.unique_id
 
@@ -267,6 +277,7 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
         command_type = kwargs[ATTR_COMMAND_TYPE]
         subdevice = kwargs[ATTR_DEVICE]
         toggle = kwargs[ATTR_ALTERNATIVE]
+        frequency = kwargs.get(ATTR_FREQUENCY)
         service = f"{RM_DOMAIN}.{SERVICE_LEARN_COMMAND}"
         device = self._device
 
@@ -284,7 +295,9 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
                 learn_command = self._async_learn_ir_command
 
             elif hasattr(device.api, "sweep_frequency"):
-                learn_command = self._async_learn_rf_command
+                learn_command = partial(
+                    self._async_learn_rf_command, frequency=frequency
+                )
 
             else:
                 err_msg = f"{self.entity_id} doesn't support learning RF commands"
@@ -351,47 +364,16 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
                 self.hass, notification_id="learn_command"
             )
 
-    async def _async_learn_rf_command(self, command):
+    async def _async_learn_rf_command(self, command, frequency=None):
         """Learn a radiofrequency command."""
         device = self._device
 
-        try:
-            await device.async_request(device.api.sweep_frequency)
-
-        except (BroadlinkException, OSError) as err:
-            _LOGGER.debug("Failed to sweep frequency: %s", err)
-            raise
-
-        persistent_notification.async_create(
-            self.hass,
-            f"Press and hold the '{command}' button.",
-            title="Sweep frequency",
-            notification_id="sweep_frequency",
-        )
+        if not frequency:
+            frequency = self._async_sweep_frequency()
+            await asyncio.sleep(2)
 
         try:
-            start_time = dt_util.utcnow()
-            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
-                await asyncio.sleep(1)
-                found = await device.async_request(device.api.check_frequency)[0]
-                if found:
-                    break
-            else:
-                await device.async_request(device.api.cancel_sweep_frequency)
-                raise TimeoutError(
-                    "No radiofrequency found within "
-                    f"{LEARNING_TIMEOUT.total_seconds()} seconds"
-                )
-
-        finally:
-            persistent_notification.async_dismiss(
-                self.hass, notification_id="sweep_frequency"
-            )
-
-        await asyncio.sleep(1)
-
-        try:
-            await device.async_request(device.api.find_rf_packet)
+            await device.async_request(device.api.find_rf_packet, frequency=frequency)
 
         except (BroadlinkException, OSError) as err:
             _LOGGER.debug("Failed to enter learning mode: %s", err)
@@ -399,7 +381,7 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
         persistent_notification.async_create(
             self.hass,
-            f"Press the '{command}' button again.",
+            f"Press the '{command}' button.",
             title="Learn command",
             notification_id="learn_command",
         )
@@ -475,3 +457,72 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
                 self._flag_storage.async_delay_save(self._get_flags, FLAG_SAVE_DELAY)
 
         self._code_storage.async_delay_save(self._get_codes, CODE_SAVE_DELAY)
+
+    async def async_sweep_frequency(self, **kwargs: Any) -> None:
+        """Sweep remote control frequency."""
+        kwargs = SERVICE_LEARN_SCHEMA(kwargs)
+        subdevice = kwargs[ATTR_DEVICE]
+        service = f"{RM_DOMAIN}.{SERVICE_SWEEP_FREQUENCY}"
+        device = self._device
+
+        if not self._attr_is_on:
+            _LOGGER.warning(
+                "%s canceled: %s entity is turned off", service, self.entity_id
+            )
+            return
+
+        async with self._lock:
+            if not hasattr(device.api, "sweep_frequency"):
+                err_msg = f"{self.entity_id} doesn't support sweeping frequency"
+                _LOGGER.error("Failed to call %s: %s", service, err_msg)
+                raise ValueError(err_msg)
+
+            frequency = await self._async_sweep_frequency()
+
+            persistent_notification.async_create(
+                self.hass,
+                f"The frequency of the device '{subdevice}' is {frequency} MHz.",
+                title="Sweep frequency success",
+                notification_id="sweep_frequency_success",
+            )
+
+    async def _async_sweep_frequency(self) -> float:
+        """Sweep remote control frequency."""
+        device = self._device
+        found = False
+        frequency = 0
+
+        try:
+            await device.async_request(device.api.sweep_frequency)
+
+        except (BroadlinkException, OSError) as err:
+            _LOGGER.debug("Failed to sweep frequency: %s", err)
+            raise
+
+        persistent_notification.async_create(
+            self.hass,
+            "Press and hold any button on the remote for 5 seconds.",
+            title="Sweep frequency",
+            notification_id="sweep_frequency",
+        )
+
+        try:
+            start_time = dt_util.utcnow()
+            while (dt_util.utcnow() - start_time) < LEARNING_TIMEOUT:
+                await asyncio.sleep(1)
+                found, frequency = await device.async_request(
+                    device.api.check_frequency
+                )
+                if found:
+                    return frequency
+
+            await device.async_request(device.api.cancel_sweep_frequency)
+            raise TimeoutError(
+                "No radiofrequency found within "
+                f"{LEARNING_TIMEOUT.total_seconds()} seconds"
+            )
+
+        finally:
+            persistent_notification.async_dismiss(
+                self.hass, notification_id="sweep_frequency"
+            )

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -90,6 +90,9 @@ _DEPRECATED_SUPPORT_DELETE_COMMAND = DeprecatedConstantEnum(
 _DEPRECATED_SUPPORT_ACTIVITY = DeprecatedConstantEnum(
     RemoteEntityFeature.ACTIVITY, "2025.1"
 )
+_DEPRECATED_SUPPORT_SWEEP_FREQUENCY = DeprecatedConstantEnum(
+    RemoteEntityFeature.SWEEP_FREQUENCY, "2025.1"
+)
 
 
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -275,7 +275,9 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
 
     async def async_sweep_frequency(self, **kwargs: Any) -> None:
         """Sweep remote control frequency."""
-        await self.hass.async_add_executor_job(ft.partial(self.sweep_frequency, **kwargs))
+        await self.hass.async_add_executor_job(
+            ft.partial(self.sweep_frequency, **kwargs)
+        )
 
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -48,6 +48,7 @@ ATTR_DEVICE = "device"
 ATTR_NUM_REPEATS = "num_repeats"
 ATTR_DELAY_SECS = "delay_secs"
 ATTR_HOLD_SECS = "hold_secs"
+ATTR_FREQUENCY = "frequency"
 ATTR_ALTERNATIVE = "alternative"
 ATTR_TIMEOUT = "timeout"
 
@@ -61,6 +62,7 @@ MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
 SERVICE_SEND_COMMAND = "send_command"
 SERVICE_LEARN_COMMAND = "learn_command"
 SERVICE_DELETE_COMMAND = "delete_command"
+SERVICE_SWEEP_FREQUENCY = "sweep_frequency"
 SERVICE_SYNC = "sync"
 
 DEFAULT_NUM_REPEATS = 1
@@ -74,6 +76,7 @@ class RemoteEntityFeature(IntFlag):
     LEARN_COMMAND = 1
     DELETE_COMMAND = 2
     ACTIVITY = 4
+    SWEEP_FREQUENCY = 8
 
 
 # These SUPPORT_* constants are deprecated as of Home Assistant 2022.5.
@@ -139,6 +142,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Optional(ATTR_DEVICE): cv.string,
             vol.Optional(ATTR_COMMAND): vol.All(cv.ensure_list, [cv.string]),
             vol.Optional(ATTR_COMMAND_TYPE): cv.string,
+            vol.Optional(ATTR_FREQUENCY): cv.positive_float,
             vol.Optional(ATTR_ALTERNATIVE): cv.boolean,
             vol.Optional(ATTR_TIMEOUT): cv.positive_int,
         },
@@ -152,6 +156,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             vol.Optional(ATTR_DEVICE): cv.string,
         },
         "async_delete_command",
+    )
+
+    component.async_register_entity_service(
+        SERVICE_SWEEP_FREQUENCY,
+        {
+            vol.Optional(ATTR_DEVICE): cv.string,
+            vol.Optional(ATTR_TIMEOUT): cv.positive_int,
+        },
+        "async_sweep_frequency",
     )
 
     return True
@@ -255,6 +268,14 @@ class RemoteEntity(ToggleEntity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_)
         await self.hass.async_add_executor_job(
             ft.partial(self.delete_command, **kwargs)
         )
+
+    def sweep_frequency(self, **kwargs: Any) -> None:
+        """Sweep remote control frequency."""
+        raise NotImplementedError
+
+    async def async_sweep_frequency(self, **kwargs: Any) -> None:
+        """Sweep remote control frequency."""
+        await self.hass.async_add_executor_job(ft.partial(self.sweep_frequency, **kwargs))
 
 
 # These can be removed if no deprecated constant are in this module anymore

--- a/homeassistant/components/remote/icons.json
+++ b/homeassistant/components/remote/icons.json
@@ -11,6 +11,7 @@
     "delete_command": "mdi:delete",
     "learn_command": "mdi:school",
     "send_command": "mdi:remote",
+    "sweep_frequency": "mdi:sine-wave",
     "toggle": "mdi:remote",
     "turn_off": "mdi:remote-off",
     "turn_on": "mdi:remote"

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -84,6 +84,7 @@ learn_command:
       selector:
         number:
           min: 0
+          max: 3072
           step: 0.01
           unit_of_measurement: MHz
     alternative:

--- a/homeassistant/components/remote/services.yaml
+++ b/homeassistant/components/remote/services.yaml
@@ -80,6 +80,12 @@ learn_command:
           options:
             - "ir"
             - "rf"
+    frequency:
+      selector:
+        number:
+          min: 0
+          step: 0.01
+          unit_of_measurement: MHz
     alternative:
       selector:
         boolean:
@@ -105,3 +111,20 @@ delete_command:
       example: "Mute"
       selector:
         object:
+
+sweep_frequency:
+  target:
+    entity:
+      domain: remote
+  fields:
+    device:
+      example: "television"
+      selector:
+        text:
+    timeout:
+      selector:
+        number:
+          min: 0
+          max: 60
+          step: 5
+          unit_of_measurement: seconds

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -86,6 +86,10 @@
           "name": "Command type",
           "description": "The type of command to be learned."
         },
+        "frequency": {
+          "name": "Frequency",
+          "description": "Frequency of the command to be learned."
+        },
         "alternative": {
           "name": "Alternative",
           "description": "If code must be stored as an alternative. This is useful for discrete codes. Discrete codes are used for toggles that only perform one function. For example, a code to only turn a device on. If it is on already, sending the code won't change the state."

--- a/homeassistant/components/remote/strings.json
+++ b/homeassistant/components/remote/strings.json
@@ -109,6 +109,20 @@
           "description": "The single command or the list of commands to be deleted."
         }
       }
+    },
+    "sweep_frequency": {
+      "name": "Sweep frequency",
+      "description": "Detects the frequency of a remote control.",
+      "fields": {
+        "device": {
+          "name": "Device",
+          "description": "Device ID to detect frequency from."
+        },
+        "timeout": {
+          "name": "Timeout",
+          "description": "Timeout for the frequency to be found."
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the process of scanning commands from radio frequency remote controls, it's essential to first scan the frequency. Currently, both tasks are managed by the same service (learn_command), which presents usability challenges for learning RF commands due to the following reasons:

- Users are required to scan the frequency repeatedly for each learned command, instead of performing it just once initially.
- Users must stay alert to notifications indicating when to initiate a long click (to sweep frequency) followed by a short click (to learn the command).

A preferable approach involves separating these tasks into distinct services — one dedicated to identifying the frequency and another to learn the commands themselves. This PR addresses this issue by creating a separate service for frequency scanning and introducing a "frequency" attribute to the command learning service.

**Note**: Not all Broadlink RM devices support this option. Some may return a frequency reading of 0.00 MHz, retaining the value internally only.

Depends on: https://github.com/home-assistant/architecture/discussions/1076 https://github.com/home-assistant/core/pull/115785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
