### PR TITLE
Refactor group state logic

### DIFF
--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -306,26 +306,25 @@ class Group(Entity):
             if domain in registry.state_group_mapping:
                 single_state_type_key.add(registry.state_group_mapping[domain])
             elif domain == DOMAIN:
-                for group in iter(registry.group_entities):
+                for group in registry.group_entities:
                     if group.entity_id == ent_id and group.single_state_type_key:
                         single_state_type_key.add(group.single_state_type_key)
                         break
             else:
                 single_state_type_key.add((STATE_ON, STATE_OFF))
 
-        self.single_state_type_key = (
-            next(iter(single_state_type_key))
-            if len(single_state_type_key) == 1
-            else None
-        )
+        if len(single_state_type_key) == 1:
+            self.single_state_type_key = next(iter(single_state_type_key))
+        else:
+            self.single_state_type_key = None
         registry.group_entities.add(self)
-        self.async_on_remove(self._deregister)
+        self.async_on_remove(self._async_deregister)
 
         self.trackable = tuple(trackable)
         self.tracking = tuple(tracking)
 
     @callback
-    def _deregister(self) -> None:
+    def _async_deregister(self) -> None:
         """Deregister group entity from the registry."""
         registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
         if self in registry.group_entities:

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import ATTR_AUTO, ATTR_ORDER, DOMAIN, GROUP_ORDER, REG_KEY
-from .registry import GroupIntegrationRegistry
+from .registry import GroupIntegrationRegistry, SingleStateType
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -133,7 +133,7 @@ class Group(Entity):
     _attr_should_poll = False
     tracking: tuple[str, ...]
     trackable: tuple[str, ...]
-    single_state_type_key: tuple[str, str] | None
+    single_state_type_key: SingleStateType | None
 
     def __init__(
         self,
@@ -296,7 +296,7 @@ class Group(Entity):
 
         tracking: list[str] = []
         trackable: list[str] = []
-        single_state_type_key: set[tuple[str, str]] = set()
+        single_state_type_set: set[SingleStateType] = set()
         for ent_id in entity_ids:
             ent_id_lower = ent_id.lower()
             domain = split_entity_id(ent_id_lower)[0]
@@ -304,17 +304,17 @@ class Group(Entity):
             if domain not in excluded_domains:
                 trackable.append(ent_id_lower)
             if domain in registry.state_group_mapping:
-                single_state_type_key.add(registry.state_group_mapping[domain])
+                single_state_type_set.add(registry.state_group_mapping[domain])
             elif domain == DOMAIN:
                 # If a group contains another group we check if that group
                 # has a specific single state type
                 if ent_id in registry.state_group_mapping:
-                    single_state_type_key.add(registry.state_group_mapping[ent_id])
+                    single_state_type_set.add(registry.state_group_mapping[ent_id])
             else:
-                single_state_type_key.add((STATE_ON, STATE_OFF))
+                single_state_type_set.add(SingleStateType(STATE_ON, STATE_OFF))
 
-        if len(single_state_type_key) == 1:
-            self.single_state_type_key = next(iter(single_state_type_key))
+        if len(single_state_type_set) == 1:
+            self.single_state_type_key = next(iter(single_state_type_set))
             # To support groups with nested groups we store the state type
             # per group entity_id if there is a single state type
             registry.state_group_mapping[self.entity_id] = self.single_state_type_key
@@ -466,7 +466,7 @@ class Group(Entity):
             self._state = None
             return
         if self.single_state_type_key:
-            on_state = self.single_state_type_key[0]
+            on_state = self.single_state_type_key.on_state
         # If the entity domains have more than one
         # on state, we use STATE_ON/STATE_OFF
         else:
@@ -474,12 +474,10 @@ class Group(Entity):
         group_is_on = self.mode(self._on_off.values())
         if group_is_on:
             self._state = on_state
+        elif self.single_state_type_key:
+            self._state = self.single_state_type_key.off_state
         else:
-            self._state = (
-                self.single_state_type_key[1]
-                if self.single_state_type_key
-                else STATE_OFF
-            )
+            self._state = STATE_OFF
 
 
 def async_get_component(hass: HomeAssistant) -> EntityComponent[Group]:

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -154,7 +154,7 @@ class Group(Entity):
         self._attr_name = name
         self._state: str | None = None
         self._attr_icon = icon
-        self._set_tracked(entity_ids)
+        self._entity_ids = entity_ids
         self._on_off: dict[str, bool] = {}
         self._assumed: dict[str, bool] = {}
         self._on_states: set[str] = set()
@@ -306,18 +306,20 @@ class Group(Entity):
             if domain in registry.state_group_mapping:
                 single_state_type_key.add(registry.state_group_mapping[domain])
             elif domain == DOMAIN:
-                for group in registry.group_entities:
-                    if group.entity_id == ent_id and group.single_state_type_key:
-                        single_state_type_key.add(group.single_state_type_key)
-                        break
+                # If a group contains another group we check if that group
+                # has a specific single state type
+                if ent_id in registry.state_group_mapping:
+                    single_state_type_key.add(registry.state_group_mapping[ent_id])
             else:
                 single_state_type_key.add((STATE_ON, STATE_OFF))
 
         if len(single_state_type_key) == 1:
             self.single_state_type_key = next(iter(single_state_type_key))
+            # To support groups with nested groups we store the state type
+            # per group entity_id if there is a single state type
+            registry.state_group_mapping[self.entity_id] = self.single_state_type_key
         else:
             self.single_state_type_key = None
-        registry.group_entities.add(self)
         self.async_on_remove(self._async_deregister)
 
         self.trackable = tuple(trackable)
@@ -327,8 +329,8 @@ class Group(Entity):
     def _async_deregister(self) -> None:
         """Deregister group entity from the registry."""
         registry: GroupIntegrationRegistry = self.hass.data[REG_KEY]
-        if self in registry.group_entities:
-            registry.group_entities.remove(self)
+        if self.entity_id in registry.state_group_mapping:
+            registry.state_group_mapping.pop(self.entity_id)
 
     @callback
     def _async_start(self, _: HomeAssistant | None = None) -> None:
@@ -368,6 +370,7 @@ class Group(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Handle addition to Home Assistant."""
+        self._set_tracked(self._entity_ids)
         self.async_on_remove(start.async_at_start(self.hass, self._async_start))
 
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.integration_platform import (
 from .const import DOMAIN, REG_KEY
 
 if TYPE_CHECKING:
-    from .entity import Group
+    pass
 
 
 async def async_setup(hass: HomeAssistant) -> None:
@@ -54,7 +54,6 @@ class GroupIntegrationRegistry:
         self.on_states_by_domain: dict[str, set[str]] = {}
         self.exclude_domains: set[str] = set()
         self.state_group_mapping: dict[str, tuple[str, str]] = {}
-        self.group_entities: set[Group] = set()
 
     @callback
     def exclude_domain(self, domain: str) -> None:

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -70,7 +70,8 @@ class GroupIntegrationRegistry:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state
 
-        if len(on_states) == 1 and off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = default_on_state
+        if off_state not in self.off_on_mapping:
+            self.off_on_mapping[off_state] = on_states[0]
+        self.state_group_mapping[domain] = (default_on_state, off_state)
 
         self.on_states_by_domain[domain] = on_states

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -71,7 +71,7 @@ class GroupIntegrationRegistry:
                 self.on_off_mapping[on_state] = off_state
 
         if off_state not in self.off_on_mapping:
-            self.off_on_mapping[off_state] = on_states[0]
+            self.off_on_mapping[off_state] = default_on_state
         self.state_group_mapping[domain] = (default_on_state, off_state)
 
         self.on_states_by_domain[domain] = on_states

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
+from typing import Protocol
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
@@ -12,9 +12,6 @@ from homeassistant.helpers.integration_platform import (
 )
 
 from .const import DOMAIN, REG_KEY
-
-if TYPE_CHECKING:
-    pass
 
 
 async def async_setup(hass: HomeAssistant) -> None:

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
 from homeassistant.const import STATE_OFF, STATE_ON
@@ -43,6 +44,14 @@ def _process_group_platform(
     platform.async_describe_on_off_states(hass, registry)
 
 
+@dataclass(frozen=True, slots=True)
+class SingleStateType:
+    """Dataclass to store a single state type."""
+
+    on_state: str
+    off_state: str
+
+
 class GroupIntegrationRegistry:
     """Class to hold a registry of integrations."""
 
@@ -53,7 +62,7 @@ class GroupIntegrationRegistry:
         self.off_on_mapping: dict[str, str] = {STATE_OFF: STATE_ON}
         self.on_states_by_domain: dict[str, set[str]] = {}
         self.exclude_domains: set[str] = set()
-        self.state_group_mapping: dict[str, tuple[str, str]] = {}
+        self.state_group_mapping: dict[str, SingleStateType] = {}
 
     @callback
     def exclude_domain(self, domain: str) -> None:
@@ -71,6 +80,6 @@ class GroupIntegrationRegistry:
 
         if off_state not in self.off_on_mapping:
             self.off_on_mapping[off_state] = default_on_state
-        self.state_group_mapping[domain] = (default_on_state, off_state)
+        self.state_group_mapping[domain] = SingleStateType(default_on_state, off_state)
 
         self.on_states_by_domain[domain] = on_states

--- a/homeassistant/components/group/registry.py
+++ b/homeassistant/components/group/registry.py
@@ -1,4 +1,7 @@
-"""Provide the functionality to group entities."""
+"""Provide the functionality to group entities.
+
+Legacy group support will not be extended for new domains.
+"""
 
 from __future__ import annotations
 
@@ -70,7 +73,10 @@ class GroupIntegrationRegistry:
     def on_off_states(
         self, domain: str, on_states: set[str], default_on_state: str, off_state: str
     ) -> None:
-        """Register on and off states for the current domain."""
+        """Register on and off states for the current domain.
+
+        Legacy group support will not be extended for new domains.
+        """
         for on_state in on_states:
             if on_state not in self.on_off_mapping:
                 self.on_off_mapping[on_state] = off_state

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -1560,6 +1560,7 @@ async def test_group_that_references_a_group_of_covers(hass: HomeAssistant) -> N
     for entity_id in entity_ids:
         hass.states.async_set(entity_id, "closed")
     await hass.async_block_till_done()
+    assert await async_setup_component(hass, "cover", {})
 
     assert await async_setup_component(
         hass,
@@ -1643,6 +1644,7 @@ async def test_group_that_references_two_types_of_groups(hass: HomeAssistant) ->
         hass.states.async_set(entity_id, "home")
     await hass.async_block_till_done()
 
+    assert await async_setup_component(hass, "cover", {})
     assert await async_setup_component(hass, "device_tracker", {})
     assert await async_setup_component(
         hass,

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -2144,7 +2144,7 @@ async def test_entity_platforms_with_multiple_on_states_no_state_match(
         ),
         # All entities have ON state `on_milk`
         # but the group state will default to on_beer
-        # wicht is the default ON state for both integrations.
+        # which is the default ON state for both integrations.
         (
             [
                 ("test1.ent1", "off_water", "on_milk"),

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -51,6 +51,7 @@ async def help_test_mixed_entity_platforms_on_off_state_test(
     entity_and_state1_state_2: tuple[str, str | None, str | None],
     group_state1: str,
     group_state2: str,
+    grouped_groups: bool = False,
 ) -> None:
     """Help test on_off_states on mixed entity platforms."""
 
@@ -80,15 +81,42 @@ async def help_test_mixed_entity_platforms_on_off_state_test(
     mock_platform(hass, "test2.group", MockGroupPlatform2())
     assert await async_setup_component(hass, "test2", {"test2": {}})
 
-    assert await async_setup_component(
-        hass,
-        "group",
-        {
-            "group": {
-                "test": {"entities": [item[0] for item in entity_and_state1_state_2]},
-            }
-        },
-    )
+    if grouped_groups:
+        assert await async_setup_component(
+            hass,
+            "group",
+            {
+                "group": {
+                    "test1": {
+                        "entities": [
+                            item[0]
+                            for item in entity_and_state1_state_2
+                            if item[0].startswith("test1.")
+                        ]
+                    },
+                    "test2": {
+                        "entities": [
+                            item[0]
+                            for item in entity_and_state1_state_2
+                            if item[0].startswith("test2.")
+                        ]
+                    },
+                    "test": {"entities": ["group.test1", "group.test2"]},
+                }
+            },
+        )
+    else:
+        assert await async_setup_component(
+            hass,
+            "group",
+            {
+                "group": {
+                    "test": {
+                        "entities": [item[0] for item in entity_and_state1_state_2]
+                    },
+                }
+            },
+        )
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
@@ -1970,6 +1998,7 @@ async def test_unhide_members_on_remove(
     assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by
 
 
+@pytest.mark.parametrize("grouped_groups", [False, True])
 @pytest.mark.parametrize(
     ("on_off_states1", "on_off_states2"),
     [
@@ -2058,6 +2087,7 @@ async def test_entity_platforms_with_multiple_on_states_no_state_match(
     entity_and_state1_state_2: tuple[str, str | None, str | None],
     group_state1: str,
     group_state2: str,
+    grouped_groups: bool,
 ) -> None:
     """Test custom entity platforms with multiple ON states without state match.
 
@@ -2070,9 +2100,11 @@ async def test_entity_platforms_with_multiple_on_states_no_state_match(
         entity_and_state1_state_2,
         group_state1,
         group_state2,
+        grouped_groups,
     )
 
 
+@pytest.mark.parametrize("grouped_groups", [False, True])
 @pytest.mark.parametrize(
     ("on_off_states1", "on_off_states2"),
     [
@@ -2162,6 +2194,7 @@ async def test_entity_platforms_with_multiple_on_states_with_state_match(
     entity_and_state1_state_2: tuple[str, str | None, str | None],
     group_state1: str,
     group_state2: str,
+    grouped_groups: bool,
 ) -> None:
     """Test custom entity platforms with multiple ON states with a state match.
 
@@ -2174,4 +2207,5 @@ async def test_entity_platforms_with_multiple_on_states_with_state_match(
         entity_and_state1_state_2,
         group_state1,
         group_state2,
+        grouped_groups,
     )

--- a/tests/components/group/test_init.py
+++ b/tests/components/group/test_init.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import group
+from homeassistant.components.group.registry import GroupIntegrationRegistry
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_FRIENDLY_NAME,
@@ -33,7 +34,88 @@ from homeassistant.setup import async_setup_component
 
 from . import common
 
-from tests.common import MockConfigEntry, assert_setup_component
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    MockPlatform,
+    assert_setup_component,
+    mock_integration,
+    mock_platform,
+)
+
+
+async def help_test_mixed_entity_platforms_on_off_state_test(
+    hass: HomeAssistant,
+    on_off_states1: tuple[set[str], str, str],
+    on_off_states2: tuple[set[str], str, str],
+    entity_and_state1_state_2: tuple[str, str | None, str | None],
+    group_state1: str,
+    group_state2: str,
+) -> None:
+    """Help test on_off_states on mixed entity platforms."""
+
+    class MockGroupPlatform1(MockPlatform):
+        """Mock a group platform module for test1 integration."""
+
+        def async_describe_on_off_states(
+            self, hass: HomeAssistant, registry: GroupIntegrationRegistry
+        ) -> None:
+            """Describe group on off states."""
+            registry.on_off_states("test1", *on_off_states1)
+
+    class MockGroupPlatform2(MockPlatform):
+        """Mock a group platform module for test2 integration."""
+
+        def async_describe_on_off_states(
+            self, hass: HomeAssistant, registry: GroupIntegrationRegistry
+        ) -> None:
+            """Describe group on off states."""
+            registry.on_off_states("test2", *on_off_states2)
+
+    mock_integration(hass, MockModule(domain="test1"))
+    mock_platform(hass, "test1.group", MockGroupPlatform1())
+    assert await async_setup_component(hass, "test1", {"test1": {}})
+
+    mock_integration(hass, MockModule(domain="test2"))
+    mock_platform(hass, "test2.group", MockGroupPlatform2())
+    assert await async_setup_component(hass, "test2", {"test2": {}})
+
+    assert await async_setup_component(
+        hass,
+        "group",
+        {
+            "group": {
+                "test": {"entities": [item[0] for item in entity_and_state1_state_2]},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("group.test")
+    assert state is not None
+
+    # Set first state
+    for entity_id, state1, _ in entity_and_state1_state_2:
+        hass.states.async_set(entity_id, state1)
+
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("group.test")
+    assert state is not None
+    assert state.state == group_state1
+
+    # Set second state
+    for entity_id, _, state2 in entity_and_state1_state_2:
+        hass.states.async_set(entity_id, state2)
+
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("group.test")
+    assert state is not None
+    assert state.state == group_state2
 
 
 async def test_setup_group_with_mixed_groupable_states(hass: HomeAssistant) -> None:
@@ -1886,3 +1968,210 @@ async def test_unhide_members_on_remove(
     # Check the group members are unhidden
     assert entity_registry.async_get(f"{group_type}.one").hidden_by == hidden_by
     assert entity_registry.async_get(f"{group_type}.three").hidden_by == hidden_by
+
+
+@pytest.mark.parametrize(
+    ("on_off_states1", "on_off_states2"),
+    [
+        (
+            (
+                {
+                    "on_beer",
+                    "on_milk",
+                },
+                "on_beer",  # default ON state test1
+                "off_water",  # default OFF state test1
+            ),
+            (
+                {
+                    "on_beer",
+                    "on_milk",
+                },
+                "on_milk",  # default ON state test2
+                "off_wine",  # default OFF state test2
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("entity_and_state1_state_2", "group_state1", "group_state2"),
+    [
+        # All OFF states, no change, so group stays OFF
+        (
+            [
+                ("test1.ent1", "off_water", "off_water"),
+                ("test1.ent2", "off_water", "off_water"),
+                ("test2.ent1", "off_wine", "off_wine"),
+                ("test2.ent2", "off_wine", "off_wine"),
+            ],
+            STATE_OFF,
+            STATE_OFF,
+        ),
+        # All entities have state on_milk, but the state groups
+        # are different so the group status defaults to ON / OFF
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_milk"),
+                ("test2.ent1", "off_wine", "on_milk"),
+                ("test2.ent2", "off_wine", "on_milk"),
+            ],
+            STATE_OFF,
+            STATE_ON,
+        ),
+        # Only test1 entities in group, all at ON state
+        # group returns the default ON state `on_beer`
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_beer"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+        # Only test1 entities in group, all at ON state
+        # group returns the default ON state `on_beer`
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_milk"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+        # Only test2 entities in group, all at ON state
+        # group returns the default ON state `on_milk`
+        (
+            [
+                ("test2.ent1", "off_wine", "on_milk"),
+                ("test2.ent2", "off_wine", "on_milk"),
+            ],
+            "off_wine",
+            "on_milk",
+        ),
+    ],
+)
+async def test_entity_platforms_with_multiple_on_states_no_state_match(
+    hass: HomeAssistant,
+    on_off_states1: tuple[set[str], str, str],
+    on_off_states2: tuple[set[str], str, str],
+    entity_and_state1_state_2: tuple[str, str | None, str | None],
+    group_state1: str,
+    group_state2: str,
+) -> None:
+    """Test custom entity platforms with multiple ON states without state match.
+
+    The test group 1 an 2 non matching (default_state_on, state_off) pairs.
+    """
+    await help_test_mixed_entity_platforms_on_off_state_test(
+        hass,
+        on_off_states1,
+        on_off_states2,
+        entity_and_state1_state_2,
+        group_state1,
+        group_state2,
+    )
+
+
+@pytest.mark.parametrize(
+    ("on_off_states1", "on_off_states2"),
+    [
+        (
+            (
+                {
+                    "on_beer",
+                    "on_milk",
+                },
+                "on_beer",  # default ON state test1
+                "off_water",  # default OFF state test1
+            ),
+            (
+                {
+                    "on_beer",
+                    "on_wine",
+                },
+                "on_beer",  # default ON state test2
+                "off_water",  # default OFF state test2
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    ("entity_and_state1_state_2", "group_state1", "group_state2"),
+    [
+        # All OFF states, no change, so group stays OFF
+        (
+            [
+                ("test1.ent1", "off_water", "off_water"),
+                ("test1.ent2", "off_water", "off_water"),
+                ("test2.ent1", "off_water", "off_water"),
+                ("test2.ent2", "off_water", "off_water"),
+            ],
+            "off_water",
+            "off_water",
+        ),
+        # All entities have ON state `on_milk`
+        # but the group state will default to on_beer
+        # wicht is the default ON state for both integrations.
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_milk"),
+                ("test2.ent1", "off_water", "on_milk"),
+                ("test2.ent2", "off_water", "on_milk"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+        # Only test1 entities in group, all at ON state
+        # group returns the default ON state `on_beer`
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_beer"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+        # Only test1 entities in group, all at ON state
+        # group returns the default ON state `on_beer`
+        (
+            [
+                ("test1.ent1", "off_water", "on_milk"),
+                ("test1.ent2", "off_water", "on_milk"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+        # Only test2 entities in group, all at ON state
+        # group returns the default ON state `on_milk`
+        (
+            [
+                ("test2.ent1", "off_water", "on_wine"),
+                ("test2.ent2", "off_water", "on_wine"),
+            ],
+            "off_water",
+            "on_beer",
+        ),
+    ],
+)
+async def test_entity_platforms_with_multiple_on_states_with_state_match(
+    hass: HomeAssistant,
+    on_off_states1: tuple[set[str], str, str],
+    on_off_states2: tuple[set[str], str, str],
+    entity_and_state1_state_2: tuple[str, str | None, str | None],
+    group_state1: str,
+    group_state2: str,
+) -> None:
+    """Test custom entity platforms with multiple ON states with a state match.
+
+    The integrations test1 and test2 have matching (default_state_on, state_off) pairs.
+    """
+    await help_test_mixed_entity_platforms_on_off_state_test(
+        hass,
+        on_off_states1,
+        on_off_states2,
+        entity_and_state1_state_2,
+        group_state1,
+        group_state2,
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR replaces #116116, which was based on #115866, but this change was [reverted](https://github.com/home-assistant/core/pull/116176).

~Needs #116317 to be merged first.~
Needed by #111968 (Add lock `open` state).

Refactors the way group states are processed. There are no functional changes.

With #116317 `on` states were passed as a tuple, allowing to assign the first  state as the default `on` state.

To allow additional `on` states that are also used for other platforms we need to `group` the on/off state state pairs to be able to check for a single use of a state pair.

To handle groups of groups some additional logic was added, as we need to know if a group uses single state group. E.g. groups of `locks` using `lock` and `unlocked`. The default state group is `on` / `off`

### The logic as it is expected to work

Multipe domains with a single shared `on` / `off` state can be combined as they are have the same group state type, e.g.:
- `person` and `device_tracker`: `home` and `not_home`
- `switch` and `light`: `ON` and `OFF`

In case a domain has multiple `on` or `off` states we use the default `on` state, e.g.:
- `lock` will have `unlocked` and `open` as `ON` state. The group `on` state will always be `unlocked`

So each group state type has its own consistent ON and OFF state.

If entities of different group state types are combined, the group state default to `on`/`off`

### Example:
In case a `lock` entities are combined with other domain entities, e.g. `cover`, then the group status will be `on` or `off`.

Some group state types when entities of multiple domains are combined:
- `on`/`off`: `switch`, `light`, `vacuum`, `siren`, `climate` etc.
- `zone`: `person`, `device_tracker` etc.
- `open`/`closed: `cover`
- `unlocked`/`locked`: `lock`. Also `open` is an `ON` state, but in a group the default `ON` state (`unlocked`) will be used.

Groups will always be consistent on and off state, so:
- when `lock` and `cover` are combined, and the group is `ON`, the status will be `ON`, and `OFF` if the group is `OFF`
- when `person ` and `device_tracker` are combined, and the group is `ON`, the status will be `home`and `not_home` if the group is `OFF`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32574

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
