### PR TITLE
Split forecasts into devices for Buienradar

### DIFF
--- a/homeassistant/components/buienradar/config_flow.py
+++ b/homeassistant/components/buienradar/config_flow.py
@@ -35,11 +35,11 @@ FORECAST_OPTIONS = vol.Schema(
             selector.SelectSelectorConfig(
                 options=[
                     "now",
-                    "_1d",
-                    "_2d",
-                    "_3d",
-                    "_4d",
-                    "_5d",
+                    "1d",
+                    "2d",
+                    "3d",
+                    "4d",
+                    "5d",
                 ],
                 multiple=True,
                 mode=selector.SelectSelectorMode("list"),

--- a/homeassistant/components/buienradar/const.py
+++ b/homeassistant/components/buienradar/const.py
@@ -1,5 +1,7 @@
 """Constants for buienradar component."""
 
+from typing import Final
+
 DOMAIN = "buienradar"
 
 DEFAULT_TIMEFRAME = 60
@@ -9,6 +11,7 @@ DEFAULT_DELTA = 600
 
 CONF_DELTA = "delta"
 CONF_TIMEFRAME = "timeframe"
+CONF_FORECAST_DAYS = "forecast_days"
 
 SUPPORTED_COUNTRY_CODES = ["NL", "BE"]
 DEFAULT_COUNTRY = "NL"
@@ -63,3 +66,5 @@ STATE_CONDITION_CODES = [
     "g",
     "s",
 ]
+
+MANUFACTURER: Final = "Buienradar"

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -748,17 +748,17 @@ class BrSensor(SensorEntity):
         self._measured = None
         self._attr_unique_id = f"{coordinates[CONF_LATITUDE]:2.6f}{coordinates[CONF_LONGITUDE]:2.6f}{description.key}"
         self._day = (
-            description.key[-3:]
+            description.key[-2:]
             if all(x in description.key[-3:] for x in ("_", "d"))
             else "now"
         )
         self._naming = {
             "now": "Today",
-            "_1d": "Tomorrow",
-            "_2d": "In 2 days",
-            "_3d": "In 3 days",
-            "_4d": "In 4 days",
-            "_5d": "In 5 days",
+            "1d": "Tomorrow",
+            "2d": "In 2 days",
+            "3d": "In 3 days",
+            "4d": "In 4 days",
+            "5d": "In 5 days",
         }
         # only enable at entity creation
         # self._attr_entity_registry_enabled_default = self._day in self._selected
@@ -787,7 +787,7 @@ class BrSensor(SensorEntity):
         if self._day not in self._selected:
             entity_registry.async_update_entity(
                 entity_id=self.entity_id,
-                disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+                disabled_by=er.RegistryEntryDisabler.USER,
             )
 
     async def async_enable_entity(self):
@@ -797,8 +797,7 @@ class BrSensor(SensorEntity):
 
     async def async_added_to_hass(self):
         """Handle options update."""
-        if self._day not in self._selected:
-            await self.async_disable_entity()
+        await self.async_disable_entity()
 
     @callback
     def data_updated(self, data: BrData):

--- a/homeassistant/components/buienradar/sensor.py
+++ b/homeassistant/components/buienradar/sensor.py
@@ -760,8 +760,6 @@ class BrSensor(SensorEntity):
             "4d": "In 4 days",
             "5d": "In 5 days",
         }
-        # only enable at entity creation
-        # self._attr_entity_registry_enabled_default = self._day in self._selected
 
         # All continuous sensors should be forced to be updated
         self._attr_force_update = (
@@ -818,9 +816,7 @@ class BrSensor(SensorEntity):
         self._measured = data.get(MEASURED)
         sensor_type = self.entity_description.key
 
-        if sensor_type.endswith("_1d") or sensor_type.endswith(
-            "_2d", "_3d", "_4d", "_5d"
-        ):
+        if sensor_type.endswith(("_1d", "_2d", "_3d", "_4d", "_5d")):
             # update forecasting sensors:
             fcday = 0
             if sensor_type.endswith("_2d"):
@@ -833,7 +829,7 @@ class BrSensor(SensorEntity):
                 fcday = 4
 
             # update weather symbol & status text
-            if sensor_type.startswith(SYMBOL, CONDITION):
+            if sensor_type.startswith((SYMBOL, CONDITION)):
                 try:
                     condition = data.get(FORECAST)[fcday].get(CONDITION)
                 except IndexError:

--- a/homeassistant/components/buienradar/strings.json
+++ b/homeassistant/components/buienradar/strings.json
@@ -27,11 +27,11 @@
     "forecast_days": {
       "options": {
         "now": "Today",
-        "d1": "Tomorrow",
-        "d2": "Over 2 days",
-        "d3": "Over 3 days",
-        "d4": "Over 4 days",
-        "d5": "Over 5 days"
+        "1d": "Tomorrow",
+        "2d": "Over 2 days",
+        "3d": "Over 3 days",
+        "4d": "Over 4 days",
+        "5d": "Over 5 days"
       }
     }
   },
@@ -41,7 +41,11 @@
         "data": {
           "country_code": "Country code of the country to display camera images.",
           "delta": "Time interval in seconds between camera image updates",
-          "timeframe": "Minutes to look ahead for precipitation forecast"
+          "timeframe": "Minutes to look ahead for precipitation forecast",
+          "forecast_days": "Forecast Days"
+        },
+        "data_description": {
+          "forecast_days": "Select the forecast days that should be enabled"
         }
       }
     }

--- a/homeassistant/components/buienradar/strings.json
+++ b/homeassistant/components/buienradar/strings.json
@@ -6,6 +6,14 @@
           "latitude": "[%key:common::config_flow::data::latitude%]",
           "longitude": "[%key:common::config_flow::data::longitude%]"
         }
+      },
+      "forecasts": {
+        "data": {
+          "forecast_days": "Forecast Days"
+        },
+        "data_description": {
+          "forecast_days": "Select the forecast days that should be enabled"
+        }
       }
     },
     "error": {
@@ -13,6 +21,18 @@
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_location%]"
+    }
+  },
+  "selector": {
+    "forecast_days": {
+      "options": {
+        "now": "Today",
+        "d1": "Tomorrow",
+        "d2": "Over 2 days",
+        "d3": "Over 3 days",
+        "d4": "Over 4 days",
+        "d5": "Over 5 days"
+      }
     }
   },
   "options": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the forecast `attributes` are not supported any more many weather integrations like Buienradar have added many entities for forecasts. To organize those entities better, I propose to split them up into devices/services for each forecast day. Added to that since all sensor entities were disabled by default, I have built the option to select which forecast days should be enabled by setup or can be disabled in the options flow.

![image](https://github.com/home-assistant/core/assets/68892092/f8c697fb-7cf1-4d92-834e-937a0303e121)
![image](https://github.com/home-assistant/core/assets/68892092/9439670d-666e-4f38-a436-26e183f9774c)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
