### PR TITLE
Use more shorthand attrs in emonitor

### DIFF
--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -12,11 +12,10 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfPower
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -63,7 +62,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
+class EmonitorPowerSensor(CoordinatorEntity[EmonitorStatus], SensorEntity):
     """Representation of an Emonitor power sensor entity."""
 
     _attr_device_class = SensorDeviceClass.POWER
@@ -81,7 +80,8 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
         self.entity_description = description
         self.channel_number = channel_number
         super().__init__(coordinator)
-        mac_address = self.emonitor_status.network.mac_address
+        emonitor_status = self.coordinator.data
+        mac_address = emonitor_status.network.mac_address
         device_name = name_short_mac(mac_address[-6:])
         label = self.channel_data.label or str(channel_number)
         if description.translation_key is not None:
@@ -94,24 +94,21 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
             connections={(dr.CONNECTION_NETWORK_MAC, mac_address)},
             manufacturer="Powerhouse Dynamics, Inc.",
             name=device_name,
-            sw_version=self.emonitor_status.hardware.firmware_version,
+            sw_version=emonitor_status.hardware.firmware_version,
         )
+        self._attr_extra_state_attributes = {"channel": channel_number}
+        self._attr_native_value = self._paired_attr(self.entity_description.key)
 
     @property
     def channels(self) -> dict[int, EmonitorChannel]:
         """Return the channels dict."""
-        channels: dict[int, EmonitorChannel] = self.emonitor_status.channels
+        channels: dict[int, EmonitorChannel] = self.coordinator.data.channels
         return channels
 
     @property
     def channel_data(self) -> EmonitorChannel:
         """Return the channel data."""
         return self.channels[self.channel_number]
-
-    @property
-    def emonitor_status(self) -> EmonitorStatus:
-        """Return the EmonitorStatus."""
-        return self.coordinator.data
 
     def _paired_attr(self, attr_name: str) -> float:
         """Cumulative attributes for channel and paired channel."""
@@ -121,12 +118,8 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
             attr_val += getattr(self.channels[paired_channel], attr_name)
         return attr_val
 
-    @property
-    def native_value(self) -> StateType:
-        """State of the sensor."""
-        return self._paired_attr(self.entity_description.key)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, int]:
-        """Return the device specific state attributes."""
-        return {"channel": self.channel_number}
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_native_value = self._paired_attr(self.entity_description.key)
+        return super()._handle_coordinator_update()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use more shorthand attrs in emonitor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
