### PR TITLE
Revert "Return specific group state if there is one"

### DIFF
--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -49,12 +49,9 @@ class GroupIntegrationRegistry:
 
     def __init__(self) -> None:
         """Imitialize registry."""
-        self.on_off_mapping: dict[str, dict[str | None, str]] = {
-            STATE_ON: {None: STATE_OFF}
-        }
+        self.on_off_mapping: dict[str, str] = {STATE_ON: STATE_OFF}
         self.off_on_mapping: dict[str, str] = {STATE_OFF: STATE_ON}
         self.on_states_by_domain: dict[str, set[str]] = {}
-        self.off_state_by_domain: dict[str, str] = {}
         self.exclude_domains: set[str] = set()
 
     def exclude_domain(self) -> None:
@@ -63,14 +60,11 @@ class GroupIntegrationRegistry:
 
     def on_off_states(self, on_states: set, off_state: str) -> None:
         """Register on and off states for the current domain."""
-        domain = current_domain.get()
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
-                self.on_off_mapping[on_state] = {domain: off_state}
-            else:
-                self.on_off_mapping[on_state][domain] = off_state
+                self.on_off_mapping[on_state] = off_state
+
         if len(on_states) == 1 and off_state not in self.off_on_mapping:
             self.off_on_mapping[off_state] = list(on_states)[0]
 
-        self.on_states_by_domain[domain] = set(on_states)
-        self.off_state_by_domain[domain] = off_state
+        self.on_states_by_domain[current_domain.get()] = set(on_states)

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import group, vacuum
+from homeassistant.components import group
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
@@ -659,24 +659,6 @@ async def test_is_on(hass: HomeAssistant) -> None:
             (STATE_ON, True),
             (STATE_OFF, False),
         ),
-        (
-            ("vacuum", "vacuum"),
-            # Cleaning is the only on state
-            (vacuum.STATE_DOCKED, vacuum.STATE_CLEANING),
-            # Returning is the only on state
-            (vacuum.STATE_RETURNING, vacuum.STATE_PAUSED),
-            (vacuum.STATE_CLEANING, True),
-            (vacuum.STATE_RETURNING, True),
-        ),
-        (
-            ("vacuum", "vacuum"),
-            # Multiple on states, so group state will be STATE_ON
-            (vacuum.STATE_RETURNING, vacuum.STATE_CLEANING),
-            # Only off states, so group state will be off
-            (vacuum.STATE_PAUSED, vacuum.STATE_IDLE),
-            (STATE_ON, True),
-            (STATE_OFF, False),
-        ),
     ],
 )
 async def test_is_on_and_state_mixed_domains(
@@ -1238,7 +1220,7 @@ async def test_group_climate_all_cool(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("group.group_zero").state == "cool"
+    assert hass.states.get("group.group_zero").state == STATE_ON
 
 
 async def test_group_climate_all_off(hass: HomeAssistant) -> None:
@@ -1352,7 +1334,7 @@ async def test_group_vacuum_on(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    assert hass.states.get("group.group_zero").state == "cleaning"
+    assert hass.states.get("group.group_zero").state == STATE_ON
 
 
 async def test_device_tracker_not_home(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Reverts home-assistant/core#115866

As discussed on Discord

The PR to  revert intended:
1. Prepare for overlap in on-states which will happen when both cover and lock have an open state
2. Change the behavior of mixed domain groups so instead of always being ON or OFF, the state of a group with (for example) locks and lights may now be unlocked if the locks in the group are unlocked but the lights are off

We only want point 1. So we take time to do this properly.