### PR TITLE
Prevent setup retry from delaying shutdown

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -698,7 +698,7 @@ class ConfigEntry:
         # Check again when we fire in case shutdown
         # has started so we do not block shutdown
         if not hass.is_stopping:
-            hass.async_create_task(
+            hass.async_create_background_task(
                 self._async_setup_retry(hass),
                 f"config entry retry {self.domain} {self.title}",
                 eager_start=True,

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -57,6 +57,6 @@ async def test_setup_retry(
     mock_client.read_char.side_effect = original_read_char
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert mock_entry.state is ConfigEntryState.LOADED

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -203,6 +203,7 @@ async def test_ecobee3_setup_connection_failure(
     # We just advance time by 5 minutes so that the retry happens, rather
     # than manually invoking async_setup_entry.
     await time_changed(hass, 5 * 60)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     climate = entity_registry.async_get("climate.homew")
     assert climate.unique_id == "00:00:00:00:00:00_1_16"

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -160,7 +160,7 @@ async def test_offline_device_raises(hass: HomeAssistant, controller) -> None:
     is_connected = True
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
@@ -217,16 +217,18 @@ async def test_ble_device_only_checks_is_available(
     is_available = True
 
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
     is_available = False
     async_fire_time_changed(hass, utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert hass.states.get("light.testdevice").state == STATE_UNAVAILABLE
 
     is_available = True
     async_fire_time_changed(hass, utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert hass.states.get("light.testdevice").state == STATE_OFF
 
 

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -74,7 +74,7 @@ async def test_vehicle_first_refresh(
     # Wait for the retry
     freezer.tick(timedelta(seconds=60))
     async_fire_time_changed(hass)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify we have loaded
     assert entry.state is ConfigEntryState.LOADED

--- a/tests/components/wiz/test_init.py
+++ b/tests/components/wiz/test_init.py
@@ -32,9 +32,9 @@ async def test_setup_retry(hass: HomeAssistant) -> None:
     bulb.getMac = AsyncMock(return_value=FAKE_MAC)
 
     with _patch_discovery(), _patch_wizlight(device=bulb):
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         async_fire_time_changed(hass, utcnow() + datetime.timedelta(minutes=15))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
     assert entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -69,7 +69,7 @@ async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
 
         assert config_entry.state is ConfigEntryState.SETUP_RETRY
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     # The discovery should update the ip address
     assert config_entry.data[CONF_HOST] == IP_ADDRESS
@@ -78,7 +78,7 @@ async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
 
     with patch(f"{MODULE}.AsyncBulb", return_value=mocked_bulb), _patch_discovery():
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert config_entry.state is ConfigEntryState.LOADED
 
     binary_sensor_entity_id = ENTITY_BINARY_SENSOR_TEMPLATE.format(
@@ -362,7 +362,7 @@ async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant) -> None:
         _patch_discovery_interval(),
     ):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -380,7 +380,7 @@ async def test_async_listen_error_late_discovery(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
     await hass.async_block_till_done()
@@ -388,7 +388,7 @@ async def test_async_listen_error_late_discovery(
 
     with _patch_discovery(), patch(f"{MODULE}.AsyncBulb", return_value=_mocked_bulb()):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert config_entry.state is ConfigEntryState.LOADED
     assert config_entry.data[CONF_DETECTED_MODEL] == MODEL
@@ -411,7 +411,7 @@ async def test_fail_to_fetch_initial_state(
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=5))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
     await hass.async_block_till_done()
@@ -419,7 +419,7 @@ async def test_fail_to_fetch_initial_state(
 
     with _patch_discovery(), patch(f"{MODULE}.AsyncBulb", return_value=_mocked_bulb()):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=10))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert config_entry.state is ConfigEntryState.LOADED
 
@@ -502,7 +502,7 @@ async def test_async_setup_with_missing_id(hass: HomeAssistant) -> None:
         assert config_entry.state is ConfigEntryState.SETUP_RETRY
         assert config_entry.data[CONF_ID] == ID
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     with (
         _patch_discovery(),
@@ -511,7 +511,7 @@ async def test_async_setup_with_missing_id(hass: HomeAssistant) -> None:
         patch(f"{MODULE}.AsyncBulb", return_value=_mocked_bulb()),
     ):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=4))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert config_entry.state is ConfigEntryState.LOADED
 
 
@@ -535,7 +535,7 @@ async def test_async_setup_with_missing_unique_id(hass: HomeAssistant) -> None:
         assert config_entry.state is ConfigEntryState.SETUP_RETRY
         assert config_entry.unique_id == ID
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=2))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     with (
         _patch_discovery(),
@@ -544,7 +544,7 @@ async def test_async_setup_with_missing_unique_id(hass: HomeAssistant) -> None:
         patch(f"{MODULE}.AsyncBulb", return_value=_mocked_bulb()),
     ):
         async_fire_time_changed(hass, dt_util.utcnow() + timedelta(minutes=4))
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
         assert config_entry.state is ConfigEntryState.LOADED
 
 

--- a/tests/components/zha/test_init.py
+++ b/tests/components/zha/test_init.py
@@ -255,10 +255,11 @@ async def test_zha_retry_unique_ids(
             lambda hass, delay, action: async_call_later(hass, 0, action),
         ):
             await hass.config_entries.async_setup(config_entry.entry_id)
-            await hass.async_block_till_done()
+            await hass.async_block_till_done(wait_background_tasks=True)
 
             # Wait for the config entry setup to retry
             await asyncio.sleep(0.1)
+            await hass.async_block_till_done(wait_background_tasks=True)
 
         assert len(mock_connect.mock_calls) == 2
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
These should have been created as background tasks as there is no reason to wait for an integration to setup at shutdown. There was a check to not create the task if stop had already been fired, but nothing handled the case were stop is fired after the task is created

This should fix a another class of issues where the container gets shutdown because stop too took long and the sqlite database gets shutdown uncleanly.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/109343 https://github.com/home-assistant/core/issues/73679 (not marked as fixes because anything can block shutdown and this is only one case and there is no way to tell if this is the issue for these)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
