### PR TITLE
Hold a lock to prevent concurrent setup of config entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -295,7 +295,7 @@ class ConfigEntry(Generic[_DataT]):
     update_listeners: list[UpdateListenerType]
     _async_cancel_retry_setup: Callable[[], Any] | None
     _on_unload: list[Callable[[], Coroutine[Any, Any, None] | None]] | None
-    reload_lock: asyncio.Lock
+    setup_lock: asyncio.Lock
     _reauth_lock: asyncio.Lock
     _reconfigure_lock: asyncio.Lock
     _tasks: set[asyncio.Future[Any]]
@@ -403,7 +403,7 @@ class ConfigEntry(Generic[_DataT]):
         _setter(self, "_on_unload", None)
 
         # Reload lock to prevent conflicting reloads
-        _setter(self, "reload_lock", asyncio.Lock())
+        _setter(self, "setup_lock", asyncio.Lock())
         # Reauth lock to prevent concurrent reauth flows
         _setter(self, "_reauth_lock", asyncio.Lock())
         # Reconfigure lock to prevent concurrent reconfigure flows
@@ -702,19 +702,17 @@ class ConfigEntry(Generic[_DataT]):
         # has started so we do not block shutdown
         if not hass.is_stopping:
             hass.async_create_background_task(
-                self._async_setup_retry(hass),
+                self.async_setup_locked(hass),
                 f"config entry retry {self.domain} {self.title}",
                 eager_start=True,
             )
 
-    async def _async_setup_retry(self, hass: HomeAssistant) -> None:
-        """Retry setup.
-
-        We hold the reload lock during setup retry to ensure
-        that nothing can reload the entry while we are retrying.
-        """
-        async with self.reload_lock:
-            await self.async_setup(hass)
+    async def async_setup_locked(
+        self, hass: HomeAssistant, integration: loader.Integration | None = None
+    ) -> None:
+        """Set up while holding the setup lock."""
+        async with self.setup_lock:
+            await self.async_setup(hass, integration=integration)
 
     @callback
     def async_shutdown(self) -> None:
@@ -1794,7 +1792,15 @@ class ConfigEntries:
         # attempts.
         entry.async_cancel_retry_setup()
 
-        async with entry.reload_lock:
+        if entry.domain not in self.hass.config.components:
+            # If the component is not loaded, just load it as
+            # the config entry will be loaded as well. We need
+            # to do this before holding the lock to avoid a
+            # deadlock.
+            await async_setup_component(self.hass, entry.domain, self._hass_config)
+            return entry.state is ConfigEntryState.LOADED
+
+        async with entry.setup_lock:
             unload_result = await self.async_unload(entry_id)
 
             if not unload_result or entry.disabled_by:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -449,7 +449,7 @@ async def _async_setup_component(
         await asyncio.gather(
             *(
                 create_eager_task(
-                    entry.async_setup(hass, integration=integration),
+                    entry.async_setup_locked(hass, integration=integration),
                     name=f"config entry setup {entry.title} {entry.domain} {entry.entry_id}",
                 )
                 for entry in entries

--- a/tests/components/androidtv_remote/test_config_flow.py
+++ b/tests/components/androidtv_remote/test_config_flow.py
@@ -324,6 +324,7 @@ async def test_user_flow_already_configured_host_changed_reloads_entry(
         state=ConfigEntryState.LOADED,
     )
     mock_config_entry.add_to_hass(hass)
+    hass.config.components.add(DOMAIN)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -640,6 +641,7 @@ async def test_zeroconf_flow_already_configured_host_changed_reloads_entry(
         state=ConfigEntryState.LOADED,
     )
     mock_config_entry.add_to_hass(hass)
+    hass.config.components.add(DOMAIN)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -769,6 +771,7 @@ async def test_reauth_flow_success(
         state=ConfigEntryState.LOADED,
     )
     mock_config_entry.add_to_hass(hass)
+    hass.config.components.add(DOMAIN)
 
     mock_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -251,6 +251,7 @@ async def test_reload_entry(hass: HomeAssistant, client) -> None:
         domain="kitchen_sink", state=core_ce.ConfigEntryState.LOADED
     )
     entry.add_to_hass(hass)
+    hass.config.components.add("kitchen_sink")
     resp = await client.post(
         f"/api/config/config_entries/entry/{entry.entry_id}/reload"
     )
@@ -298,6 +299,7 @@ async def test_reload_entry_in_failed_state(
     """Test reloading an entry via the API that has already failed to unload."""
     entry = MockConfigEntry(domain="demo", state=core_ce.ConfigEntryState.FAILED_UNLOAD)
     entry.add_to_hass(hass)
+    hass.config.components.add("demo")
     resp = await client.post(
         f"/api/config/config_entries/entry/{entry.entry_id}/reload"
     )
@@ -326,6 +328,7 @@ async def test_reload_entry_in_setup_retry(
     entry = MockConfigEntry(domain="comp", state=core_ce.ConfigEntryState.SETUP_RETRY)
     entry.supports_unload = True
     entry.add_to_hass(hass)
+    hass.config.components.add("comp")
 
     with patch.dict(HANDLERS, {"comp": ConfigFlow, "test": ConfigFlow}):
         resp = await client.post(
@@ -1109,6 +1112,7 @@ async def test_update_prefrences(
         domain="kitchen_sink", state=core_ce.ConfigEntryState.LOADED
     )
     entry.add_to_hass(hass)
+    hass.config.components.add("kitchen_sink")
 
     assert entry.pref_disable_new_entities is False
     assert entry.pref_disable_polling is False
@@ -1209,6 +1213,7 @@ async def test_disable_entry(
     )
     entry.add_to_hass(hass)
     assert entry.disabled_by is None
+    hass.config.components.add("kitchen_sink")
 
     # Disable
     await ws_client.send_json(

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -1873,6 +1873,7 @@ async def test_reload_entry_with_restored_subscriptions(
     # Setup the MQTT entry
     entry = MockConfigEntry(domain=mqtt.DOMAIN, data={mqtt.CONF_BROKER: "test-broker"})
     entry.add_to_hass(hass)
+    hass.config.components.add(mqtt.DOMAIN)
     mqtt_client_mock.connect.return_value = 0
     with patch("homeassistant.config.load_yaml_config_file", return_value={}):
         await entry.async_setup(hass)

--- a/tests/components/opower/test_config_flow.py
+++ b/tests/components/opower/test_config_flow.py
@@ -279,6 +279,7 @@ async def test_form_valid_reauth(
 ) -> None:
     """Test that we can handle a valid reauth."""
     mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    hass.config.components.add(DOMAIN)
     mock_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 
@@ -328,6 +329,7 @@ async def test_form_valid_reauth_with_mfa(
         },
     )
     mock_config_entry.mock_state(hass, ConfigEntryState.LOADED)
+    hass.config.components.add(DOMAIN)
     mock_config_entry.async_start_reauth(hass)
     await hass.async_block_till_done()
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -825,7 +825,7 @@ async def test_as_dict(snapshot: SnapshotAssertion) -> None:
         "error_reason_translation_placeholders",
         "_async_cancel_retry_setup",
         "_on_unload",
-        "reload_lock",
+        "setup_lock",
         "_reauth_lock",
         "_tasks",
         "_background_tasks",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If something triggers a config entry to reload while we are still in the setup of the underlying component/integration, the lock was not held because `async_setup_component` does not hold the reload lock.  We only had a lock to prevent concurrent reloads, and there wasn't anything to handle a reload during startup.  The common case is that there is a config entry update listener and it triggers a reload because something during its setup updates its config entry data.  

This has been a problem for a long time but it wasn't fast enough until 2024.5.x for us to see this happen on a regular basis.

`config_entries.async_remove` should also probably hold the lock to unload the entry and remove it but I didn't want to make that change in this PR as the problem is far less likely to happen

Rename the reload lock to setup lock.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #116480 fixes #116275 fixes #116479
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
