### PR TITLE
Ecobee preset mode icon translations

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -12,7 +12,10 @@ from homeassistant.components.climate import (
     ATTR_TARGET_TEMP_LOW,
     FAN_AUTO,
     FAN_ON,
+    PRESET_AWAY,
+    PRESET_HOME,
     PRESET_NONE,
+    PRESET_SLEEP,
     ClimateEntity,
     ClimateEntityFeature,
     HVACAction,
@@ -60,9 +63,6 @@ PRESET_TEMPERATURE = "temp"
 PRESET_VACATION = "vacation"
 PRESET_HOLD_NEXT_TRANSITION = "next_transition"
 PRESET_HOLD_INDEFINITE = "indefinite"
-AWAY_MODE = "awayMode"
-PRESET_HOME = "home"
-PRESET_SLEEP = "sleep"
 HAS_HEAT_PUMP = "hasHeatPump"
 
 DEFAULT_MIN_HUMIDITY = 15
@@ -102,6 +102,13 @@ ECOBEE_HVAC_ACTION_TO_HASS = {
     "auxHotWater": None,
     "compWaterHeater": None,
 }
+
+ECOBEE_TO_HASS_PRESET = {
+    "Away": PRESET_AWAY,
+    "Home": PRESET_HOME,
+    "Sleep": PRESET_SLEEP,
+}
+HASS_TO_ECOBEE_PRESET = {v: k for k, v in ECOBEE_TO_HASS_PRESET.items()}
 
 PRESET_TO_ECOBEE_HOLD = {
     PRESET_HOLD_NEXT_TRANSITION: "nextTransition",
@@ -348,10 +355,6 @@ class Thermostat(ClimateEntity):
             self._attr_hvac_modes.insert(0, HVACMode.HEAT_COOL)
         self._attr_hvac_modes.append(HVACMode.OFF)
 
-        self._preset_modes = {
-            comfort["climateRef"]: comfort["name"]
-            for comfort in self.thermostat["program"]["climates"]
-        }
         self.update_without_throttle = False
 
     async def async_update(self) -> None:
@@ -474,7 +477,7 @@ class Thermostat(ClimateEntity):
         return self.thermostat["runtime"]["desiredFanMode"]
 
     @property
-    def preset_mode(self):
+    def preset_mode(self) -> str | None:
         """Return current preset mode."""
         events = self.thermostat["events"]
         for event in events:
@@ -487,8 +490,8 @@ class Thermostat(ClimateEntity):
                 ):
                     return PRESET_AWAY_INDEFINITELY
 
-                if event["holdClimateRef"] in self._preset_modes:
-                    return self._preset_modes[event["holdClimateRef"]]
+                if name := self.comfort_settings.get(event["holdClimateRef"]):
+                    return ECOBEE_TO_HASS_PRESET.get(name, name)
 
                 # Any hold not based on a climate is a temp hold
                 return PRESET_TEMPERATURE
@@ -499,7 +502,12 @@ class Thermostat(ClimateEntity):
                 self.vacation = event["name"]
                 return PRESET_VACATION
 
-        return self._preset_modes[self.thermostat["program"]["currentClimateRef"]]
+        if name := self.comfort_settings.get(
+            self.thermostat["program"]["currentClimateRef"]
+        ):
+            return ECOBEE_TO_HASS_PRESET.get(name, name)
+
+        return None
 
     @property
     def hvac_mode(self):
@@ -545,14 +553,14 @@ class Thermostat(ClimateEntity):
         return HVACAction.IDLE
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return device specific state attributes."""
         status = self.thermostat["equipmentStatus"]
         return {
             "fan": self.fan,
-            "climate_mode": self._preset_modes[
+            "climate_mode": self.comfort_settings.get(
                 self.thermostat["program"]["currentClimateRef"]
-            ],
+            ),
             "equipment_running": status,
             "fan_min_on_time": self.settings["fanMinOnTime"],
         }
@@ -577,6 +585,8 @@ class Thermostat(ClimateEntity):
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Activate a preset."""
+        preset_mode = HASS_TO_ECOBEE_PRESET.get(preset_mode, preset_mode)
+
         if preset_mode == self.preset_mode:
             return
 
@@ -605,25 +615,14 @@ class Thermostat(ClimateEntity):
         elif preset_mode == PRESET_NONE:
             self.data.ecobee.resume_program(self.thermostat_index)
 
-        elif preset_mode in self.preset_modes:
-            climate_ref = None
-
-            for comfort in self.thermostat["program"]["climates"]:
-                if comfort["name"] == preset_mode:
-                    climate_ref = comfort["climateRef"]
+        else:
+            for climate_ref, name in self.comfort_settings.items():
+                if name == preset_mode:
+                    preset_mode = climate_ref
                     break
-
-            if climate_ref is not None:
-                self.data.ecobee.set_climate_hold(
-                    self.thermostat_index,
-                    climate_ref,
-                    self.hold_preference(),
-                    self.hold_hours(),
-                )
             else:
                 _LOGGER.warning("Received unknown preset mode: %s", preset_mode)
 
-        else:
             self.data.ecobee.set_climate_hold(
                 self.thermostat_index,
                 preset_mode,
@@ -632,11 +631,22 @@ class Thermostat(ClimateEntity):
             )
 
     @property
-    def preset_modes(self):
+    def preset_modes(self) -> list[str] | None:
         """Return available preset modes."""
         # Return presets provided by the ecobee API, and an indefinite away
         # preset which we handle separately in set_preset_mode().
-        return [*self._preset_modes.values(), PRESET_AWAY_INDEFINITELY]
+        return [
+            ECOBEE_TO_HASS_PRESET.get(name, name)
+            for name in self.comfort_settings.values()
+        ] + [PRESET_AWAY_INDEFINITELY]
+
+    @property
+    def comfort_settings(self) -> dict[str, str]:
+        """Return ecobee API comfort settings."""
+        return {
+            comfort["climateRef"]: comfort["name"]
+            for comfort in self.thermostat["program"]["climates"]
+        }
 
     def set_auto_temp_hold(self, heat_temp, cool_temp):
         """Set temperature hold in auto mode."""

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -441,7 +441,7 @@ async def test_preset_indefinite_away(ecobee_fixture, thermostat) -> None:
     """Test indefinite away showing correctly, and not as temporary away."""
     ecobee_fixture["program"]["currentClimateRef"] = "away"
     ecobee_fixture["events"][0]["holdClimateRef"] = "away"
-    assert thermostat.preset_mode == "Away"
+    assert thermostat.preset_mode == "away"
 
     ecobee_fixture["events"][0]["endDate"] = "2999-01-01"
     assert thermostat.preset_mode == PRESET_AWAY_INDEFINITELY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The ecobee API backing this integration represents preset modes as "climates", or "comfort settings" in the app. Each "climate" has a `climateRef` that maps to a human readable `name`:

```python
# climateRef: name
{'away': 'Away', 'home': 'Home', 'sleep': 'Sleep', 'smart1': 'Custom Climate', 'smart2': 'Another Custom Climate'}
```

The ecobee integration uses the more representational `name` to feed into the `preset_modes` property. However, these capitalized presets don't map correctly to the default icon translations in [homeassistant/components/climate/icons.json#L36](https://github.com/home-assistant/core/blob/dev/homeassistant/components/climate/icons.json#L36).

*Preferably, ecobee's icon translations would be updated to include `Away`, `Home`, and `Sleep`, and simply map them to the default icon translations, but capitalization is forbidden there and enforced by a `pre-commit` step.*

As described below, this change maps ecobee API `name`s to Home Assistant presets -- essentially mapping to the lower case representation -- to support default icon translations on the front end.

> [!IMPORTANT] 
> This means any service calls or other preset comparisons that used `Away`, `Home`, or `Sleep` will fail, and would need to use the Home Assistant presets `away`, `home`, and `sleep`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `ecobee` integration does not use lower case naming convention for its preset modes (ecobee API calls these "climates", "comfort settings" in the app). This causes the front end to not display icon translations for known preset modes: `Away`, `Home`, and `Sleep`.

<img width="502" alt="Screenshot 2024-04-21 at 10 34 50 PM" src="https://github.com/home-assistant/core/assets/22921548/ebef7d3f-0a0d-4898-bcc1-78414b1ca213">

This change maps known ecobee comfort setting `name`s to [Home Assistant preset modes](https://developers.home-assistant.io/docs/core/entity/climate/#presets) that have default icon translations, if such a mapping exists. If no mapping exists, continue to use the comfort setting's `name` -- these will remain capitalized.

<img width="481" alt="Screenshot 2024-04-21 at 10 31 49 PM" src="https://github.com/home-assistant/core/assets/22921548/b6532ae4-82c7-4372-97b7-64409fe4184a">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
