### PR TITLE
Bump total_connect_client to 2024 4

### DIFF
--- a/homeassistant/components/totalconnect/__init__.py
+++ b/homeassistant/components/totalconnect/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import AUTO_BYPASS, CONF_USERCODES, DOMAIN
 
-PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR]
+PLATFORMS = [Platform.ALARM_CONTROL_PANEL, Platform.BINARY_SENSOR, Platform.BUTTON]
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 SCAN_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
             if zone.can_be_bypassed
         )
 
-    async_add_entities(buttons, True)
+    async_add_entities(buttons)
 
 
 class TotalConnectZoneBypassButton(ButtonEntity):

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -65,10 +65,8 @@ async def async_setup_entry(
 class TotalConnectZoneBypassButton(TotalConnectZoneEntity, ButtonEntity):
     """Represent a TotalConnect zone bypass button."""
 
-    _attr_has_entity_name = True
     _attr_translation_key = "bypass"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    entity_description = ButtonEntityDescription(key="bypass", name="bypass")
 
     def __init__(
         self,
@@ -87,8 +85,6 @@ class TotalConnectZoneBypassButton(TotalConnectZoneEntity, ButtonEntity):
 
 class TotalConnectPanelButton(TotalConnectLocationEntity, ButtonEntity):
     """Generic TotalConnect panel button."""
-
-    _attr_has_entity_name = True
 
     entity_description: TotalConnectButtonEntityDescription
 

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -1,4 +1,4 @@
-"""Interfaces with TotalConnect sensors."""
+"""Interfaces with TotalConnect buttons."""
 
 import logging
 

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -27,7 +27,7 @@ async def async_setup_entry(
         buttons.append(TotalConnectBypassAllButton(location))
 
         for zone in location.zones.values():
-            if not zone.is_type_button():
+            if zone.can_be_bypassed:
                 buttons.append(TotalConnectZoneBypassButton(location_id, zone))  # noqa: PERF401
 
     async_add_entities(buttons, True)

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -28,11 +28,13 @@ PANEL_BUTTONS: tuple[TotalConnectButtonEntityDescription, ...] = (
     TotalConnectButtonEntityDescription(
         key="clear_bypass",
         name="Clear Bypass",
+        translation_key="clear_bypass",
         press_fn=lambda location: location.clear_bypass(),
     ),
     TotalConnectButtonEntityDescription(
         key="bypass_all",
         name="Bypass All",
+        translation_key="bypass_all",
         press_fn=lambda location: location.zone_bypass_all(),
     ),
 )

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -32,32 +32,26 @@ async def async_setup_entry(
 
 
 class TotalConnectZoneBypassButton(ButtonEntity):
-    """Represent an TotalConnect zone bypass button."""
+    """Represent a TotalConnect zone bypass button."""
 
-    def __init__(self, location_id, zone):
+    _attr_has_entity_name = True
+    _attr_translation_key = "bypass"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, location_id, zone) -> None:
         """Initialize the TotalConnect status."""
         self._zone = zone
-        self.entity_description: ButtonEntityDescription = ButtonEntityDescription(
-            key="bypass", name="Bypass", entity_category=EntityCategory.DIAGNOSTIC
+        identifier = self._zone.sensor_serial_number or f"zone_{self._zone.zoneid}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, identifier)},
+            name=self._zone.description,
+            serial_number=self._zone.sensor_serial_number,
         )
-        self._attr_name = f"{zone.description} {self.entity_description.name}"
-        self._attr_unique_id = (
-            f"{location_id}_{zone.zoneid}_{self.entity_description.key}"
-        )
+        self._attr_unique_id = f"{location_id}_{zone.zoneid}_bypass"
 
     def press(self):
         """Press the bypass button."""
         self._zone.bypass()
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        identifier = self._zone.sensor_serial_number or f"zone_{self._zone.zoneid}"
-        return DeviceInfo(
-            name=self._zone.description,
-            identifiers={(DOMAIN, identifier)},
-            serial_number=self._zone.sensor_serial_number,
-        )
 
 
 class TotalConnectPanelButton(ButtonEntity):

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -26,9 +26,11 @@ async def async_setup_entry(
         buttons.append(TotalConnectClearBypassButton(location))
         buttons.append(TotalConnectBypassAllButton(location))
 
-        for zone in location.zones.values():
-            if zone.can_be_bypassed:
-                buttons.append(TotalConnectZoneBypassButton(location_id, zone))  # noqa: PERF401
+        buttons.extend(
+            TotalConnectZoneBypassButton(location_id, zone)
+            for zone in location.zones.values()
+            if zone.can_be_bypassed
+        )
 
     async_add_entities(buttons, True)
 

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from total_connect_client.location import TotalConnectLocation
+from total_connect_client.zone import TotalConnectZone
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -67,7 +68,12 @@ class TotalConnectZoneBypassButton(TotalConnectZoneEntity, ButtonEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     entity_description = ButtonEntityDescription(key="bypass", name="bypass")
 
-    def __init__(self, coordinator, zone, location_id) -> None:
+    def __init__(
+        self,
+        coordinator: TotalConnectDataUpdateCoordinator,
+        zone: TotalConnectZone,
+        location_id,
+    ) -> None:
         """Initialize the TotalConnect status."""
         super().__init__(coordinator, zone, location_id, "bypass")
         self.entity_description = ButtonEntityDescription(key="bypass", name="bypass")
@@ -86,8 +92,8 @@ class TotalConnectPanelButton(TotalConnectLocationEntity, ButtonEntity):
 
     def __init__(
         self,
-        coordinator,
-        location,
+        coordinator: TotalConnectDataUpdateCoordinator,
+        location: TotalConnectLocation,
         entity_description: TotalConnectButtonEntityDescription,
     ) -> None:
         """Initialize the TotalConnect button."""

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -57,44 +57,22 @@ class TotalConnectZoneBypassButton(ButtonEntity):
 class TotalConnectPanelButton(ButtonEntity):
     """Generic TotalConnect panel button."""
 
-    def __init__(self, location):
-        """Initialize the TotalConnect clear bypass button."""
-        self._location = location
-        self._device = self._location.devices[self._location.security_device_id]
-        self._attr_name = f"{self.entity_description.name}"
-        self._attr_unique_id = f"{location.location_id}_{self.entity_description.key}"
+    _attr_has_entity_name = True
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._device.serial_number)},
-            name=self._device.name,
-            serial_number=self._device.serial_number,
+    entity_description: TotalConnectButtonEntityDescription
+
+    def __init__(self, location, entity_description: TotalConnectButtonEntityDescription) -> None:
+        """Initialize the TotalConnect button."""
+        self._location = location
+        device = location.devices[location.security_device_id]
+        self._attr_unique_id = f"{location.location_id}_{entity_description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.serial_number)},
+            name=device.name,
+            serial_number=device.serial_number,
         )
 
 
-class TotalConnectClearBypassButton(TotalConnectPanelButton):
-    """Clear Bypass button."""
-
-    entity_description: ButtonEntityDescription = ButtonEntityDescription(
-        key="clear_bypass",
-        name="Clear Bypass",
-        entity_category=EntityCategory.DIAGNOSTIC,
-    )
-
-    def press(self):
-        """Press the clear bypass button."""
-        self._location.clear_bypass()
-
-
-class TotalConnectBypassAllButton(TotalConnectPanelButton):
-    """Bypass All button."""
-
-    entity_description: ButtonEntityDescription = ButtonEntityDescription(
-        key="bypass_all", name="Bypass All", entity_category=EntityCategory.DIAGNOSTIC
-    )
-
-    def press(self):
-        """Press the bypass all button."""
-        self._location.zone_bypass_all()
+    def press(self) -> None:
+        """Press the button."""
+        self.entity_description.press_fn()

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -1,7 +1,5 @@
 """Interfaces with TotalConnect buttons."""
 
-import logging
-
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -10,8 +8,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -1,0 +1,108 @@
+"""Interfaces with TotalConnect sensors."""
+
+import logging
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up TotalConnect buttons based on a config entry."""
+    buttons: list = []
+
+    client_locations = hass.data[DOMAIN][entry.entry_id].client.locations
+
+    for location_id, location in client_locations.items():
+        buttons.append(TotalConnectClearBypassButton(location))
+        buttons.append(TotalConnectBypassAllButton(location))
+
+        for zone in location.zones.values():
+            if not zone.is_type_button():
+                buttons.append(TotalConnectZoneBypassButton(location_id, zone))  # noqa: PERF401
+
+    async_add_entities(buttons, True)
+
+
+class TotalConnectZoneBypassButton(ButtonEntity):
+    """Represent an TotalConnect zone bypass button."""
+
+    def __init__(self, location_id, zone):
+        """Initialize the TotalConnect status."""
+        self._zone = zone
+        self.entity_description: ButtonEntityDescription = ButtonEntityDescription(
+            key="bypass", name="Bypass", entity_category=EntityCategory.DIAGNOSTIC
+        )
+        self._attr_name = f"{zone.description} {self.entity_description.name}"
+        self._attr_unique_id = (
+            f"{location_id}_{zone.zoneid}_{self.entity_description.key}"
+        )
+
+    def press(self):
+        """Press the bypass button."""
+        self._zone.bypass()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        identifier = self._zone.sensor_serial_number or f"zone_{self._zone.zoneid}"
+        return DeviceInfo(
+            name=self._zone.description,
+            identifiers={(DOMAIN, identifier)},
+            serial_number=self._zone.sensor_serial_number,
+        )
+
+
+class TotalConnectPanelButton(ButtonEntity):
+    """Generic TotalConnect panel button."""
+
+    def __init__(self, location):
+        """Initialize the TotalConnect clear bypass button."""
+        self._location = location
+        self._device = self._location.devices[self._location.security_device_id]
+        self._attr_name = f"{self.entity_description.name}"
+        self._attr_unique_id = f"{location.location_id}_{self.entity_description.key}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._device.serial_number)},
+            name=self._device.name,
+            serial_number=self._device.serial_number,
+        )
+
+
+class TotalConnectClearBypassButton(TotalConnectPanelButton):
+    """Clear Bypass button."""
+
+    entity_description: ButtonEntityDescription = ButtonEntityDescription(
+        key="clear_bypass",
+        name="Clear Bypass",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    )
+
+    def press(self):
+        """Press the clear bypass button."""
+        self._location.clear_bypass()
+
+
+class TotalConnectBypassAllButton(TotalConnectPanelButton):
+    """Bypass All button."""
+
+    entity_description: ButtonEntityDescription = ButtonEntityDescription(
+        key="bypass_all", name="Bypass All", entity_category=EntityCategory.DIAGNOSTIC
+    )
+
+    def press(self):
+        """Press the bypass all button."""
+        self._location.zone_bypass_all()

--- a/homeassistant/components/totalconnect/button.py
+++ b/homeassistant/components/totalconnect/button.py
@@ -1,5 +1,10 @@
 """Interfaces with TotalConnect buttons."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from total_connect_client.location import TotalConnectLocation
+
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -8,6 +13,27 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+
+
+@dataclass(frozen=True, kw_only=True)
+class TotalConnectButtonEntityDescription(ButtonEntityDescription):
+    """TotalConnect button description."""
+
+    press_fn: Callable[[TotalConnectLocation], None]
+
+
+PANEL_BUTTONS: tuple[TotalConnectButtonEntityDescription, ...] = (
+    TotalConnectButtonEntityDescription(
+        key="clear_bypass",
+        name="Clear Bypass",
+        press_fn=lambda location: location.clear_bypass(),
+    ),
+    TotalConnectButtonEntityDescription(
+        key="bypass_all",
+        name="Bypass All",
+        press_fn=lambda location: location.zone_bypass_all(),
+    ),
+)
 
 
 async def async_setup_entry(
@@ -19,8 +45,10 @@ async def async_setup_entry(
     client_locations = hass.data[DOMAIN][entry.entry_id].client.locations
 
     for location_id, location in client_locations.items():
-        buttons.append(TotalConnectClearBypassButton(location))
-        buttons.append(TotalConnectBypassAllButton(location))
+        buttons.extend(
+            TotalConnectPanelButton(location, description)
+            for description in PANEL_BUTTONS
+        )
 
         buttons.extend(
             TotalConnectZoneBypassButton(location_id, zone)
@@ -37,10 +65,12 @@ class TotalConnectZoneBypassButton(ButtonEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "bypass"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    entity_description = ButtonEntityDescription(key="bypass", name="bypass")
 
     def __init__(self, location_id, zone) -> None:
         """Initialize the TotalConnect status."""
         self._zone = zone
+        self.entity_description = ButtonEntityDescription(key="bypass", name="bypass")
         identifier = self._zone.sensor_serial_number or f"zone_{self._zone.zoneid}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, identifier)},
@@ -61,9 +91,12 @@ class TotalConnectPanelButton(ButtonEntity):
 
     entity_description: TotalConnectButtonEntityDescription
 
-    def __init__(self, location, entity_description: TotalConnectButtonEntityDescription) -> None:
+    def __init__(
+        self, location, entity_description: TotalConnectButtonEntityDescription
+    ) -> None:
         """Initialize the TotalConnect button."""
         self._location = location
+        self.entity_description = entity_description
         device = location.devices[location.security_device_id]
         self._attr_unique_id = f"{location.location_id}_{entity_description.key}"
         self._attr_device_info = DeviceInfo(
@@ -72,7 +105,6 @@ class TotalConnectPanelButton(ButtonEntity):
             serial_number=device.serial_number,
         )
 
-
     def press(self) -> None:
         """Press the button."""
-        self.entity_description.press_fn()
+        self.entity_description.press_fn(self._location)

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
   "iot_class": "cloud_polling",
   "loggers": ["total_connect_client"],
-  "requirements": ["total-connect-client==2023.2"]
+  "requirements": ["total-connect-client==2023.12.1"]
 }

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
   "iot_class": "cloud_polling",
   "loggers": ["total_connect_client"],
-  "requirements": ["total-connect-client==2023.12.1"]
+  "requirements": ["total-connect-client==2024.4"]
 }

--- a/homeassistant/components/totalconnect/manifest.json
+++ b/homeassistant/components/totalconnect/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/totalconnect",
   "iot_class": "cloud_polling",
   "loggers": ["total_connect_client"],
-  "requirements": ["total-connect-client==2023.12.1"]
+  "requirements": ["total-connect-client==2023.2"]
 }

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -55,6 +55,14 @@
       "partition": {
         "name": "Partition {partition_id}"
       }
+    },
+    "button": {
+      "clear_bypass": {
+        "name": "Clear Bypass"
+      },
+      "bypass_all": {
+        "name": "Bypass All"
+      }
     }
   }
 }

--- a/homeassistant/components/totalconnect/strings.json
+++ b/homeassistant/components/totalconnect/strings.json
@@ -58,10 +58,10 @@
     },
     "button": {
       "clear_bypass": {
-        "name": "Clear Bypass"
+        "name": "Clear bypass"
       },
       "bypass_all": {
-        "name": "Bypass All"
+        "name": "Bypass all"
       }
     }
   }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2734,7 +2734,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.2
+total-connect-client==2023.12.1
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2734,7 +2734,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.12.1
+total-connect-client==2023.2
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2734,7 +2734,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.12.1
+total-connect-client==2024.4
 
 # homeassistant.components.tplink_lte
 tp-connected==0.0.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2111,7 +2111,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.12.1
+total-connect-client==2023.2
 
 # homeassistant.components.tplink_omada
 tplink-omada-client==1.3.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2111,7 +2111,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.12.1
+total-connect-client==2024.4
 
 # homeassistant.components.tplink_omada
 tplink-omada-client==1.3.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2111,7 +2111,7 @@ tololib==1.1.0
 toonapi==0.3.0
 
 # homeassistant.components.totalconnect
-total-connect-client==2023.2
+total-connect-client==2023.12.1
 
 # homeassistant.components.tplink_omada
 tplink-omada-client==1.3.12

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -206,6 +206,17 @@ ZONE_7 = {
     "CanBeBypassed": 0,
 }
 
+# ZoneType security that cannot be bypassed is a Button on the alarm panel
+ZONE_8 = {
+    "ZoneID": 8,
+    "ZoneDescription": "Button",
+    "ZoneStatus": ZoneStatus.FAULT,
+    "ZoneTypeId": ZoneType.SECURITY,
+    "PartitionId": "1",
+    "CanBeBypassed": 0,
+}
+
+
 ZONE_INFO = [ZONE_NORMAL, ZONE_2, ZONE_3, ZONE_4, ZONE_5, ZONE_6, ZONE_7]
 ZONES = {"ZoneInfo": ZONE_INFO}
 
@@ -318,6 +329,14 @@ RESPONSE_USER_CODE_INVALID = {
     "ResultData": "testing user code invalid",
 }
 RESPONSE_SUCCESS = {"ResultCode": ResultCode.SUCCESS.value}
+RESPONSE_ZONE_BYPASS_SUCCESS = {
+    "ResultCode": ResultCode.SUCCESS.value,
+    "ResultData": "None",
+}
+RESPONSE_ZONE_BYPASS_FAILURE = {
+    "ResultCode": ResultCode.FAILED_TO_BYPASS_ZONE.value,
+    "ResultData": "None",
+}
 
 USERNAME = "username@me.com"
 PASSWORD = "password"

--- a/tests/components/totalconnect/snapshots/test_button.ambr
+++ b/tests/components/totalconnect/snapshots/test_button.ambr
@@ -1,0 +1,277 @@
+# serializer version: 1
+# name: test_entity_registry[button.fire_bypass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.fire_bypass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'bypass',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'bypass',
+    'unique_id': '123456_2_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.fire_bypass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Fire bypass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.fire_bypass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity_registry[button.gas_bypass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.gas_bypass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'bypass',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'bypass',
+    'unique_id': '123456_3_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.gas_bypass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Gas bypass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.gas_bypass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity_registry[button.motion_bypass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.motion_bypass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'bypass',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'bypass',
+    'unique_id': '123456_4_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.motion_bypass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Motion bypass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.motion_bypass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity_registry[button.security_bypass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'button.security_bypass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'bypass',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'bypass',
+    'unique_id': '123456_1_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.security_bypass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Security bypass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.security_bypass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity_registry[button.test_bypass_all-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_bypass_all',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Bypass All',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'bypass_all',
+    'unique_id': '123456_bypass_all',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.test_bypass_all-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test Bypass All',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_bypass_all',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_entity_registry[button.test_clear_bypass-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.test_clear_bypass',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Clear Bypass',
+    'platform': 'totalconnect',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'clear_bypass',
+    'unique_id': '123456_clear_bypass',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_entity_registry[button.test_clear_bypass-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'test Clear Bypass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.test_clear_bypass',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/totalconnect/test_button.py
+++ b/tests/components/totalconnect/test_button.py
@@ -76,11 +76,9 @@ async def test_clear_button(hass: HomeAssistant) -> None:
     """Test pushing the clear bypass button."""
     data = {ATTR_ENTITY_ID: PANEL_CLEAR_ID}
     await setup_platform(hass, BUTTON)
-    """ 'clear bypass' is actually just a call to Disarm the panel
-    which is tested thoroughly in test_alarm_control_panel.py
-    so just make sure it gets called
-    """
-    TOTALCONNECT_REQUEST = "total_connect_client.location.TotalConnectLocation.disarm"
+    TOTALCONNECT_REQUEST = (
+        "total_connect_client.location.TotalConnectLocation.clear_bypass"
+    )
 
     with patch(TOTALCONNECT_REQUEST) as mock_request:
         await hass.services.async_call(

--- a/tests/components/totalconnect/test_button.py
+++ b/tests/components/totalconnect/test_button.py
@@ -20,8 +20,8 @@ from .common import (
 )
 
 ZONE_BYPASS_ID = "button.security_bypass"
-PANEL_CLEAR_ID = "button.clear_bypass"
-PANEL_BYPASS_ID = "button.bypass_all"
+PANEL_CLEAR_ID = "button.test_clear_bypass"
+PANEL_BYPASS_ID = "button.test_bypass_all"
 
 
 async def test_entity_registry(hass: HomeAssistant) -> None:

--- a/tests/components/totalconnect/test_button.py
+++ b/tests/components/totalconnect/test_button.py
@@ -1,0 +1,89 @@
+"""Tests for the TotalConnect buttons."""
+
+from unittest.mock import patch
+
+import pytest
+from total_connect_client.exceptions import FailedToBypassZone
+
+from homeassistant.components.button import DOMAIN as BUTTON, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .common import (
+    LOCATION_ID,
+    RESPONSE_ZONE_BYPASS_FAILURE,
+    RESPONSE_ZONE_BYPASS_SUCCESS,
+    TOTALCONNECT_REQUEST,
+    ZONE_NORMAL,
+    setup_platform,
+)
+
+ZONE_BYPASS_ID = "button.security_bypass"
+PANEL_CLEAR_ID = "button.clear_bypass"
+PANEL_BYPASS_ID = "button.bypass_all"
+
+
+async def test_entity_registry(hass: HomeAssistant) -> None:
+    """Test the button is registered in entity registry."""
+    await setup_platform(hass, BUTTON)
+    entity_registry = er.async_get(hass)
+
+    # ensure zone 1 bypass is created
+    entry = entity_registry.async_get(ZONE_BYPASS_ID)
+    assert entry.unique_id == f"{LOCATION_ID}_{ZONE_NORMAL['ZoneID']}_bypass"
+
+    # ensure panel BypassAll and Clear are created
+    panel_bypass = entity_registry.async_get(PANEL_BYPASS_ID)
+    panel_clear = entity_registry.async_get(PANEL_CLEAR_ID)
+
+    assert panel_bypass.unique_id == f"{LOCATION_ID}_bypass_all"
+    assert panel_clear.unique_id == f"{LOCATION_ID}_clear_bypass"
+
+
+async def _test_bypass_button(hass: HomeAssistant, data: {}) -> None:
+    """Test pushing a bypass button."""
+    responses = [RESPONSE_ZONE_BYPASS_FAILURE, RESPONSE_ZONE_BYPASS_SUCCESS]
+    await setup_platform(hass, BUTTON)
+    with patch(TOTALCONNECT_REQUEST, side_effect=responses) as mock_request:
+        # try to bypass, but fails
+        with pytest.raises(FailedToBypassZone):
+            await hass.services.async_call(
+                domain=BUTTON, service=SERVICE_PRESS, service_data=data, blocking=True
+            )
+            assert mock_request.call_count == 1
+
+        # try to bypass, works this time
+        await hass.services.async_call(
+            domain=BUTTON, service=SERVICE_PRESS, service_data=data, blocking=True
+        )
+        assert mock_request.call_count == 2
+
+
+async def test_zone_bypass(hass: HomeAssistant) -> None:
+    """Test pushing the zone bypass button."""
+    data = {ATTR_ENTITY_ID: ZONE_BYPASS_ID}
+    await _test_bypass_button(hass, data)
+
+
+async def test_bypass_all(hass: HomeAssistant) -> None:
+    """Test pushing the panel bypass all button."""
+    data = {ATTR_ENTITY_ID: PANEL_BYPASS_ID}
+    await _test_bypass_button(hass, data)
+
+
+async def test_clear_button(hass: HomeAssistant) -> None:
+    """Test pushing the clear bypass button."""
+    data = {ATTR_ENTITY_ID: PANEL_CLEAR_ID}
+    await setup_platform(hass, BUTTON)
+    """ 'clear bypass' is actually just a call to Disarm the panel
+    which is tested thoroughly in test_alarm_control_panel.py
+    so just make sure it gets called
+    """
+    TOTALCONNECT_REQUEST = "total_connect_client.location.TotalConnectLocation.disarm"
+
+    with patch(TOTALCONNECT_REQUEST) as mock_request:
+        await hass.services.async_call(
+            domain=BUTTON, service=SERVICE_PRESS, service_data=data, blocking=True
+        )
+        assert mock_request.call_count == 1

--- a/tests/components/totalconnect/test_button.py
+++ b/tests/components/totalconnect/test_button.py
@@ -41,7 +41,10 @@ async def test_entity_registry(hass: HomeAssistant) -> None:
     assert panel_clear.unique_id == f"{LOCATION_ID}_clear_bypass"
 
 
-async def _test_bypass_button(hass: HomeAssistant, data: {}) -> None:
+@pytest.mark.parametrize(
+    "data", [{ATTR_ENTITY_ID: ZONE_BYPASS_ID}, {ATTR_ENTITY_ID: PANEL_BYPASS_ID}]
+)
+async def test_bypass_button(hass: HomeAssistant, data: {}) -> None:
     """Test pushing a bypass button."""
     responses = [RESPONSE_ZONE_BYPASS_FAILURE, RESPONSE_ZONE_BYPASS_SUCCESS]
     await setup_platform(hass, BUTTON)
@@ -58,18 +61,6 @@ async def _test_bypass_button(hass: HomeAssistant, data: {}) -> None:
             domain=BUTTON, service=SERVICE_PRESS, service_data=data, blocking=True
         )
         assert mock_request.call_count == 2
-
-
-async def test_zone_bypass(hass: HomeAssistant) -> None:
-    """Test pushing the zone bypass button."""
-    data = {ATTR_ENTITY_ID: ZONE_BYPASS_ID}
-    await _test_bypass_button(hass, data)
-
-
-async def test_bypass_all(hass: HomeAssistant) -> None:
-    """Test pushing the panel bypass all button."""
-    data = {ATTR_ENTITY_ID: PANEL_BYPASS_ID}
-    await _test_bypass_button(hass, data)
 
 
 async def test_clear_button(hass: HomeAssistant) -> None:

--- a/tests/components/totalconnect/test_button.py
+++ b/tests/components/totalconnect/test_button.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+from syrupy import SnapshotAssertion
 from total_connect_client.exceptions import FailedToBypassZone
 
 from homeassistant.components.button import DOMAIN as BUTTON, SERVICE_PRESS
@@ -11,34 +12,26 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .common import (
-    LOCATION_ID,
     RESPONSE_ZONE_BYPASS_FAILURE,
     RESPONSE_ZONE_BYPASS_SUCCESS,
     TOTALCONNECT_REQUEST,
-    ZONE_NORMAL,
     setup_platform,
 )
+
+from tests.common import snapshot_platform
 
 ZONE_BYPASS_ID = "button.security_bypass"
 PANEL_CLEAR_ID = "button.test_clear_bypass"
 PANEL_BYPASS_ID = "button.test_bypass_all"
 
 
-async def test_entity_registry(hass: HomeAssistant) -> None:
+async def test_entity_registry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, snapshot: SnapshotAssertion
+) -> None:
     """Test the button is registered in entity registry."""
-    await setup_platform(hass, BUTTON)
-    entity_registry = er.async_get(hass)
+    entry = await setup_platform(hass, BUTTON)
 
-    # ensure zone 1 bypass is created
-    entry = entity_registry.async_get(ZONE_BYPASS_ID)
-    assert entry.unique_id == f"{LOCATION_ID}_{ZONE_NORMAL['ZoneID']}_bypass"
-
-    # ensure panel BypassAll and Clear are created
-    panel_bypass = entity_registry.async_get(PANEL_BYPASS_ID)
-    panel_clear = entity_registry.async_get(PANEL_CLEAR_ID)
-
-    assert panel_bypass.unique_id == f"{LOCATION_ID}_bypass_all"
-    assert panel_clear.unique_id == f"{LOCATION_ID}_clear_bypass"
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumps total_connect_client to version 2024.4

Changelog at https://github.com/craigjmidwinter/total-connect-client/compare/2023.12.1...2024.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: https://github.com/craigjmidwinter/total-connect-client/issues/221
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [todo] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
