### PR TITLE
Move thread safety check in area_registry sooner

### DIFF
--- a/tests/helpers/test_area_registry.py
+++ b/tests/helpers/test_area_registry.py
@@ -1,5 +1,6 @@
 """Tests for the Area Registry."""
 
+from functools import partial
 from typing import Any
 
 import pytest
@@ -491,3 +492,40 @@ async def test_entries_for_label(
 
     assert not ar.async_entries_for_label(area_registry, "unknown")
     assert not ar.async_entries_for_label(area_registry, "")
+
+
+async def test_async_get_or_create_thread_checks(
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
+) -> None:
+    """We raise when trying to create in the wrong thread."""
+    with pytest.raises(
+        RuntimeError,
+        match="Detected code that calls async_create from a thread. Please report this issue.",
+    ):
+        await hass.async_add_executor_job(area_registry.async_create, "Mock1")
+
+
+async def test_async_update_thread_checks(
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
+) -> None:
+    """We raise when trying to update in the wrong thread."""
+    area = area_registry.async_create("Mock1")
+    with pytest.raises(
+        RuntimeError,
+        match="Detected code that calls _async_update from a thread. Please report this issue.",
+    ):
+        await hass.async_add_executor_job(
+            partial(area_registry.async_update, area.id, name="Mock2")
+        )
+
+
+async def test_async_delete_thread_checks(
+    hass: HomeAssistant, area_registry: ar.AreaRegistry
+) -> None:
+    """We raise when trying to delete in the wrong thread."""
+    area = area_registry.async_create("Mock1")
+    with pytest.raises(
+        RuntimeError,
+        match="Detected code that calls async_delete from a thread. Please report this issue.",
+    ):
+        await hass.async_add_executor_job(area_registry.async_delete, area.id)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It turns out we have custom components that are writing to the area registry using the async APIs from threads. We currently catch it at the point `async_fire` is called. Instead we should check sooner and use `async_fire_internal` so we catch the unsafe operation before it can corrupt the registry.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
