### PR TITLE
Add Jewish Calendar attributes for non-date sensors

### DIFF
--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -266,11 +266,9 @@ class JewishCalendarSensor(SensorEntity):
             return after_shkia_date.hebrew_date
         if self.entity_description.key == "weekly_portion":
             self._attr_device_class = SensorDeviceClass.ENUM
-            self._attrs = {
-                "options": [
-                    (p.hebrew if self._hebrew else p.english) for p in htables.PARASHAOT
-                ],
-            }
+            self._attr_options = [
+                (p.hebrew if self._hebrew else p.english) for p in htables.PARASHAOT
+            ]
             # Compute the weekly portion based on the upcoming shabbat.
             return after_tzais_date.upcoming_shabbat.parasha
         if self.entity_description.key == "holiday":
@@ -279,15 +277,12 @@ class JewishCalendarSensor(SensorEntity):
                 "id": after_shkia_date.holiday_name,
                 "type": after_shkia_date.holiday_type.name,
                 "type_id": after_shkia_date.holiday_type.value,
-                "options": [
-                    (
-                        h.description.hebrew.long
-                        if self._hebrew
-                        else h.description.english
-                    )
-                    for h in htables.HOLIDAYS
-                ],
             }
+            self._attr_options = [
+                h.description.hebrew.long if self._hebrew else h.description.english
+                for h in htables.HOLIDAYS
+            ]
+
             return after_shkia_date.holiday_description
         if self.entity_description.key == "omer_count":
             return after_shkia_date.omer_day

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -36,6 +36,7 @@ INFO_SENSORS: tuple[SensorEntityDescription, ...] = (
         key="date",
         name="Date",
         icon="mdi:star-david",
+        translation_key="hebrew_date",
     ),
     SensorEntityDescription(
         key="weekly_portion",

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -42,11 +42,13 @@ INFO_SENSORS: tuple[SensorEntityDescription, ...] = (
         key="weekly_portion",
         name="Parshat Hashavua",
         icon="mdi:book-open-variant",
+        device_class=SensorDeviceClass.ENUM,
     ),
     SensorEntityDescription(
         key="holiday",
         name="Holiday",
         icon="mdi:calendar-star",
+        device_class=SensorDeviceClass.ENUM,
     ),
     SensorEntityDescription(
         key="omer_count",
@@ -260,20 +262,18 @@ class JewishCalendarSensor(SensorEntity):
             hdate = cast(HebrewDate, after_shkia_date.hdate)
             month = htables.MONTHS[hdate.month.value - 1]
             self._attrs = {
-                "year": hdate.year,
-                "month_name": month.hebrew if self._hebrew else month.english,
-                "day": hdate.day,
+                "hebrew_year": hdate.year,
+                "hebrew_month_name": month.hebrew if self._hebrew else month.english,
+                "hebrew_day": hdate.day,
             }
             return after_shkia_date.hebrew_date
         if self.entity_description.key == "weekly_portion":
-            self._attr_device_class = SensorDeviceClass.ENUM
             self._attr_options = [
                 (p.hebrew if self._hebrew else p.english) for p in htables.PARASHAOT
             ]
             # Compute the weekly portion based on the upcoming shabbat.
             return after_tzais_date.upcoming_shabbat.parasha
         if self.entity_description.key == "holiday":
-            self._attr_device_class = SensorDeviceClass.ENUM
             self._attrs = {
                 "id": after_shkia_date.holiday_name,
                 "type": after_shkia_date.holiday_type.name,

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -3,9 +3,9 @@
     "sensor": {
       "hebrew_date": {
         "state_attributes": {
-          "year": { "name": "Year" },
-          "month_name": { "name": "Month Name" },
-          "day": { "name": "Day" }
+          "hebrew_year": { "name": "Hebrew Year" },
+          "hebrew_month_name": { "name": "Hebrew Month Name" },
+          "hebrew_day": { "name": "Hebrew Day" }
         }
       }
     }

--- a/homeassistant/components/jewish_calendar/strings.json
+++ b/homeassistant/components/jewish_calendar/strings.json
@@ -1,4 +1,15 @@
 {
+  "entity": {
+    "sensor": {
+      "hebrew_date": {
+        "state_attributes": {
+          "year": { "name": "Year" },
+          "month_name": { "name": "Month Name" },
+          "day": { "name": "Day" }
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -163,9 +163,9 @@ TEST_PARAMS = [
         False,
         "ו' מרחשוון ה' תשע\"ט",
         {
-            "year": 5779,
-            "month_name": "מרחשוון",
-            "day": 6,
+            "hebrew_year": 5779,
+            "hebrew_month_name": "מרחשוון",
+            "hebrew_day": 6,
             "icon": "mdi:star-david",
             "friendly_name": "Jewish Calendar Date",
         },

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -85,7 +85,7 @@ TEST_PARAMS = [
         "Rosh Hashana I",
         {
             "device_class": "enum",
-            "friendly_name": "test Holiday",
+            "friendly_name": "Jewish Calendar Holiday",
             "icon": "mdi:calendar-star",
             "id": "rosh_hashana_i",
             "type": "YOM_TOV",
@@ -104,7 +104,7 @@ TEST_PARAMS = [
         "נצבים",
         {
             "device_class": "enum",
-            "friendly_name": "test Parshat Hashavua",
+            "friendly_name": "Jewish Calendar Parshat Hashavua",
             "icon": "mdi:book-open-variant",
             "options": [p.hebrew for p in htables.PARASHAOT],
         },
@@ -167,7 +167,7 @@ TEST_PARAMS = [
             "month_name": "מרחשוון",
             "day": 6,
             "icon": "mdi:star-david",
-            "friendly_name": "test Date",
+            "friendly_name": "Jewish Calendar Date",
         },
     ),
 ]

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime as dt, timedelta
 
+from hdate import htables
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
@@ -40,7 +41,17 @@ async def test_jewish_calendar_hebrew(hass: HomeAssistant) -> None:
 
 
 TEST_PARAMS = [
-    (dt(2018, 9, 3), "UTC", 31.778, 35.235, "english", "date", False, "23 Elul 5778"),
+    (
+        dt(2018, 9, 3),
+        "UTC",
+        31.778,
+        35.235,
+        "english",
+        "date",
+        False,
+        "23 Elul 5778",
+        None,
+    ),
     (
         dt(2018, 9, 3),
         "UTC",
@@ -50,8 +61,19 @@ TEST_PARAMS = [
         "date",
         False,
         'כ"ג אלול ה\' תשע"ח',
+        None,
     ),
-    (dt(2018, 9, 10), "UTC", 31.778, 35.235, "hebrew", "holiday", False, "א' ראש השנה"),
+    (
+        dt(2018, 9, 10),
+        "UTC",
+        31.778,
+        35.235,
+        "hebrew",
+        "holiday",
+        False,
+        "א' ראש השנה",
+        None,
+    ),
     (
         dt(2018, 9, 10),
         "UTC",
@@ -61,6 +83,15 @@ TEST_PARAMS = [
         "holiday",
         False,
         "Rosh Hashana I",
+        {
+            "device_class": "enum",
+            "friendly_name": "test Holiday",
+            "icon": "mdi:calendar-star",
+            "id": "rosh_hashana_i",
+            "type": "YOM_TOV",
+            "type_id": 1,
+            "options": [h.description.english for h in htables.HOLIDAYS],
+        },
     ),
     (
         dt(2018, 9, 8),
@@ -71,6 +102,12 @@ TEST_PARAMS = [
         "parshat_hashavua",
         False,
         "נצבים",
+        {
+            "device_class": "enum",
+            "friendly_name": "test Parshat Hashavua",
+            "icon": "mdi:book-open-variant",
+            "options": [p.hebrew for p in htables.PARASHAOT],
+        },
     ),
     (
         dt(2018, 9, 8),
@@ -81,6 +118,7 @@ TEST_PARAMS = [
         "t_set_hakochavim",
         True,
         dt(2018, 9, 8, 19, 45),
+        None,
     ),
     (
         dt(2018, 9, 8),
@@ -91,6 +129,7 @@ TEST_PARAMS = [
         "t_set_hakochavim",
         False,
         dt(2018, 9, 8, 19, 19),
+        None,
     ),
     (
         dt(2018, 10, 14),
@@ -101,6 +140,7 @@ TEST_PARAMS = [
         "parshat_hashavua",
         False,
         "לך לך",
+        None,
     ),
     (
         dt(2018, 10, 14, 17, 0, 0),
@@ -111,6 +151,7 @@ TEST_PARAMS = [
         "date",
         False,
         "ה' מרחשוון ה' תשע\"ט",
+        None,
     ),
     (
         dt(2018, 10, 14, 19, 0, 0),
@@ -121,6 +162,13 @@ TEST_PARAMS = [
         "date",
         False,
         "ו' מרחשוון ה' תשע\"ט",
+        {
+            "year": 5779,
+            "month_name": "מרחשוון",
+            "day": 6,
+            "icon": "mdi:star-david",
+            "friendly_name": "test Date",
+        },
     ),
 ]
 
@@ -148,6 +196,7 @@ TEST_IDS = [
         "sensor",
         "diaspora",
         "result",
+        "attrs",
     ),
     TEST_PARAMS,
     ids=TEST_IDS,
@@ -162,6 +211,7 @@ async def test_jewish_calendar_sensor(
     sensor,
     diaspora,
     result,
+    attrs,
 ) -> None:
     """Test Jewish calendar sensor output."""
     time_zone = dt_util.get_time_zone(tzname)
@@ -196,10 +246,8 @@ async def test_jewish_calendar_sensor(
     sensor_object = hass.states.get(f"sensor.jewish_calendar_{sensor}")
     assert sensor_object.state == result
 
-    if sensor == "holiday":
-        assert sensor_object.attributes.get("id") == "rosh_hashana_i"
-        assert sensor_object.attributes.get("type") == "YOM_TOV"
-        assert sensor_object.attributes.get("type_id") == 1
+    if attrs:
+        assert sensor_object.attributes == attrs
 
 
 SHABBAT_PARAMS = [


### PR DESCRIPTION
 - Add attributes for individual date components.
   - This makes it possible to check information about the current date without trying to parse the string.
 - Mark holiday and parsha sensors as Enum.
   - This shows users a dropdown of valid values when using these sensors in a condition or trigger, which is much more convenient.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
