### PR TITLE
Add service to log all the current asyncio Tasks to the profiler

### DIFF
--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -1,6 +1,8 @@
 """The profiler integration."""
 
 import asyncio
+from collections.abc import Generator
+import contextlib
 from contextlib import suppress
 from datetime import timedelta
 from functools import _lru_cache_wrapper
@@ -37,6 +39,7 @@ SERVICE_LRU_STATS = "lru_stats"
 SERVICE_LOG_THREAD_FRAMES = "log_thread_frames"
 SERVICE_LOG_EVENT_LOOP_SCHEDULED = "log_event_loop_scheduled"
 SERVICE_SET_ASYNCIO_DEBUG = "set_asyncio_debug"
+SERVICE_LOG_CURRENT_TASKS = "log_current_tasks"
 
 _LRU_CACHE_WRAPPER_OBJECT = _lru_cache_wrapper.__name__
 _SQLALCHEMY_LRU_OBJECT = "LRUCache"
@@ -59,6 +62,7 @@ SERVICES = (
     SERVICE_LOG_THREAD_FRAMES,
     SERVICE_LOG_EVENT_LOOP_SCHEDULED,
     SERVICE_SET_ASYNCIO_DEBUG,
+    SERVICE_LOG_CURRENT_TASKS,
 )
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
@@ -241,21 +245,20 @@ async def async_setup_entry(  # noqa: C901
                 "".join(traceback.format_stack(frames.get(ident))).strip(),
             )
 
+    async def _async_dump_current_tasks(call: ServiceCall) -> None:
+        """Log all current tasks in the event loop."""
+        with _increase_repr_limit():
+            for task in asyncio.all_tasks():
+                if not task.cancelled():
+                    _LOGGER.critical("Task: %s", task)
+
     async def _async_dump_scheduled(call: ServiceCall) -> None:
         """Log all scheduled in the event loop."""
-        arepr = reprlib.aRepr
-        original_maxstring = arepr.maxstring
-        original_maxother = arepr.maxother
-        arepr.maxstring = 300
-        arepr.maxother = 300
-        handle: asyncio.Handle
-        try:
+        with _increase_repr_limit():
+            handle: asyncio.Handle
             for handle in getattr(hass.loop, "_scheduled"):
                 if not handle.cancelled():
                     _LOGGER.critical("Scheduled: %s", handle)
-        finally:
-            arepr.maxstring = original_maxstring
-            arepr.maxother = original_maxother
 
     async def _async_asyncio_debug(call: ServiceCall) -> None:
         """Enable or disable asyncio debug."""
@@ -370,6 +373,13 @@ async def async_setup_entry(  # noqa: C901
         SERVICE_SET_ASYNCIO_DEBUG,
         _async_asyncio_debug,
         schema=vol.Schema({vol.Optional(CONF_ENABLED, default=True): cv.boolean}),
+    )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_LOG_CURRENT_TASKS,
+        _async_dump_current_tasks,
     )
 
     return True
@@ -573,3 +583,18 @@ def _log_object_sources(
         _LOGGER.critical("New objects overflowed by %s", new_objects_overflow)
     elif not had_new_object_growth:
         _LOGGER.critical("No new object growth found")
+
+
+@contextlib.contextmanager
+def _increase_repr_limit() -> Generator[None, None, None]:
+    """Increase the repr limit."""
+    arepr = reprlib.aRepr
+    original_maxstring = arepr.maxstring
+    original_maxother = arepr.maxother
+    arepr.maxstring = 300
+    arepr.maxother = 300
+    try:
+        yield
+    finally:
+        arepr.maxstring = original_maxstring
+        arepr.maxother = original_maxother

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -250,7 +250,7 @@ async def async_setup_entry(  # noqa: C901
         with _increase_repr_limit():
             for task in asyncio.all_tasks():
                 if not task.cancelled():
-                    _LOGGER.critical("Task: %s", task)
+                    _LOGGER.critical("Task: %s", _safe_repr(task))
 
     async def _async_dump_scheduled(call: ServiceCall) -> None:
         """Log all scheduled in the event loop."""

--- a/homeassistant/components/profiler/icons.json
+++ b/homeassistant/components/profiler/icons.json
@@ -8,6 +8,7 @@
     "start_log_object_sources": "mdi:play",
     "stop_log_object_sources": "mdi:stop",
     "lru_stats": "mdi:chart-areaspline",
+    "log_current_tasks": "mdi:format-list-bulleted",
     "log_thread_frames": "mdi:format-list-bulleted",
     "log_event_loop_scheduled": "mdi:calendar-clock",
     "set_asyncio_debug": "mdi:bug-check"

--- a/homeassistant/components/profiler/services.yaml
+++ b/homeassistant/components/profiler/services.yaml
@@ -59,3 +59,4 @@ set_asyncio_debug:
       default: true
       selector:
         boolean:
+log_current_tasks:

--- a/homeassistant/components/profiler/strings.json
+++ b/homeassistant/components/profiler/strings.json
@@ -93,6 +93,10 @@
           "description": "Whether to enable or disable asyncio debug."
         }
       }
+    },
+    "log_current_tasks": {
+      "name": "Log current asyncio tasks",
+      "description": "Logs all the current asyncio tasks."
     }
   }
 }

--- a/tests/components/profiler/test_init.py
+++ b/tests/components/profiler/test_init.py
@@ -18,6 +18,7 @@ from homeassistant.components.profiler import (
     CONF_ENABLED,
     CONF_SECONDS,
     SERVICE_DUMP_LOG_OBJECTS,
+    SERVICE_LOG_CURRENT_TASKS,
     SERVICE_LOG_EVENT_LOOP_SCHEDULED,
     SERVICE_LOG_THREAD_FRAMES,
     SERVICE_LRU_STATS,
@@ -215,6 +216,28 @@ async def test_log_thread_frames(
     await hass.services.async_call(DOMAIN, SERVICE_LOG_THREAD_FRAMES, {}, blocking=True)
 
     assert "SyncWorker_0" in caplog.text
+    caplog.clear()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_log_current_tasks(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test we can log current tasks."""
+
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service(DOMAIN, SERVICE_LOG_CURRENT_TASKS)
+
+    await hass.services.async_call(DOMAIN, SERVICE_LOG_CURRENT_TASKS, {}, blocking=True)
+
+    assert "test_log_current_tasks" in caplog.text
     caplog.clear()
 
     assert await hass.config_entries.async_unload(entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have been helping users look for a task leaks and startup blocks, and need a way to examine tasks at run time as trying to get someone to run Home Assistant and attach `aiomonitor` is too difficult in many cases.

example log:
`Apr 29 13:43:19 homeassistant homeassistant[575]: 2024-04-29 03:43:19.515 CRITICAL (MainThread) [homeassistant.components.profiler] Task: <Task pending name="homeassistant trigger {'domain': 'automation', 'name': 'Turn on Time Based Automations at startup', 'home_assistant_start': True, 'variables': {'this': {'entity_id': 'automation.turn_on_time_based_automations_at_startup', 'state': 'on', 'attributes': {'id': '1573627922700', 'last_triggered': datetime.datetime(2024, 4, 29, 13, 0, 1, 726387, tzinfo=datetime.timezone.utc), 'mode': 'single', 'current': 0, 'friendly_name': 'Turn on Time Based Automations at startup'}, 'last_changed': '2024-04-29T13:41:17.588412+00:00', 'last_reported': '2024-04-29T13:41:17.588412+00:00', 'last_updated': '2024-04-29T13:41:17.588412+00:00', 'context': {'id': '01HWN1D8MMG9HADGWMZ8AK7AS0', 'parent_id': None, 'user_id': None}}}, 'trigger_data': {'id': '0', 'idx': '0', 'alias': None}}" coro=<AutomationEntity._async_trigger_if_enabled() running at /usr/src/homeassistant/homeassistant/components/automation/__init__.py:826> wait_for=<Future pending cb=[shield.<locals>._outer_done_callback() at /usr/local/lib/python3.12/asyncio/tasks.py:922, Task.task_wakeup()]> cb=[set.remove()]>`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32520

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
