### PR TITLE
Replace setdefault with defaultdict for translations and icons

### DIFF
--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from collections.abc import Iterable
 from functools import lru_cache
 import logging
@@ -70,7 +71,7 @@ class _IconsCache:
         """Initialize the cache."""
         self._hass = hass
         self._loaded: set[str] = set()
-        self._cache: dict[str, dict[str, Any]] = {}
+        self._cache: defaultdict[str, dict[str, Any]] = defaultdict(dict)
         self._lock = asyncio.Lock()
 
     async def async_fetch(
@@ -121,9 +122,7 @@ class _IconsCache:
             category for component in icons.values() for category in component
         }
         for category in categories:
-            self._cache.setdefault(category, {}).update(
-                build_resources(icons, components, category)
-            )
+            self._cache[category].update(build_resources(icons, components, category))
 
 
 async def async_get_icons(

--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -92,7 +92,7 @@ class _IconsCache:
         return {
             component: result
             for component in components
-            if (result := self._cache.get(category, {}).get(component))
+            if (result := self._cache[category].get(component))
         }
 
     async def _async_load(self, components: set[str]) -> None:

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -196,7 +196,12 @@ class _TranslationCache:
         components: set[str],
     ) -> dict[str, str]:
         """Read resources from the cache."""
-        category_cache = self.cache[language][category]
+        if language not in self.cache:
+            return {}
+        language_cache = self.cache[language]
+        if category not in language_cache:
+            return {}
+        category_cache = language_cache[category]
         # If only one component was requested, return it directly
         # to avoid merging the dictionaries and keeping additional
         # copies of the same data in memory.

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from contextlib import suppress
 import logging
@@ -56,16 +57,16 @@ def component_translation_path(language: str, integration: Integration) -> pathl
 
 def _load_translations_files_by_language(
     translation_files: dict[str, dict[str, pathlib.Path]],
-) -> dict[str, dict[str, Any]]:
+) -> defaultdict[str, defaultdict[str, Any]]:
     """Load and parse translation.json files."""
-    loaded: dict[str, dict[str, Any]] = {}
+    loaded: defaultdict[str, defaultdict[str, Any]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
     for language, component_translation_file in translation_files.items():
-        loaded_for_language: dict[str, Any] = {}
-        loaded[language] = loaded_for_language
+        loaded_for_language = loaded[language]
 
         for component, translation_file in component_translation_file.items():
             loaded_json = load_json(translation_file)
-
             if not isinstance(loaded_json, dict):
                 _LOGGER.warning(
                     "Translation file is unexpected type %s. Expected dict for %s",
@@ -101,10 +102,12 @@ async def _async_get_component_strings(
     integrations: dict[str, Integration],
 ) -> dict[str, dict[str, Any]]:
     """Load translations."""
-    translations_by_language: dict[str, dict[str, Any]] = {}
+    translations_by_language: defaultdict[str, dict[str, Any]] = defaultdict(dict)
     # Determine paths of missing components/platforms
     files_to_load_by_language: dict[str, dict[str, pathlib.Path]] = {}
-    loaded_translations_by_language: dict[str, dict[str, Any]] = {}
+    loaded_translations_by_language: defaultdict[str, defaultdict[str, Any]] = (
+        defaultdict(lambda: defaultdict(dict))
+    )
     has_files_to_load = False
     for language in languages:
         files_to_load: dict[str, pathlib.Path] = {
@@ -124,16 +127,16 @@ async def _async_get_component_strings(
         )
 
     for language in languages:
-        loaded_translations = loaded_translations_by_language.setdefault(language, {})
+        loaded_translations = loaded_translations_by_language[language]
         for domain in components:
             # Translations that miss "title" will get integration put in.
-            component_translations = loaded_translations.setdefault(domain, {})
+            component_translations = loaded_translations[domain]
             if "title" not in component_translations and (
                 integration := integrations.get(domain)
             ):
                 component_translations["title"] = integration.name
 
-        translations_by_language.setdefault(language, {}).update(loaded_translations)
+        translations_by_language[language].update(loaded_translations)
 
     return translations_by_language
 
@@ -146,8 +149,10 @@ class _TranslationCache:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the cache."""
         self.hass = hass
-        self.loaded: dict[str, set[str]] = {}
-        self.cache: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
+        self.loaded: defaultdict[str, set[str]] = defaultdict(set)
+        self.cache: defaultdict[
+            str, defaultdict[str, defaultdict[str, dict[str, str]]]
+        ] = defaultdict(lambda: defaultdict(lambda: defaultdict(dict)))
         self.lock = asyncio.Lock()
 
     @callback
@@ -161,7 +166,7 @@ class _TranslationCache:
         components: set[str],
     ) -> None:
         """Load resources into the cache."""
-        loaded = self.loaded.setdefault(language, set())
+        loaded = self.loaded[language]
         if components_to_load := components - loaded:
             # Translations are never unloaded so if there are no components to load
             # we can skip the lock which reduces contention when multiple different
@@ -191,12 +196,12 @@ class _TranslationCache:
         components: set[str],
     ) -> dict[str, str]:
         """Read resources from the cache."""
-        category_cache = self.cache.get(language, {}).get(category, {})
+        category_cache = self.cache[language][category]
         # If only one component was requested, return it directly
         # to avoid merging the dictionaries and keeping additional
         # copies of the same data in memory.
         if len(components) == 1 and (component := next(iter(components))):
-            return category_cache.get(component, {})
+            return category_cache[component]
 
         result: dict[str, str] = {}
         for component in components.intersection(category_cache):
@@ -238,7 +243,7 @@ class _TranslationCache:
                 language, components, translation_by_language_strings[language]
             )
 
-            loaded_english_components = self.loaded.setdefault(LOCALE_EN, set())
+            loaded_english_components = self.loaded[LOCALE_EN]
             # Since we just loaded english anyway we can avoid loading
             # again if they switch back to english.
             if loaded_english_components.isdisjoint(components):
@@ -302,7 +307,7 @@ class _TranslationCache:
     ) -> None:
         """Extract resources into the cache."""
         resource: dict[str, Any] | str
-        cached = self.cache.setdefault(language, {})
+        cached = self.cache[language]
         categories = {
             category
             for component in translation_strings.values()
@@ -311,10 +316,10 @@ class _TranslationCache:
 
         for category in categories:
             new_resources = build_resources(translation_strings, components, category)
-            category_cache = cached.setdefault(category, {})
+            category_cache = cached[category]
 
             for component, resource in new_resources.items():
-                component_cache = category_cache.setdefault(component, {})
+                component_cache = category_cache[component]
 
                 if not isinstance(resource, dict):
                     component_cache[f"component.{component}.{category}"] = resource

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -196,12 +196,9 @@ class _TranslationCache:
         components: set[str],
     ) -> dict[str, str]:
         """Read resources from the cache."""
-        if language not in self.cache:
+        if language not in self.cache or category not in self.cache[language]:
             return {}
-        language_cache = self.cache[language]
-        if category not in language_cache:
-            return {}
-        category_cache = language_cache[category]
+        category_cache = self.cache[language][category]
         # If only one component was requested, return it directly
         # to avoid merging the dictionaries and keeping additional
         # copies of the same data in memory.

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -1,6 +1,7 @@
 """Test the translation helper."""
 
 import asyncio
+from collections import defaultdict
 from os import path
 import pathlib
 from typing import Any
@@ -698,7 +699,7 @@ async def test_get_translations_still_has_title_without_translations_files(
         ),
         patch(
             "homeassistant.helpers.translation._load_translations_files_by_language",
-            return_value={},
+            return_value=defaultdict(lambda: defaultdict(dict)),
         ),
         patch(
             "homeassistant.helpers.translation.async_get_integrations",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `setdefault` with `defaultdict` for translations and icons.

Note that icons depends on `build_resources` in `translations` so these are a bit intertwined so I did them both at once.

implemented suggestion in https://github.com/home-assistant/core/pull/115583#discussion_r1564903625

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
