### PR TITLE
Avoid re-encoding the message id as bytes for every event/state change

### DIFF
--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -105,7 +105,7 @@ def pong_message(iden: int) -> dict[str, Any]:
 def _forward_events_check_permissions(
     send_message: Callable[[bytes | str | dict[str, Any] | Callable[[], str]], None],
     user: User,
-    iden_bytes: bytes,
+    message_id_as_bytes: bytes,
     event: Event,
 ) -> None:
     """Forward state changed events to websocket."""
@@ -118,17 +118,17 @@ def _forward_events_check_permissions(
         and not permissions.check_entity(event.data["entity_id"], POLICY_READ)
     ):
         return
-    send_message(messages.cached_event_message(iden_bytes, event))
+    send_message(messages.cached_event_message(message_id_as_bytes, event))
 
 
 @callback
 def _forward_events_unconditional(
     send_message: Callable[[bytes | str | dict[str, Any] | Callable[[], str]], None],
-    iden_bytes: bytes,
+    message_id_as_bytes: bytes,
     event: Event,
 ) -> None:
     """Forward events to websocket."""
-    send_message(messages.cached_event_message(iden_bytes, event))
+    send_message(messages.cached_event_message(message_id_as_bytes, event))
 
 
 @callback
@@ -152,18 +152,18 @@ def handle_subscribe_events(
         )
         raise Unauthorized(user_id=connection.user.id)
 
-    iden_bytes = str(msg["id"]).encode()
+    message_id_as_bytes = str(msg["id"]).encode()
 
     if event_type == EVENT_STATE_CHANGED:
         forward_events = partial(
             _forward_events_check_permissions,
             connection.send_message,
             connection.user,
-            iden_bytes,
+            message_id_as_bytes,
         )
     else:
         forward_events = partial(
-            _forward_events_unconditional, connection.send_message, iden_bytes
+            _forward_events_unconditional, connection.send_message, message_id_as_bytes
         )
 
     connection.subscriptions[msg["id"]] = hass.bus.async_listen(
@@ -368,7 +368,7 @@ def _forward_entity_changes(
     send_message: Callable[[str | bytes | dict[str, Any] | Callable[[], str]], None],
     entity_ids: set[str],
     user: User,
-    iden_bytes: bytes,
+    message_id_as_bytes: bytes,
     event: Event[EventStateChangedData],
 ) -> None:
     """Forward entity state changed events to websocket."""
@@ -384,7 +384,7 @@ def _forward_entity_changes(
         and not permissions.check_entity(event.data["entity_id"], POLICY_READ)
     ):
         return
-    send_message(messages.cached_state_diff_message(iden_bytes, event))
+    send_message(messages.cached_state_diff_message(message_id_as_bytes, event))
 
 
 @callback
@@ -403,7 +403,7 @@ def handle_subscribe_entities(
     # state changed events or we will introduce a race condition
     # where some states are missed
     states = _async_get_allowed_states(hass, connection)
-    iden_bytes = str(msg["id"]).encode()
+    message_id_as_bytes = str(msg["id"]).encode()
     connection.subscriptions[msg["id"]] = hass.bus.async_listen(
         EVENT_STATE_CHANGED,
         partial(
@@ -411,7 +411,7 @@ def handle_subscribe_entities(
             connection.send_message,
             entity_ids,
             connection.user,
-            iden_bytes,
+            message_id_as_bytes,
         ),
     )
     connection.send_result(msg["id"])

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -109,7 +109,7 @@ def event_message(iden: int, event: Any) -> dict[str, Any]:
     return {"id": iden, "type": "event", "event": event}
 
 
-def cached_event_message(iden: int, event: Event) -> bytes:
+def cached_event_message(iden_bytes: bytes, event: Event) -> bytes:
     """Return an event message.
 
     Serialize to json once per message.
@@ -122,7 +122,7 @@ def cached_event_message(iden: int, event: Event) -> bytes:
         (
             _partial_cached_event_message(event)[:-1],
             b',"id":',
-            str(iden).encode(),
+            iden_bytes,
             b"}",
         )
     )
@@ -141,7 +141,9 @@ def _partial_cached_event_message(event: Event) -> bytes:
     )
 
 
-def cached_state_diff_message(iden: int, event: Event[EventStateChangedData]) -> bytes:
+def cached_state_diff_message(
+    iden_bytes: bytes, event: Event[EventStateChangedData]
+) -> bytes:
     """Return an event message.
 
     Serialize to json once per message.
@@ -154,7 +156,7 @@ def cached_state_diff_message(iden: int, event: Event[EventStateChangedData]) ->
         (
             _partial_cached_state_diff_message(event)[:-1],
             b',"id":',
-            str(iden).encode(),
+            iden_bytes,
             b"}",
         )
     )

--- a/homeassistant/components/websocket_api/messages.py
+++ b/homeassistant/components/websocket_api/messages.py
@@ -109,7 +109,7 @@ def event_message(iden: int, event: Any) -> dict[str, Any]:
     return {"id": iden, "type": "event", "event": event}
 
 
-def cached_event_message(iden_bytes: bytes, event: Event) -> bytes:
+def cached_event_message(message_id_as_bytes: bytes, event: Event) -> bytes:
     """Return an event message.
 
     Serialize to json once per message.
@@ -122,7 +122,7 @@ def cached_event_message(iden_bytes: bytes, event: Event) -> bytes:
         (
             _partial_cached_event_message(event)[:-1],
             b',"id":',
-            iden_bytes,
+            message_id_as_bytes,
             b"}",
         )
     )
@@ -142,7 +142,7 @@ def _partial_cached_event_message(event: Event) -> bytes:
 
 
 def cached_state_diff_message(
-    iden_bytes: bytes, event: Event[EventStateChangedData]
+    message_id_as_bytes: bytes, event: Event[EventStateChangedData]
 ) -> bytes:
     """Return an event message.
 
@@ -156,7 +156,7 @@ def cached_state_diff_message(
         (
             _partial_cached_state_diff_message(event)[:-1],
             b',"id":',
-            iden_bytes,
+            message_id_as_bytes,
             b"}",
         )
     )

--- a/tests/components/websocket_api/test_messages.py
+++ b/tests/components/websocket_api/test_messages.py
@@ -32,11 +32,11 @@ async def test_cached_event_message(hass: HomeAssistant) -> None:
     assert len(events) == 2
     lru_event_cache.cache_clear()
 
-    msg0 = cached_event_message(2, events[0])
-    assert msg0 == cached_event_message(2, events[0])
+    msg0 = cached_event_message(b"2", events[0])
+    assert msg0 == cached_event_message(b"2", events[0])
 
-    msg1 = cached_event_message(2, events[1])
-    assert msg1 == cached_event_message(2, events[1])
+    msg1 = cached_event_message(b"2", events[1])
+    assert msg1 == cached_event_message(b"2", events[1])
 
     assert msg0 != msg1
 
@@ -45,7 +45,7 @@ async def test_cached_event_message(hass: HomeAssistant) -> None:
     assert cache_info.misses == 2
     assert cache_info.currsize == 2
 
-    cached_event_message(2, events[1])
+    cached_event_message(b"2", events[1])
     cache_info = lru_event_cache.cache_info()
     assert cache_info.hits == 3
     assert cache_info.misses == 2
@@ -70,9 +70,9 @@ async def test_cached_event_message_with_different_idens(hass: HomeAssistant) ->
 
     lru_event_cache.cache_clear()
 
-    msg0 = cached_event_message(2, events[0])
-    msg1 = cached_event_message(3, events[0])
-    msg2 = cached_event_message(4, events[0])
+    msg0 = cached_event_message(b"2", events[0])
+    msg1 = cached_event_message(b"3", events[0])
+    msg2 = cached_event_message(b"4", events[0])
 
     assert msg0 != msg1
     assert msg0 != msg2


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the id never changes we can avoid re-encoding (convert from int to str, than str to bytes) it for every message since it can take more time than the json encoding (or about the same)

<img width="1494" alt="Screenshot 2024-04-30 at 10 05 57 AM" src="https://github.com/home-assistant/core/assets/663432/ce953c6e-8811-46ad-9109-d480ec1e6373">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
