### PR TITLE
Refactor group setup

### DIFF
--- a/homeassistant/components/air_quality/__init__.py
+++ b/homeassistant/components/air_quality/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, StateType
 
 from . import group as group_pre_import  # noqa: F401
+from .const import DOMAIN
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -32,8 +33,6 @@ ATTR_PM_0_1: Final = "particulate_matter_0_1"
 ATTR_PM_10: Final = "particulate_matter_10"
 ATTR_PM_2_5: Final = "particulate_matter_2_5"
 ATTR_SO2: Final = "sulphur_dioxide"
-
-DOMAIN: Final = "air_quality"
 
 ENTITY_ID_FORMAT: Final = DOMAIN + ".{}"
 

--- a/homeassistant/components/air_quality/const.py
+++ b/homeassistant/components/air_quality/const.py
@@ -1,0 +1,5 @@
+"""Constants for the air_quality entity platform."""
+
+from typing import Final
+
+DOMAIN: Final = "air_quality"

--- a/homeassistant/components/air_quality/group.py
+++ b/homeassistant/components/air_quality/group.py
@@ -7,10 +7,12 @@ from homeassistant.core import HomeAssistant, callback
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
+from .const import DOMAIN
+
 
 @callback
 def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.exclude_domain()
+    registry.exclude_domain(DOMAIN)

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -10,8 +10,11 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_VACATION,
     STATE_ALARM_TRIGGERED,
     STATE_OFF,
+    STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
 
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
@@ -23,13 +26,15 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        {
+        DOMAIN,
+        (
+            STATE_ON,
             STATE_ALARM_ARMED_AWAY,
             STATE_ALARM_ARMED_CUSTOM_BYPASS,
             STATE_ALARM_ARMED_HOME,
             STATE_ALARM_ARMED_NIGHT,
             STATE_ALARM_ARMED_VACATION,
             STATE_ALARM_TRIGGERED,
-        },
+        ),
         STATE_OFF,
     )

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -27,7 +27,7 @@ def async_describe_on_off_states(
     """Describe group on off states."""
     registry.on_off_states(
         DOMAIN,
-        (
+        {
             STATE_ON,
             STATE_ALARM_ARMED_AWAY,
             STATE_ALARM_ARMED_CUSTOM_BYPASS,
@@ -35,6 +35,7 @@ def async_describe_on_off_states(
             STATE_ALARM_ARMED_NIGHT,
             STATE_ALARM_ARMED_VACATION,
             STATE_ALARM_TRIGGERED,
-        ),
+        },
+        STATE_ON,
         STATE_OFF,
     )

--- a/homeassistant/components/climate/group.py
+++ b/homeassistant/components/climate/group.py
@@ -2,10 +2,10 @@
 
 from typing import TYPE_CHECKING
 
-from homeassistant.const import STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 
-from .const import HVAC_MODES, HVACMode
+from .const import DOMAIN, HVACMode
 
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
@@ -17,6 +17,14 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        set(HVAC_MODES) - {HVACMode.OFF},
+        DOMAIN,
+        (
+            STATE_ON,
+            HVACMode.HEAT,
+            HVACMode.COOL,
+            HVACMode.HEAT_COOL,
+            HVACMode.AUTO,
+            HVACMode.FAN_ONLY,
+        ),
         STATE_OFF,
     )

--- a/homeassistant/components/climate/group.py
+++ b/homeassistant/components/climate/group.py
@@ -18,13 +18,14 @@ def async_describe_on_off_states(
     """Describe group on off states."""
     registry.on_off_states(
         DOMAIN,
-        (
+        {
             STATE_ON,
             HVACMode.HEAT,
             HVACMode.COOL,
             HVACMode.HEAT_COOL,
             HVACMode.AUTO,
             HVACMode.FAN_ONLY,
-        ),
+        },
+        STATE_ON,
         STATE_OFF,
     )

--- a/homeassistant/components/cover/__init__.py
+++ b/homeassistant/components/cover/__init__.py
@@ -46,10 +46,10 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from . import group as group_pre_import  # noqa: F401
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "cover"
 SCAN_INTERVAL = timedelta(seconds=15)
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"

--- a/homeassistant/components/cover/const.py
+++ b/homeassistant/components/cover/const.py
@@ -1,0 +1,3 @@
+"""Constants for cover entity platform."""
+
+DOMAIN = "cover"

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -15,4 +17,4 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     # On means open, Off means closed
-    registry.on_off_states({STATE_OPEN}, STATE_CLOSED)
+    registry.on_off_states(DOMAIN, (STATE_OPEN,), STATE_CLOSED)

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -17,4 +17,4 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     # On means open, Off means closed
-    registry.on_off_states(DOMAIN, (STATE_OPEN,), STATE_CLOSED)
+    registry.on_off_states(DOMAIN, {STATE_OPEN}, STATE_OPEN, STATE_CLOSED)

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -16,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states(DOMAIN, (STATE_HOME,), STATE_NOT_HOME)
+    registry.on_off_states(DOMAIN, {STATE_HOME}, STATE_HOME, STATE_NOT_HOME)

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -14,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states({STATE_HOME}, STATE_NOT_HOME)
+    registry.on_off_states(DOMAIN, (STATE_HOME,), STATE_NOT_HOME)

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from contextvars import ContextVar
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
@@ -13,12 +12,13 @@ from homeassistant.helpers.integration_platform import (
 
 from .const import DOMAIN, REG_KEY
 
-current_domain: ContextVar[str] = ContextVar("current_domain")
+if TYPE_CHECKING:
+    from .entity import Group
 
 
 async def async_setup(hass: HomeAssistant) -> None:
     """Set up the Group integration registry of integration platforms."""
-    hass.data[REG_KEY] = GroupIntegrationRegistry()
+    hass.data[REG_KEY] = GroupIntegrationRegistry(hass)
 
     await async_process_integration_platforms(
         hass, DOMAIN, _process_group_platform, wait_for_platforms=True
@@ -39,7 +39,6 @@ def _process_group_platform(
     hass: HomeAssistant, domain: str, platform: GroupProtocol
 ) -> None:
     """Process a group platform."""
-    current_domain.set(domain)
     registry: GroupIntegrationRegistry = hass.data[REG_KEY]
     platform.async_describe_on_off_states(hass, registry)
 
@@ -47,24 +46,30 @@ def _process_group_platform(
 class GroupIntegrationRegistry:
     """Class to hold a registry of integrations."""
 
-    def __init__(self) -> None:
+    def __init__(self, hass: HomeAssistant) -> None:
         """Imitialize registry."""
+        self.hass = hass
         self.on_off_mapping: dict[str, str] = {STATE_ON: STATE_OFF}
         self.off_on_mapping: dict[str, str] = {STATE_OFF: STATE_ON}
         self.on_states_by_domain: dict[str, set[str]] = {}
         self.exclude_domains: set[str] = set()
+        self.state_group_mapping: dict[str, tuple[str, str]] = {}
+        self.group_entities: set[Group] = set()
 
-    def exclude_domain(self) -> None:
+    def exclude_domain(self, domain: str) -> None:
         """Exclude the current domain."""
-        self.exclude_domains.add(current_domain.get())
+        self.exclude_domains.add(domain)
 
-    def on_off_states(self, on_states: set, off_state: str) -> None:
+    def on_off_states(
+        self, domain: str, on_states: tuple[str, ...], off_state: str
+    ) -> None:
         """Register on and off states for the current domain."""
+        # domain = current_domain.get()
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state
 
         if len(on_states) == 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = list(on_states)[0]
+            self.off_on_mapping[off_state] = on_states[0]
 
-        self.on_states_by_domain[current_domain.get()] = set(on_states)
+        self.on_states_by_domain[domain] = set(on_states)

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -56,15 +56,16 @@ class GroupIntegrationRegistry:
         self.state_group_mapping: dict[str, tuple[str, str]] = {}
         self.group_entities: set[Group] = set()
 
+    @callback
     def exclude_domain(self, domain: str) -> None:
         """Exclude the current domain."""
         self.exclude_domains.add(domain)
 
+    @callback
     def on_off_states(
         self, domain: str, on_states: tuple[str, ...], off_state: str
     ) -> None:
         """Register on and off states for the current domain."""
-        # domain = current_domain.get()
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -63,7 +63,7 @@ class GroupIntegrationRegistry:
 
     @callback
     def on_off_states(
-        self, domain: str, on_states: tuple[str, ...], off_state: str
+        self, domain: str, on_states: set[str], default_on_state: str, off_state: str
     ) -> None:
         """Register on and off states for the current domain."""
         for on_state in on_states:
@@ -71,6 +71,6 @@ class GroupIntegrationRegistry:
                 self.on_off_mapping[on_state] = off_state
 
         if len(on_states) == 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = on_states[0]
+            self.off_on_mapping[off_state] = default_on_state
 
-        self.on_states_by_domain[domain] = set(on_states)
+        self.on_states_by_domain[domain] = on_states

--- a/homeassistant/components/lock/__init__.py
+++ b/homeassistant/components/lock/__init__.py
@@ -44,13 +44,13 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.typing import ConfigType, StateType
 
 from . import group as group_pre_import  # noqa: F401
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_CHANGED_BY = "changed_by"
 CONF_DEFAULT_CODE = "default_code"
 
-DOMAIN = "lock"
 SCAN_INTERVAL = timedelta(seconds=30)
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"

--- a/homeassistant/components/lock/const.py
+++ b/homeassistant/components/lock/const.py
@@ -1,0 +1,3 @@
+"""Constants for the lock entity platform."""
+
+DOMAIN = "lock"

--- a/homeassistant/components/lock/group.py
+++ b/homeassistant/components/lock/group.py
@@ -16,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states(DOMAIN, (STATE_UNLOCKED,), STATE_LOCKED)
+    registry.on_off_states(DOMAIN, {STATE_UNLOCKED}, STATE_UNLOCKED, STATE_LOCKED)

--- a/homeassistant/components/lock/group.py
+++ b/homeassistant/components/lock/group.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -14,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states({STATE_UNLOCKED}, STATE_LOCKED)
+    registry.on_off_states(DOMAIN, (STATE_UNLOCKED,), STATE_LOCKED)

--- a/homeassistant/components/media_player/group.py
+++ b/homeassistant/components/media_player/group.py
@@ -24,11 +24,12 @@ def async_describe_on_off_states(
     """Describe group on off states."""
     registry.on_off_states(
         DOMAIN,
-        (
+        {
             STATE_ON,
             STATE_PAUSED,
             STATE_PLAYING,
             STATE_IDLE,
-        ),
+        },
+        STATE_ON,
         STATE_OFF,
     )

--- a/homeassistant/components/media_player/group.py
+++ b/homeassistant/components/media_player/group.py
@@ -11,6 +11,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -21,5 +23,12 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        {STATE_ON, STATE_PAUSED, STATE_PLAYING, STATE_IDLE}, STATE_OFF
+        DOMAIN,
+        (
+            STATE_ON,
+            STATE_PAUSED,
+            STATE_PLAYING,
+            STATE_IDLE,
+        ),
+        STATE_OFF,
     )

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -55,6 +55,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from . import group as group_pre_import  # noqa: F401
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,8 +66,6 @@ ATTR_DEVICE_TRACKERS = "device_trackers"
 CONF_DEVICE_TRACKERS = "device_trackers"
 CONF_USER_ID = "user_id"
 CONF_PICTURE = "picture"
-
-DOMAIN = "person"
 
 STORAGE_KEY = DOMAIN
 STORAGE_VERSION = 2

--- a/homeassistant/components/person/const.py
+++ b/homeassistant/components/person/const.py
@@ -1,0 +1,3 @@
+"""Constants for the person entity platform."""
+
+DOMAIN = "person"

--- a/homeassistant/components/person/group.py
+++ b/homeassistant/components/person/group.py
@@ -16,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states(DOMAIN, (STATE_HOME,), STATE_NOT_HOME)
+    registry.on_off_states(DOMAIN, {STATE_HOME}, STATE_HOME, STATE_NOT_HOME)

--- a/homeassistant/components/person/group.py
+++ b/homeassistant/components/person/group.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -14,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states({STATE_HOME}, STATE_NOT_HOME)
+    registry.on_off_states(DOMAIN, (STATE_HOME,), STATE_NOT_HOME)

--- a/homeassistant/components/plant/group.py
+++ b/homeassistant/components/plant/group.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING
 from homeassistant.const import STATE_OK, STATE_PROBLEM
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
+
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
@@ -14,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states({STATE_PROBLEM}, STATE_OK)
+    registry.on_off_states(DOMAIN, (STATE_PROBLEM,), STATE_OK)

--- a/homeassistant/components/plant/group.py
+++ b/homeassistant/components/plant/group.py
@@ -16,4 +16,4 @@ def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states(DOMAIN, (STATE_PROBLEM,), STATE_OK)
+    registry.on_off_states(DOMAIN, {STATE_PROBLEM}, STATE_PROBLEM, STATE_OK)

--- a/homeassistant/components/sensor/group.py
+++ b/homeassistant/components/sensor/group.py
@@ -7,10 +7,12 @@ from homeassistant.core import HomeAssistant, callback
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
+from .const import DOMAIN
+
 
 @callback
 def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.exclude_domain()
+    registry.exclude_domain(DOMAIN)

--- a/homeassistant/components/vacuum/__init__.py
+++ b/homeassistant/components/vacuum/__init__.py
@@ -36,11 +36,10 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from . import group as group_pre_import  # noqa: F401
-from .const import STATE_CLEANING, STATE_DOCKED, STATE_ERROR, STATE_RETURNING
+from .const import DOMAIN, STATE_CLEANING, STATE_DOCKED, STATE_ERROR, STATE_RETURNING
 
 _LOGGER = logging.getLogger(__name__)
 
-DOMAIN = "vacuum"
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SCAN_INTERVAL = timedelta(seconds=20)
 

--- a/homeassistant/components/vacuum/const.py
+++ b/homeassistant/components/vacuum/const.py
@@ -1,5 +1,7 @@
 """Support for vacuum cleaner robots (botvacs)."""
 
+DOMAIN = "vacuum"
+
 STATE_CLEANING = "cleaning"
 STATE_DOCKED = "docked"
 STATE_RETURNING = "returning"

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -18,11 +18,12 @@ def async_describe_on_off_states(
     """Describe group on off states."""
     registry.on_off_states(
         DOMAIN,
-        (
+        {
             STATE_ON,
             STATE_CLEANING,
             STATE_RETURNING,
             STATE_ERROR,
-        ),
+        },
+        STATE_ON,
         STATE_OFF,
     )

--- a/homeassistant/components/vacuum/group.py
+++ b/homeassistant/components/vacuum/group.py
@@ -7,7 +7,8 @@ from homeassistant.core import HomeAssistant, callback
 
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
-from .const import STATE_CLEANING, STATE_ERROR, STATE_RETURNING
+
+from .const import DOMAIN, STATE_CLEANING, STATE_ERROR, STATE_RETURNING
 
 
 @callback
@@ -16,5 +17,12 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        {STATE_CLEANING, STATE_ON, STATE_RETURNING, STATE_ERROR}, STATE_OFF
+        DOMAIN,
+        (
+            STATE_ON,
+            STATE_CLEANING,
+            STATE_RETURNING,
+            STATE_ERROR,
+        ),
+        STATE_OFF,
     )

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -44,11 +44,10 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import group as group_pre_import  # noqa: F401
+from .const import DOMAIN
 
 DEFAULT_MIN_TEMP = 110
 DEFAULT_MAX_TEMP = 140
-
-DOMAIN = "water_heater"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 SCAN_INTERVAL = timedelta(seconds=60)

--- a/homeassistant/components/water_heater/const.py
+++ b/homeassistant/components/water_heater/const.py
@@ -1,5 +1,7 @@
 """Support for water heater devices."""
 
+DOMAIN = "water_heater"
+
 STATE_ECO = "eco"
 STATE_ELECTRIC = "electric"
 STATE_PERFORMANCE = "performance"

--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -2,12 +2,14 @@
 
 from typing import TYPE_CHECKING
 
-from homeassistant.const import STATE_OFF
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
+
 from .const import (
+    DOMAIN,
     STATE_ECO,
     STATE_ELECTRIC,
     STATE_GAS,
@@ -23,13 +25,15 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-        {
+        DOMAIN,
+        (
+            STATE_ON,
             STATE_ECO,
             STATE_ELECTRIC,
             STATE_PERFORMANCE,
             STATE_HIGH_DEMAND,
             STATE_HEAT_PUMP,
             STATE_GAS,
-        },
+        ),
         STATE_OFF,
     )

--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -26,7 +26,7 @@ def async_describe_on_off_states(
     """Describe group on off states."""
     registry.on_off_states(
         DOMAIN,
-        (
+        {
             STATE_ON,
             STATE_ECO,
             STATE_ELECTRIC,
@@ -34,6 +34,7 @@ def async_describe_on_off_states(
             STATE_HIGH_DEMAND,
             STATE_HEAT_PUMP,
             STATE_GAS,
-        ),
+        },
+        STATE_ON,
         STATE_OFF,
     )

--- a/homeassistant/components/weather/group.py
+++ b/homeassistant/components/weather/group.py
@@ -7,10 +7,12 @@ from homeassistant.core import HomeAssistant, callback
 if TYPE_CHECKING:
     from homeassistant.components.group import GroupIntegrationRegistry
 
+from .const import DOMAIN
+
 
 @callback
 def async_describe_on_off_states(
     hass: HomeAssistant, registry: "GroupIntegrationRegistry"
 ) -> None:
     """Describe group on off states."""
-    registry.exclude_domain()
+    registry.exclude_domain(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changes the way entity platform domains register the group on/off states or exclusions.
This will break any custom integrations that implement the group platform and use alternative `ON`/`OFF` states, or want to exclude a custom entity platform.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor group setup up to:
-  not use current_domain context var but let the domain to be passed as an argument
- also pass a default `on` state.

This is a first step in the refactoring the `group` integration to allow multiple `ON` states to be processed correctly in mixed groups. See #116318 

Add PR for blogpost: https://github.com/home-assistant/developers.home-assistant/pull/2157

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/2157

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
