### PR TITLE
Add matter during onboarding

### DIFF
--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -230,6 +230,7 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle zeroconf discovery."""
         if not async_is_onboarded(self.hass) and is_hassio(self.hass):
+            await self._async_handle_discovery_without_unique_id()
             return await self.async_step_on_supervisor(
                 user_input={CONF_USE_ADDON: True}
             )

--- a/homeassistant/components/matter/config_flow.py
+++ b/homeassistant/components/matter/config_flow.py
@@ -17,6 +17,8 @@ from homeassistant.components.hassio import (
     HassioServiceInfo,
     is_hassio,
 )
+from homeassistant.components.onboarding import async_is_onboarded
+from homeassistant.components.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
@@ -222,6 +224,16 @@ class MatterConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="manual", data_schema=get_manual_schema(user_input), errors=errors
         )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle zeroconf discovery."""
+        if not async_is_onboarded(self.hass) and is_hassio(self.hass):
+            return await self.async_step_on_supervisor(
+                user_input={CONF_USE_ADDON: True}
+            )
+        return await self._async_step_discovery_without_unique_id()
 
     async def async_step_hassio(
         self, discovery_info: HassioServiceInfo

--- a/homeassistant/components/matter/manifest.json
+++ b/homeassistant/components/matter/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/matter",
   "iot_class": "local_push",
   "requirements": ["python-matter-server==5.7.0"],
-  "zeroconf": ["_matter._tcp.local."]
+  "zeroconf": ["_matter._tcp.local.", "_matterc._udp.local."]
 }

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -608,6 +608,11 @@ ZEROCONF = {
             "domain": "matter",
         },
     ],
+    "_matterc._udp.local.": [
+        {
+            "domain": "matter",
+        },
+    ],
     "_mediaremotetv._tcp.local.": [
         {
             "domain": "apple_tv",

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -80,6 +80,16 @@ def addon_setup_time_fixture() -> Generator[int, None, None]:
         yield addon_setup_time
 
 
+@pytest.fixture(name="not_onboarded")
+def mock_onboarded_fixture() -> Generator[MagicMock, None, None]:
+    """Mock that Home Assistant is not yet onboarded."""
+    with patch(
+        "homeassistant.components.matter.config_flow.async_is_onboarded",
+        return_value=False,
+    ) as mock_onboarded:
+        yield mock_onboarded
+
+
 async def test_manual_create_entry(
     hass: HomeAssistant,
     client_connect: AsyncMock,
@@ -217,6 +227,44 @@ async def test_zeroconf_discovery(
         "url": "ws://localhost:5580/ws",
         "integration_created_addon": False,
         "use_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_zeroconf_not_onboarded_running(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_running: AsyncMock,
+    addon_info: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+    not_onboarded: MagicMock,
+) -> None:
+    """Test flow Zeroconf discovery when not onboarded and add-on running."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
+            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
+            port=5540,
+            hostname="CDEFGHIJ12345678.local.",
+            type="_matter._tcp.local.",
+            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
+            properties={"SII": "3300", "SAI": "1100", "T": "0"},
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert addon_info.call_count == 1
+    assert client_connect.call_count == 1
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Matter"
+    assert result["data"] == {
+        "url": "ws://host1:5581/ws",
+        "use_addon": True,
+        "integration_created_addon": False,
     }
     assert setup_entry.call_count == 1
 

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -1059,14 +1059,6 @@ async def test_addon_installed(
 
 
 @pytest.mark.parametrize(
-    ("onboarded_return_value", "flow_source", "flow_data"),
-    [
-        (True, config_entries.SOURCE_USER, None),
-        (False, config_entries.SOURCE_ZEROCONF, ZEROCONF_INFO_TCP),
-        (False, config_entries.SOURCE_ZEROCONF, ZEROCONF_INFO_UDP),
-    ],
-)
-@pytest.mark.parametrize(
     (
         "discovery_info",
         "start_addon_error",
@@ -1110,18 +1102,13 @@ async def test_addon_installed_failures(
     client_connect_error: Exception | None,
     discovery_info_called: bool,
     client_connect_called: bool,
-    not_onboarded: MagicMock,
-    onboarded_return_value: bool,
-    flow_source: dict[str, Any],
-    flow_data: Any,
 ) -> None:
     """Test add-on start failure when add-on is installed."""
-    not_onboarded.return_value = onboarded_return_value
     start_addon.side_effect = start_addon_error
     client_connect.side_effect = client_connect_error
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": flow_source}, data=flow_data
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.FORM

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -347,12 +347,6 @@ async def test_zeroconf_not_onboarded_installed(
     await hass.async_block_till_done()
 
     assert addon_info.call_count == 1
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "start_addon"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    await hass.async_block_till_done()
-
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert client_connect.call_count == 1
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -390,19 +384,7 @@ async def test_zeroconf_not_onboarded_not_installed(
 
     assert addon_info.call_count == 0
     assert addon_store_info.call_count == 2
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "install_addon"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    await hass.async_block_till_done()
-
     assert install_addon.call_args == call(hass, "core_matter_server")
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "start_addon"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    await hass.async_block_till_done()
-
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert client_connect.call_count == 1
     assert result["type"] is FlowResultType.CREATE_ENTRY
@@ -1190,12 +1172,6 @@ async def test_addon_installed_failures_zeroconf(
     await hass.async_block_till_done()
 
     assert addon_info.call_count == 1
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "start_addon"
-
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
-    await hass.async_block_till_done()
-
     assert start_addon.call_args == call(hass, "core_matter_server")
     assert get_addon_discovery_info.called is discovery_info_called
     assert client_connect.called is client_connect_called
@@ -1351,13 +1327,6 @@ async def test_addon_not_installed_failures_zeroconf(
         DOMAIN, context={"source": config_entries.SOURCE_ZEROCONF}, data=zeroconf_info
     )
     await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.SHOW_PROGRESS
-    assert result["step_id"] == "install_addon"
-
-    # Make sure the flow continues when the progress task is done.
-    await hass.async_block_till_done()
-    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert install_addon.call_args == call(hass, "core_matter_server")
     assert addon_info.call_count == 0

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -66,6 +66,15 @@ def setup_entry_fixture() -> Generator[AsyncMock, None, None]:
         yield mock_setup_entry
 
 
+@pytest.fixture(name="unload_entry", autouse=True)
+def unload_entry_fixture() -> Generator[AsyncMock, None, None]:
+    """Mock entry unload."""
+    with patch(
+        "homeassistant.components.matter.async_unload_entry", return_value=True
+    ) as mock_unload_entry:
+        yield mock_unload_entry
+
+
 @pytest.fixture(name="client_connect", autouse=True)
 def client_connect_fixture() -> Generator[AsyncMock, None, None]:
     """Mock server version."""

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -295,6 +295,44 @@ async def test_zeroconf_discovery_not_onboarded_not_supervisor(
 
 @pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_zeroconf_not_onboarded_already_discovered(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_info: AsyncMock,
+    addon_running: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+    not_onboarded: MagicMock,
+    zeroconf_info: ZeroconfServiceInfo,
+) -> None:
+    """Test flow Zeroconf discovery when not onboarded and already discovered."""
+    result_flow_1 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf_info,
+    )
+    result_flow_2 = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=zeroconf_info,
+    )
+    await hass.async_block_till_done()
+    assert result_flow_2["type"] is FlowResultType.ABORT
+    assert result_flow_2["reason"] == "already_configured"
+    assert addon_info.call_count == 1
+    assert client_connect.call_count == 1
+    assert result_flow_1["type"] is FlowResultType.CREATE_ENTRY
+    assert result_flow_1["title"] == "Matter"
+    assert result_flow_1["data"] == {
+        "url": "ws://host1:5581/ws",
+        "use_addon": True,
+        "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_zeroconf_not_onboarded_running(
     hass: HomeAssistant,
     supervisor: MagicMock,

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -24,6 +24,15 @@ ADDON_DISCOVERY_INFO = {
     "host": "host1",
     "port": 5581,
 }
+ZEROCONF_INFO = ZeroconfServiceInfo(
+    ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
+    ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
+    port=5540,
+    hostname="CDEFGHIJ12345678.local.",
+    type="_matter._tcp.local.",
+    name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
+    properties={"SII": "3300", "SAI": "1100", "T": "0"},
+)
 
 
 @pytest.fixture(name="setup_entry", autouse=True)
@@ -198,15 +207,7 @@ async def test_zeroconf_discovery(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZeroconfServiceInfo(
-            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
-            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
-            port=5540,
-            hostname="CDEFGHIJ12345678.local.",
-            type="_matter._tcp.local.",
-            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
-            properties={"SII": "3300", "SAI": "1100", "T": "0"},
-        ),
+        data=ZEROCONF_INFO,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
@@ -241,15 +242,7 @@ async def test_zeroconf_discovery_not_onboarded_not_supervisor(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZeroconfServiceInfo(
-            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
-            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
-            port=5540,
-            hostname="CDEFGHIJ12345678.local.",
-            type="_matter._tcp.local.",
-            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
-            properties={"SII": "3300", "SAI": "1100", "T": "0"},
-        ),
+        data=ZEROCONF_INFO,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
@@ -288,15 +281,7 @@ async def test_zeroconf_not_onboarded_running(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZeroconfServiceInfo(
-            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
-            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
-            port=5540,
-            hostname="CDEFGHIJ12345678.local.",
-            type="_matter._tcp.local.",
-            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
-            properties={"SII": "3300", "SAI": "1100", "T": "0"},
-        ),
+        data=ZEROCONF_INFO,
     )
     await hass.async_block_till_done()
 
@@ -327,15 +312,7 @@ async def test_zeroconf_not_onboarded_installed(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZeroconfServiceInfo(
-            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
-            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
-            port=5540,
-            hostname="CDEFGHIJ12345678.local.",
-            type="_matter._tcp.local.",
-            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
-            properties={"SII": "3300", "SAI": "1100", "T": "0"},
-        ),
+        data=ZEROCONF_INFO,
     )
     await hass.async_block_till_done()
 
@@ -375,15 +352,7 @@ async def test_zeroconf_not_onboarded_not_installed(
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZeroconfServiceInfo(
-            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
-            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
-            port=5540,
-            hostname="CDEFGHIJ12345678.local.",
-            type="_matter._tcp.local.",
-            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
-            properties={"SII": "3300", "SAI": "1100", "T": "0"},
-        ),
+        data=ZEROCONF_INFO,
     )
     await hass.async_block_till_done()
 

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -24,7 +24,7 @@ ADDON_DISCOVERY_INFO = {
     "host": "host1",
     "port": 5581,
 }
-ZEROCONF_INFO = ZeroconfServiceInfo(
+ZEROCONF_INFO_TCP = ZeroconfServiceInfo(
     ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
     ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
     port=5540,
@@ -32,6 +32,28 @@ ZEROCONF_INFO = ZeroconfServiceInfo(
     type="_matter._tcp.local.",
     name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
     properties={"SII": "3300", "SAI": "1100", "T": "0"},
+)
+
+ZEROCONF_INFO_UDP = ZeroconfServiceInfo(
+    ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
+    ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
+    port=5540,
+    hostname="CDEFGHIJ12345678.local.",
+    type="_matterc._udp.local.",
+    name="ABCDEFGH123456789._matterc._udp.local.",
+    properties={
+        "VP": "4874+77",
+        "DT": "21",
+        "DN": "Eve Door",
+        "SII": "3300",
+        "SAI": "1100",
+        "T": "0",
+        "D": "183",
+        "CM": "2",
+        "RI": "0400530980B950D59BF473CFE42BD7DDBF2D",
+        "PH": "36",
+        "PI": None,
+    },
 )
 
 
@@ -198,16 +220,18 @@ async def test_manual_already_configured(
     assert setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 async def test_zeroconf_discovery(
     hass: HomeAssistant,
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
+    zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow started from Zeroconf discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZEROCONF_INFO,
+        data=zeroconf_info,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
@@ -232,17 +256,19 @@ async def test_zeroconf_discovery(
     assert setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 async def test_zeroconf_discovery_not_onboarded_not_supervisor(
     hass: HomeAssistant,
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
     not_onboarded: MagicMock,
+    zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow started from Zeroconf discovery when not onboarded."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZEROCONF_INFO,
+        data=zeroconf_info,
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "manual"
@@ -267,6 +293,7 @@ async def test_zeroconf_discovery_not_onboarded_not_supervisor(
     assert setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_zeroconf_not_onboarded_running(
     hass: HomeAssistant,
@@ -276,12 +303,13 @@ async def test_zeroconf_not_onboarded_running(
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
     not_onboarded: MagicMock,
+    zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow Zeroconf discovery when not onboarded and add-on running."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZEROCONF_INFO,
+        data=zeroconf_info,
     )
     await hass.async_block_till_done()
 
@@ -297,6 +325,7 @@ async def test_zeroconf_not_onboarded_running(
     assert setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_zeroconf_not_onboarded_installed(
     hass: HomeAssistant,
@@ -307,12 +336,13 @@ async def test_zeroconf_not_onboarded_installed(
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
     not_onboarded: MagicMock,
+    zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow Zeroconf discovery when not onboarded and add-on installed."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZEROCONF_INFO,
+        data=zeroconf_info,
     )
     await hass.async_block_till_done()
 
@@ -335,6 +365,7 @@ async def test_zeroconf_not_onboarded_installed(
     assert setup_entry.call_count == 1
 
 
+@pytest.mark.parametrize("zeroconf_info", [ZEROCONF_INFO_TCP, ZEROCONF_INFO_UDP])
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
 async def test_zeroconf_not_onboarded_not_installed(
     hass: HomeAssistant,
@@ -347,12 +378,13 @@ async def test_zeroconf_not_onboarded_not_installed(
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
     not_onboarded: MagicMock,
+    zeroconf_info: ZeroconfServiceInfo,
 ) -> None:
     """Test flow Zeroconf discovery when not onboarded and add-on not installed."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": config_entries.SOURCE_ZEROCONF},
-        data=ZEROCONF_INFO,
+        data=zeroconf_info,
     )
     await hass.async_block_till_done()
 

--- a/tests/components/matter/test_config_flow.py
+++ b/tests/components/matter/test_config_flow.py
@@ -235,8 +235,8 @@ async def test_zeroconf_discovery(
 async def test_zeroconf_not_onboarded_running(
     hass: HomeAssistant,
     supervisor: MagicMock,
-    addon_running: AsyncMock,
     addon_info: AsyncMock,
+    addon_running: AsyncMock,
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
     not_onboarded: MagicMock,
@@ -273,8 +273,8 @@ async def test_zeroconf_not_onboarded_running(
 async def test_zeroconf_not_onboarded_installed(
     hass: HomeAssistant,
     supervisor: MagicMock,
-    addon_installed: AsyncMock,
     addon_info: AsyncMock,
+    addon_installed: AsyncMock,
     start_addon: AsyncMock,
     client_connect: AsyncMock,
     setup_entry: AsyncMock,
@@ -311,6 +311,62 @@ async def test_zeroconf_not_onboarded_installed(
         "url": "ws://host1:5581/ws",
         "use_addon": True,
         "integration_created_addon": False,
+    }
+    assert setup_entry.call_count == 1
+
+
+@pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
+async def test_zeroconf_not_onboarded_not_installed(
+    hass: HomeAssistant,
+    supervisor: MagicMock,
+    addon_info: AsyncMock,
+    addon_store_info: AsyncMock,
+    addon_not_installed: AsyncMock,
+    install_addon: AsyncMock,
+    start_addon: AsyncMock,
+    client_connect: AsyncMock,
+    setup_entry: AsyncMock,
+    not_onboarded: MagicMock,
+) -> None:
+    """Test flow Zeroconf discovery when not onboarded and add-on not installed."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=ZeroconfServiceInfo(
+            ip_address=ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6"),
+            ip_addresses=[ip_address("fd11:be53:8d46:0:729e:5a4f:539d:1ee6")],
+            port=5540,
+            hostname="CDEFGHIJ12345678.local.",
+            type="_matter._tcp.local.",
+            name="ABCDEFGH123456789-0000000012345678._matter._tcp.local.",
+            properties={"SII": "3300", "SAI": "1100", "T": "0"},
+        ),
+    )
+    await hass.async_block_till_done()
+
+    assert addon_info.call_count == 0
+    assert addon_store_info.call_count == 2
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "install_addon"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert install_addon.call_args == call(hass, "core_matter_server")
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "start_addon"
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_matter_server")
+    assert client_connect.call_count == 1
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Matter"
+    assert result["data"] == {
+        "url": "ws://host1:5581/ws",
+        "use_addon": True,
+        "integration_created_addon": True,
     }
     assert setup_entry.call_count == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Set up matter integration if the user isn't onboarded yet, ie during onboarding. This flow will run in the background to either create entry on success or abort on failure. We can't use show progress since the frontend will not update the flow.
- Add Zeroconf discovery trigger for UDP Matter address, which will be sent for Matter devices that are commisionable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
