### PR TITLE
Change SkyConnect integration type back to `hardware` and fix multi-PAN migration bug

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -597,6 +597,36 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
         """Return the name of the hardware."""
         return self._hw_variant.full_name
 
+    async def async_step_finish_addon_setup(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Prepare info needed to complete the config entry update."""
+        self.hass.config_entries.async_update_entry(
+            entry=self.config_entry,
+            data={
+                **self.config_entry.data,
+                "firmware": ApplicationType.CPC.value,
+            },
+            options=self.config_entry.options,
+        )
+
+        return await super().async_step_finish_addon_setup(user_input)
+
+    async def async_step_flashing_complete(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Finish flashing and update the config entry."""
+        self.hass.config_entries.async_update_entry(
+            entry=self.config_entry,
+            data={
+                **self.config_entry.data,
+                "firmware": ApplicationType.EZSP.value,
+            },
+            options=self.config_entry.options,
+        )
+
+        return await super().async_step_flashing_complete(user_input)
+
 
 class HomeAssistantSkyConnectOptionsFlowHandler(
     BaseFirmwareInstallFlow, OptionsFlowWithConfigEntry

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -597,21 +597,6 @@ class HomeAssistantSkyConnectMultiPanOptionsFlowHandler(
         """Return the name of the hardware."""
         return self._hw_variant.full_name
 
-    async def async_step_finish_addon_setup(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Prepare info needed to complete the config entry update."""
-        self.hass.config_entries.async_update_entry(
-            entry=self.config_entry,
-            data={
-                **self.config_entry.data,
-                "firmware": ApplicationType.CPC.value,
-            },
-            options=self.config_entry.options,
-        )
-
-        return await super().async_step_finish_addon_setup(user_input)
-
     async def async_step_flashing_complete(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/homeassistant_sky_connect/manifest.json
+++ b/homeassistant/components/homeassistant_sky_connect/manifest.json
@@ -5,7 +5,7 @@
   "config_flow": true,
   "dependencies": ["hardware", "usb", "homeassistant_hardware"],
   "documentation": "https://www.home-assistant.io/integrations/homeassistant_sky_connect",
-  "integration_type": "device",
+  "integration_type": "hardware",
   "usb": [
     {
       "vid": "10C4",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -2565,11 +2565,6 @@
       "integration_type": "virtual",
       "supported_by": "netatmo"
     },
-    "homeassistant_sky_connect": {
-      "name": "Home Assistant SkyConnect",
-      "integration_type": "device",
-      "config_flow": true
-    },
     "homematic": {
       "name": "Homematic",
       "integrations": {

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -11,6 +11,8 @@ from universal_silabs_flasher.const import ApplicationType
 from homeassistant.components import usb
 from homeassistant.components.hassio.addon_manager import AddonInfo, AddonState
 from homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon import (
+    CONF_DISABLE_MULTI_PAN,
+    get_flasher_addon_manager,
     get_multiprotocol_addon_manager,
 )
 from homeassistant.components.homeassistant_sky_connect.config_flow import (
@@ -869,10 +871,24 @@ async def test_options_flow_multipan_uninstall(
         version="1.0.0",
     )
 
+    mock_flasher_manager = Mock(spec_set=get_flasher_addon_manager(hass))
+    mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
+        available=True,
+        hostname=None,
+        options={},
+        state=AddonState.NOT_RUNNING,
+        update_available=False,
+        version="1.0.0",
+    )
+
     with (
         patch(
             "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.get_multiprotocol_addon_manager",
             return_value=mock_multipan_manager,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.get_flasher_addon_manager",
+            return_value=mock_flasher_manager,
         ),
         patch(
             "homeassistant.components.homeassistant_hardware.silabs_multiprotocol_addon.is_hassio",
@@ -883,3 +899,25 @@ async def test_options_flow_multipan_uninstall(
         assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "addon_menu"
         assert "uninstall_addon" in result["menu_options"]
+
+        # Pick the uninstall option
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            user_input={"next_step_id": "uninstall_addon"},
+        )
+
+        # Check the box
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_DISABLE_MULTI_PAN: True}
+        )
+
+        # Finish the flow
+        result = await hass.config_entries.options.async_configure(result["flow_id"])
+        await hass.async_block_till_done(wait_background_tasks=True)
+        result = await hass.config_entries.options.async_configure(result["flow_id"])
+        await hass.async_block_till_done(wait_background_tasks=True)
+        result = await hass.config_entries.options.async_configure(result["flow_id"])
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    # We've reverted the firmware back to Zigbee
+    assert config_entry.data["firmware"] == "ezsp"

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -917,7 +917,7 @@ async def test_options_flow_multipan_uninstall(
         result = await hass.config_entries.options.async_configure(result["flow_id"])
         await hass.async_block_till_done(wait_background_tasks=True)
         result = await hass.config_entries.options.async_configure(result["flow_id"])
-        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["type"] is FlowResultType.CREATE_ENTRY
 
     # We've reverted the firmware back to Zigbee
     assert config_entry.data["firmware"] == "ezsp"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move the SkyConnect integration back into the Hardware menu by changing the integration type from `device` back to `hardware`:
<img width="642" alt="image" src="https://github.com/home-assistant/core/assets/32534428/27c30cdb-f17d-42a8-97e1-cb7008083e7a">

This will hide the integration as before and just extend the options flow to allow managing the other types of firmware. I've also fixed a bug with multi-PAN uninstallation where the firmware type was not updated to EZSP (thanks @agners!).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
