### PR TITLE
Handle invalid device type in onewire

### DIFF
--- a/homeassistant/components/onewire/binary_sensor.py
+++ b/homeassistant/components/onewire/binary_sensor.py
@@ -117,7 +117,7 @@ def get_entities(onewire_hub: OneWireHub) -> list[OneWireBinarySensor]:
         device_type = device.type
         device_info = device.device_info
         device_sub_type = "std"
-        if "EF" in family:
+        if device_type and "EF" in family:
             device_sub_type = "HobbyBoard"
             family = device_type
 

--- a/homeassistant/components/onewire/model.py
+++ b/homeassistant/components/onewire/model.py
@@ -16,4 +16,4 @@ class OWDeviceDescription:
     family: str
     id: str
     path: str
-    type: str
+    type: str | None

--- a/homeassistant/components/onewire/onewirehub.py
+++ b/homeassistant/components/onewire/onewirehub.py
@@ -45,7 +45,7 @@ DEVICE_MANUFACTURER = {
 _LOGGER = logging.getLogger(__name__)
 
 
-def _is_known_device(device_family: str, device_type: str) -> bool:
+def _is_known_device(device_family: str, device_type: str | None) -> bool:
     """Check if device family/type is known to the library."""
     if device_family in ("7E", "EF"):  # EDS or HobbyBoard
         return device_type in DEVICE_SUPPORT[device_family]
@@ -144,11 +144,15 @@ class OneWireHub:
 
         return devices
 
-    def _get_device_type(self, device_path: str) -> str:
+    def _get_device_type(self, device_path: str) -> str | None:
         """Get device model."""
         if TYPE_CHECKING:
             assert self.owproxy
-        device_type = self.owproxy.read(f"{device_path}type").decode()
+        try:
+            device_type = self.owproxy.read(f"{device_path}type").decode()
+        except protocol.ProtocolError as exc:
+            _LOGGER.debug("Unable to read `%stype`: %s", device_path, exc)
+            return None
         _LOGGER.debug("read `%stype`: %s", device_path, device_type)
         if device_type == "EDS":
             device_type = self.owproxy.read(f"{device_path}device_type").decode()

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -377,10 +377,10 @@ def get_entities(
         device_info = device.device_info
         device_sub_type = "std"
         device_path = device.path
-        if "EF" in family:
+        if device_type and "EF" in family:
             device_sub_type = "HobbyBoard"
             family = device_type
-        elif "7E" in family:
+        elif device_type and "7E" in family:
             device_sub_type = "EDS"
             family = device_type
         elif "A6" in family:

--- a/homeassistant/components/onewire/switch.py
+++ b/homeassistant/components/onewire/switch.py
@@ -178,7 +178,7 @@ def get_entities(onewire_hub: OneWireHub) -> list[OneWireSwitch]:
         device_id = device.id
         device_info = device.device_info
         device_sub_type = "std"
-        if "EF" in family:
+        if device_type and "EF" in family:
             device_sub_type = "HobbyBoard"
             family = device_type
         elif "A6" in family:

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -1,6 +1,6 @@
 """Constants for 1-Wire integration."""
 
-from pyownet.protocol import Error as ProtocolError
+from pyownet.protocol import ProtocolError
 
 from homeassistant.components.onewire.const import Platform
 
@@ -56,6 +56,11 @@ MOCK_OWPROXY_DEVICES = {
         Platform.SENSOR: [
             {ATTR_INJECT_READS: b"    251123"},
             {ATTR_INJECT_READS: b"    248125"},
+        ],
+    },
+    "16.111111111111": {
+        ATTR_INJECT_READS: [
+            ProtocolError(),  # read device type
         ],
     },
     "1F.111111111111": {

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -59,6 +59,7 @@ MOCK_OWPROXY_DEVICES = {
         ],
     },
     "16.111111111111": {
+        # Test case for issue #115984, where the device type cannot be read
         ATTR_INJECT_READS: [
             ProtocolError(),  # read device type
         ],

--- a/tests/components/onewire/snapshots/test_binary_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_binary_sensor.ambr
@@ -219,6 +219,18 @@
     }),
   ])
 # ---
+# name: test_binary_sensors[16.111111111111]
+  list([
+  ])
+# ---
+# name: test_binary_sensors[16.111111111111].1
+  list([
+  ])
+# ---
+# name: test_binary_sensors[16.111111111111].2
+  list([
+  ])
+# ---
 # name: test_binary_sensors[1D.111111111111]
   list([
     DeviceRegistryEntrySnapshot({

--- a/tests/components/onewire/snapshots/test_sensor.ambr
+++ b/tests/components/onewire/snapshots/test_sensor.ambr
@@ -278,6 +278,18 @@
     }),
   ])
 # ---
+# name: test_sensors[16.111111111111]
+  list([
+  ])
+# ---
+# name: test_sensors[16.111111111111].1
+  list([
+  ])
+# ---
+# name: test_sensors[16.111111111111].2
+  list([
+  ])
+# ---
 # name: test_sensors[1D.111111111111]
   list([
     DeviceRegistryEntrySnapshot({

--- a/tests/components/onewire/snapshots/test_switch.ambr
+++ b/tests/components/onewire/snapshots/test_switch.ambr
@@ -351,6 +351,18 @@
     }),
   ])
 # ---
+# name: test_switches[16.111111111111]
+  list([
+  ])
+# ---
+# name: test_switches[16.111111111111].1
+  list([
+  ])
+# ---
+# name: test_switches[16.111111111111].2
+  list([
+  ])
+# ---
 # name: test_switches[1D.111111111111]
   list([
     DeviceRegistryEntrySnapshot({


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #115984

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #115984
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
