### PR TITLE
Add support for listening on a UNIX socket instead of IP

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -7,6 +7,7 @@ import datetime
 from ipaddress import IPv4Network, IPv6Network, ip_network
 import logging
 import os
+import shutil
 import socket
 import ssl
 from tempfile import NamedTemporaryFile
@@ -85,6 +86,9 @@ from .web_runner import HomeAssistantTCPSite
 
 CONF_SERVER_HOST: Final = "server_host"
 CONF_SERVER_PORT: Final = "server_port"
+CONF_SOCKET_USER: Final = "socket_user"
+CONF_SOCKET_GROUP: Final = "socket_group"
+CONF_SOCKET_PERMISSIONS: Final = "socket_permissions"
 CONF_BASE_URL: Final = "base_url"
 CONF_SSL_CERTIFICATE: Final = "ssl_certificate"
 CONF_SSL_PEER_CERTIFICATE: Final = "ssl_peer_certificate"
@@ -127,6 +131,11 @@ HTTP_SCHEMA: Final = vol.All(
                 cv.ensure_list, vol.Length(min=1), [cv.string]
             ),
             vol.Optional(CONF_SERVER_PORT, default=SERVER_PORT): cv.port,
+            vol.Optional(CONF_SOCKET_USER): vol.Any(vol.Coerce(int), vol.Coerce(str)),
+            vol.Optional(CONF_SOCKET_GROUP): vol.Any(vol.Coerce(int), vol.Coerce(str)),
+            vol.Optional(CONF_SOCKET_PERMISSIONS): vol.All(
+                vol.Coerce(int), vol.Range(min=0, max=0o777)
+            ),
             vol.Optional(CONF_BASE_URL): cv.string,
             vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
             vol.Optional(CONF_SSL_PEER_CERTIFICATE): cv.isfile,
@@ -161,6 +170,9 @@ class ConfData(TypedDict, total=False):
 
     server_host: list[str]
     server_port: int
+    socket_user: int | str
+    socket_group: int | str
+    socket_permissions: int
     base_url: str
     ssl_certificate: str
     ssl_peer_certificate: str
@@ -210,6 +222,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     server_host = conf[CONF_SERVER_HOST]
     server_port = conf[CONF_SERVER_PORT]
+    socket_user = conf.get(CONF_SOCKET_USER)
+    socket_group = conf.get(CONF_SOCKET_GROUP)
+    socket_permissions = conf.get(CONF_SOCKET_PERMISSIONS)
     ssl_certificate = conf.get(CONF_SSL_CERTIFICATE)
     ssl_peer_certificate = conf.get(CONF_SSL_PEER_CERTIFICATE)
     ssl_key = conf.get(CONF_SSL_KEY)
@@ -232,6 +247,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         ssl_key=ssl_key,
         trusted_proxies=trusted_proxies,
         ssl_profile=ssl_profile,
+        socket_user=socket_user,
+        socket_group=socket_group,
+        socket_permissions=socket_permissions,
     )
     await server.async_initialize(
         cors_origins=cors_origins,
@@ -320,6 +338,9 @@ class HomeAssistantHTTP:
         server_port: int,
         trusted_proxies: list[IPv4Network | IPv6Network],
         ssl_profile: str,
+        socket_user: int | str | None,
+        socket_group: int | str | None,
+        socket_permissions: int | None,
     ) -> None:
         """Initialize the HTTP Home Assistant server."""
         self.app = HomeAssistantApplication(
@@ -342,8 +363,11 @@ class HomeAssistantHTTP:
         self.server_port = server_port
         self.trusted_proxies = trusted_proxies
         self.ssl_profile = ssl_profile
+        self.socket_user = socket_user
+        self.socket_group = socket_group
+        self.socket_permissions = socket_permissions
         self.runner: web.AppRunner | None = None
-        self.site: HomeAssistantTCPSite | None = None
+        self.site: web.BaseSite | None = None
         self.context: ssl.SSLContext | None = None
 
     async def async_initialize(
@@ -563,9 +587,21 @@ class HomeAssistantHTTP:
         )
         await self.runner.setup()
 
-        self.site = HomeAssistantTCPSite(
-            self.runner, self.server_host, self.server_port, ssl_context=self.context
-        )
+        socket_path: str | None = None
+        if self.server_host and self.server_host[0].startswith("unix:"):
+            socket_path = self.server_host[0].removeprefix("unix:")
+            self.site = web.UnixSite(
+                self.runner,
+                socket_path,
+                ssl_context=self.context,
+            )
+        else:
+            self.site = HomeAssistantTCPSite(
+                self.runner,
+                self.server_host,
+                self.server_port,
+                ssl_context=self.context,
+            )
         try:
             await self.site.start()
         except OSError as error:
@@ -573,7 +609,29 @@ class HomeAssistantHTTP:
                 "Failed to create HTTP server at port %d: %s", self.server_port, error
             )
 
-        _LOGGER.info("Now listening on port %d", self.server_port)
+        if socket_path is not None:
+            # They didn't find a way to put this in aiohttp yet so we have to do it here
+            # https://github.com/aio-libs/aiohttp/issues/4155#issuecomment-643509809
+            if self.socket_permissions is not None:
+                try:
+                    os.chmod(socket_path, self.socket_permissions)
+                except OSError as error:
+                    _LOGGER.error(
+                        "Failed to change permissions on %s: %s", socket_path, error
+                    )
+            if self.socket_user is not None or self.socket_group is not None:
+                try:
+                    shutil.chown(
+                        socket_path,
+                        self.socket_user or -1,
+                        self.socket_group or -1,
+                    )
+                except OSError as error:
+                    _LOGGER.error(
+                        "Failed to change user/group on %s: %s", socket_path, error
+                    )
+
+        _LOGGER.info("Now listening on %s", self.site.name)
 
     async def stop(self) -> None:
         """Stop the aiohttp server."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I'm running HA in a Docker container on Linux with a reverse proxy setup through Apache that takes care of outside connectivity. Binding HA to 127.0.0.1 works in not having the instance directly accessible from outside the machine, but it will still be accessible from the machine itself bypassing the proxy. I'm personally moving as many localhost-only services as possible to UNIX sockets so they won't need a port and can be locked down to only the relevant users/groups having access to them. As a bonus there's usually a little bit of a performance improvement as well, as the network stack isn't used and the packets don't need to traverse the firewall either, however this impact will be negligible on most/all HA instances I believe.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Aiohttp already supports this easily by using a `UnixSite` instead of a `TCPSite`. That is exactly what I've done. Since the socket creation is affected by the active `umask`, it generally results in a socket with 755 permissions allowing effectively only the user to connect, which could be undesirable depending on the setup (e.g. shared group between HA and the proxy), so the effective permissions after creation are configurable.

I have no idea what tests to make for this, if any. It looks like the TCP client isn't tested either. The `aiohttp.test_utils.TestClient` doesn't take into account any possible HA configuration changes in terms of bound interfaces and port but talks more or less directly to the app, seemingly bypassing most of the network stack. Tests still pass if I block traffic to the port configured in the respective tests, and in the socket case even if I set the socket permissions to 000 so I don't think it's easy to test this in the same style as the rest. I have at least verified that this is working for me.

A sample configuration would be:

```yaml
http:
  server_host: unix:/run/homeassistant.sock
  #socket_user: someone
  socket_group: web
  socket_permissions: 0660
  use_x_forwarded_for: true
  trusted_proxies:
    - 127.0.0.1
```

For me, a more natural configuration would be

```yaml
http:
  server_host: unix:/run/homeassistant.sock
  socket:
    #user: someone
    group: web
    permissions: 0660
  use_x_forwarded_for: true
  trusted_proxies:
    - 127.0.0.1
```

however so far I haven't really found this extra nesting level being used for things other than defining multiple similar entities, so I left it as a flat structure for now. That seems to be the preferred way.

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32484

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
