### PR TITLE
Use existing monotonic timestamp on mqtt messages for debugging 

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -40,7 +40,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
-from homeassistant.util import dt as dt_util
 from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.logging import catch_log_exception
 
@@ -991,8 +990,6 @@ class MQTT:
             msg.qos,
             msg.payload[0:8192],
         )
-        timestamp = dt_util.utcnow()
-
         subscriptions = self._matching_subscriptions(topic)
         msg_cache_by_subscription_topic: dict[str, ReceiveMessage] = {}
 
@@ -1030,7 +1027,7 @@ class MQTT:
                     msg.qos,
                     msg.retain,
                     subscription_topic,
-                    timestamp,
+                    msg.timestamp,
                 )
                 msg_cache_by_subscription_topic[subscription_topic] = receive_msg
             else:

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -185,7 +185,8 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "qos": msg.qos,
                     "retain": msg.retain,
                     "time": dt.datetime.fromtimestamp(
-                        msg.timestamp + monotonic_time_diff
+                        msg.timestamp + monotonic_time_diff,
+                        tz=dt.UTC,
                     ),
                     "topic": msg.topic,
                 }
@@ -203,7 +204,8 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "qos": msg.qos,
                     "retain": msg.retain,
                     "time": dt.datetime.fromtimestamp(
-                        msg.timestamp + monotonic_time_diff
+                        msg.timestamp + monotonic_time_diff,
+                        tz=dt.UTC,
                     ),
                     "topic": msg.topic,
                 }

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -7,12 +7,12 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import datetime as dt
 from functools import wraps
+import time
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import DiscoveryInfoType
-from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DISCOVERY_PAYLOAD, ATTR_DISCOVERY_TOPIC
 from .models import MessageCallbackType, PublishPayloadType
@@ -57,7 +57,7 @@ class TimestampedPublishMessage:
     payload: PublishPayloadType
     qos: int
     retain: bool
-    timestamp: dt.datetime
+    timestamp: float
 
 
 def log_message(
@@ -77,7 +77,7 @@ def log_message(
             "messages": deque([], STORED_MESSAGES),
         }
     msg = TimestampedPublishMessage(
-        topic, payload, qos, retain, timestamp=dt_util.utcnow()
+        topic, payload, qos, retain, timestamp=time.monotonic()
     )
     entity_info["transmitted"][topic]["messages"].append(msg)
 
@@ -175,6 +175,7 @@ def remove_trigger_discovery_data(
 
 def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
     entity_info = get_mqtt_data(hass).debug_info_entities[entity_id]
+    monotonic_time_diff = time.time() - time.monotonic()
     subscriptions = [
         {
             "topic": topic,
@@ -183,7 +184,9 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "payload": str(msg.payload),
                     "qos": msg.qos,
                     "retain": msg.retain,
-                    "time": msg.timestamp,
+                    "time": dt.datetime.fromtimestamp(
+                        msg.timestamp + monotonic_time_diff
+                    ),
                     "topic": msg.topic,
                 }
                 for msg in subscription["messages"]
@@ -199,7 +202,9 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "payload": str(msg.payload),
                     "qos": msg.qos,
                     "retain": msg.retain,
-                    "time": msg.timestamp,
+                    "time": dt.datetime.fromtimestamp(
+                        msg.timestamp + monotonic_time_diff
+                    ),
                     "topic": msg.topic,
                 }
                 for msg in subscription["messages"]

--- a/homeassistant/components/mqtt/debug_info.py
+++ b/homeassistant/components/mqtt/debug_info.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DISCOVERY_PAYLOAD, ATTR_DISCOVERY_TOPIC
 from .models import MessageCallbackType, PublishPayloadType
@@ -184,7 +185,7 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "payload": str(msg.payload),
                     "qos": msg.qos,
                     "retain": msg.retain,
-                    "time": dt.datetime.fromtimestamp(
+                    "time": dt_util.utc_from_timestamp(
                         msg.timestamp + monotonic_time_diff,
                         tz=dt.UTC,
                     ),
@@ -203,7 +204,7 @@ def _info_for_entity(hass: HomeAssistant, entity_id: str) -> dict[str, Any]:
                     "payload": str(msg.payload),
                     "qos": msg.qos,
                     "retain": msg.retain,
-                    "time": dt.datetime.fromtimestamp(
+                    "time": dt_util.utc_from_timestamp(
                         msg.timestamp + monotonic_time_diff,
                         tz=dt.UTC,
                     ),

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -7,7 +7,6 @@ import asyncio
 from collections import deque
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
-import datetime as dt
 from enum import StrEnum
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -67,7 +66,7 @@ class ReceiveMessage:
     qos: int
     retain: bool
     subscribed_topic: str
-    timestamp: dt.datetime
+    timestamp: float
 
 
 AsyncMessageCallbackType = Callable[[ReceiveMessage], Coroutine[Any, Any, None]]

--- a/homeassistant/helpers/service_info/mqtt.py
+++ b/homeassistant/helpers/service_info/mqtt.py
@@ -1,7 +1,6 @@
 """MQTT Discovery data."""
 
 from dataclasses import dataclass
-import datetime as dt
 
 from homeassistant.data_entry_flow import BaseServiceInfo
 
@@ -17,4 +16,4 @@ class MqttServiceInfo(BaseServiceInfo):
     qos: int
     retain: bool
     subscribed_topic: str
-    timestamp: dt.datetime
+    timestamp: float

--- a/tests/common.py
+++ b/tests/common.py
@@ -449,6 +449,7 @@ def async_fire_mqtt_message(
     msg.payload = payload
     msg.qos = qos
     msg.retain = retain
+    msg.timestamp = time.monotonic()
 
     mqtt_data: MqttData = hass.data["mqtt"]
     assert mqtt_data.client

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -1044,7 +1044,7 @@ async def test_entity_id_update_discovery_update(
 
 
 async def test_entity_debug_info_message(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator, freezer
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
 ) -> None:
     """Test MQTT debug info."""
     config = {

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -1044,7 +1044,7 @@ async def test_entity_id_update_discovery_update(
 
 
 async def test_entity_debug_info_message(
-    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator
+    hass: HomeAssistant, mqtt_mock_entry: MqttMockHAClientGenerator, freezer
 ) -> None:
     """Test MQTT debug info."""
     config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A timestamp is set on incoming and outgoing MQTT messages for debugging purposes.

This PR will change this and use the existing monotonic timestamp on incoming message, instead of re-assigning it with `datetime.utcnow()`, which is more time consuming.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
