### PR TITLE
Translation support for device automation extra fields

### DIFF
--- a/homeassistant/components/alarm_control_panel/strings.json
+++ b/homeassistant/components/alarm_control_panel/strings.json
@@ -17,6 +17,10 @@
       "is_armed_night": "{entity_name} is armed night",
       "is_armed_vacation": "{entity_name} is armed vacation"
     },
+    "extra_fields": {
+      "code": "Code",
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    },
     "trigger_type": {
       "triggered": "{entity_name} triggered",
       "disarmed": "{entity_name} disarmed",

--- a/homeassistant/components/binary_sensor/strings.json
+++ b/homeassistant/components/binary_sensor/strings.json
@@ -55,6 +55,9 @@
       "is_on": "[%key:common::device_automation::condition_type::is_on%]",
       "is_off": "[%key:common::device_automation::condition_type::is_off%]"
     },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
+    },
     "trigger_type": {
       "bat_low": "{entity_name} battery low",
       "not_bat_low": "{entity_name} battery normal",

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -13,6 +13,14 @@
     "action_type": {
       "set_hvac_mode": "Change HVAC mode on {entity_name}",
       "set_preset_mode": "Change preset on {entity_name}"
+    },
+    "extra_fields": {
+      "above": "[%key:common::device_automation::extra_fields::above%]",
+      "below": "[%key:common::device_automation::extra_fields::below%]",
+      "for": "[%key:common::device_automation::extra_fields::for%]",
+      "to": "[%key:common::device_automation::extra_fields::to%]",
+      "preset_mode": "Preset mode",
+      "hvac_mode": "HVAC mode"
     }
   },
   "entity_component": {

--- a/homeassistant/components/cover/strings.json
+++ b/homeassistant/components/cover/strings.json
@@ -18,6 +18,12 @@
       "is_position": "Current {entity_name} position is",
       "is_tilt_position": "Current {entity_name} tilt position is"
     },
+    "extra_fields": {
+      "above": "[%key:common::device_automation::extra_fields::above%]",
+      "below": "[%key:common::device_automation::extra_fields::below%]",
+      "for": "[%key:common::device_automation::extra_fields::for%]",
+      "position": "Position"
+    },
     "trigger_type": {
       "opened": "{entity_name} opened",
       "closed": "{entity_name} closed",

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -5,6 +5,9 @@
       "is_home": "{entity_name} is home",
       "is_not_home": "{entity_name} is not home"
     },
+    "extra_fields": {
+      "zone": "[%key:common::device_automation::extra_fields::zone%]"
+    },
     "trigger_type": {
       "enters": "{entity_name} enters a zone",
       "leaves": "{entity_name} leaves a zone"

--- a/homeassistant/components/humidifier/strings.json
+++ b/homeassistant/components/humidifier/strings.json
@@ -18,6 +18,13 @@
       "toggle": "[%key:common::device_automation::action_type::toggle%]",
       "turn_on": "[%key:common::device_automation::action_type::turn_on%]",
       "turn_off": "[%key:common::device_automation::action_type::turn_off%]"
+    },
+    "extra_fields": {
+      "above": "[%key:common::device_automation::extra_fields::above%]",
+      "below": "[%key:common::device_automation::extra_fields::below%]",
+      "for": "[%key:common::device_automation::extra_fields::for%]",
+      "mode": "Mode",
+      "humidity": "Humidity"
     }
   },
   "entity_component": {

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -17,6 +17,10 @@
       "changed_states": "[%key:common::device_automation::trigger_type::changed_states%]",
       "turned_on": "[%key:common::device_automation::trigger_type::turned_on%]",
       "turned_off": "[%key:common::device_automation::trigger_type::turned_off%]"
+    },
+    "extra_fields": {
+      "brightness_pct": "Brightness",
+      "flash": "Flash"
     }
   },
   "entity_component": {

--- a/homeassistant/components/lock/strings.json
+++ b/homeassistant/components/lock/strings.json
@@ -15,6 +15,9 @@
       "locked": "{entity_name} locked",
       "unlocked": "{entity_name} unlocked",
       "open": "{entity_name} opened"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
     }
   },
   "entity_component": {

--- a/homeassistant/components/media_player/strings.json
+++ b/homeassistant/components/media_player/strings.json
@@ -17,6 +17,9 @@
       "paused": "{entity_name} is paused",
       "playing": "{entity_name} starts playing",
       "changed_states": "[%key:common::device_automation::trigger_type::changed_states%]"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
     }
   },
   "entity_component": {

--- a/homeassistant/components/mobile_app/strings.json
+++ b/homeassistant/components/mobile_app/strings.json
@@ -13,6 +13,10 @@
   "device_automation": {
     "action_type": {
       "notify": "Send a notification"
+    },
+    "extra_fields": {
+      "message": "Message",
+      "title": "Title"
     }
   }
 }

--- a/homeassistant/components/number/strings.json
+++ b/homeassistant/components/number/strings.json
@@ -3,6 +3,9 @@
   "device_automation": {
     "action_type": {
       "set_value": "Set value for {entity_name}"
+    },
+    "extra_fields": {
+      "value": "[%key:common::device_automation::extra_fields::value%]"
     }
   },
   "entity_component": {

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -13,6 +13,13 @@
     },
     "condition_type": {
       "selected_option": "Current {entity_name} selected option"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]",
+      "to": "[%key:common::device_automation::extra_fields::to%]",
+      "cycle": "Cycle",
+      "from": "From",
+      "option": "Option"
     }
   },
   "entity_component": {

--- a/homeassistant/components/sensor/strings.json
+++ b/homeassistant/components/sensor/strings.json
@@ -98,6 +98,11 @@
       "water": "{entity_name} water changes",
       "weight": "{entity_name} weight changes",
       "wind_speed": "{entity_name} wind speed changes"
+    },
+    "extra_fields": {
+      "above": "[%key:common::device_automation::extra_fields::above%]",
+      "below": "[%key:common::device_automation::extra_fields::below%]",
+      "for": "[%key:common::device_automation::extra_fields::for%]"
     }
   },
   "entity_component": {

--- a/homeassistant/components/text/strings.json
+++ b/homeassistant/components/text/strings.json
@@ -3,6 +3,9 @@
   "device_automation": {
     "action_type": {
       "set_value": "Set value for {entity_name}"
+    },
+    "extra_fields": {
+      "value": "[%key:common::device_automation::extra_fields::value%]"
     }
   },
   "entity_component": {

--- a/homeassistant/components/vacuum/strings.json
+++ b/homeassistant/components/vacuum/strings.json
@@ -12,6 +12,9 @@
     "action_type": {
       "clean": "Let {entity_name} clean",
       "dock": "Let {entity_name} return to the dock"
+    },
+    "extra_fields": {
+      "for": "[%key:common::device_automation::extra_fields::for%]"
     }
   },
   "entity_component": {

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -9,6 +9,14 @@
         "is_on": "{entity_name} is on",
         "is_off": "{entity_name} is off"
       },
+      "extra_fields": {
+        "above": "Above",
+        "below": "Below",
+        "for": "Duration",
+        "to": "To",
+        "value": "Value",
+        "zone": "Zone"
+      },
       "trigger_type": {
         "changed_states": "{entity_name} turned on or off",
         "turned_on": "{entity_name} turned on",

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -284,6 +284,10 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 vol.Optional("condition_type"): {str: translation_value_validator},
                 vol.Optional("trigger_type"): {str: translation_value_validator},
                 vol.Optional("trigger_subtype"): {str: translation_value_validator},
+                vol.Optional("extra_fields"): {str: translation_value_validator},
+                vol.Optional("extra_fields_descriptions"): {
+                    str: translation_value_validator
+                },
             },
             vol.Optional("system_health"): {
                 vol.Optional("info"): cv.schema_with_slug_keys(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow new keys in integrations `strings.json` to support translation of device automation (trigger, condition, action) extra fields.
- "extra_fields"
- "extra_fields_descriptions" for selector helper texts

Frontend PR: https://github.com/home-assistant/frontend/pull/20567

Integrations that already use custom extra fields in device actions and can make use of this :
- knx
- lcn
- zha
- zwave-js

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
