### PR TITLE
Mock dwdwfsapi in all tests that use it

### DIFF
--- a/tests/components/dwd_weather_warnings/__init__.py
+++ b/tests/components/dwd_weather_warnings/__init__.py
@@ -1,1 +1,16 @@
 """Tests for Deutscher Wetterdienst (DWD) Weather Warnings."""
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def init_integration(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> MockConfigEntry:
+    """Set up the integration based on the config entry."""
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    return entry

--- a/tests/components/dwd_weather_warnings/conftest.py
+++ b/tests/components/dwd_weather_warnings/conftest.py
@@ -5,6 +5,22 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
+from homeassistant.components.dwd_weather_warnings.const import (
+    ADVANCE_WARNING_SENSOR,
+    CONF_REGION_DEVICE_TRACKER,
+    CONF_REGION_IDENTIFIER,
+    CURRENT_WARNING_SENSOR,
+    DOMAIN,
+)
+from homeassistant.const import CONF_MONITORED_CONDITIONS, CONF_NAME
+
+from tests.common import MockConfigEntry
+
+MOCK_NAME = "Unit Test"
+MOCK_REGION_IDENTIFIER = "807111000"
+MOCK_REGION_DEVICE_TRACKER = "device_tracker.test_gps"
+MOCK_CONDITIONS = [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR]
+
 
 @pytest.fixture
 def mock_setup_entry() -> Generator[AsyncMock, None, None]:
@@ -14,6 +30,32 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         return_value=True,
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_identifier_entry() -> MockConfigEntry:
+    """Return a mocked config entry with a region identifier."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: MOCK_NAME,
+            CONF_REGION_IDENTIFIER: MOCK_REGION_IDENTIFIER,
+            CONF_MONITORED_CONDITIONS: MOCK_CONDITIONS,
+        },
+    )
+
+
+@pytest.fixture
+def mock_tracker_entry() -> MockConfigEntry:
+    """Return a mocked config entry with a region identifier."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_NAME: MOCK_NAME,
+            CONF_REGION_DEVICE_TRACKER: MOCK_REGION_DEVICE_TRACKER,
+            CONF_MONITORED_CONDITIONS: MOCK_CONDITIONS,
+        },
+    )
 
 
 @pytest.fixture

--- a/tests/components/dwd_weather_warnings/conftest.py
+++ b/tests/components/dwd_weather_warnings/conftest.py
@@ -1,7 +1,7 @@
 """Configuration for Deutscher Wetterdienst (DWD) Weather Warnings tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
@@ -14,3 +14,32 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
         return_value=True,
     ) as mock_setup_entry:
         yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_dwdwfsapi() -> Generator[MagicMock, None, None]:
+    """Return a mocked dwdwfsapi API client."""
+    with (
+        patch(
+            "homeassistant.components.dwd_weather_warnings.coordinator.DwdWeatherWarningsAPI",
+            autospec=True,
+        ) as mock_api,
+        patch(
+            "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
+            new=mock_api,
+        ),
+    ):
+        api = mock_api.return_value
+        api.data_valid = False
+        api.warncell_id = None
+        api.warncell_name = None
+        api.last_update = None
+        api.current_warning_level = None
+        api.current_warnings = None
+        api.expected_warning_level = None
+        api.expected_warnings = None
+        api.update = Mock()
+        api.__bool__ = Mock()
+        api.__bool__.return_value = True
+
+        yield api

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -71,7 +71,7 @@ async def test_create_entry_gps(
         DOMAIN, context={"source": SOURCE_USER}
     )
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     # Test for missing registry entry error.
     result = await hass.config_entries.flow.async_configure(
@@ -79,7 +79,7 @@ async def test_create_entry_gps(
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "entity_not_found"}
 
     # Test for missing device tracker error.
@@ -92,7 +92,7 @@ async def test_create_entry_gps(
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "entity_not_found"}
 
     # Test for missing attribute error.
@@ -107,7 +107,7 @@ async def test_create_entry_gps(
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "attribute_not_found"}
 
     # Test for invalid provided identifier.
@@ -123,7 +123,7 @@ async def test_create_entry_gps(
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_identifier"}
 
     # Test for successfully created entry.
@@ -133,7 +133,7 @@ async def test_create_entry_gps(
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "test_gps"
     assert result["data"] == {
         CONF_REGION_DEVICE_TRACKER: registry_entry.id,
@@ -175,7 +175,7 @@ async def test_config_flow_with_errors(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
 
     # Test error for empty input data.
     result = await hass.config_entries.flow.async_configure(
@@ -183,7 +183,7 @@ async def test_config_flow_with_errors(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "no_identifier"}
 
     # Test error for setting both options during configuration.
@@ -195,5 +195,5 @@ async def test_config_flow_with_errors(hass: HomeAssistant) -> None:
     )
 
     await hass.async_block_till_done()
-    assert result["type"] == FlowResultType.FORM
+    assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "ambiguous_identifier"}

--- a/tests/components/dwd_weather_warnings/test_config_flow.py
+++ b/tests/components/dwd_weather_warnings/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for Deutscher Wetterdienst (DWD) Weather Warnings config flow."""
 
 from typing import Final
-from unittest.mock import patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -29,7 +29,9 @@ DEMO_CONFIG_ENTRY_GPS: Final = {
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
 
-async def test_create_entry_region(hass: HomeAssistant) -> None:
+async def test_create_entry_region(
+    hass: HomeAssistant, mock_dwdwfsapi: MagicMock
+) -> None:
     """Test that the full config flow works for a region identifier."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -37,26 +39,20 @@ async def test_create_entry_region(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.FORM
 
-    with patch(
-        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
-        return_value=False,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
-        )
+    mock_dwdwfsapi.__bool__.return_value = False
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
+    )
 
     # Test for invalid region identifier.
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_identifier"}
 
-    with patch(
-        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
-        )
+    mock_dwdwfsapi.__bool__.return_value = True
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
+    )
 
     # Test for successfully created entry.
     await hass.async_block_till_done()
@@ -68,7 +64,7 @@ async def test_create_entry_region(hass: HomeAssistant) -> None:
 
 
 async def test_create_entry_gps(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_dwdwfsapi: MagicMock
 ) -> None:
     """Test that the full config flow works for a device tracker."""
     result = await hass.config_entries.flow.async_init(
@@ -121,26 +117,20 @@ async def test_create_entry_gps(
         {ATTR_LATITUDE: "50.180454", ATTR_LONGITUDE: "7.610263"},
     )
 
-    with patch(
-        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
-        return_value=False,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
-        )
+    mock_dwdwfsapi.__bool__.return_value = False
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
+    )
 
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.FORM
     assert result["errors"] == {"base": "invalid_identifier"}
 
     # Test for successfully created entry.
-    with patch(
-        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
-        )
+    mock_dwdwfsapi.__bool__.return_value = True
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=DEMO_CONFIG_ENTRY_GPS
+    )
 
     await hass.async_block_till_done()
     assert result["type"] == FlowResultType.CREATE_ENTRY
@@ -150,7 +140,9 @@ async def test_create_entry_gps(
     }
 
 
-async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
+async def test_config_flow_already_configured(
+    hass: HomeAssistant, mock_dwdwfsapi: MagicMock
+) -> None:
     """Test aborting, if the warncell ID / name is already configured during the config."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -167,13 +159,9 @@ async def test_config_flow_already_configured(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.FORM
 
-    with patch(
-        "homeassistant.components.dwd_weather_warnings.config_flow.DwdWeatherWarningsAPI",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=DEMO_CONFIG_ENTRY_REGION
+    )
 
     await hass.async_block_till_done()
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -44,7 +44,7 @@ async def test_load_invalid_registry_entry(
     entry = await init_integration(
         hass, MockConfigEntry(domain=DOMAIN, data=INVALID_DATA)
     )
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_missing_device_tracker(
@@ -52,7 +52,7 @@ async def test_load_missing_device_tracker(
 ) -> None:
     """Test loading the integration with a missing device tracker."""
     entry = await init_integration(hass, mock_tracker_entry)
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_missing_required_attribute(
@@ -68,7 +68,7 @@ async def test_load_missing_required_attribute(
 
     await hass.config_entries.async_setup(mock_tracker_entry.entry_id)
     await hass.async_block_till_done()
-    assert mock_tracker_entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_tracker_entry.state is ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_valid_device_tracker(
@@ -96,5 +96,5 @@ async def test_load_valid_device_tracker(
     await hass.config_entries.async_setup(mock_tracker_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert mock_tracker_entry.state == ConfigEntryState.LOADED
+    assert mock_tracker_entry.state is ConfigEntryState.LOADED
     assert mock_tracker_entry.entry_id in hass.data[DOMAIN]

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -1,50 +1,28 @@
 """Tests for Deutscher Wetterdienst (DWD) Weather Warnings integration."""
 
-from typing import Final
 from unittest.mock import MagicMock
 
 from homeassistant.components.dwd_weather_warnings.const import (
-    ADVANCE_WARNING_SENSOR,
     CONF_REGION_DEVICE_TRACKER,
-    CONF_REGION_IDENTIFIER,
-    CURRENT_WARNING_SENSOR,
     DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
-    CONF_MONITORED_CONDITIONS,
-    CONF_NAME,
-    STATE_HOME,
-)
+from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, STATE_HOME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
+from . import init_integration
+
 from tests.common import MockConfigEntry
-
-DEMO_IDENTIFIER_CONFIG_ENTRY: Final = {
-    CONF_NAME: "Unit Test",
-    CONF_REGION_IDENTIFIER: "807111000",
-    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
-}
-
-DEMO_TRACKER_CONFIG_ENTRY: Final = {
-    CONF_NAME: "Unit Test",
-    CONF_REGION_DEVICE_TRACKER: "device_tracker.test_gps",
-    CONF_MONITORED_CONDITIONS: [CURRENT_WARNING_SENSOR, ADVANCE_WARNING_SENSOR],
-}
 
 
 async def test_load_unload_entry(
-    hass: HomeAssistant, mock_dwdwfsapi: MagicMock
+    hass: HomeAssistant,
+    mock_identifier_entry: MockConfigEntry,
+    mock_dwdwfsapi: MagicMock,
 ) -> None:
     """Test loading and unloading the integration with a region identifier based entry."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_IDENTIFIER_CONFIG_ENTRY)
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    entry = await init_integration(hass, mock_identifier_entry)
 
     assert entry.state is ConfigEntryState.LOADED
     assert entry.entry_id in hass.data[DOMAIN]
@@ -56,66 +34,67 @@ async def test_load_unload_entry(
     assert entry.entry_id not in hass.data[DOMAIN]
 
 
-async def test_load_invalid_registry_entry(hass: HomeAssistant) -> None:
+async def test_load_invalid_registry_entry(
+    hass: HomeAssistant, mock_tracker_entry: MockConfigEntry
+) -> None:
     """Test loading the integration with an invalid registry entry ID."""
-    INVALID_DATA = DEMO_TRACKER_CONFIG_ENTRY.copy()
+    INVALID_DATA = mock_tracker_entry.data.copy()
     INVALID_DATA[CONF_REGION_DEVICE_TRACKER] = "invalid_registry_id"
-    entry = MockConfigEntry(domain=DOMAIN, data=INVALID_DATA)
-    entry.add_to_hass(hass)
 
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    entry = await init_integration(
+        hass, MockConfigEntry(domain=DOMAIN, data=INVALID_DATA)
+    )
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_load_missing_device_tracker(hass: HomeAssistant) -> None:
+async def test_load_missing_device_tracker(
+    hass: HomeAssistant, mock_tracker_entry: MockConfigEntry
+) -> None:
     """Test loading the integration with a missing device tracker."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
-    entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+    entry = await init_integration(hass, mock_tracker_entry)
     assert entry.state == ConfigEntryState.SETUP_RETRY
 
 
-async def test_load_missing_required_attribute(hass: HomeAssistant) -> None:
+async def test_load_missing_required_attribute(
+    hass: HomeAssistant, mock_tracker_entry: MockConfigEntry
+) -> None:
     """Test loading the integration with a device tracker missing a required attribute."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
-    entry.add_to_hass(hass)
-
+    mock_tracker_entry.add_to_hass(hass)
     hass.states.async_set(
-        DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
+        mock_tracker_entry.data[CONF_REGION_DEVICE_TRACKER],
         STATE_HOME,
         {ATTR_LONGITUDE: "7.610263"},
     )
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(mock_tracker_entry.entry_id)
     await hass.async_block_till_done()
-    assert entry.state == ConfigEntryState.SETUP_RETRY
+    assert mock_tracker_entry.state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_load_valid_device_tracker(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_dwdwfsapi: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_tracker_entry: MockConfigEntry,
+    mock_dwdwfsapi: MagicMock,
 ) -> None:
     """Test loading the integration with a valid device tracker based entry."""
-    entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)
-    entry.add_to_hass(hass)
+    mock_tracker_entry.add_to_hass(hass)
     entity_registry.async_get_or_create(
         "device_tracker",
-        entry.domain,
+        mock_tracker_entry.domain,
         "uuid",
         suggested_object_id="test_gps",
-        config_entry=entry,
+        config_entry=mock_tracker_entry,
     )
 
     hass.states.async_set(
-        DEMO_TRACKER_CONFIG_ENTRY[CONF_REGION_DEVICE_TRACKER],
+        mock_tracker_entry.data[CONF_REGION_DEVICE_TRACKER],
         STATE_HOME,
         {ATTR_LATITUDE: "50.180454", ATTR_LONGITUDE: "7.610263"},
     )
 
-    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.config_entries.async_setup(mock_tracker_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state == ConfigEntryState.LOADED
-    assert entry.entry_id in hass.data[DOMAIN]
+    assert mock_tracker_entry.state == ConfigEntryState.LOADED
+    assert mock_tracker_entry.entry_id in hass.data[DOMAIN]

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -1,6 +1,7 @@
 """Tests for Deutscher Wetterdienst (DWD) Weather Warnings integration."""
 
 from typing import Final
+from unittest.mock import MagicMock
 
 from homeassistant.components.dwd_weather_warnings.const import (
     ADVANCE_WARNING_SENSOR,
@@ -35,10 +36,13 @@ DEMO_TRACKER_CONFIG_ENTRY: Final = {
 }
 
 
-async def test_load_unload_entry(hass: HomeAssistant) -> None:
+async def test_load_unload_entry(
+    hass: HomeAssistant, mock_dwdwfsapi: MagicMock
+) -> None:
     """Test loading and unloading the integration with a region identifier based entry."""
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_IDENTIFIER_CONFIG_ENTRY)
     entry.add_to_hass(hass)
+
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
@@ -91,7 +95,7 @@ async def test_load_missing_required_attribute(hass: HomeAssistant) -> None:
 
 
 async def test_load_valid_device_tracker(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_dwdwfsapi: MagicMock
 ) -> None:
     """Test loading the integration with a valid device tracker based entry."""
     entry = MockConfigEntry(domain=DOMAIN, data=DEMO_TRACKER_CONFIG_ENTRY)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I've been messaged about flaky tests in `dwd_weather_warnings` where the API is used. This should eliminate the need for external API access in the tests by using a fixture. The patches in the `config_flow` tests have been replaced accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
