### PR TITLE
Mask current password in MQTT option flow

### DIFF
--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -173,9 +173,9 @@ def update_password_from_user_input(
 ) -> dict[str, Any]:
     """Update the password if the entry has been updated.
 
-    As we want to avoid reflecting the stored password in the UI
+    As we want to avoid reflecting the stored password in the UI,
     we replace the suggested value in the UI with a sentitel,
-    and we change it back here is it has changed.
+    and we change it back here if it was changed.
     """
     substituted_used_data = dict(user_input)
     # Take out the password submitted

--- a/homeassistant/components/mqtt/config_flow.py
+++ b/homeassistant/components/mqtt/config_flow.py
@@ -171,7 +171,12 @@ PWD_NOT_CHANGED = "__**password_not_changed**__"
 def update_password_from_user_input(
     entry_password: str | None, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Update the password if the entry has been updated."""
+    """Update the password if the entry has been updated.
+
+    As we want to avoid reflecting the stored password in the UI
+    we replace the suggested value in the UI with a sentitel,
+    and we change it back here is it has changed.
+    """
     substituted_used_data = dict(user_input)
     # Take out the password submitted
     user_password: str | None = substituted_used_data.pop(CONF_PASSWORD, None)

--- a/tests/components/mqtt/test_config_flow.py
+++ b/tests/components/mqtt/test_config_flow.py
@@ -902,7 +902,7 @@ async def test_option_flow_default_suggested_values(
     }
     suggested = {
         mqtt.CONF_USERNAME: "user",
-        mqtt.CONF_PASSWORD: "pass",
+        mqtt.CONF_PASSWORD: PWD_NOT_CHANGED,
     }
     for key, value in defaults.items():
         assert get_default(result["data_schema"].schema, key) == value
@@ -964,7 +964,7 @@ async def test_option_flow_default_suggested_values(
     }
     suggested = {
         mqtt.CONF_USERNAME: "us3r",
-        mqtt.CONF_PASSWORD: "p4ss",
+        mqtt.CONF_PASSWORD: PWD_NOT_CHANGED,
     }
     for key, value in defaults.items():
         assert get_default(result["data_schema"].schema, key) == value
@@ -1329,7 +1329,7 @@ async def test_try_connection_with_advanced_parameters(
     }
     suggested = {
         mqtt.CONF_USERNAME: "user",
-        mqtt.CONF_PASSWORD: "pass",
+        mqtt.CONF_PASSWORD: PWD_NOT_CHANGED,
         mqtt.CONF_TLS_INSECURE: True,
         mqtt.CONF_PROTOCOL: "3.1.1",
         mqtt.CONF_TRANSPORT: "websockets",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mask current password in MQTT option flow. We already mask the reauth flow broker password, but not yet in the option flow.

After this PR, if the user tries to show the current password from the entry it will show:

![image](https://github.com/home-assistant/core/assets/7188918/5fb3df2f-3fea-4084-8cf4-cc5bd4276ad7)

Using a sentinal ensures the user can change options without the need to re-enter the broker-password.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
