### PR TITLE
Use websocket client to test device removal in Unifi

### DIFF
--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -175,25 +175,14 @@ async def test_remove_config_entry_device(
     )
 
     assert await async_setup_component(hass, "config", {})
-    await hass.async_block_till_done()
-
     ws_client = await hass_ws_client(hass)
 
     # Try to remove an active client from UI: not allowed
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_1["mac"])}
     )
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry.entry_id,
-            "device_id": device_entry.id,
-        }
-    )
-    response = await ws_client.receive_json()
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert not response["success"]
-    await hass.async_block_till_done()
     assert device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_1["mac"])}
     )
@@ -202,17 +191,8 @@ async def test_remove_config_entry_device(
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, device_1["mac"])}
     )
-    await ws_client.send_json(
-        {
-            "id": 2,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry.entry_id,
-            "device_id": device_entry.id,
-        }
-    )
-    response = await ws_client.receive_json()
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert not response["success"]
-    await hass.async_block_till_done()
     assert device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, device_1["mac"])}
     )
@@ -225,17 +205,8 @@ async def test_remove_config_entry_device(
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_2["mac"])}
     )
-    await ws_client.send_json(
-        {
-            "id": 3,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry.entry_id,
-            "device_id": device_entry.id,
-        }
-    )
-    response = await ws_client.receive_json()
+    response = await ws_client.remove_device(device_entry.id, config_entry.entry_id)
     assert response["success"]
-    await hass.async_block_till_done()
     assert not device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_2["mac"])}
     )

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -177,13 +177,13 @@ async def test_remove_config_entry_device(
     assert await async_setup_component(hass, "config", {})
     await hass.async_block_till_done()
 
-    client = await hass_ws_client(hass)
+    ws_client = await hass_ws_client(hass)
 
     # Try to remove an active client from UI: not allowed
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_1["mac"])}
     )
-    await client.send_json(
+    await ws_client.send_json(
         {
             "id": 1,
             "type": "config/device_registry/remove_config_entry",
@@ -191,7 +191,7 @@ async def test_remove_config_entry_device(
             "device_id": device_entry.id,
         }
     )
-    response = await client.receive_json()
+    response = await ws_client.receive_json()
     assert not response["success"]
     await hass.async_block_till_done()
     assert device_registry.async_get_device(
@@ -202,7 +202,7 @@ async def test_remove_config_entry_device(
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, device_1["mac"])}
     )
-    await client.send_json(
+    await ws_client.send_json(
         {
             "id": 2,
             "type": "config/device_registry/remove_config_entry",
@@ -210,7 +210,7 @@ async def test_remove_config_entry_device(
             "device_id": device_entry.id,
         }
     )
-    response = await client.receive_json()
+    response = await ws_client.receive_json()
     assert not response["success"]
     await hass.async_block_till_done()
     assert device_registry.async_get_device(
@@ -225,7 +225,7 @@ async def test_remove_config_entry_device(
     device_entry = device_registry.async_get_device(
         connections={(dr.CONNECTION_NETWORK_MAC, client_2["mac"])}
     )
-    await client.send_json(
+    await ws_client.send_json(
         {
             "id": 3,
             "type": "config/device_registry/remove_config_entry",
@@ -233,7 +233,7 @@ async def test_remove_config_entry_device(
             "device_id": device_entry.id,
         }
     )
-    response = await client.receive_json()
+    response = await ws_client.receive_json()
     assert response["success"]
     await hass.async_block_till_done()
     assert not device_registry.async_get_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Unit test cleanup:
use websocket client to test device removal from registry as per this review comment : 
https://github.com/home-assistant/core/pull/115267#discussion_r1574477074

The logic of the unit test is otherwise the same as previously.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
https://github.com/home-assistant/core/pull/115267
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
