### PR TITLE
Also update background_color in web app manifest on theme change

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -49,6 +49,7 @@ CONF_FRONTEND_REPO = "development_repo"
 CONF_JS_VERSION = "javascript_version"
 
 DEFAULT_THEME_COLOR = "#03A9F4"
+DEFAULT_BACKGROUND_COLOR = "#FFFFFF"
 
 
 DATA_PANELS = "frontend_panels"
@@ -67,6 +68,7 @@ DEFAULT_THEME = "default"
 VALUE_NO_THEME = "none"
 
 PRIMARY_COLOR = "primary-color"
+PRIMARY_BACKGROUND_COLOR = "primary-background-color"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -151,7 +153,7 @@ class Manifest:
 
 MANIFEST_JSON = Manifest(
     {
-        "background_color": "#FFFFFF",
+        "background_color": DEFAULT_BACKGROUND_COLOR,
         "description": (
             "Home automation platform that puts local control and privacy first."
         ),
@@ -436,7 +438,7 @@ async def _async_setup_themes(
 
     @callback
     def update_theme_and_fire_event() -> None:
-        """Update theme_color in manifest."""
+        """Update theme_color and background_color in manifest."""
         name = hass.data[DATA_DEFAULT_THEME]
         themes = hass.data[DATA_THEMES]
         if name != DEFAULT_THEME:
@@ -447,8 +449,13 @@ async def _async_setup_themes(
                     themes[name].get(PRIMARY_COLOR, DEFAULT_THEME_COLOR),
                 ),
             )
+            MANIFEST_JSON.update_key(
+                "background_color",
+                themes[name].get(PRIMARY_BACKGROUND_COLOR, DEFAULT_BACKGROUND_COLOR),
+            )
         else:
             MANIFEST_JSON.update_key("theme_color", DEFAULT_THEME_COLOR)
+            MANIFEST_JSON.update_key("background_color", DEFAULT_BACKGROUND_COLOR)
         hass.bus.async_fire(EVENT_THEMES_UPDATED)
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When installing HA as a PWA using Firefox, the navigation bar on Android currently remains bright white even when using a theme with a dark background. The notification bar however does successfully pick up the primary color of the theme.

This is because a backend theme change updates the `theme_color` but not the `background_color` property in the `manifest.json`. Thus, I just extended that to also update `background_color`.

Honestly this seemed a bit too easy so sorry in advance if I missed something blatantly obvious.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
