### PR TITLE
Testing: Add sun device trigger for testing extra_fields UI

### DIFF
--- a/homeassistant/components/sun/device_trigger.py
+++ b/homeassistant/components/sun/device_trigger.py
@@ -1,0 +1,100 @@
+"""Provides device triggers for KNX."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Final
+
+import voluptuous as vol
+
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_EVENT,
+    CONF_OFFSET,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    SUN_EVENT_SUNRISE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import selector
+from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
+from homeassistant.helpers.typing import ConfigType
+
+from . import trigger
+from .const import DOMAIN
+
+TEST_TRIGGER_TYPE: Final = "test_sun_trigger"
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): TEST_TRIGGER_TYPE,
+        # TODO: using vol.Required fails validation if user didn't change
+        #       any extra fields and they are not set in `async_get_triggers`
+        #       even though they have default values
+        vol.Optional("bool"): bool,
+        vol.Optional("const"): bool,
+    }
+)
+
+
+async def async_get_triggers(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, Any]]:
+    """List device triggers for sun devices."""
+    return [
+        {
+            # Default fields when initializing the trigger
+            CONF_PLATFORM: "device",
+            CONF_DOMAIN: DOMAIN,
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: TEST_TRIGGER_TYPE,
+        }
+    ]
+
+
+async def async_get_trigger_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, vol.Schema]:
+    """List trigger capabilities."""
+    # TODO: no translation support for extra_fields
+    return {
+        "extra_fields": vol.Schema(
+            {
+                # TODO: default values are not reflected in the UI
+                vol.Required("bool", default=True): selector.BooleanSelector(),
+                # TODO: ConstantSelector does not show checkbox in UI
+                vol.Required("const", default=True): selector.ConstantSelector(
+                    selector.ConstantSelectorConfig(label="Constant", value=True)
+                ),
+            }
+        )
+    }
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    print(f"attaching trigger\n{trigger_info=}\n{config=}")
+    # Validate the configuration of the trigger
+    try:
+        TRIGGER_SCHEMA(config)
+    except vol.Invalid as err:
+        raise InvalidDeviceAutomationConfig(f"{err}") from err
+
+    # forward dummy data to sun trigger
+    trigger_config = {
+        CONF_EVENT: SUN_EVENT_SUNRISE,
+        CONF_OFFSET: timedelta(0),
+    }
+    return await trigger.async_attach_trigger(
+        hass, config=trigger_config, action=action, trigger_info=trigger_info
+    )

--- a/homeassistant/components/sun/device_trigger.py
+++ b/homeassistant/components/sun/device_trigger.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers import selector
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
@@ -71,6 +72,20 @@ async def async_get_trigger_capabilities(
                 vol.Required("const", default=True): selector.ConstantSelector(
                     selector.ConstantSelectorConfig(label="Constant", value=True)
                 ),
+                vol.Required("time"): selector.TimeSelector(
+                    selector.TimeSelectorConfig()
+                ),
+                vol.Required("datetime"): selector.DateTimeSelector(
+                    selector.DateTimeSelectorConfig()
+                ),
+                vol.Required("duration"): selector.DurationSelector(
+                    selector.DurationSelectorConfig(enable_day=False)
+                ),
+                vol.Required("number"): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=10, max=100)
+                ),
+                vol.Required("cv_bool"): cv.boolean,
+                vol.Required("plain_bool"): bool,
             }
         )
     }

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -28,5 +28,26 @@
       "solar_elevation": { "name": "Solar elevation" },
       "solar_rising": { "name": "Solar rising" }
     }
+  },
+  "device_automation": {
+    "trigger_type": {
+      "test_sun_trigger": "Sun trigger 🌞"
+    },
+    "extra_fields": {
+      "bool": "Boolean",
+      "time": "Time ⏰",
+      "number": "Number 🔢",
+      "datetime": "Date and time",
+      "duration": "Duration ⏳",
+      "cv_bool": "Config validation boolean",
+      "plain_bool": "Plain boolean"
+    },
+    "extra_fields_descriptions": {
+      "bool": "Boolean helper text",
+      "time": "A nice time",
+      "number": "Some number between 10 and 100",
+      "datetime": "Today may be the day 📅",
+      "duration": "Duration ⏳"
+    }
   }
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR is a dummy to test frontend changes for device trigger extra fields. It adds a device trigger to the `Sun` device since everyone has that and can try it out.

You can head to `/config/automation/edit/new` -> "Add trigger" -> "Device" -> select "Sun" to see the extra fields.

Things that are currently not working:
- [x] Default values of extra fields are not reflected in the UI https://github.com/home-assistant/frontend/pull/20555
- [ ] ConstantSelector does not show checkbox in UI
- [ ] Validation of required fields when extra_field keys have default values / default values not applied when user doesn't interact with ha-form
- [ ] Translation of extra field names https://github.com/home-assistant/frontend/pull/20567

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
