### PR TITLE
Add lawn_mower platform to template integration

### DIFF
--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -18,6 +18,7 @@ PLATFORMS = [
     Platform.COVER,
     Platform.FAN,
     Platform.IMAGE,
+    Platform.LAWN_MOWER,
     Platform.LIGHT,
     Platform.LOCK,
     Platform.NUMBER,

--- a/homeassistant/components/template/lawn_mower.py
+++ b/homeassistant/components/template/lawn_mower.py
@@ -1,0 +1,204 @@
+"""Support for Template lawn mowers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.lawn_mower import (
+    DOMAIN as LAWN_MOWER_DOMAIN,
+    SERVICE_DOCK,
+    SERVICE_PAUSE,
+    SERVICE_START_MOWING,
+    LawnMowerActivity,
+    LawnMowerEntity,
+    LawnMowerEntityFeature,
+)
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    CONF_FRIENDLY_NAME,
+    CONF_UNIQUE_ID,
+    CONF_VALUE_TEMPLATE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import TemplateError
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import async_generate_entity_id
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.script import Script
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from .const import DOMAIN
+from .template_entity import (
+    TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY,
+    TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY,
+    TemplateEntity,
+    rewrite_common_legacy_to_modern_conf,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_LAWN_MOWERS = "lawn_mowers"
+
+ENTITY_ID_FORMAT = LAWN_MOWER_DOMAIN + ".{}"
+_VALID_STATES = [
+    LawnMowerActivity.DOCKED,
+    LawnMowerActivity.ERROR,
+    LawnMowerActivity.MOWING,
+    LawnMowerActivity.PAUSED,
+]
+
+LAWN_MOWER_SCHEMA = vol.All(
+    cv.deprecated(CONF_ENTITY_ID),
+    vol.Schema(
+        {
+            vol.Optional(CONF_FRIENDLY_NAME): cv.string,
+            vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+            vol.Optional(SERVICE_START_MOWING): cv.SCRIPT_SCHEMA,
+            vol.Optional(SERVICE_PAUSE): cv.SCRIPT_SCHEMA,
+            vol.Optional(SERVICE_DOCK): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_ENTITY_ID): cv.entity_ids,
+            vol.Optional(CONF_UNIQUE_ID): cv.string,
+        }
+    )
+    .extend(TEMPLATE_ENTITY_ATTRIBUTES_SCHEMA_LEGACY.schema)
+    .extend(TEMPLATE_ENTITY_AVAILABILITY_SCHEMA_LEGACY.schema),
+)
+
+PLATFORM_SCHEMA = cv.PLATFORM_SCHEMA.extend(
+    {vol.Required(CONF_LAWN_MOWERS): vol.Schema({cv.slug: LAWN_MOWER_SCHEMA})}
+)
+
+
+async def _async_create_entities(hass: HomeAssistant, config: ConfigType):
+    """Create the Lawn Mowers."""
+    lawn_mowers = []
+
+    for object_id, entity_config in config[CONF_LAWN_MOWERS].items():
+        entity_config = rewrite_common_legacy_to_modern_conf(entity_config)
+        unique_id = entity_config.get(CONF_UNIQUE_ID)
+
+        lawn_mowers.append(
+            TemplateLawnMower(
+                hass,
+                object_id,
+                entity_config,
+                unique_id,
+            )
+        )
+
+    return lawn_mowers
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Set up the template lawn mowers."""
+    async_add_entities(await _async_create_entities(hass, config))
+
+
+class TemplateLawnMower(TemplateEntity, LawnMowerEntity):
+    """A template lawn mower component."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass,
+        object_id,
+        config,
+        unique_id,
+    ):
+        """Initialize the lawn mower."""
+        super().__init__(
+            hass, config=config, fallback_name=object_id, unique_id=unique_id
+        )
+        self.entity_id = async_generate_entity_id(
+            ENTITY_ID_FORMAT, object_id, hass=hass
+        )
+        friendly_name = self._attr_name
+
+        self._template = config.get(CONF_VALUE_TEMPLATE)
+
+        self._start_mowing_script = None
+        if start_mowing_action := config.get(SERVICE_START_MOWING):
+            self._start_mowing_script = Script(
+                hass, start_mowing_action, friendly_name, DOMAIN
+            )
+            self._attr_supported_features |= LawnMowerEntityFeature.START_MOWING
+
+        self._pause_script = None
+        if pause_action := config.get(SERVICE_PAUSE):
+            self._pause_script = Script(hass, pause_action, friendly_name, DOMAIN)
+            self._attr_supported_features |= LawnMowerEntityFeature.PAUSE
+
+        self._dock_script = None
+        if dock_action := config.get(SERVICE_DOCK):
+            self._dock_script = Script(hass, dock_action, friendly_name, DOMAIN)
+            self._attr_supported_features |= LawnMowerEntityFeature.DOCK
+
+        self._attr_activity = None
+
+    @property
+    def activity(self) -> LawnMowerActivity | None:
+        """Return the status of the lawn mower."""
+        return self._attr_activity
+
+    async def async_start_mowing(self) -> None:
+        """Start or resume the mowing task."""
+        if self._start_mowing_script is None:
+            return
+        await self.async_run_script(self._start_mowing_script, context=self._context)
+
+    async def async_pause(self) -> None:
+        """Pause the mowing task."""
+        if self._pause_script is None:
+            return
+
+        await self.async_run_script(self._pause_script, context=self._context)
+
+    async def async_dock(self, **kwargs: Any) -> None:
+        """Set the lawn mower to return to the dock."""
+        if self._dock_script is None:
+            return
+
+        await self.async_run_script(self._dock_script, context=self._context)
+
+    @callback
+    def _async_setup_templates(self) -> None:
+        """Set up templates."""
+        if self._template is not None:
+            self.add_template_attribute(
+                "_attr_activity", self._template, None, self._update_state
+            )
+        super()._async_setup_templates()
+
+    @callback
+    def _update_state(self, result):
+        super()._update_state(result)
+        if isinstance(result, TemplateError):
+            # This is legacy behavior
+            self._attr_activity = None
+            if not self._availability_template:
+                self._attr_available = True
+            return
+
+        # Validate state
+        if result in _VALID_STATES:
+            self._attr_activity = LawnMowerActivity(result)
+        elif result == STATE_UNKNOWN:
+            self._attr_activity = None
+        else:
+            _LOGGER.error(
+                "Received invalid lawn mower state: %s for entity %s. Expected: %s",
+                result,
+                self.entity_id,
+                ", ".join(_VALID_STATES),
+            )
+            self._attr_activity = None

--- a/tests/components/template/test_lawn_mower.py
+++ b/tests/components/template/test_lawn_mower.py
@@ -1,0 +1,505 @@
+"""The tests for the Template lawn_mower platform."""
+
+import pytest
+
+from homeassistant import setup
+from homeassistant.components.lawn_mower import (
+    DOMAIN,
+    SERVICE_DOCK,
+    SERVICE_PAUSE,
+    SERVICE_START_MOWING,
+    LawnMowerActivity,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_component import async_update_entity
+
+from tests.common import assert_setup_component
+
+_TEST_LAWN_MOWER = "lawn_mower.test_lawn_mower"
+_STATE_INPUT_SELECT = "input_select.state"
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, "lawn_mower")])
+@pytest.mark.parametrize(
+    ("parm1", "config"),
+    [
+        (
+            STATE_UNKNOWN,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {
+                            "start_mowing": {"service": "script.lawn_mower_start"}
+                        }
+                    },
+                }
+            },
+        ),
+        (
+            LawnMowerActivity.MOWING,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {"value_template": "{{ 'mowing' }}"}
+                    },
+                }
+            },
+        ),
+        (
+            LawnMowerActivity.MOWING,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {
+                            "value_template": "{{ 'mowing' }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        },
+                    },
+                }
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {"value_template": "{{ 'abc' }}"}
+                    },
+                }
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {
+                            "value_template": "{{ this_function_does_not_exist() }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        }
+                    },
+                }
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {"test_lawn_mower": {}},
+                }
+            },
+        ),
+    ],
+)
+async def test_valid_configs(hass: HomeAssistant, count, parm1, start_ha) -> None:
+    """Test: configs."""
+    assert len(hass.states.async_all("lawn_mower")) == count
+    _verify(hass, parm1)
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_lawn_mower": {
+                            "value_template": "{{ states('input_select.state') }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_templates_with_entities(hass: HomeAssistant, start_ha) -> None:
+    """Test templates with values from other entities."""
+    _verify(hass, STATE_UNKNOWN)
+
+    hass.states.async_set(_STATE_INPUT_SELECT, LawnMowerActivity.MOWING)
+    await hass.async_block_till_done()
+    _verify(hass, LawnMowerActivity.MOWING)
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_template_lawn_mower": {
+                            "availability_template": "{{ is_state('availability_state.state', 'on') }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_available_template_with_entities(hass: HomeAssistant, start_ha) -> None:
+    """Test availability templates with values from other entities."""
+
+    # When template returns true..
+    hass.states.async_set("availability_state.state", STATE_ON)
+    await hass.async_block_till_done()
+
+    # Device State should not be unavailable
+    assert (
+        hass.states.get("lawn_mower.test_template_lawn_mower").state
+        != STATE_UNAVAILABLE
+    )
+
+    # When Availability template returns false
+    hass.states.async_set("availability_state.state", STATE_OFF)
+    await hass.async_block_till_done()
+
+    # device state should be unavailable
+    assert (
+        hass.states.get("lawn_mower.test_template_lawn_mower").state
+        == STATE_UNAVAILABLE
+    )
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_template_lawn_mower": {
+                            "availability_template": "{{ x - 12 }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_invalid_availability_template_keeps_component_available(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
+    """Test that an invalid availability keeps the device available."""
+    assert hass.states.get("lawn_mower.test_template_lawn_mower") != STATE_UNAVAILABLE
+    assert "UndefinedError: 'x' is undefined" in caplog_setup_text
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_template_lawn_mower": {
+                            "value_template": "{{ 'cleaning' }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                            "attribute_templates": {
+                                "test_attribute": "It {{ states.sensor.test_state.state }}."
+                            },
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_attribute_templates(hass: HomeAssistant, start_ha) -> None:
+    """Test attribute_templates template."""
+    state = hass.states.get("lawn_mower.test_template_lawn_mower")
+    assert state.attributes["test_attribute"] == "It ."
+
+    hass.states.async_set("sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    await async_update_entity(hass, "lawn_mower.test_template_lawn_mower")
+    state = hass.states.get("lawn_mower.test_template_lawn_mower")
+    assert state.attributes["test_attribute"] == "It Works."
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "invalid_template": {
+                            "value_template": "{{ states('input_select.state') }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                            "attribute_templates": {
+                                "test_attribute": "{{ this_function_does_not_exist() }}"
+                            },
+                        }
+                    },
+                }
+            },
+        )
+    ],
+)
+async def test_invalid_attribute_template(
+    hass: HomeAssistant, start_ha, caplog_setup_text
+) -> None:
+    """Test that errors are logged if rendering template fails."""
+    assert len(hass.states.async_all("lawn_mower")) == 1
+    assert "test_attribute" in caplog_setup_text
+    assert "TemplateError" in caplog_setup_text
+
+
+@pytest.mark.parametrize(
+    ("count", "domain", "config"),
+    [
+        (
+            1,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {
+                        "test_template_lawn_mower_01": {
+                            "unique_id": "not-so-unique-anymore",
+                            "value_template": "{{ true }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        },
+                        "test_template_lawn_mower_02": {
+                            "unique_id": "not-so-unique-anymore",
+                            "value_template": "{{ false }}",
+                            "start_mowing": {"service": "script.lawn_mower_start"},
+                        },
+                    },
+                }
+            },
+        ),
+    ],
+)
+async def test_unique_id(hass: HomeAssistant, start_ha) -> None:
+    """Test unique_id option only creates one lawn_mower per id."""
+    assert len(hass.states.async_all("lawn_mower")) == 1
+
+
+async def test_unused_services(hass: HomeAssistant) -> None:
+    """Test calling unused services raises."""
+    await _register_basic_lawn_mower(hass)
+
+    data = {ATTR_ENTITY_ID: _TEST_LAWN_MOWER}
+
+    # Start mowing lawn_mower
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_START_MOWING, data, blocking=True
+        )
+    await hass.async_block_till_done()
+
+    # Pause lawn_mower
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(DOMAIN, SERVICE_PAUSE, data, blocking=True)
+    await hass.async_block_till_done()
+
+    # Dock lawn_mower
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(DOMAIN, SERVICE_DOCK, data, blocking=True)
+    await hass.async_block_till_done()
+
+    _verify(hass, STATE_UNKNOWN)
+
+
+async def test_state_services(hass: HomeAssistant, calls) -> None:
+    """Test state services."""
+    await _register_components(hass)
+
+    data = {ATTR_ENTITY_ID: _TEST_LAWN_MOWER}
+
+    # Start lawn_mower
+    await hass.services.async_call(DOMAIN, SERVICE_START_MOWING, data, blocking=True)
+    await hass.async_block_till_done()
+
+    # verify
+    assert hass.states.get(_STATE_INPUT_SELECT).state == LawnMowerActivity.MOWING
+    _verify(hass, LawnMowerActivity.MOWING)
+    assert len(calls) == 1
+    assert calls[-1].data["action"] == "start_mowing"
+    assert calls[-1].data["caller"] == _TEST_LAWN_MOWER
+
+    # Pause lawn_mower
+    await hass.services.async_call(DOMAIN, SERVICE_PAUSE, data, blocking=True)
+    await hass.async_block_till_done()
+
+    # verify
+    assert hass.states.get(_STATE_INPUT_SELECT).state == LawnMowerActivity.PAUSED
+    _verify(hass, LawnMowerActivity.PAUSED)
+    assert len(calls) == 2
+    assert calls[-1].data["action"] == "pause"
+    assert calls[-1].data["caller"] == _TEST_LAWN_MOWER
+
+    # Return lawn_mower to base
+    await hass.services.async_call(DOMAIN, SERVICE_DOCK, data, blocking=True)
+    await hass.async_block_till_done()
+
+    # verify
+    assert hass.states.get(_STATE_INPUT_SELECT).state == LawnMowerActivity.DOCKED
+    _verify(hass, LawnMowerActivity.DOCKED)
+    assert len(calls) == 3
+    assert calls[-1].data["action"] == "dock"
+    assert calls[-1].data["caller"] == _TEST_LAWN_MOWER
+
+
+def _verify(hass: HomeAssistant, expected_state: str):
+    """Verify lawn mower's state."""
+    state = hass.states.get(_TEST_LAWN_MOWER)
+    assert state.state == expected_state
+
+
+async def _register_basic_lawn_mower(hass: HomeAssistant):
+    """Register basic lawn mower with only required options for testing."""
+    with assert_setup_component(1, "input_select"):
+        assert await setup.async_setup_component(
+            hass,
+            "input_select",
+            {
+                "input_select": {
+                    "state": {"name": "State", "options": [LawnMowerActivity.MOWING]}
+                }
+            },
+        )
+
+    with assert_setup_component(1, "lawn_mower"):
+        assert await setup.async_setup_component(
+            hass,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {"test_lawn_mower": {}},
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+
+async def _register_components(hass: HomeAssistant):
+    """Register basic components for testing."""
+    with assert_setup_component(1, "input_select"):
+        assert await setup.async_setup_component(
+            hass,
+            "input_select",
+            {
+                "input_select": {
+                    "state": {
+                        "name": "State",
+                        "options": [
+                            LawnMowerActivity.DOCKED,
+                            LawnMowerActivity.ERROR,
+                            LawnMowerActivity.MOWING,
+                            LawnMowerActivity.PAUSED,
+                        ],
+                    },
+                }
+            },
+        )
+
+    with assert_setup_component(1, "lawn_mower"):
+        test_lawn_mower_config = {
+            "value_template": "{{ states('input_select.state') }}",
+            "start_mowing": [
+                {
+                    "service": "input_select.select_option",
+                    "data": {
+                        "entity_id": _STATE_INPUT_SELECT,
+                        "option": LawnMowerActivity.MOWING,
+                    },
+                },
+                {
+                    "service": "test.automation",
+                    "data_template": {
+                        "action": "start_mowing",
+                        "caller": "{{ this.entity_id }}",
+                    },
+                },
+            ],
+            "pause": [
+                {
+                    "service": "input_select.select_option",
+                    "data": {
+                        "entity_id": _STATE_INPUT_SELECT,
+                        "option": LawnMowerActivity.PAUSED,
+                    },
+                },
+                {
+                    "service": "test.automation",
+                    "data_template": {
+                        "action": "pause",
+                        "caller": "{{ this.entity_id }}",
+                    },
+                },
+            ],
+            "dock": [
+                {
+                    "service": "input_select.select_option",
+                    "data": {
+                        "entity_id": _STATE_INPUT_SELECT,
+                        "option": LawnMowerActivity.DOCKED,
+                    },
+                },
+                {
+                    "service": "test.automation",
+                    "data_template": {
+                        "action": "dock",
+                        "caller": "{{ this.entity_id }}",
+                    },
+                },
+            ],
+            "attribute_templates": {
+                "test_attribute": "It {{ states.sensor.test_state.state }}."
+            },
+        }
+
+        assert await setup.async_setup_component(
+            hass,
+            "lawn_mower",
+            {
+                "lawn_mower": {
+                    "platform": "template",
+                    "lawn_mowers": {"test_lawn_mower": test_lawn_mower_config},
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds the Lawn mower platform to the template integration. The code is based on the template vacuum because it is almost similar, except for some different names of states (mowing in stead of cleaning) and different services (start_mowing in stead of start and no stop for example).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32519

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
