### PR TITLE
Simplify timezone setting in recorder test

### DIFF
--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -554,7 +554,7 @@ def test_saving_state_with_commit_interval_zero(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test saving a state with a commit interval of zero."""
-    hass = hass_recorder({"commit_interval": 0})
+    hass = hass_recorder(config={"commit_interval": 0})
     assert get_instance(hass).commit_interval == 0
 
     entity_id = "test.recorder"
@@ -611,7 +611,7 @@ def test_saving_state_include_domains(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test saving and restoring a state."""
-    hass = hass_recorder({"include": {"domains": "test2"}})
+    hass = hass_recorder(config={"include": {"domains": "test2"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
     assert _state_with_context(hass, "test2.recorder").as_dict() == states[0].as_dict()
@@ -622,7 +622,7 @@ def test_saving_state_include_domains_globs(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {"include": {"domains": "test2", "entity_globs": "*.included_*"}}
+        config={"include": {"domains": "test2", "entity_globs": "*.included_*"}}
     )
     states = _add_entities(
         hass, ["test.recorder", "test2.recorder", "test3.included_entity"]
@@ -644,7 +644,7 @@ def test_saving_state_incl_entities(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test saving and restoring a state."""
-    hass = hass_recorder({"include": {"entities": "test2.recorder"}})
+    hass = hass_recorder(config={"include": {"entities": "test2.recorder"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
     assert _state_with_context(hass, "test2.recorder").as_dict() == states[0].as_dict()
@@ -705,7 +705,7 @@ def test_saving_state_exclude_domains(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test saving and restoring a state."""
-    hass = hass_recorder({"exclude": {"domains": "test"}})
+    hass = hass_recorder(config={"exclude": {"domains": "test"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
     assert _state_with_context(hass, "test2.recorder").as_dict() == states[0].as_dict()
@@ -716,7 +716,7 @@ def test_saving_state_exclude_domains_globs(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {"exclude": {"domains": "test", "entity_globs": "*.excluded_*"}}
+        config={"exclude": {"domains": "test", "entity_globs": "*.excluded_*"}}
     )
     states = _add_entities(
         hass, ["test.recorder", "test2.recorder", "test2.excluded_entity"]
@@ -729,7 +729,7 @@ def test_saving_state_exclude_entities(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test saving and restoring a state."""
-    hass = hass_recorder({"exclude": {"entities": "test.recorder"}})
+    hass = hass_recorder(config={"exclude": {"entities": "test.recorder"}})
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 1
     assert _state_with_context(hass, "test2.recorder").as_dict() == states[0].as_dict()
@@ -740,7 +740,10 @@ def test_saving_state_exclude_domain_include_entity(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {"include": {"entities": "test.recorder"}, "exclude": {"domains": "test"}}
+        config={
+            "include": {"entities": "test.recorder"},
+            "exclude": {"domains": "test"},
+        }
     )
     states = _add_entities(hass, ["test.recorder", "test2.recorder"])
     assert len(states) == 2
@@ -751,7 +754,7 @@ def test_saving_state_exclude_domain_glob_include_entity(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {
+        config={
             "include": {"entities": ["test.recorder", "test.excluded_entity"]},
             "exclude": {"domains": "test", "entity_globs": "*._excluded_*"},
         }
@@ -767,7 +770,10 @@ def test_saving_state_include_domain_exclude_entity(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {"exclude": {"entities": "test.recorder"}, "include": {"domains": "test"}}
+        config={
+            "exclude": {"entities": "test.recorder"},
+            "include": {"domains": "test"},
+        }
     )
     states = _add_entities(hass, ["test.recorder", "test2.recorder", "test.ok"])
     assert len(states) == 1
@@ -780,7 +786,7 @@ def test_saving_state_include_domain_glob_exclude_entity(
 ) -> None:
     """Test saving and restoring a state."""
     hass = hass_recorder(
-        {
+        config={
             "exclude": {"entities": ["test.recorder", "test2.included_entity"]},
             "include": {"domains": "test", "entity_globs": "*._included_*"},
         }
@@ -985,12 +991,9 @@ def run_tasks_at_time(hass, test_time):
 @pytest.mark.parametrize("enable_nightly_purge", [True])
 def test_auto_purge(hass_recorder: Callable[..., HomeAssistant]) -> None:
     """Test periodic purge scheduling."""
-    hass = hass_recorder()
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     # Purging is scheduled to happen at 4:12am every day. Exercise this behavior by
     # firing time changed events and advancing the clock around this time. Pick an
@@ -1040,20 +1043,15 @@ def test_auto_purge(hass_recorder: Callable[..., HomeAssistant]) -> None:
         assert len(purge_old_data.mock_calls) == 1
         assert len(periodic_db_cleanups.mock_calls) == 1
 
-    dt_util.set_default_time_zone(original_tz)
-
 
 @pytest.mark.parametrize("enable_nightly_purge", [True])
 def test_auto_purge_auto_repack_on_second_sunday(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test periodic purge scheduling does a repack on the 2nd sunday."""
-    hass = hass_recorder()
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     # Purging is scheduled to happen at 4:12am every day. Exercise this behavior by
     # firing time changed events and advancing the clock around this time. Pick an
@@ -1084,20 +1082,15 @@ def test_auto_purge_auto_repack_on_second_sunday(
         assert args[2] is True  # repack
         assert len(periodic_db_cleanups.mock_calls) == 1
 
-    dt_util.set_default_time_zone(original_tz)
-
 
 @pytest.mark.parametrize("enable_nightly_purge", [True])
 def test_auto_purge_auto_repack_disabled_on_second_sunday(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test periodic purge scheduling does not auto repack on the 2nd sunday if disabled."""
-    hass = hass_recorder({CONF_AUTO_REPACK: False})
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(config={CONF_AUTO_REPACK: False}, timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     # Purging is scheduled to happen at 4:12am every day. Exercise this behavior by
     # firing time changed events and advancing the clock around this time. Pick an
@@ -1128,20 +1121,15 @@ def test_auto_purge_auto_repack_disabled_on_second_sunday(
         assert args[2] is False  # repack
         assert len(periodic_db_cleanups.mock_calls) == 1
 
-    dt_util.set_default_time_zone(original_tz)
-
 
 @pytest.mark.parametrize("enable_nightly_purge", [True])
 def test_auto_purge_no_auto_repack_on_not_second_sunday(
     hass_recorder: Callable[..., HomeAssistant],
 ) -> None:
     """Test periodic purge scheduling does not do a repack unless its the 2nd sunday."""
-    hass = hass_recorder()
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     # Purging is scheduled to happen at 4:12am every day. Exercise this behavior by
     # firing time changed events and advancing the clock around this time. Pick an
@@ -1173,18 +1161,13 @@ def test_auto_purge_no_auto_repack_on_not_second_sunday(
         assert args[2] is False  # repack
         assert len(periodic_db_cleanups.mock_calls) == 1
 
-    dt_util.set_default_time_zone(original_tz)
-
 
 @pytest.mark.parametrize("enable_nightly_purge", [True])
 def test_auto_purge_disabled(hass_recorder: Callable[..., HomeAssistant]) -> None:
     """Test periodic db cleanup still run when auto purge is disabled."""
-    hass = hass_recorder({CONF_AUTO_PURGE: False})
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(config={CONF_AUTO_PURGE: False}, timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     # Purging is scheduled to happen at 4:12am every day. We want
     # to verify that when auto purge is disabled periodic db cleanups
@@ -1212,18 +1195,13 @@ def test_auto_purge_disabled(hass_recorder: Callable[..., HomeAssistant]) -> Non
         purge_old_data.reset_mock()
         periodic_db_cleanups.reset_mock()
 
-    dt_util.set_default_time_zone(original_tz)
-
 
 @pytest.mark.parametrize("enable_statistics", [True])
 def test_auto_statistics(hass_recorder: Callable[..., HomeAssistant], freezer) -> None:
     """Test periodic statistics scheduling."""
-    hass = hass_recorder()
-
-    original_tz = dt_util.DEFAULT_TIME_ZONE
-
-    tz = dt_util.get_time_zone("Europe/Copenhagen")
-    dt_util.set_default_time_zone(tz)
+    timezone = "Europe/Copenhagen"
+    hass = hass_recorder(timezone=timezone)
+    tz = dt_util.get_time_zone(timezone)
 
     stats_5min = []
     stats_hourly = []
@@ -1301,8 +1279,6 @@ def test_auto_statistics(hass_recorder: Callable[..., HomeAssistant], freezer) -
         hass.block_till_done()
         assert len(stats_5min) == 3
         assert len(stats_hourly) == 1
-
-    dt_util.set_default_time_zone(original_tz)
 
 
 def test_statistics_runs_initiated(hass_recorder: Callable[..., HomeAssistant]) -> None:
@@ -1719,7 +1695,10 @@ async def test_database_corruption_while_running(
 def test_entity_id_filter(hass_recorder: Callable[..., HomeAssistant]) -> None:
     """Test that entity ID filtering filters string and list."""
     hass = hass_recorder(
-        {"include": {"domains": "hello"}, "exclude": {"domains": "hidden_domain"}}
+        config={
+            "include": {"domains": "hello"},
+            "exclude": {"domains": "hidden_domain"},
+        }
     )
     event_types = ("hello",)
 

--- a/tests/components/recorder/test_statistics.py
+++ b/tests/components/recorder/test_statistics.py
@@ -1119,9 +1119,7 @@ def test_daily_statistics_sum(
     timezone,
 ) -> None:
     """Test daily statistics."""
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -1291,8 +1289,6 @@ def test_daily_statistics_sum(
     )
     assert stats == {}
 
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))
-
 
 @pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])
 @pytest.mark.freeze_time("2022-10-01 00:00:00+00:00")
@@ -1302,9 +1298,7 @@ def test_weekly_statistics_mean(
     timezone,
 ) -> None:
     """Test weekly statistics."""
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -1429,8 +1423,6 @@ def test_weekly_statistics_mean(
     )
     assert stats == {}
 
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))
-
 
 @pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])
 @pytest.mark.freeze_time("2022-10-01 00:00:00+00:00")
@@ -1440,9 +1432,7 @@ def test_weekly_statistics_sum(
     timezone,
 ) -> None:
     """Test weekly statistics."""
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -1612,8 +1602,6 @@ def test_weekly_statistics_sum(
     )
     assert stats == {}
 
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))
-
 
 @pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])
 @pytest.mark.freeze_time("2021-08-01 00:00:00+00:00")
@@ -1623,9 +1611,7 @@ def test_monthly_statistics_sum(
     timezone,
 ) -> None:
     """Test monthly statistics."""
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -1851,8 +1837,6 @@ def test_monthly_statistics_sum(
     )
     assert stats == {}
 
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))
-
 
 def test_cache_key_for_generate_statistics_during_period_stmt() -> None:
     """Test cache key for _generate_statistics_during_period_stmt."""
@@ -1946,9 +1930,7 @@ def test_change(
     timezone,
 ) -> None:
     """Test deriving change from sum statistic."""
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -2273,8 +2255,6 @@ def test_change(
     )
     assert stats == {}
 
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))
-
 
 @pytest.mark.parametrize("timezone", ["America/Regina", "Europe/Vienna", "UTC"])
 @pytest.mark.freeze_time("2022-10-01 00:00:00+00:00")
@@ -2288,9 +2268,7 @@ def test_change_with_none(
     This tests the behavior when some record has None sum. The calculated change
     is not expected to be correct, but we should not raise on this error.
     """
-    dt_util.set_default_time_zone(dt_util.get_time_zone(timezone))
-
-    hass = hass_recorder()
+    hass = hass_recorder(timezone=timezone)
     wait_recording_done(hass)
     assert "Compiling statistics for" not in caplog.text
     assert "Statistics already compiled" not in caplog.text
@@ -2502,5 +2480,3 @@ def test_change_with_none(
         types={"change"},
     )
     assert stats == {}
-
-    dt_util.set_default_time_zone(dt_util.get_time_zone("UTC"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1404,8 +1404,12 @@ def hass_recorder(
             ),
         ):
 
-            def setup_recorder(config: dict[str, Any] | None = None) -> HomeAssistant:
+            def setup_recorder(
+                *, config: dict[str, Any] | None = None, timezone: str | None = None
+            ) -> HomeAssistant:
                 """Set up with params."""
+                if timezone is not None:
+                    hass.config.set_time_zone(timezone)
                 init_recorder_component(hass, config, recorder_db_url)
                 hass.start()
                 hass.block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify timezone setting in recorder test:
- Use hass.config.set_timezone
- Remove uneeded cleanup

The cleanup can be simplified because the `async_test_home_assistant` context manager, which is used both by the `hass` and by the `hass_recorder` test fixtures, resets the timezone as part of its cleanup:
https://github.com/home-assistant/core/blob/09a18459ff8625b631fc524c4fc37adfe30ee714/tests/common.py#L365-L366

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
