### PR TITLE
Prioritize the correct CP2102N serial port on macOS

### DIFF
--- a/homeassistant/components/usb/__init__.py
+++ b/homeassistant/components/usb/__init__.py
@@ -362,10 +362,33 @@ class USBDiscovery:
 
     async def _async_process_ports(self, ports: list[ListPortInfo]) -> None:
         """Process each discovered port."""
-        for port in ports:
-            if port.vid is None and port.pid is None:
-                continue
-            await self._async_process_discovered_usb_device(usb_device_from_port(port))
+        usb_devices = [
+            usb_device_from_port(port)
+            for port in ports
+            if port.vid is not None or port.pid is not None
+        ]
+
+        # CP2102N chips create *two* serial ports on macOS: `/dev/cu.usbserial-` and
+        # `/dev/cu.SLAB_USBtoUART*`. The former does not work and we should ignore them.
+        if sys.platform == "darwin":
+            silabs_serials = {
+                dev.serial_number
+                for dev in usb_devices
+                if dev.device.startswith("/dev/cu.SLAB_USBtoUART")
+            }
+
+            usb_devices = [
+                dev
+                for dev in usb_devices
+                if dev.serial_number not in silabs_serials
+                or (
+                    dev.serial_number in silabs_serials
+                    and dev.device.startswith("/dev/cu.SLAB_USBtoUART")
+                )
+            ]
+
+        for usb_device in usb_devices:
+            await self._async_process_discovered_usb_device(usb_device)
 
     async def _async_scan_serial(self) -> None:
         """Scan serial ports."""

--- a/tests/components/usb/test_init.py
+++ b/tests/components/usb/test_init.py
@@ -1052,3 +1052,109 @@ async def test_resolve_serial_by_id(
     assert len(mock_config_flow.mock_calls) == 1
     assert mock_config_flow.mock_calls[0][1][0] == "test1"
     assert mock_config_flow.mock_calls[0][2]["data"].device == "/dev/serial/by-id/bla"
+
+
+@pytest.mark.parametrize(
+    "ports",
+    [
+        [
+            MagicMock(
+                device="/dev/cu.usbserial-2120",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=conbee_device.serial_number,
+                manufacturer=conbee_device.manufacturer,
+                description=conbee_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.usbserial-1120",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=slae_sh_device.serial_number,
+                manufacturer=slae_sh_device.manufacturer,
+                description=slae_sh_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.SLAB_USBtoUART",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=conbee_device.serial_number,
+                manufacturer=conbee_device.manufacturer,
+                description=conbee_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.SLAB_USBtoUART2",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=slae_sh_device.serial_number,
+                manufacturer=slae_sh_device.manufacturer,
+                description=slae_sh_device.description,
+            ),
+        ],
+        [
+            MagicMock(
+                device="/dev/cu.SLAB_USBtoUART2",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=slae_sh_device.serial_number,
+                manufacturer=slae_sh_device.manufacturer,
+                description=slae_sh_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.SLAB_USBtoUART",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=conbee_device.serial_number,
+                manufacturer=conbee_device.manufacturer,
+                description=conbee_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.usbserial-1120",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=slae_sh_device.serial_number,
+                manufacturer=slae_sh_device.manufacturer,
+                description=slae_sh_device.description,
+            ),
+            MagicMock(
+                device="/dev/cu.usbserial-2120",
+                vid=0x3039,
+                pid=0x3039,
+                serial_number=conbee_device.serial_number,
+                manufacturer=conbee_device.manufacturer,
+                description=conbee_device.description,
+            ),
+        ],
+    ],
+)
+async def test_cp2102n_ordering_on_macos(
+    ports: list[MagicMock], hass: HomeAssistant, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Test CP2102N ordering on macOS."""
+
+    new_usb = [
+        {"domain": "test1", "vid": "3039", "pid": "3039", "description": "*2652*"}
+    ]
+
+    with (
+        patch("sys.platform", "darwin"),
+        patch("pyudev.Context", side_effect=ImportError),
+        patch("homeassistant.components.usb.async_get_usb", return_value=new_usb),
+        patch("homeassistant.components.usb.comports", return_value=ports),
+        patch.object(hass.config_entries.flow, "async_init") as mock_config_flow,
+    ):
+        assert await async_setup_component(hass, "usb", {"usb": {}})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+        ws_client = await hass_ws_client(hass)
+        await ws_client.send_json({"id": 1, "type": "usb/scan"})
+        response = await ws_client.receive_json()
+        assert response["success"]
+        await hass.async_block_till_done()
+
+    assert len(mock_config_flow.mock_calls) == 1
+    assert mock_config_flow.mock_calls[0][1][0] == "test1"
+
+    # We always use `cu.SLAB_USBtoUART`
+    assert mock_config_flow.mock_calls[0][2]["data"].device == "/dev/cu.SLAB_USBtoUART2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When scanning for USB-serial ports on macOS, CP2102N devices have an unfortunate driver bug: each device yields two serial ports. The one named `/dev/cu.usbserial-\d+` is broken, while the one named `/dev/cu.SLAB_USBtoUART\d+` is functional.

This PR removes the `/dev/cu.usbserial-` ports on macOS if there is a corresponding `/dev/cu.SLAB_USBtoUART` port sharing a serial number with it. This allows properly using discovery.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
