### PR TITLE
Fix accuweather system_health after data change

### DIFF
--- a/homeassistant/components/accuweather/system_health.py
+++ b/homeassistant/components/accuweather/system_health.py
@@ -24,7 +24,7 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the info page."""
     remaining_requests = list(hass.data[DOMAIN].values())[
         0
-    ].accuweather.requests_remaining
+    ].coordinator_observation.accuweather.requests_remaining
 
     return {
         "can_reach_server": system_health.async_check_can_reach_url(hass, ENDPOINT),

--- a/tests/components/accuweather/test_system_health.py
+++ b/tests/components/accuweather/test_system_health.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 
 from aiohttp import ClientError
 
+from homeassistant.components.accuweather import AccuWeatherData
 from homeassistant.components.accuweather.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -23,8 +24,10 @@ async def test_accuweather_system_health(
     await hass.async_block_till_done()
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN]["0123xyz"] = {}
-    hass.data[DOMAIN]["0123xyz"] = Mock(accuweather=Mock(requests_remaining="42"))
+    hass.data[DOMAIN]["0123xyz"] = AccuWeatherData(
+        coordinator_observation=Mock(accuweather=Mock(requests_remaining="42")),
+        coordinator_daily_forecast=Mock(),
+    )
 
     info = await get_system_health_info(hass, DOMAIN)
 
@@ -48,8 +51,10 @@ async def test_accuweather_system_health_fail(
     await hass.async_block_till_done()
 
     hass.data[DOMAIN] = {}
-    hass.data[DOMAIN]["0123xyz"] = {}
-    hass.data[DOMAIN]["0123xyz"] = Mock(accuweather=Mock(requests_remaining="0"))
+    hass.data[DOMAIN]["0123xyz"] = AccuWeatherData(
+        coordinator_observation=Mock(accuweather=Mock(requests_remaining="0")),
+        coordinator_daily_forecast=Mock(),
+    )
 
     info = await get_system_health_info(hass, DOMAIN)
 


### PR DESCRIPTION
## Proposed change
Fix for issue introduced in #115628.
The PR changed the data structure stored in `hass.data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
