### PR TITLE
Add distinct import / export entities to Fronius

### DIFF
--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -549,6 +549,25 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_battery_discharge",
+        response_key="power_battery",
+        default_value=0,
+        value_fn=lambda value: max(value, 0),  # type: ignore[type-var]
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_battery_charge",
+        response_key="power_battery",
+        default_value=0,
+        value_fn=lambda value: max(0 - value, 0),  # type: ignore[operator]
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     FroniusSensorEntityDescription(
         key="power_grid",
@@ -556,10 +575,49 @@ POWER_FLOW_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_grid_import",
+        response_key="power_grid",
+        default_value=0,
+        value_fn=lambda value: max(value, 0),  # type: ignore[type-var]
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_grid_export",
+        response_key="power_grid",
+        default_value=0,
+        value_fn=lambda value: max(0 - value, 0),  # type: ignore[operator]
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
     ),
     FroniusSensorEntityDescription(
         key="power_load",
         default_value=0,
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_load_generated",
+        response_key="power_load",
+        default_value=0,
+        value_fn=lambda value: max(value, 0),  # type: ignore[type-var]
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+    ),
+    FroniusSensorEntityDescription(
+        key="power_load_consumed",
+        response_key="power_load",
+        default_value=0,
+        value_fn=lambda value: max(0 - value, 0),  # type: ignore[operator]
         native_unit_of_measurement=UnitOfPower.WATT,
         device_class=SensorDeviceClass.POWER,
         state_class=SensorStateClass.MEASUREMENT,
@@ -670,7 +728,7 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
         if self.entity_description.invalid_when_falsy and not new_value:
             return None
         if self.entity_description.value_fn is not None:
-            return self.entity_description.value_fn(new_value)
+            new_value = self.entity_description.value_fn(new_value)
         if isinstance(new_value, float):
             return round(new_value, 4)
         return new_value

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -234,11 +234,29 @@
       "power_battery": {
         "name": "Power battery"
       },
+      "power_battery_discharge": {
+        "name": "Power battery discharge"
+      },
+      "power_battery_charge": {
+        "name": "Power battery charge"
+      },
       "power_grid": {
         "name": "Power grid"
       },
+      "power_grid_import": {
+        "name": "Power grid import"
+      },
+      "power_grid_export": {
+        "name": "Power grid export"
+      },
       "power_load": {
         "name": "Power load"
+      },
+      "power_load_generated": {
+        "name": "Power load generated"
+      },
+      "power_load_consumed": {
+        "name": "Power load consumed"
       },
       "power_photovoltaics": {
         "name": "Power photovoltaics"

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -34,14 +34,14 @@ async def test_symo_inverter(
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 21
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 22
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     assert_state("sensor.symo_20_dc_current", 0)
     assert_state("sensor.symo_20_energy_day", 10828)
     assert_state("sensor.symo_20_total_energy", 44186900)
@@ -54,14 +54,14 @@ async def test_symo_inverter(
     freezer.tick(FroniusInverterUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 62
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 64
     # 4 additional AC entities
     assert_state("sensor.symo_20_dc_current", 2.19)
     assert_state("sensor.symo_20_energy_day", 1113)
@@ -97,7 +97,7 @@ async def test_symo_logger(
 
     mock_responses(aioclient_mock)
     await setup_fronius_integration(hass)
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 26
     # states are rounded to 4 decimals
     assert_state("sensor.solarnet_grid_export_tariff", 0.078)
     assert_state("sensor.solarnet_co2_factor", 0.53)
@@ -119,14 +119,14 @@ async def test_symo_meter(
     mock_responses(aioclient_mock)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 25
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 26
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 64
     # states are rounded to 4 decimals
     assert_state("sensor.smart_meter_63a_current_phase_1", 7.755)
     assert_state("sensor.smart_meter_63a_current_phase_2", 6.68)
@@ -222,20 +222,23 @@ async def test_symo_power_flow(
     mock_responses(aioclient_mock, night=True)
     config_entry = await setup_fronius_integration(hass)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 21
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 22
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusInverterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # states are rounded to 4 decimals
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
     assert_state("sensor.solarnet_energy_year", 25507686)
     assert_state("sensor.solarnet_power_grid", 975.31)
+    assert_state("sensor.solarnet_power_grid_import", 975.31)
+    assert_state("sensor.solarnet_power_grid_export", 0)
     assert_state("sensor.solarnet_power_load", -975.31)
+    assert_state("sensor.solarnet_power_load_consumed", 975.31)
     assert_state("sensor.solarnet_relative_autonomy", 0)
 
     # Second test at daytime when inverter is producing
@@ -244,12 +247,16 @@ async def test_symo_power_flow(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
     # 54 because power_flow `rel_SelfConsumption` and `P_PV` is not `null` anymore
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
     assert_state("sensor.solarnet_energy_day", 1101.7001)
     assert_state("sensor.solarnet_total_energy", 44188000)
     assert_state("sensor.solarnet_energy_year", 25508788)
     assert_state("sensor.solarnet_power_grid", 1703.74)
+    assert_state("sensor.solarnet_power_grid_import", 1703.74)
+    assert_state("sensor.solarnet_power_grid_export", 0)
     assert_state("sensor.solarnet_power_load", -2814.74)
+    assert_state("sensor.solarnet_power_load_generated", 0)
+    assert_state("sensor.solarnet_power_load_consumed", 2814.74)
     assert_state("sensor.solarnet_power_photovoltaics", 1111)
     assert_state("sensor.solarnet_relative_autonomy", 39.4708)
     assert_state("sensor.solarnet_relative_self_consumption", 100)
@@ -259,7 +266,7 @@ async def test_symo_power_flow(
     freezer.tick(FroniusPowerFlowUpdateCoordinator.default_interval)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 56
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 60
     assert_state("sensor.solarnet_energy_day", 10828)
     assert_state("sensor.solarnet_total_energy", 44186900)
     assert_state("sensor.solarnet_energy_year", 25507686)
@@ -285,14 +292,14 @@ async def test_gen24(
     mock_responses(aioclient_mock, fixture_set="gen24")
     config_entry = await setup_fronius_integration(hass, is_logger=False)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 23
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 24
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 54
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 58
     # inverter 1
     assert_state("sensor.inverter_name_ac_current", 0.1589)
     assert_state("sensor.inverter_name_dc_current_2", 0.0754)
@@ -386,14 +393,14 @@ async def test_gen24_storage(
         hass, is_logger=False, unique_id="12345678"
     )
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 35
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 37
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 66
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 72
     # inverter 1
     assert_state("sensor.gen24_storage_dc_current", 0.3952)
     assert_state("sensor.gen24_storage_dc_voltage_2", 318.8103)
@@ -452,6 +459,8 @@ async def test_gen24_storage(
     # power_flow
     assert_state("sensor.solarnet_power_grid", 2274.9)
     assert_state("sensor.solarnet_power_battery", 0.1591)
+    assert_state("sensor.solarnet_power_battery_charge", 0)
+    assert_state("sensor.solarnet_power_battery_discharge", 0.1591)
     assert_state("sensor.solarnet_power_load", -2459.3092)
     assert_state("sensor.solarnet_relative_self_consumption", 100.0)
     assert_state("sensor.solarnet_power_photovoltaics", 216.4328)
@@ -514,14 +523,14 @@ async def test_primo_s0(
     mock_responses(aioclient_mock, fixture_set="primo_s0", inverter_ids=[1, 2])
     config_entry = await setup_fronius_integration(hass, is_logger=True)
 
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 30
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 31
     await enable_all_entities(
         hass,
         freezer,
         config_entry.entry_id,
         FroniusMeterUpdateCoordinator.default_interval,
     )
-    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 43
+    assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 47
     # logger
     assert_state("sensor.solarnet_grid_export_tariff", 1)
     assert_state("sensor.solarnet_co2_factor", 0.53)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add distinct power entities to Fronius SolarNet device for
- grid import / export
- battery charge / discharge
- load consumed / generated

Default power entities use single entity with positive / negative values for this. Since energy dashboard requires distinct entities this is a common source of issues - especially for new users. The new entities make it clear which entity to use for Riemann sum and is also easier to read since users don't need to know about API internals (is a negative value "charge" or "discharge", "import" or "export" etc.)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33363

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
