### PR TITLE
Use remove_device helper in tests (2/2)

### DIFF
--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -384,20 +384,6 @@ async def test_load_triggers_ble_discovery(
     }
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -411,20 +397,13 @@ async def test_device_remove_devices(
     entity = entity_registry.entities["lock.a6697750d607098bae8d6baa11ef8063_name"]
 
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, config_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]

--- a/tests/components/bond/common.py
+++ b/tests/components/bond/common.py
@@ -19,20 +19,6 @@ from homeassistant.util import utcnow
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 def ceiling_fan_with_breeze(name: str):
     """Create a ceiling fan with given name with breeze support."""
     return {

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -24,7 +24,6 @@ from .common import (
     patch_bond_version,
     patch_setup_entry,
     patch_start_bpup,
-    remove_device,
     setup_bond_entity,
     setup_platform,
 )
@@ -318,45 +317,30 @@ async def test_device_remove_devices(
     assert entity.unique_id == "test-hub-id_test-device-id"
 
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, config_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "test-hub-id", "remove-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "wrong-hub-id", "test-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]
 
     hub_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "test-hub-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), hub_device_entry.id, config_entry.entry_id
-        )
-        is False
-    )
+    response = await client.remove_device(hub_device_entry.id, config_entry.entry_id)
+    assert not response["success"]
 
 
 async def test_smart_by_bond_v3_firmware(hass: HomeAssistant) -> None:

--- a/tests/components/fronius/__init__.py
+++ b/tests/components/fronius/__init__.py
@@ -126,17 +126,3 @@ async def enable_all_entities(hass, freezer, config_entry_id, time_till_next_upd
     freezer.tick(time_till_next_update)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-
-
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from . import mock_responses, remove_device, setup_fronius_integration
+from . import mock_responses, setup_fronius_integration
 
 from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -159,11 +159,8 @@ async def test_device_remove_devices(
     )
 
     inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "12345678")})
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), inverter_1.id, config_entry.entry_id
-        )
-        is True
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(inverter_1.id, config_entry.entry_id)
+    assert response["success"]
 
     assert not device_registry.async_get_device(identifiers={(DOMAIN, "12345678")})

--- a/tests/components/homekit_controller/common.py
+++ b/tests/components/homekit_controller/common.py
@@ -399,20 +399,6 @@ async def assert_devices_and_entities_created(
     assert root_device.via_device_id is None
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 def get_next_aid():
     """Get next aid."""
     return model_mixin.id_counter + 1

--- a/tests/components/homekit_controller/test_init.py
+++ b/tests/components/homekit_controller/test_init.py
@@ -23,7 +23,6 @@ from homeassistant.util.dt import utcnow
 
 from .common import (
     Helper,
-    remove_device,
     setup_accessories_from_file,
     setup_test_accessories,
     setup_test_accessories_with_controller,
@@ -99,19 +98,16 @@ async def test_device_remove_devices(
     entity = entity_registry.entities[ALIVE_DEVICE_ENTITY_ID]
 
     live_device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(live_device_entry.id, entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={("homekit_controller:accessory-id", "E9:88:E7:B8:B4:40:aid:1")},
     )
-    assert (
-        await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, entry_id)
+    assert response["success"]
 
 
 async def test_offline_device_raises(hass: HomeAssistant, controller) -> None:

--- a/tests/components/ibeacon/test_init.py
+++ b/tests/components/ibeacon/test_init.py
@@ -19,20 +19,6 @@ def mock_bluetooth(enable_bluetooth):
     """Auto mock bluetooth."""
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -58,17 +44,13 @@ async def test_device_remove_devices(
             )
         },
     )
-    assert (
-        await remove_device(await hass_ws_client(hass), device_entry.id, entry.entry_id)
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, entry.entry_id)
+    assert not response["success"]
+
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={(DOMAIN, "not_seen")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, entry.entry_id)
+    assert response["success"]

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -11,23 +11,7 @@ from homeassistant.setup import async_setup_component
 from . import async_load_json_fixture
 
 from tests.common import MockConfigEntry
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
-
-
-async def remove_device(
-    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
+from tests.typing import WebSocketGenerator
 
 
 async def test_config_entry_not_ready(
@@ -116,19 +100,15 @@ async def test_device_remove_devices(
             )
         },
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, mock_config_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, mock_config_entry.entry_id)
+    assert not response["success"]
+
     old_device_entry = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={(DOMAIN, "OLD-DEVICE-UUID")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), old_device_entry.id, mock_config_entry.entry_id
-        )
-        is True
+    response = await client.remove_device(
+        old_device_entry.id, mock_config_entry.entry_id
     )
+    assert response["success"]

--- a/tests/components/litterrobot/common.py
+++ b/tests/components/litterrobot/common.py
@@ -144,17 +144,3 @@ FEEDER_ROBOT_DATA = {
 }
 
 VACUUM_ENTITY_ID = "vacuum.test_litter_box"
-
-
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]

--- a/tests/components/litterrobot/test_init.py
+++ b/tests/components/litterrobot/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from .common import CONFIG, VACUUM_ENTITY_ID, remove_device
+from .common import CONFIG, VACUUM_ENTITY_ID
 from .conftest import setup_integration
 
 from tests.common import MockConfigEntry
@@ -87,20 +87,13 @@ async def test_device_remove_devices(
     assert entity.unique_id == "LR3C012345-litter_box"
 
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, config_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(litterrobot.DOMAIN, "test-serial", "remove-serial")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -31,7 +31,7 @@ from tests.common import (
     async_get_persistent_notifications,
 )
 from tests.components.cloud import mock_cloud
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import WebSocketGenerator
 
 # Fake webhook thermostat mode change to "Max"
 FAKE_WEBHOOK = {
@@ -517,22 +517,6 @@ async def test_devices(
         assert device_entry == snapshot(name=f"{identifier[0]}-{identifier[1]}")
 
 
-async def remove_device(
-    ws_client: MockHAClientWebSocket, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
@@ -554,20 +538,13 @@ async def test_device_remove_devices(
     entity = entity_registry.async_get(climate_entity_livingroom)
 
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, config_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, config_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, config_entry.entry_id)
+    assert response["success"]

--- a/tests/components/nexia/test_init.py
+++ b/tests/components/nexia/test_init.py
@@ -20,20 +20,6 @@ async def test_setup_retry_client_os_error(hass: HomeAssistant) -> None:
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> None:
@@ -47,27 +33,18 @@ async def test_device_remove_devices(
     entity = registry.entities["sensor.nick_office_temperature"]
 
     live_zone_device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), live_zone_device_entry.id, entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(live_zone_device_entry.id, entry_id)
+    assert not response["success"]
 
     entity = registry.entities["sensor.master_suite_humidity"]
     live_thermostat_device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), live_thermostat_device_entry.id, entry_id
-        )
-        is False
-    )
+    response = await client.remove_device(live_thermostat_device_entry.id, entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "unused")},
     )
-    assert (
-        await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, entry_id)
+    assert response["success"]

--- a/tests/components/onewire/test_init.py
+++ b/tests/components/onewire/test_init.py
@@ -3,7 +3,6 @@
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
-import aiohttp
 from pyownet import protocol
 import pytest
 
@@ -17,22 +16,6 @@ from homeassistant.setup import async_setup_component
 from . import setup_owproxy_mock_devices
 
 from tests.typing import WebSocketGenerator
-
-
-async def remove_device(
-    ws_client: aiohttp.ClientWebSocketResponse, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 1,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
 
 
 @pytest.mark.usefixtures("owproxy_with_connerror")
@@ -125,12 +108,15 @@ async def test_registry_cleanup(
 
     # Try to remove "10.111111111111" - fails as it is live
     device = device_registry.async_get_device(identifiers={(DOMAIN, live_id)})
-    assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is False
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device.id, entry_id)
+    assert not response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 2
     assert device_registry.async_get_device(identifiers={(DOMAIN, live_id)}) is not None
 
     # Try to remove "28.111111111111" - succeeds as it is dead
     device = device_registry.async_get_device(identifiers={(DOMAIN, dead_id)})
-    assert await remove_device(await hass_ws_client(hass), device.id, entry_id) is True
+    response = await client.remove_device(device.id, entry_id)
+    assert response["success"]
     assert len(dr.async_entries_for_config_entry(device_registry, entry_id)) == 1
     assert device_registry.async_get_device(identifiers={(DOMAIN, dead_id)}) is None

--- a/tests/components/scrape/test_init.py
+++ b/tests/components/scrape/test_init.py
@@ -129,20 +129,6 @@ async def test_unload_entry(hass: HomeAssistant, loaded_entry: MockConfigEntry) 
     assert loaded_entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant,
     loaded_entry: MockConfigEntry,
@@ -155,20 +141,13 @@ async def test_device_remove_devices(
 
     device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, loaded_entry.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, loaded_entry.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=loaded_entry.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, loaded_entry.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, loaded_entry.entry_id)
+    assert response["success"]

--- a/tests/components/sensibo/test_init.py
+++ b/tests/components/sensibo/test_init.py
@@ -152,20 +152,6 @@ async def test_unload_entry(hass: HomeAssistant, get_data: SensiboData) -> None:
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-async def remove_device(ws_client, device_id, config_entry_id):
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
-
-
 async def test_device_remove_devices(
     hass: HomeAssistant,
     load_int: ConfigEntry,
@@ -178,20 +164,13 @@ async def test_device_remove_devices(
 
     device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), device_entry.id, load_int.entry_id
-        )
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(device_entry.id, load_int.entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=load_int.entry_id,
         identifiers={(DOMAIN, "remove-device-id")},
     )
-    assert (
-        await remove_device(
-            await hass_ws_client(hass), dead_device_entry.id, load_int.entry_id
-        )
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, load_int.entry_id)
+    assert response["success"]

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-import aiohttp
 from pyunifiprotect import NotAuthorized, NvrError, ProtectApiClient
 from pyunifiprotect.data import NVR, Bootstrap, CloudAccount, Light
 
@@ -24,22 +23,6 @@ from .utils import MockUFPFixture, init_entry, time_changed
 
 from tests.common import MockConfigEntry
 from tests.typing import WebSocketGenerator
-
-
-async def remove_device(
-    ws_client: aiohttp.ClientWebSocketResponse, device_id: str, config_entry_id: str
-) -> bool:
-    """Remove config entry from a device."""
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    return response["success"]
 
 
 async def test_setup(hass: HomeAssistant, ufp: MockUFPFixture) -> None:
@@ -275,19 +258,16 @@ async def test_device_remove_devices(
     device_registry = dr.async_get(hass)
 
     live_device_entry = device_registry.async_get(entity.device_id)
-    assert (
-        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(live_device_entry.id, entry_id)
+    assert not response["success"]
 
     dead_device_entry = device_registry.async_get_or_create(
         config_entry_id=entry_id,
         connections={(dr.CONNECTION_NETWORK_MAC, "e9:88:e7:b8:b4:40")},
     )
-    assert (
-        await remove_device(await hass_ws_client(hass), dead_device_entry.id, entry_id)
-        is True
-    )
+    response = await client.remove_device(dead_device_entry.id, entry_id)
+    assert response["success"]
 
 
 async def test_device_remove_devices_nvr(
@@ -306,7 +286,6 @@ async def test_device_remove_devices_nvr(
     device_registry = dr.async_get(hass)
 
     live_device_entry = list(device_registry.devices.values())[0]
-    assert (
-        await remove_device(await hass_ws_client(hass), live_device_entry.id, entry_id)
-        is False
-    )
+    client = await hass_ws_client(hass)
+    response = await client.remove_device(live_device_entry.id, entry_id)
+    assert not response["success"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #116234

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
