### PR TITLE
Fix invalid tuple annotations

### DIFF
--- a/homeassistant/components/imap/coordinator.py
+++ b/homeassistant/components/imap/coordinator.py
@@ -125,13 +125,13 @@ class ImapMessage:
             return str(part.get_payload())
 
     @property
-    def headers(self) -> dict[str, tuple[str,]]:
+    def headers(self) -> dict[str, tuple[str, ...]]:
         """Get the email headers."""
-        header_base: dict[str, tuple[str,]] = {}
+        header_base: dict[str, tuple[str, ...]] = {}
         for key, value in self.email_message.items():
-            header_instances: tuple[str,] = (str(value),)
+            header_instances: tuple[str, ...] = (str(value),)
             if header_base.setdefault(key, header_instances) != header_instances:
-                header_base[key] += header_instances  # type: ignore[assignment]
+                header_base[key] += header_instances
         return header_base
 
     @property

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -663,9 +663,9 @@ async def test_is_on(hass: HomeAssistant) -> None:
 )
 async def test_is_on_and_state_mixed_domains(
     hass: HomeAssistant,
-    domains: tuple[str,],
-    states_old: tuple[str,],
-    states_new: tuple[str,],
+    domains: tuple[str, ...],
+    states_old: tuple[str, ...],
+    states_new: tuple[str, ...],
     state_ison_group_old: tuple[str, bool],
     state_ison_group_new: tuple[str, bool],
 ) -> None:

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -83,7 +83,7 @@ def help_all_subscribe_calls(mqtt_client_mock: MqttMockPahoClient) -> list[Any]:
 def help_custom_config(
     mqtt_entity_domain: str,
     mqtt_base_config: ConfigType,
-    mqtt_entity_configs: Iterable[ConfigType,],
+    mqtt_entity_configs: Iterable[ConfigType],
 ) -> ConfigType:
     """Tweak a default config for parametrization.
 

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -236,7 +236,7 @@ async def test_warning_if_color_mode_flags_are_used(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
-    color_modes: tuple[str,],
+    color_modes: tuple[str, ...],
 ) -> None:
     """Test warnings deprecated config keys without supported color modes defined."""
     with patch(
@@ -278,7 +278,7 @@ async def test_warning_on_discovery_if_color_mode_flags_are_used(
     mqtt_mock_entry: MqttMockHAClientGenerator,
     caplog: pytest.LogCaptureFixture,
     config: dict[str, Any],
-    color_modes: tuple[str,],
+    color_modes: tuple[str, ...],
 ) -> None:
     """Test warnings deprecated config keys with discovery."""
     with patch(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -102,7 +102,7 @@ def test_template_message(arg: str | Exception, expected: str) -> None:
 )
 async def test_home_assistant_error(
     hass: HomeAssistant,
-    exception_args: tuple[Any,],
+    exception_args: tuple[Any, ...],
     exception_kwargs: dict[str, Any],
     args_base_class: tuple[Any],
     message: str,


### PR DESCRIPTION
## Proposed change
`tuple[<type>, ...]` should be used to annotate a tuple with 0 or more elements.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
