### PR TITLE
Bump ZHA dependencies

### DIFF
--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -26,7 +26,7 @@
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.115",
     "zigpy-deconz==0.23.1",
-    "zigpy==0.63.5",
+    "zigpy==0.64.0",
     "zigpy-xbee==0.20.1",
     "zigpy-zigate==0.12.0",
     "zigpy-znp==0.12.1",

--- a/homeassistant/components/zha/manifest.json
+++ b/homeassistant/components/zha/manifest.json
@@ -21,7 +21,7 @@
     "universal_silabs_flasher"
   ],
   "requirements": [
-    "bellows==0.38.1",
+    "bellows==0.38.2",
     "pyserial==3.5",
     "pyserial-asyncio==0.6",
     "zha-quirks==0.0.115",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2959,7 +2959,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.63.5
+zigpy==0.64.0
 
 # homeassistant.components.zoneminder
 zm-py==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -541,7 +541,7 @@ beautifulsoup4==4.12.3
 # beewi-smartclim==0.0.10
 
 # homeassistant.components.zha
-bellows==0.38.1
+bellows==0.38.2
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2300,7 +2300,7 @@ zigpy-zigate==0.12.0
 zigpy-znp==0.12.1
 
 # homeassistant.components.zha
-zigpy==0.63.5
+zigpy==0.64.0
 
 # homeassistant.components.zwave_js
 zwave-js-server-python==0.55.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -466,7 +466,7 @@ base36==0.1.1
 beautifulsoup4==4.12.3
 
 # homeassistant.components.zha
-bellows==0.38.1
+bellows==0.38.2
 
 # homeassistant.components.bmw_connected_drive
 bimmer-connected[china]==0.14.6


### PR DESCRIPTION
## Proposed change
Bump ZHA dependencies:
 - bellows to [0.38.2](https://github.com/zigpy/bellows/releases/tag/0.38.2)
 - zigpy to [0.64.0](https://github.com/zigpy/zigpy/releases/tag/0.64.0)

The new bellows version fixes Python 3.12.3 compatibility which currently/mostly affects HA Core container environments.

The zigpy release mostly has minor changes, except for https://github.com/zigpy/zigpy/pull/1381 which now also allows zigpy to cache output/client clusters. (This will allow us to remove a workaround in HA Core in a future PR.)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #115459
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
