### PR TITLE
Add support for tplink ks240 with fan

### DIFF
--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -21,4 +21,4 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
 CONF_DEVICE_CONFIG: Final = "device_config"
 
-PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: Final = [Platform.FAN, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -47,6 +47,7 @@ DEVICETYPES_WITH_SPECIALIZED_PLATFORMS = {
     DeviceType.Bulb,
     DeviceType.LightStrip,
     DeviceType.Dimmer,
+    DeviceType.Fan,
 }
 
 
@@ -181,8 +182,10 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
             return unique_id
 
         # For legacy sensors, we construct our IDs from the entity description
-        if self.entity_description is not None:
+        if hasattr(self, "entity_description") and self.entity_description is not None:
             return f"{legacy_device_id(device)}_{self.entity_description.key}"
+
+        return legacy_device_id(device)
 
     def _category_for_feature(self, feature: Feature | None) -> EntityCategory | None:
         """Return entity category for a feature."""

--- a/homeassistant/components/tplink/fan.py
+++ b/homeassistant/components/tplink/fan.py
@@ -1,0 +1,112 @@
+"""Support for TPLink Fan devices."""
+
+import logging
+import math
+from typing import Any
+
+from kasa import Device, Module
+from kasa.interfaces import Fan
+
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.percentage import (
+    percentage_to_ranged_value,
+    ranged_value_to_percentage,
+)
+from homeassistant.util.scaling import int_states_in_range
+
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import CoordinatedTPLinkEntity, async_refresh_after
+from .models import TPLinkData
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up fans."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = parent_coordinator.device
+    entities: list = []
+    if Module.Fan in device.modules:
+        entities.append(
+            TPLinkFan(device, parent_coordinator, device.modules[Module.Fan])
+        )
+    entities.extend(
+        TPLinkFan(child, parent_coordinator, child.modules[Module.Fan], parent=device)
+        for child in device.children
+        if Module.Fan in child.modules
+    )
+    async_add_entities(entities)
+
+
+SPEED_RANGE = (1, 4)  # off is not included
+
+
+class TPLinkFan(CoordinatedTPLinkEntity, FanEntity):
+    """Representation of a fan for a TPLink Fan device."""
+
+    _attr_speed_count = int_states_in_range(SPEED_RANGE)
+    _attr_supported_features = FanEntityFeature.SET_SPEED
+    _attr_name = None
+
+    def __init__(
+        self,
+        device: Device,
+        coordinator: TPLinkDataUpdateCoordinator,
+        fan_module: Fan,
+        parent: Device | None = None,
+    ) -> None:
+        """Initialize the fan."""
+        super().__init__(device, coordinator, parent=parent)
+        self.fan_module = fan_module
+        self._async_update_attrs()
+
+    @async_refresh_after
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        if percentage is not None:
+            value_in_range = math.ceil(
+                percentage_to_ranged_value(SPEED_RANGE, percentage)
+            )
+        else:
+            value_in_range = SPEED_RANGE[1]
+        await self.fan_module.set_fan_speed_level(value_in_range)
+
+    @async_refresh_after
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the fan off."""
+        await self.fan_module.set_fan_speed_level(0)
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the speed percentage of the fan."""
+        value_in_range = math.ceil(percentage_to_ranged_value(SPEED_RANGE, percentage))
+        await self.fan_module.set_fan_speed_level(value_in_range)
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        fan_speed = self.fan_module.fan_speed_level
+        self._attr_is_on = fan_speed != 0
+        if self._attr_is_on:
+            self._attr_percentage = ranged_value_to_percentage(SPEED_RANGE, fan_speed)
+        else:
+            self._attr_percentage = None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._async_update_attrs()
+        super()._handle_coordinator_update()

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -15,7 +15,7 @@ from kasa import (
     KasaException,
     Module,
 )
-from kasa.interfaces import Light, LightEffect
+from kasa.interfaces import Fan, Light, LightEffect, LightState
 from kasa.protocol import BaseProtocol
 
 from homeassistant.components.tplink import (
@@ -167,6 +167,9 @@ def _mocked_light_module() -> Light:
     light.update = AsyncMock()
     light.brightness = 50
     light.color_temp = 4000
+    light.state = LightState(
+        light_on=True, brightness=light.brightness, color_temp=light.color_temp
+    )
     light.is_color = True
     light.is_variable_color_temp = True
     light.is_dimmable = True
@@ -194,6 +197,13 @@ def _mocked_light_effect_module() -> LightEffect:
     return effect
 
 
+def _mocked_fan_module() -> Fan:
+    fan = MagicMock(auto_spec=Fan, name="Mocked fan")
+    fan.fan_speed_level = 0
+    fan.set_fan_speed_level = AsyncMock()
+    return fan
+
+
 def _mocked_strip_children(features=None) -> list[Device]:
     plug0 = _mocked_device(
         alias="Plug0",
@@ -217,6 +227,7 @@ def _mocked_strip_children(features=None) -> list[Device]:
 MODULE_TO_MOCK_GEN = {
     Module.Light: _mocked_light_module,
     Module.LightEffect: _mocked_light_effect_module,
+    Module.Fan: _mocked_fan_module,
 }
 
 FEATURE_TO_MOCK_GEN = {

--- a/tests/components/tplink/test_fan.py
+++ b/tests/components/tplink/test_fan.py
@@ -1,0 +1,95 @@
+"""Tests for fan platform."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from kasa import Module
+
+from homeassistant.components import tplink
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    DOMAIN as FAN_DOMAIN,
+    SERVICE_SET_PERCENTAGE,
+)
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
+
+from . import DEVICE_ID, MAC_ADDRESS, _mocked_device, _patch_connect, _patch_discovery
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+async def test_fan_unique_id(hass: HomeAssistant) -> None:
+    """Test a fan unique id."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    fan = _mocked_device(modules=[Module.Fan], alias="my_fan")
+    with _patch_discovery(device=fan), _patch_connect(device=fan):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "fan.my_fan"
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(entity_id).unique_id == DEVICE_ID
+
+
+async def test_fan(hass: HomeAssistant) -> None:
+    """Test a color fan and that all transitions are correctly passed."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    device = _mocked_device(modules=[Module.Fan], alias="my_fan")
+    fan = device.modules[Module.Fan]
+    fan.fan_speed_level = 0
+    with _patch_discovery(device=device), _patch_connect(device=device):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    entity_id = "fan.my_fan"
+
+    state = hass.states.get(entity_id)
+    assert state.state == "off"
+
+    await hass.services.async_call(
+        FAN_DOMAIN, "turn_on", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    fan.set_fan_speed_level.assert_called_once_with(4)
+    fan.set_fan_speed_level.reset_mock()
+
+    fan.fan_speed_level = 4
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state.state == "on"
+
+    await hass.services.async_call(
+        FAN_DOMAIN, "turn_off", {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    fan.set_fan_speed_level.assert_called_once_with(0)
+    fan.set_fan_speed_level.reset_mock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        "turn_on",
+        {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 50},
+        blocking=True,
+    )
+    fan.set_fan_speed_level.assert_called_once_with(2)
+    fan.set_fan_speed_level.reset_mock()
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 25},
+        blocking=True,
+    )
+    fan.set_fan_speed_level.assert_called_once_with(1)
+    fan.set_fan_speed_level.reset_mock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

PR for adding ks240 device with child devices and new fan entity.

See https://github.com/home-assistant/core/pull/117785 for an explanation of the approach for merging into the tplink_rewrite branch.

Parent (both child devices will display once the dimmer picks up other platforms):

![image](https://github.com/home-assistant/core/assets/51370195/bd64aaab-8615-42d7-add4-8158312b4ea8)


Child Fan:

![image](https://github.com/home-assistant/core/assets/51370195/0ccb9f73-6755-4eaa-9d73-7d5be8b51bf8)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33115

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
