### PR TITLE
Add test helper to remove device

### DIFF
--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -278,14 +278,9 @@ async def test_remove_config_entry_from_device(
 
     # Try removing a config entry from the device, it should fail because
     # async_remove_config_entry_device returns False
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_1.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_1.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -294,14 +289,9 @@ async def test_remove_config_entry_from_device(
     can_remove = True
 
     # Remove the 1st config entry
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_1.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_1.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert response["success"]
     assert response["result"]["config_entries"] == [entry_2.entry_id]
@@ -312,14 +302,9 @@ async def test_remove_config_entry_from_device(
     }
 
     # Remove the 2nd config entry
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_2.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_2.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert response["success"]
     assert response["result"] is None
@@ -398,28 +383,18 @@ async def test_remove_config_entry_from_device_fails(
     assert device_entry.id != fake_device_id
 
     # Try removing a non existing config entry from the device
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": fake_entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, fake_entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown config entry"
 
     # Try removing a config entry which does not support removal from the device
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_1.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_1.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -428,28 +403,18 @@ async def test_remove_config_entry_from_device_fails(
     )
 
     # Try removing a config entry from a device which does not exist
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_2.entry_id,
-            "device_id": fake_device_id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        fake_device_id, entry_2.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown device"
 
     # Try removing a config entry from a device which it's not connected to
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_2.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_2.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert response["success"]
     assert set(response["result"]["config_entries"]) == {
@@ -457,28 +422,18 @@ async def test_remove_config_entry_from_device_fails(
         entry_3.entry_id,
     }
 
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_2.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_2.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Config entry not in device"
 
     # Try removing a config entry which can't be loaded from a device - allowed
-    await ws_client.send_json_auto_id(
-        {
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": entry_3.entry_id,
-            "device_id": device_entry.id,
-        }
+    response = await ws_client.remove_device_from_config_entry(
+        device_entry.id, entry_3.entry_id
     )
-    response = await ws_client.receive_json()
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -278,9 +278,7 @@ async def test_remove_config_entry_from_device(
 
     # Try removing a config entry from the device, it should fail because
     # async_remove_config_entry_device returns False
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_1.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_1.entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -289,9 +287,7 @@ async def test_remove_config_entry_from_device(
     can_remove = True
 
     # Remove the 1st config entry
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_1.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_1.entry_id)
 
     assert response["success"]
     assert response["result"]["config_entries"] == [entry_2.entry_id]
@@ -302,9 +298,7 @@ async def test_remove_config_entry_from_device(
     }
 
     # Remove the 2nd config entry
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_2.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
 
     assert response["success"]
     assert response["result"] is None
@@ -383,18 +377,14 @@ async def test_remove_config_entry_from_device_fails(
     assert device_entry.id != fake_device_id
 
     # Try removing a non existing config entry from the device
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, fake_entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, fake_entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown config entry"
 
     # Try removing a config entry which does not support removal from the device
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_1.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_1.entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -403,18 +393,14 @@ async def test_remove_config_entry_from_device_fails(
     )
 
     # Try removing a config entry from a device which does not exist
-    response = await ws_client.remove_device_from_config_entry(
-        fake_device_id, entry_2.entry_id
-    )
+    response = await ws_client.remove_device(fake_device_id, entry_2.entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Unknown device"
 
     # Try removing a config entry from a device which it's not connected to
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_2.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
 
     assert response["success"]
     assert set(response["result"]["config_entries"]) == {
@@ -422,18 +408,14 @@ async def test_remove_config_entry_from_device_fails(
         entry_3.entry_id,
     }
 
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_2.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Config entry not in device"
 
     # Try removing a config entry which can't be loaded from a device - allowed
-    response = await ws_client.remove_device_from_config_entry(
-        device_entry.id, entry_3.entry_id
-    )
+    response = await ws_client.remove_device(device_entry.id, entry_3.entry_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,9 +856,7 @@ def hass_ws_client(
             data["id"] = next(id_generator)
             return websocket.send_json(data)
 
-        async def _remove_device(
-            device_id: str, config_entry_id: str
-        ) -> Coroutine[Any, Any, Any]:
+        async def _remove_device(device_id: str, config_entry_id: str) -> Any:
             await _send_json_auto_id(
                 {
                     "type": "config/device_registry/remove_config_entry",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,10 +856,25 @@ def hass_ws_client(
             data["id"] = next(id_generator)
             return websocket.send_json(data)
 
+        async def _remove_device_from_config_entry(
+            device_id: str, config_entry_id: str
+        ) -> Coroutine[Any, Any, Any]:
+            await _send_json_auto_id(
+                {
+                    "type": "config/device_registry/remove_config_entry",
+                    "config_entry_id": config_entry_id,
+                    "device_id": device_id,
+                }
+            )
+            return await websocket.receive_json()
+
         # wrap in client
         wrapped_websocket = cast(MockHAClientWebSocket, websocket)
         wrapped_websocket.client = client
         wrapped_websocket.send_json_auto_id = _send_json_auto_id
+        wrapped_websocket.remove_device_from_config_entry = (
+            _remove_device_from_config_entry
+        )
         return wrapped_websocket
 
     return create_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -856,7 +856,7 @@ def hass_ws_client(
             data["id"] = next(id_generator)
             return websocket.send_json(data)
 
-        async def _remove_device_from_config_entry(
+        async def _remove_device(
             device_id: str, config_entry_id: str
         ) -> Coroutine[Any, Any, Any]:
             await _send_json_auto_id(
@@ -872,9 +872,7 @@ def hass_ws_client(
         wrapped_websocket = cast(MockHAClientWebSocket, websocket)
         wrapped_websocket.client = client
         wrapped_websocket.send_json_auto_id = _send_json_auto_id
-        wrapped_websocket.remove_device_from_config_entry = (
-            _remove_device_from_config_entry
-        )
+        wrapped_websocket.remove_device = _remove_device
         return wrapped_websocket
 
     return create_client

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -20,7 +20,7 @@ class MockHAClientWebSocket(ClientWebSocketResponse):
 
     client: TestClient
     send_json_auto_id: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
-    remove_device_from_config_entry: Callable[[str, str], Coroutine[Any, Any, Any]]
+    remove_device: Callable[[str, str], Coroutine[Any, Any, Any]]
 
 
 ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -20,6 +20,7 @@ class MockHAClientWebSocket(ClientWebSocketResponse):
 
     client: TestClient
     send_json_auto_id: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
+    remove_device_from_config_entry: Callable[[str, str], Coroutine[Any, Any, Any]]
 
 
 ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
These few lines are duplicated about 40 times in tests (search for `config/device_registry/remove_config_entry`)
I spotted whilst working on #116229

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
