### PR TITLE
Improve group state behavior

### DIFF
--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -111,7 +111,7 @@ def is_on(hass: HomeAssistant, entity_id: str) -> bool:
 
     if (state := hass.states.get(entity_id)) is not None:
         registry: GroupIntegrationRegistry = hass.data[REG_KEY]
-        return state.state in registry.on_off_mapping
+        return state.state in registry.on_states
 
     return False
 

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -456,7 +456,7 @@ class Group(Entity):
                 domain_on_states := registry.on_states_by_domain.get(domain)
             ) and current_state in domain_on_states:
                 active_on_states.add(current_state)
-                # If we have more than on state, the group state
+                # If we have more than one on state, the group state
                 # will result in STATE_ON and we can stop checking
                 if len(active_on_states) > 1:
                     break

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -414,6 +414,33 @@ class Group(Entity):
                 self._on_states.update(entity_on_state)
             self._on_off[entity_id] = state in entity_on_state
 
+    def _detect_specific_on_off_state(self, group_is_on: bool) -> set[str]:
+        """Check if a specific ON or OFF state is possible."""
+        # In case the group contains entities of the same domain with the same ON
+        # or an OFF state (one or more domains), we want to use that specific state.
+        # If we have more then one ON or OFF state we default to STATE_ON or STATE_OFF.
+        registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
+        active_on_states: set[str] = set()
+        active_off_states: set[str] = set()
+        for entity_id in self.tracking:
+            if (state := self.hass.states.get(entity_id)) is None:
+                continue
+            current_state = state.state
+            domain = state.domain
+            if (
+                domain_on_states := registry.on_states_by_domain.get(domain)
+            ) and current_state in domain_on_states:
+                active_on_states.add(current_state)
+                # If we have more than one on state, the group state
+                # will result in STATE_ON and we can stop checking
+                if len(active_on_states) > 1:
+                    break
+                continue
+            if current_state in registry.off_on_mapping:
+                active_off_states.add(current_state)
+
+        return active_on_states if group_is_on else active_off_states
+
     @callback
     def _async_update_group_state(self, tr_state: State | None = None) -> None:
         """Update group state.
@@ -440,50 +467,23 @@ class Group(Entity):
         elif tr_state.attributes.get(ATTR_ASSUMED_STATE):
             self._assumed_state = True
 
-        group_is_on = self.mode(self._on_off.values())
         # If we do not have an on state for any domains
         # we use None (which will be STATE_UNKNOWN)
         if (num_on_states := len(self._on_states)) == 0:
             self._state = None
             return
 
-        registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
-
-        # In case the group contains entities of the same domain with the same ON
-        # or an OFF state (one or more domains), we want to use that specific state.
-        # If we have more then one ON or OFF state we default to STATE_ON or STATE_OFF.
-        active_on_states: set[str] = set()
-        active_off_states: set[str] = set()
-
-        def _detect_specific_on_off_state() -> None:
-            """Check if a specific ON or OFF state is possible."""
-            for entity_id in self.tracking:
-                if (state := self.hass.states.get(entity_id)) is None:
-                    continue
-                current_state = state.state
-                domain = state.domain
-                if (
-                    domain_on_states := registry.on_states_by_domain.get(domain)
-                ) and current_state in domain_on_states:
-                    active_on_states.add(current_state)
-                    # If we have more than one on state, the group state
-                    # will result in STATE_ON and we can stop checking
-                    if len(active_on_states) > 1:
-                        break
-                    continue
-                if current_state in registry.off_on_mapping:
-                    active_off_states.add(current_state)
-
         # If all the entity domains we are tracking
         # have the same on state we use this state
         # and its hass.data[REG_KEY].on_off_mapping to off
+        group_is_on = self.mode(self._on_off.values())
         if num_on_states == 1:
             on_state = list(self._on_states)[0]
         # If the entity domains have more than one
         # on state, we use STATE_ON/STATE_OFF, unless there is
         # only one specific `on` state in use for one specific domain
         elif self.single_active_domain and num_on_states:
-            _detect_specific_on_off_state()
+            active_on_states = self._detect_specific_on_off_state(True)
             on_state = (
                 list(active_on_states)[0] if len(active_on_states) == 1 else STATE_ON
             )
@@ -493,14 +493,15 @@ class Group(Entity):
             self._state = on_state
             return
 
+        registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
         if (
             active_domain := self.single_active_domain
         ) and active_domain in registry.off_state_by_domain:
             # If there is only one domain used,
-            # then we return the off state for that domain.
+            # then we return the off state for that domain.s
             self._state = registry.off_state_by_domain[active_domain]
         else:
-            _detect_specific_on_off_state()
+            active_off_states = self._detect_specific_on_off_state(False)
             # If there is one off state in use then we return that specific state,
             # also if there a multiple domains involved, e.g.
             # person and device_tracker, with a shared state.

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -444,6 +444,10 @@ class Group(Entity):
                         and value in registry.on_states_by_domain[domain]
                     ):
                         active_on_states.add(value)
+                        # If we have more than on state, the group state
+                        # will result in STATE_ON and we can stop checking
+                        if len(active_on_states) > 1:
+                            break
                         continue
                     if value in registry.off_on_mapping:
                         active_off_states.add(value)

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -298,21 +298,25 @@ class Group(Entity):
 
         tracking: list[str] = []
         trackable: list[str] = []
-        active_domains: set[str] = set()
+        self.single_active_domain = None
+        multiple_domains: bool = False
         for ent_id in entity_ids:
             ent_id_lower = ent_id.lower()
             domain = split_entity_id(ent_id_lower)[0]
             tracking.append(ent_id_lower)
-            if domain not in excluded_domains:
-                active_domains.add(domain)
-                trackable.append(ent_id_lower)
+            if domain in excluded_domains:
+                continue
+
+            trackable.append(ent_id_lower)
+
+            if not multiple_domains and self.single_active_domain is None:
+                self.single_active_domain = domain
+            if self.single_active_domain != domain:
+                multiple_domains = True
+                self.single_active_domain = None
 
         self.trackable = tuple(trackable)
         self.tracking = tuple(tracking)
-        if len(active_domains) == 1:
-            self.single_active_domain = list(active_domains)[0]
-        else:
-            self.single_active_domain = None
 
     @callback
     def _async_start(self, _: HomeAssistant | None = None) -> None:

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -426,10 +426,11 @@ class Group(Entity):
             if (state := self.hass.states.get(entity_id)) is None:
                 continue
             current_state = state.state
-            domain = state.domain
             if (
-                domain_on_states := registry.on_states_by_domain.get(domain)
-            ) and current_state in domain_on_states:
+                group_is_on
+                and (domain_on_states := registry.on_states_by_domain.get(state.domain))
+                and current_state in domain_on_states
+            ):
                 active_on_states.add(current_state)
                 # If we have more than one on state, the group state
                 # will result in STATE_ON and we can stop checking

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -302,9 +302,9 @@ class Group(Entity):
         for ent_id in entity_ids:
             ent_id_lower = ent_id.lower()
             domain = split_entity_id(ent_id_lower)[0]
-            active_domains.add(domain)
             tracking.append(ent_id_lower)
             if domain not in excluded_domains:
+                active_domains.add(domain)
                 trackable.append(ent_id_lower)
 
         self.trackable = tuple(trackable)

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -438,6 +438,9 @@ class Group(Entity):
 
         registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
 
+        # In case the group contains entities of the same domain with the same on
+        # or off state, we want to use that specific state.
+        # If we have more then one ON or OFF state we default to STATE_ON or STATE_OFF.
         active_on_states: set[str] = set()
         active_off_states: set[str] = set()
         for entity_id in self.tracking:

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -402,11 +402,12 @@ class Group(Entity):
 
         if domain not in registry.on_states_by_domain:
             # Handle the group of a group case
-            if state in registry.on_off_mapping:
+            if state in registry.on_states:
                 self._on_states.add(state)
+            # Only in case of a registered off state we add STATE_ON
             elif state in registry.off_states:
                 self._on_states.add(STATE_ON)
-            self._on_off[entity_id] = state in registry.on_off_mapping
+            self._on_off[entity_id] = state in registry.on_states
         else:
             entity_on_state = registry.on_states_by_domain[domain]
             self._on_states.update(entity_on_state)
@@ -475,7 +476,7 @@ class Group(Entity):
 
         # If all the entity domains we are tracking
         # have the same on state we use this state
-        # and its hass.data[REG_KEY].on_off_mapping to off
+        # and its hass.data[REG_KEY].on_states to off
         if num_on_states == 1:
             on_state = next(iter(self._on_states))
         # If the entity domains have more than one

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -471,12 +471,13 @@ class Group(Entity):
             self._state = None
             return
 
+        group_is_on = self.mode(self._on_off.values())
+
         # If all the entity domains we are tracking
         # have the same on state we use this state
         # and its hass.data[REG_KEY].on_off_mapping to off
-        group_is_on = self.mode(self._on_off.values())
         if num_on_states == 1:
-            on_state = list(self._on_states)[0]
+            on_state = next(iter(self._on_states))
         # If the entity domains have more than one
         # on state, we use STATE_ON/STATE_OFF, unless there is
         # only one specific `on` state in use for one specific domain

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -131,7 +131,11 @@ class Group(Entity):
     _unrecorded_attributes = frozenset({ATTR_ENTITY_ID, ATTR_ORDER, ATTR_AUTO})
 
     _attr_should_poll = False
+    # Holds the a set of used domains for the tracked entities
+    # used determine to use a specific or generic ON or OFF state
     active_domains: set[str]
+    # In case there is only one active domain we use specific ON or OFF
+    # values, if all ON or OFF states are equal
     single_active_domain: str | None
     tracking: tuple[str, ...]
     trackable: tuple[str, ...]

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -404,8 +404,8 @@ class Group(Entity):
             # Handle the group of a group case
             if state in registry.on_off_mapping:
                 self._on_states.add(state)
-            elif state in registry.off_on_mapping:
-                self._on_states.add(registry.off_on_mapping[state])
+            elif state in registry.off_states:
+                self._on_states.add(STATE_ON)
             self._on_off[entity_id] = state in registry.on_off_mapping
         else:
             entity_on_state = registry.on_states_by_domain[domain]
@@ -434,7 +434,7 @@ class Group(Entity):
                 # will result in STATE_ON and we can stop checking
                 if len(active_on_states) > 1:
                     break
-            elif current_state in registry.off_on_mapping:
+            elif current_state in registry.off_states:
                 active_off_states.add(current_state)
 
         return active_on_states if group_is_on else active_off_states

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -49,9 +49,7 @@ class GroupIntegrationRegistry:
 
     def __init__(self) -> None:
         """Imitialize registry."""
-        self.on_off_mapping: dict[str, dict[str | None, str]] = {
-            STATE_ON: {None: STATE_OFF}
-        }
+        self.on_states: set[str] = {STATE_ON}
         self.off_states: set[str] = {STATE_OFF}
         self.on_states_by_domain: dict[str, set[str]] = {}
         self.off_state_by_domain: dict[str, str] = {}
@@ -65,10 +63,7 @@ class GroupIntegrationRegistry:
         """Register on and off states for the current domain."""
         domain = current_domain.get()
         for on_state in on_states:
-            if on_state not in self.on_off_mapping:
-                self.on_off_mapping[on_state] = {domain: off_state}
-            else:
-                self.on_off_mapping[on_state][domain] = off_state
+            self.on_states.add(on_state)
         self.off_states.add(off_state)
 
         self.on_states_by_domain[domain] = set(on_states)

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -52,7 +52,7 @@ class GroupIntegrationRegistry:
         self.on_off_mapping: dict[str, dict[str | None, str]] = {
             STATE_ON: {None: STATE_OFF}
         }
-        self.off_on_mapping: dict[str, str] = {STATE_OFF: STATE_ON}
+        self.off_states: set[str] = {STATE_OFF}
         self.on_states_by_domain: dict[str, set[str]] = {}
         self.off_state_by_domain: dict[str, str] = {}
         self.exclude_domains: set[str] = set()
@@ -61,9 +61,7 @@ class GroupIntegrationRegistry:
         """Exclude the current domain."""
         self.exclude_domains.add(current_domain.get())
 
-    def on_off_states(
-        self, on_states: set, off_state: str, default_on_state: str | None = None
-    ) -> None:
+    def on_off_states(self, on_states: set, off_state: str) -> None:
         """Register on and off states for the current domain."""
         domain = current_domain.get()
         for on_state in on_states:
@@ -71,8 +69,7 @@ class GroupIntegrationRegistry:
                 self.on_off_mapping[on_state] = {domain: off_state}
             else:
                 self.on_off_mapping[on_state][domain] = off_state
-        if len(on_states) >= 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = default_on_state or next(iter(on_states))
+        self.off_states.add(off_state)
 
         self.on_states_by_domain[domain] = set(on_states)
         self.off_state_by_domain[domain] = off_state

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
+import logging
 from typing import Protocol
 
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -12,6 +13,8 @@ from homeassistant.helpers.integration_platform import (
 )
 
 from .const import DOMAIN, REG_KEY
+
+_LOGGER = logging.getLogger(__name__)
 
 current_domain: ContextVar[str] = ContextVar("current_domain")
 
@@ -49,9 +52,12 @@ class GroupIntegrationRegistry:
 
     def __init__(self) -> None:
         """Imitialize registry."""
-        self.on_off_mapping: dict[str, str] = {STATE_ON: STATE_OFF}
+        self.on_off_mapping: dict[str, dict[str | None, str]] = {
+            STATE_ON: {None: STATE_OFF}
+        }
         self.off_on_mapping: dict[str, str] = {STATE_OFF: STATE_ON}
         self.on_states_by_domain: dict[str, set[str]] = {}
+        self.off_state_by_domain: dict[str, str] = {}
         self.exclude_domains: set[str] = set()
 
     def exclude_domain(self) -> None:
@@ -60,11 +66,15 @@ class GroupIntegrationRegistry:
 
     def on_off_states(self, on_states: set, off_state: str) -> None:
         """Register on and off states for the current domain."""
+        domain = current_domain.get()
+        _LOGGER.info("Enter on_off_states for %s", domain)
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
-                self.on_off_mapping[on_state] = off_state
-
+                self.on_off_mapping[on_state] = {domain: off_state}
+            else:
+                self.on_off_mapping[on_state][domain] = off_state
         if len(on_states) == 1 and off_state not in self.off_on_mapping:
             self.off_on_mapping[off_state] = list(on_states)[0]
 
-        self.on_states_by_domain[current_domain.get()] = set(on_states)
+        self.on_states_by_domain[domain] = set(on_states)
+        self.off_state_by_domain[domain] = off_state

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from contextvars import ContextVar
-import logging
 from typing import Protocol
 
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -13,8 +12,6 @@ from homeassistant.helpers.integration_platform import (
 )
 
 from .const import DOMAIN, REG_KEY
-
-_LOGGER = logging.getLogger(__name__)
 
 current_domain: ContextVar[str] = ContextVar("current_domain")
 
@@ -67,7 +64,6 @@ class GroupIntegrationRegistry:
     def on_off_states(self, on_states: set, off_state: str) -> None:
         """Register on and off states for the current domain."""
         domain = current_domain.get()
-        _LOGGER.info("Enter on_off_states for %s", domain)
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = {domain: off_state}

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -61,7 +61,9 @@ class GroupIntegrationRegistry:
         """Exclude the current domain."""
         self.exclude_domains.add(current_domain.get())
 
-    def on_off_states(self, on_states: set, off_state: str) -> None:
+    def on_off_states(
+        self, on_states: set, off_state: str, default_on_state: str | None = None
+    ) -> None:
         """Register on and off states for the current domain."""
         domain = current_domain.get()
         for on_state in on_states:
@@ -69,8 +71,8 @@ class GroupIntegrationRegistry:
                 self.on_off_mapping[on_state] = {domain: off_state}
             else:
                 self.on_off_mapping[on_state][domain] = off_state
-        if len(on_states) == 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = list(on_states)[0]
+        if len(on_states) >= 1 and off_state not in self.off_on_mapping:
+            self.off_on_mapping[off_state] = default_on_state or next(iter(on_states))
 
         self.on_states_by_domain[domain] = set(on_states)
         self.off_state_by_domain[domain] = off_state

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -653,6 +653,13 @@ async def test_is_on(hass: HomeAssistant) -> None:
             (STATE_OFF, False),
         ),
         (
+            ("cover", "lock"),
+            (STATE_OPEN, STATE_OPEN),
+            (STATE_CLOSED, STATE_LOCKED),
+            (STATE_ON, True),
+            (STATE_OFF, False),
+        ),
+        (
             ("cover", "lock", "light"),
             (STATE_OPEN, STATE_LOCKED, STATE_ON),
             (STATE_CLOSED, STATE_LOCKED, STATE_OFF),

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -653,13 +653,6 @@ async def test_is_on(hass: HomeAssistant) -> None:
             (STATE_OFF, False),
         ),
         (
-            ("cover", "lock"),
-            (STATE_OPEN, STATE_OPEN),
-            (STATE_CLOSED, STATE_LOCKED),
-            (STATE_ON, True),
-            (STATE_OFF, False),
-        ),
-        (
             ("cover", "lock", "light"),
             (STATE_OPEN, STATE_LOCKED, STATE_ON),
             (STATE_CLOSED, STATE_LOCKED, STATE_OFF),

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1220,7 +1220,7 @@ async def test_group_climate_all_cool(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("group.group_zero").state == STATE_ON
+    assert hass.states.get("group.group_zero").state == "cool"
 
 
 async def test_group_climate_all_off(hass: HomeAssistant) -> None:
@@ -1334,7 +1334,7 @@ async def test_group_vacuum_on(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("group.group_zero").state == STATE_ON
+    assert hass.states.get("group.group_zero").state == "cleaning"
 
 
 async def test_device_tracker_not_home(hass: HomeAssistant) -> None:

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import group
+from homeassistant.components import group, vacuum
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
@@ -656,6 +656,24 @@ async def test_is_on(hass: HomeAssistant) -> None:
             ("cover", "lock", "light"),
             (STATE_OPEN, STATE_LOCKED, STATE_ON),
             (STATE_CLOSED, STATE_LOCKED, STATE_OFF),
+            (STATE_ON, True),
+            (STATE_OFF, False),
+        ),
+        (
+            ("vacuum", "vacuum"),
+            # Cleaning is the only on state
+            (vacuum.STATE_DOCKED, vacuum.STATE_CLEANING),
+            # Returning is the only on state
+            (vacuum.STATE_RETURNING, vacuum.STATE_PAUSED),
+            (vacuum.STATE_CLEANING, True),
+            (vacuum.STATE_RETURNING, True),
+        ),
+        (
+            ("vacuum", "vacuum"),
+            # Multiple on states, so group state will be STATE_ON
+            (vacuum.STATE_RETURNING, vacuum.STATE_CLEANING),
+            # Only off states, so group state will be off
+            (vacuum.STATE_PAUSED, vacuum.STATE_IDLE),
             (STATE_ON, True),
             (STATE_OFF, False),
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Intention is to improve the group state behavior and allow an entity platform to have specific states in case there are more then one on or off states. This prepares for support of `lock.open` state we want to add. Currently only `lock.unlocked` is a valid open state.

The PR include the commits of #115866, but this change was [reverted](116176). Details of the final behaviour will be added to the PR's documentation

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
