### PR TITLE
Use remove_device helper in tasmota tests

### DIFF
--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -20,7 +20,7 @@ from hatasmota.utils import (
     get_topic_tele_will,
 )
 
-from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
+from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -106,22 +106,6 @@ DEFAULT_SENSOR_CONFIG = {
         "TempUnit": "C",
     }
 }
-
-
-async def remove_device(hass, ws_client, device_id, config_entry_id=None):
-    """Remove config entry from a device."""
-    if config_entry_id is None:
-        config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config/device_registry/remove_config_entry",
-            "config_entry_id": config_entry_id,
-            "device_id": device_id,
-        }
-    )
-    response = await ws_client.receive_json()
-    assert response["success"]
 
 
 async def help_test_availability_when_connection_lost(

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
 
-from .test_common import DEFAULT_CONFIG, remove_device
+from .test_common import DEFAULT_CONFIG
 
 from tests.common import async_fire_mqtt_message, async_get_device_automations
 from tests.typing import MqttMockHAClient, WebSocketGenerator
@@ -849,7 +849,9 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     assert len(calls) == 1
 
     # Remove the device
-    await remove_device(hass, await hass_ws_client(hass), device_entry.id)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry_id)
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(
@@ -1139,7 +1141,9 @@ async def test_attach_unknown_remove_device_from_registry(
     )
 
     # Remove the device
-    await remove_device(hass, await hass_ws_client(hass), device_entry.id)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry_id)
     await hass.async_block_till_done()
 
 

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -851,7 +851,8 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     # Remove the device
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry_id)
+    response = await client.remove_device(device_entry.id, config_entry_id)
+    assert response["success"]
     await hass.async_block_till_done()
 
     async_fire_mqtt_message(
@@ -1143,7 +1144,8 @@ async def test_attach_unknown_remove_device_from_registry(
     # Remove the device
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry_id)
+    response = await client.remove_device(device_entry.id, config_entry_id)
+    assert response["success"]
     await hass.async_block_till_done()
 
 

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -6,7 +6,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 
-from homeassistant.components.tasmota.const import DEFAULT_PREFIX
+from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
 from homeassistant.components.tasmota.discovery import ALREADY_DISCOVERED
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
@@ -17,7 +17,7 @@ from homeassistant.helpers import (
 from homeassistant.setup import async_setup_component
 
 from .conftest import setup_tasmota_helper
-from .test_common import DEFAULT_CONFIG, DEFAULT_CONFIG_9_0_0_3, remove_device
+from .test_common import DEFAULT_CONFIG, DEFAULT_CONFIG_9_0_0_3
 
 from tests.common import MockConfigEntry, async_fire_mqtt_message
 from tests.typing import MqttMockHAClient, WebSocketGenerator
@@ -446,7 +446,9 @@ async def test_device_remove_stale(
     assert device_entry is not None
 
     # Remove the device
-    await remove_device(hass, await hass_ws_client(hass), device_entry.id)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry_id)
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(

--- a/tests/components/tasmota/test_discovery.py
+++ b/tests/components/tasmota/test_discovery.py
@@ -448,7 +448,8 @@ async def test_device_remove_stale(
     # Remove the device
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry_id)
+    response = await client.remove_device(device_entry.id, config_entry_id)
+    assert response["success"]
 
     # Verify device entry is removed
     device_entry = device_reg.async_get_device(

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -51,7 +51,8 @@ async def test_device_remove(
 
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry_id)
+    response = await client.remove_device(device_entry.id, config_entry_id)
+    assert response["success"]
     await hass.async_block_till_done()
 
     # Verify device entry is removed
@@ -101,7 +102,8 @@ async def test_device_remove_non_tasmota_device(
     assert device_entry is not None
 
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry.entry_id)
+    response = await client.remove_device(device_entry.id, config_entry.entry_id)
+    assert response["success"]
     await hass.async_block_till_done()
 
     # Verify device entry is removed
@@ -134,7 +136,8 @@ async def test_device_remove_stale_tasmota_device(
 
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
     client = await hass_ws_client(hass)
-    await client.remove_device(device_entry.id, config_entry_id)
+    response = await client.remove_device(device_entry.id, config_entry_id)
+    assert response["success"]
     await hass.async_block_till_done()
 
     # Verify device entry is removed

--- a/tests/components/tasmota/test_init.py
+++ b/tests/components/tasmota/test_init.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
-from .test_common import DEFAULT_CONFIG, DEFAULT_SENSOR_CONFIG, remove_device
+from .test_common import DEFAULT_CONFIG, DEFAULT_SENSOR_CONFIG
 
 from tests.common import (
     MockConfigEntry,
@@ -49,7 +49,9 @@ async def test_device_remove(
     )
     assert device_entry is not None
 
-    await remove_device(hass, await hass_ws_client(hass), device_entry.id)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry_id)
     await hass.async_block_till_done()
 
     # Verify device entry is removed
@@ -98,9 +100,8 @@ async def test_device_remove_non_tasmota_device(
     )
     assert device_entry is not None
 
-    await remove_device(
-        hass, await hass_ws_client(hass), device_entry.id, config_entry.entry_id
-    )
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry.entry_id)
     await hass.async_block_till_done()
 
     # Verify device entry is removed
@@ -131,7 +132,9 @@ async def test_device_remove_stale_tasmota_device(
     )
     assert device_entry is not None
 
-    await remove_device(hass, await hass_ws_client(hass), device_entry.id)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    client = await hass_ws_client(hass)
+    await client.remove_device(device_entry.id, config_entry_id)
     await hass.async_block_till_done()
 
     # Verify device entry is removed


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #116234
Alternative to #116617

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
