### PR TITLE
Reduce number of time calls needed to write state

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -2205,6 +2205,7 @@ class StateMachine:
         force_update: bool = False,
         context: Context | None = None,
         state_info: StateInfo | None = None,
+        timestamp: float | None = None,
     ) -> None:
         """Set the state of an entity, add entity if it does not exist.
 
@@ -2244,7 +2245,8 @@ class StateMachine:
         # timestamp implementation:
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6387
         # https://github.com/python/cpython/blob/c90a862cdcf55dc1753c6466e5fa4a467a13ae24/Modules/_datetimemodule.c#L6323
-        timestamp = time.time()
+        if timestamp is None:
+            timestamp = time.time()
         now = dt_util.utc_from_timestamp(timestamp)
 
         if same_state and same_attr:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -14,6 +14,7 @@ import logging
 import math
 from operator import attrgetter
 import sys
+import time
 from types import FunctionType
 from typing import (
     TYPE_CHECKING,
@@ -72,6 +73,8 @@ from .event import (
     async_track_entity_registry_updated_event,
 )
 from .typing import UNDEFINED, StateType, UndefinedType
+
+timer = time.time
 
 if TYPE_CHECKING:
     from .entity_platform import EntityPlatform
@@ -926,7 +929,7 @@ class Entity(
     def async_set_context(self, context: Context) -> None:
         """Set the context the entity currently operates under."""
         self._context = context
-        self._context_set = self.hass.loop.time()
+        self._context_set = time.time()
 
     async def async_update_ha_state(self, force_refresh: bool = False) -> None:
         """Update Home Assistant with current state of entity.
@@ -1127,10 +1130,9 @@ class Entity(
                 )
             return
 
-        loop = hass.loop
-        state_calculate_start = loop.time()
+        state_calculate_start = timer()
         state, attr, capabilities, shadowed_attr = self.__async_calculate_state()
-        time_now = loop.time()
+        time_now = timer()
 
         if entry:
             # Make sure capabilities in the entity registry are up to date. Capabilities
@@ -1206,6 +1208,7 @@ class Entity(
                 self.force_update,
                 self._context,
                 self._state_info,
+                time_now,
             )
         except InvalidStateError:
             _LOGGER.exception(

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -770,7 +770,7 @@ async def test_warn_slow_write_state(
     mock_entity.entity_id = "comp_test.test_entity"
     mock_entity.platform = MagicMock(platform_name="hue")
 
-    with patch("homeassistant.helpers.entity.timer", side_effect=[0, 10]):
+    with patch.object(hass.loop, "time", side_effect=[0, 10]):
         mock_entity.async_write_ha_state()
 
     assert (
@@ -797,7 +797,7 @@ async def test_warn_slow_write_state_custom_component(
     mock_entity.entity_id = "comp_test.test_entity"
     mock_entity.platform = MagicMock(platform_name="hue")
 
-    with patch("homeassistant.helpers.entity.timer", side_effect=[0, 10]):
+    with patch.object(hass.loop, "time", side_effect=[0, 10]):
         mock_entity.async_write_ha_state()
 
     assert (

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -770,7 +770,7 @@ async def test_warn_slow_write_state(
     mock_entity.entity_id = "comp_test.test_entity"
     mock_entity.platform = MagicMock(platform_name="hue")
 
-    with patch.object(hass.loop, "time", side_effect=[0, 10]):
+    with patch("homeassistant.helpers.entity.timer", side_effect=[0, 10]):
         mock_entity.async_write_ha_state()
 
     assert (
@@ -797,7 +797,7 @@ async def test_warn_slow_write_state_custom_component(
     mock_entity.entity_id = "comp_test.test_entity"
     mock_entity.platform = MagicMock(platform_name="hue")
 
-    with patch.object(hass.loop, "time", side_effect=[0, 10]):
+    with patch("homeassistant.helpers.entity.timer", side_effect=[0, 10]):
         mock_entity.async_write_ha_state()
 
     assert (


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Align time calls on `time.time()` for entity checks since we are likely going to call `time.time()` anyways in `async_set`

This cuts the number of time calls in half, and if context or capabilities change, its even less calls.

For systems that do not have VDSO support for time, this avoids thousands of syscalls per minute

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
