### PR TITLE
Support in service descriptions for input sections

### DIFF
--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -199,45 +199,6 @@ turn_on:
       example: "[255, 100, 100]"
       selector:
         color_rgb:
-    rgbw_color: &rgbw_color
-      filter: *color_support
-      advanced: true
-      example: "[255, 100, 100, 50]"
-      selector:
-        object:
-    rgbww_color: &rgbww_color
-      filter: *color_support
-      advanced: true
-      example: "[255, 100, 100, 50, 70]"
-      selector:
-        object:
-    color_name: &color_name
-      filter: *color_support
-      advanced: true
-      selector:
-        select:
-          translation_key: color_name
-          options: *named_colors
-    hs_color: &hs_color
-      filter: *color_support
-      advanced: true
-      example: "[300, 70]"
-      selector:
-        object:
-    xy_color: &xy_color
-      filter: *color_support
-      advanced: true
-      example: "[0.52, 0.43]"
-      selector:
-        object:
-    color_temp: &color_temp
-      filter: *color_temp_support
-      advanced: true
-      selector:
-        color_temp:
-          unit: "mired"
-          min: 153
-          max: 500
     kelvin: &kelvin
       filter: *color_temp_support
       selector:
@@ -245,13 +206,6 @@ turn_on:
           unit: "kelvin"
           min: 2000
           max: 6500
-    brightness: &brightness
-      filter: *brightness_support
-      advanced: true
-      selector:
-        number:
-          min: 0
-          max: 255
     brightness_pct: &brightness_pct
       filter: *brightness_support
       selector:
@@ -259,13 +213,6 @@ turn_on:
           min: 0
           max: 100
           unit_of_measurement: "%"
-    brightness_step:
-      filter: *brightness_support
-      advanced: true
-      selector:
-        number:
-          min: -225
-          max: 255
     brightness_step_pct:
       filter: *brightness_support
       selector:
@@ -273,39 +220,84 @@ turn_on:
           min: -100
           max: 100
           unit_of_measurement: "%"
-    white: &white
-      filter:
-        attribute:
-          supported_color_modes:
-            - light.ColorMode.WHITE
-      advanced: true
-      selector:
-        constant:
-          value: true
-          label: Enabled
-    profile: &profile
-      advanced: true
-      example: relax
-      selector:
-        text:
-    flash: &flash
-      filter:
-        supported_features:
-          - light.LightEntityFeature.FLASH
-      advanced: true
-      selector:
-        select:
-          options:
-            - label: "Long"
-              value: "long"
-            - label: "Short"
-              value: "short"
     effect: &effect
       filter:
         supported_features:
           - light.LightEntityFeature.EFFECT
       selector:
         text:
+    advanced_fields:
+      collapsed: true
+      fields:
+        rgbw_color: &rgbw_color
+          filter: *color_support
+          example: "[255, 100, 100, 50]"
+          selector:
+            object:
+        rgbww_color: &rgbww_color
+          filter: *color_support
+          example: "[255, 100, 100, 50, 70]"
+          selector:
+            object:
+        color_name: &color_name
+          filter: *color_support
+          selector:
+            select:
+              translation_key: color_name
+              options: *named_colors
+        hs_color: &hs_color
+          filter: *color_support
+          example: "[300, 70]"
+          selector:
+            object:
+        xy_color: &xy_color
+          filter: *color_support
+          example: "[0.52, 0.43]"
+          selector:
+            object:
+        color_temp: &color_temp
+          filter: *color_temp_support
+          selector:
+            color_temp:
+              unit: "mired"
+              min: 153
+              max: 500
+        brightness: &brightness
+          filter: *brightness_support
+          selector:
+            number:
+              min: 0
+              max: 255
+        brightness_step:
+          filter: *brightness_support
+          selector:
+            number:
+              min: -225
+              max: 255
+        white: &white
+          filter:
+            attribute:
+              supported_color_modes:
+                - light.ColorMode.WHITE
+          selector:
+            constant:
+              value: true
+              label: Enabled
+        profile: &profile
+          example: relax
+          selector:
+            text:
+        flash: &flash
+          filter:
+            supported_features:
+              - light.LightEntityFeature.FLASH
+          selector:
+            select:
+              options:
+                - label: "Long"
+                  value: "long"
+                - label: "Short"
+                  value: "short"
 
 turn_off:
   target:
@@ -313,7 +305,9 @@ turn_off:
       domain: light
   fields:
     transition: *transition
-    flash: *flash
+    advanced_fields:
+      collapsed: true
+      fields: *flash
 
 toggle:
   target:
@@ -322,16 +316,19 @@ toggle:
   fields:
     transition: *transition
     rgb_color: *rgb_color
-    rgbw_color: *rgbw_color
-    rgbww_color: *rgbww_color
-    color_name: *color_name
-    hs_color: *hs_color
-    xy_color: *xy_color
-    color_temp: *color_temp
     kelvin: *kelvin
-    brightness: *brightness
     brightness_pct: *brightness_pct
-    white: *white
-    profile: *profile
-    flash: *flash
     effect: *effect
+    advanced_fields:
+      collapsed: true
+      fields:
+        rgbw_color: *rgbw_color
+        rgbww_color: *rgbww_color
+        color_name: *color_name
+        hs_color: *hs_color
+        xy_color: *xy_color
+        color_temp: *color_temp
+        brightness: *brightness
+        white: *white
+        profile: *profile
+        flash: *flash

--- a/homeassistant/components/light/services.yaml
+++ b/homeassistant/components/light/services.yaml
@@ -307,7 +307,8 @@ turn_off:
     transition: *transition
     advanced_fields:
       collapsed: true
-      fields: *flash
+      fields:
+        flash: *flash
 
 toggle:
   target:

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -354,6 +354,11 @@
           "name": "[%key:component::light::common::field_effect_name%]",
           "description": "[%key:component::light::common::field_effect_description%]"
         }
+      },
+      "sections": {
+        "advanced_fields": {
+          "name": "Advanced options"
+        }
       }
     },
     "turn_off": {
@@ -367,6 +372,11 @@
         "flash": {
           "name": "[%key:component::light::common::field_flash_name%]",
           "description": "[%key:component::light::common::field_flash_description%]"
+        }
+      },
+      "sections": {
+        "advanced_fields": {
+          "name": "Advanced options"
         }
       }
     },
@@ -433,6 +443,11 @@
         "effect": {
           "name": "[%key:component::light::common::field_effect_name%]",
           "description": "[%key:component::light::common::field_effect_description%]"
+        }
+      },
+      "sections": {
+        "advanced_fields": {
+          "name": "Advanced options"
         }
       }
     }

--- a/homeassistant/components/light/strings.json
+++ b/homeassistant/components/light/strings.json
@@ -34,7 +34,8 @@
     "field_white_description": "Set the light to white mode.",
     "field_white_name": "White",
     "field_xy_color_description": "Color in XY-format. A list of two decimal numbers between 0 and 1.",
-    "field_xy_color_name": "XY-color"
+    "field_xy_color_name": "XY-color",
+    "section_advanced_fields_name": "Advanced options"
   },
   "device_automation": {
     "action_type": {
@@ -357,7 +358,7 @@
       },
       "sections": {
         "advanced_fields": {
-          "name": "Advanced options"
+          "name": "[%key:component::light::common::section_advanced_fields_name%]"
         }
       }
     },
@@ -376,7 +377,7 @@
       },
       "sections": {
         "advanced_fields": {
-          "name": "Advanced options"
+          "name": "[%key:component::light::common::section_advanced_fields_name%]"
         }
       }
     },
@@ -447,7 +448,7 @@
       },
       "sections": {
         "advanced_fields": {
-          "name": "Advanced options"
+          "name": "[%key:component::light::common::section_advanced_fields_name%]"
         }
       }
     }

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -190,7 +190,7 @@ _SERVICE_SCHEMA = vol.Schema(
     {
         vol.Optional("target"): vol.Any(TargetSelector.CONFIG_SCHEMA, None),
         vol.Optional("fields"): vol.Schema(
-            {str: vol.Any(_FIELD_SCHEMA, _SECTION_SCHEMA)}
+            {str: vol.Any(_SECTION_SCHEMA, _FIELD_SCHEMA)}
         ),
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -179,10 +179,19 @@ _FIELD_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+_SECTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("fields"): vol.Schema({str: _FIELD_SCHEMA}),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
 _SERVICE_SCHEMA = vol.Schema(
     {
         vol.Optional("target"): vol.Any(TargetSelector.CONFIG_SCHEMA, None),
-        vol.Optional("fields"): vol.Schema({str: _FIELD_SCHEMA}),
+        vol.Optional("fields"): vol.Schema(
+            {str: vol.Any(_FIELD_SCHEMA, _SECTION_SCHEMA)}
+        ),
     },
     extra=vol.ALLOW_EXTRA,
 )

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -376,6 +376,13 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                         },
                         slug_validator=translation_key_validator,
                     ),
+                    vol.Optional("sections"): cv.schema_with_slug_keys(
+                        {
+                            vol.Required("name"): str,
+                            vol.Optional("description"): translation_value_validator,
+                        },
+                        slug_validator=translation_key_validator,
+                    ),
                 },
                 slug_validator=translation_key_validator,
             ),

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -990,6 +990,17 @@ async def test_async_get_all_descriptions_filter(hass: HomeAssistant) -> None:
                     - light.ColorMode.COLOR_TEMP
               selector:
                 number:
+            advanced_stuff:
+              fields:
+                temperature:
+                  filter:
+                    supported_features:
+                      - alarm_control_panel.AlarmControlPanelEntityFeature.ARM_HOME
+                    attribute:
+                      supported_color_modes:
+                        - light.ColorMode.COLOR_TEMP
+                  selector:
+                    number:
     """
 
     domain = "test_domain"
@@ -1024,6 +1035,17 @@ async def test_async_get_all_descriptions_filter(hass: HomeAssistant) -> None:
     test_service_schema = {
         "description": "",
         "fields": {
+            "advanced_stuff": {
+                "fields": {
+                    "temperature": {
+                        "filter": {
+                            "attribute": {"supported_color_modes": ["color_temp"]},
+                            "supported_features": [1],
+                        },
+                        "selector": {"number": None},
+                    },
+                },
+            },
             "temperature": {
                 "filter": {
                     "attribute": {"supported_color_modes": ["color_temp"]},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support in service descriptions for input sections

As an example, this is light.turn_off with advanced options collapsed:

services.yaml
```yaml
turn_off:
  target:
    entity:
      domain: light
  fields:
    transition:
      filter:
        supported_features:
          - light.LightEntityFeature.TRANSITION
      selector:
        number:
          min: 0
          max: 300
          unit_of_measurement: seconds
    advanced_fields:
      collapsed: true
      fields:
        flash:
          filter:
            supported_features:
              - light.LightEntityFeature.FLASH
          selector:
            select:
              options:
                - label: "Long"
                  value: "long"
                - label: "Short"
                  value: "short"
```
strings.json:
```json
    "turn_off": {
      "name": "[%key:common::action::turn_off%]",
      "description": "Turn off one or more lights.",
      "fields": {
        "transition": {
          "name": "[%key:component::light::services::turn_on::fields::transition::name%]",
          "description": "[%key:component::light::services::turn_on::fields::transition::description%]"
        },
        "flash": {
          "name": "[%key:component::light::services::turn_on::fields::flash::name%]",
          "description": "[%key:component::light::services::turn_on::fields::flash::description%]"
        }
      },
      "sections": {
        "advanced_fields": {
          "name": "Advanced options"
        }
      }
    },
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2232

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
