### PR TITLE
Add missing availability string in sensor scrape config flow

### DIFF
--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -72,6 +72,7 @@
           "index": "[%key:component::scrape::config::step::sensor::data::index%]",
           "select": "[%key:component::scrape::config::step::sensor::data::select%]",
           "value_template": "[%key:component::scrape::config::step::sensor::data::value_template%]",
+          "availability": "[%key:component::scrape::config::step::sensor::data::availability%]",
           "device_class": "[%key:component::scrape::config::step::sensor::data::device_class%]",
           "state_class": "[%key:component::scrape::config::step::sensor::data::state_class%]",
           "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data::unit_of_measurement%]"
@@ -81,6 +82,7 @@
           "attribute": "[%key:component::scrape::config::step::sensor::data_description::attribute%]",
           "index": "[%key:component::scrape::config::step::sensor::data_description::index%]",
           "value_template": "[%key:component::scrape::config::step::sensor::data_description::value_template%]",
+          "availability": "[%key:component::scrape::config::step::sensor::data_description::availability%]",
           "device_class": "[%key:component::scrape::config::step::sensor::data_description::device_class%]",
           "state_class": "[%key:component::scrape::config::step::sensor::data_description::state_class%]",
           "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data_description::unit_of_measurement%]"
@@ -93,6 +95,7 @@
           "index": "[%key:component::scrape::config::step::sensor::data::index%]",
           "select": "[%key:component::scrape::config::step::sensor::data::select%]",
           "value_template": "[%key:component::scrape::config::step::sensor::data::value_template%]",
+          "availability": "[%key:component::scrape::config::step::sensor::data::availability%]",
           "device_class": "[%key:component::scrape::config::step::sensor::data::device_class%]",
           "state_class": "[%key:component::scrape::config::step::sensor::data::state_class%]",
           "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data::unit_of_measurement%]"
@@ -102,6 +105,7 @@
           "attribute": "[%key:component::scrape::config::step::sensor::data_description::attribute%]",
           "index": "[%key:component::scrape::config::step::sensor::data_description::index%]",
           "value_template": "[%key:component::scrape::config::step::sensor::data_description::value_template%]",
+          "availability": "[%key:component::scrape::config::step::sensor::data_description::availability%]",
           "device_class": "[%key:component::scrape::config::step::sensor::data_description::device_class%]",
           "state_class": "[%key:component::scrape::config::step::sensor::data_description::state_class%]",
           "unit_of_measurement": "[%key:component::scrape::config::step::sensor::data_description::unit_of_measurement%]"

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -37,7 +37,7 @@
           "index": "Index",
           "select": "Select",
           "value_template": "Value Template",
-          "availability": "Availability Template"
+          "availability": "Availability Template",
           "device_class": "Device Class",
           "state_class": "State Class",
           "unit_of_measurement": "Unit of Measurement"

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -37,6 +37,7 @@
           "index": "Index",
           "select": "Select",
           "value_template": "Value Template",
+          "availability": "Availability Template"
           "device_class": "Device Class",
           "state_class": "State Class",
           "unit_of_measurement": "Unit of Measurement"

--- a/homeassistant/components/scrape/strings.json
+++ b/homeassistant/components/scrape/strings.json
@@ -47,6 +47,7 @@
           "attribute": "Get value of an attribute on the selected tag",
           "index": "Defines which of the elements returned by the CSS selector to use",
           "value_template": "Defines a template to get the state of the sensor",
+          "availability": "Defines a template to get the availability of the sensor",
           "device_class": "The type/class of the sensor to set the icon in the frontend",
           "state_class": "The state_class of the sensor",
           "unit_of_measurement": "Choose temperature measurement or create your own"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently missing strings in sensor config flow.

![image](https://github.com/home-assistant/core/assets/9977955/7c3b7890-7b4f-4638-a42a-e45f746a6e75)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
