### PR TITLE
Remove YAML support from Hydrawise

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,50 +1,15 @@
 """Support for Hydrawise cloud."""
 
 from pydrawise import legacy
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_API_KEY,
-    CONF_SCAN_INTERVAL,
-    Platform,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, Platform
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, SCAN_INTERVAL
 from .coordinator import HydrawiseDataUpdateCoordinator
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_ACCESS_TOKEN): cv.string,
-                vol.Optional(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL): cv.time_period,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
-
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR, Platform.SWITCH]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Hunter Hydrawise component."""
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_API_KEY: config[DOMAIN][CONF_ACCESS_TOKEN]},
-        )
-    )
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/hydrawise/strings.json
+++ b/homeassistant/components/hydrawise/strings.json
@@ -16,12 +16,6 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
   },
-  "issues": {
-    "deprecated_yaml_import_issue": {
-      "title": "The Hydrawise YAML configuration import failed",
-      "description": "Configuring Hydrawise using YAML is being removed but there was an {error_type} error importing your YAML configuration.\n\nEnsure connection to Hydrawise works and restart Home Assistant to try again or remove the Hydrawise YAML configuration from your configuration.yaml file and continue to [set up the integration]({url}) manually."
-    }
-  },
   "entity": {
     "binary_sensor": {
       "watering": {

--- a/tests/components/hydrawise/test_config_flow.py
+++ b/tests/components/hydrawise/test_config_flow.py
@@ -8,12 +8,8 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.hydrawise.const import DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_SCAN_INTERVAL
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-import homeassistant.helpers.issue_registry as ir
-
-from tests.common import MockConfigEntry
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -87,115 +83,3 @@ async def test_form_connect_timeout(
     mock_pydrawise.get_user.return_value = user
     result2 = await hass.config_entries.flow.async_configure(result["flow_id"], data)
     assert result2["type"] is FlowResultType.CREATE_ENTRY
-
-
-async def test_flow_import_success(
-    hass: HomeAssistant, mock_pydrawise: AsyncMock, user: User
-) -> None:
-    """Test that we can import a YAML config."""
-    mock_pydrawise.get_user.return_value = User
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_API_KEY: "__api_key__",
-            CONF_SCAN_INTERVAL: 120,
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Hydrawise"
-    assert result["data"] == {
-        CONF_API_KEY: "__api_key__",
-    }
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        HOMEASSISTANT_DOMAIN, "deprecated_yaml_hydrawise"
-    )
-    assert issue.translation_key == "deprecated_yaml"
-
-
-async def test_flow_import_api_error(
-    hass: HomeAssistant, mock_pydrawise: AsyncMock
-) -> None:
-    """Test that we handle API errors on YAML import."""
-    mock_pydrawise.get_user.side_effect = ClientError
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_API_KEY: "__api_key__",
-            CONF_SCAN_INTERVAL: 120,
-        },
-    )
-    await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        DOMAIN, "deprecated_yaml_import_issue_cannot_connect"
-    )
-    assert issue.translation_key == "deprecated_yaml_import_issue"
-
-
-async def test_flow_import_connect_timeout(
-    hass: HomeAssistant, mock_pydrawise: AsyncMock
-) -> None:
-    """Test that we handle connection timeouts on YAML import."""
-    mock_pydrawise.get_user.side_effect = TimeoutError
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_API_KEY: "__api_key__",
-            CONF_SCAN_INTERVAL: 120,
-        },
-    )
-    await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "timeout_connect"
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        DOMAIN, "deprecated_yaml_import_issue_timeout_connect"
-    )
-    assert issue.translation_key == "deprecated_yaml_import_issue"
-
-
-async def test_flow_import_already_imported(
-    hass: HomeAssistant, mock_pydrawise: AsyncMock, user: User
-) -> None:
-    """Test that we can handle a YAML config already imported."""
-    mock_config_entry = MockConfigEntry(
-        title="Hydrawise",
-        domain=DOMAIN,
-        data={
-            CONF_API_KEY: "__api_key__",
-        },
-        unique_id="hydrawise-12345",
-    )
-    mock_config_entry.add_to_hass(hass)
-
-    mock_pydrawise.get_user.return_value = user
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
-            CONF_API_KEY: "__api_key__",
-            CONF_SCAN_INTERVAL: 120,
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result.get("reason") == "already_configured"
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        HOMEASSISTANT_DOMAIN, "deprecated_yaml_hydrawise"
-    )
-    assert issue.translation_key == "deprecated_yaml"

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -5,27 +5,9 @@ from unittest.mock import AsyncMock
 from aiohttp import ClientError
 
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_ACCESS_TOKEN
-from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
-import homeassistant.helpers.issue_registry as ir
-from homeassistant.setup import async_setup_component
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
-
-
-async def test_setup_import_success(
-    hass: HomeAssistant, mock_pydrawise: AsyncMock
-) -> None:
-    """Test that setup with a YAML config triggers an import and warning."""
-    config = {"hydrawise": {CONF_ACCESS_TOKEN: "_access-token_"}}
-    assert await async_setup_component(hass, "hydrawise", config)
-    await hass.async_block_till_done()
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        HOMEASSISTANT_DOMAIN, "deprecated_yaml_hydrawise"
-    )
-    assert issue.translation_key == "deprecated_yaml"
 
 
 async def test_connect_retry(


### PR DESCRIPTION
## Breaking change
Remove support for configuring Hydrawise with YAML.

This was slated for removal in 2024.4.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
