### PR TITLE
Ensure MQTT resubscribes happen before birth message

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -918,7 +918,7 @@ class MQTT:
             result_code,
         )
 
-        birth = self.conf.get(CONF_BIRTH_MESSAGE, DEFAULT_BIRTH)
+        birth: dict[str, Any] = self.conf.get(CONF_BIRTH_MESSAGE, DEFAULT_BIRTH)
         self._async_queue_resubscribe()
 
         if birth:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -924,9 +924,11 @@ class MQTT:
         if birth:
 
             async def publish_birth_message(birth_message: PublishMessage) -> None:
+                await self._async_perform_subscriptions()
                 await self._ha_started.wait()  # Wait for Home Assistant to start
                 await self._discovery_cooldown()  # Wait for MQTT discovery to cool down
-                # Ensure the queue is empty before publishing the birth message
+                # Check subscriptions again to ensure we are subscribed
+                # in case anything pending was while HA was starting
                 await self._async_perform_subscriptions()
                 # Update subscribe cooldown period to a shorter time
                 self._subscribe_debouncer.set_timeout(SUBSCRIBE_COOLDOWN)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -877,7 +877,7 @@ class MQTT:
 
         await self._wait_for_mid(mid)
 
-    async def _resubscribe_and_publish_birth_message(
+    async def _async_resubscribe_and_publish_birth_message(
         self, birth_message: PublishMessage
     ) -> None:
         """Resubscribe to all topics and publish birth message."""
@@ -943,7 +943,7 @@ class MQTT:
             birth_message = PublishMessage(**birth)
             self.config_entry.async_create_background_task(
                 self.hass,
-                self._resubscribe_and_publish_birth_message(birth_message),
+                self._async_resubscribe_and_publish_birth_message(birth_message),
                 name="mqtt re-subscribe and birth",
             )
         else:

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -918,13 +918,16 @@ class MQTT:
             result_code,
         )
 
-        self.hass.async_create_task(self._async_resubscribe())
+        birth = self.conf.get(CONF_BIRTH_MESSAGE, DEFAULT_BIRTH)
+        self._async_queue_resubscribe()
 
-        if birth := self.conf.get(CONF_BIRTH_MESSAGE, DEFAULT_BIRTH):
+        if birth:
 
             async def publish_birth_message(birth_message: PublishMessage) -> None:
                 await self._ha_started.wait()  # Wait for Home Assistant to start
                 await self._discovery_cooldown()  # Wait for MQTT discovery to cool down
+                # Ensure the queue is empty before publishing the birth message
+                await self._async_perform_subscriptions()
                 # Update subscribe cooldown period to a shorter time
                 self._subscribe_debouncer.set_timeout(SUBSCRIBE_COOLDOWN)
                 await self.async_publish(
@@ -942,11 +945,17 @@ class MQTT:
             )
         else:
             # Update subscribe cooldown period to a shorter time
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self._async_perform_subscriptions(),
+                name="mqtt re-subscriptions",
+            )
             self._subscribe_debouncer.set_timeout(SUBSCRIBE_COOLDOWN)
 
         self._async_connection_result(True)
 
-    async def _async_resubscribe(self) -> None:
+    @callback
+    def _async_queue_resubscribe(self) -> None:
         """Resubscribe on reconnect."""
         self._max_qos.clear()
         self._retained_topics.clear()
@@ -962,7 +971,6 @@ class MQTT:
             ],
             queue_only=True,
         )
-        await self._async_perform_subscriptions()
 
     @lru_cache(None)  # pylint: disable=method-cache-max-size-none
     def _matching_subscriptions(self, topic: str) -> list[Subscription]:
@@ -1049,7 +1057,9 @@ class MQTT:
         # The callback signature for on_unsubscribe is different from on_subscribe
         # see https://github.com/eclipse/paho.mqtt.python/issues/687
         # properties and reasoncodes are not used in Home Assistant
-        self.hass.async_create_task(self._mqtt_handle_mid(mid))
+        self.config_entry.async_create_task(
+            self.hass, self._mqtt_handle_mid(mid), name=f"mqtt handle mid {mid}"
+        )
 
     async def _mqtt_handle_mid(self, mid: int) -> None:
         # Create the mid event if not created, either _mqtt_handle_mid or _wait_for_mid

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -928,7 +928,7 @@ class MQTT:
                 await self._ha_started.wait()  # Wait for Home Assistant to start
                 await self._discovery_cooldown()  # Wait for MQTT discovery to cool down
                 # Check subscriptions again to ensure we are subscribed
-                # in case anything pending was while HA was starting
+                # in case anything pending was added while HA was starting
                 await self._async_perform_subscriptions()
                 # Update subscribe cooldown period to a shorter time
                 self._subscribe_debouncer.set_timeout(SUBSCRIBE_COOLDOWN)

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -884,9 +884,6 @@ class MQTT:
         await self._async_perform_subscriptions()
         await self._ha_started.wait()  # Wait for Home Assistant to start
         await self._discovery_cooldown()  # Wait for MQTT discovery to cool down
-        # Check subscriptions again to ensure we are subscribed
-        # in case anything pending was added while HA was starting
-        await self._async_perform_subscriptions()
         # Update subscribe cooldown period to a shorter time
         self._subscribe_debouncer.set_timeout(SUBSCRIBE_COOLDOWN)
         await self.async_publish(

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -956,7 +956,11 @@ class MQTT:
 
     @callback
     def _async_queue_resubscribe(self) -> None:
-        """Resubscribe on reconnect."""
+        """Queue subscriptions on reconnect.
+
+        self._async_perform_subscriptions must be called
+        after this method to actually subscribe.
+        """
         self._max_qos.clear()
         self._retained_topics.clear()
         # Group subscriptions to only re-subscribe once for each topic.


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There were two tasks running but there was no synchronization to ensure the resubs were done before the birth message was published.

related issue #115958


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
