### PR TITLE
Add constraint for tuf

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -192,3 +192,8 @@ pycountry>=23.12.11
 
 # scapy<2.5.0 will not work with python3.12
 scapy>=2.5.0
+
+# tuf isn't updated to deal with breaking changes in securesystemslib==1.0.
+# Only tuf>=4 includes a constraint to <1.0.
+# https://github.com/theupdateframework/python-tuf/releases/tag/v4.0.0
+tuf>=4.0.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -214,6 +214,11 @@ pycountry>=23.12.11
 
 # scapy<2.5.0 will not work with python3.12
 scapy>=2.5.0
+
+# tuf isn't updated to deal with breaking changes in securesystemslib==1.0.
+# Only tuf>=4 includes a constraint to <1.0.
+# https://github.com/theupdateframework/python-tuf/releases/tag/v4.0.0
+tuf>=4.0.0
 """
 
 GENERATED_MESSAGE = (


### PR DESCRIPTION
## Proposed change
`securesystemslib==1.0` was released today which contains breaking changes.
That lib is required by `tuf`. However, that lib isn't updated yet. Therefore they added a `<1.0` constraint in `v4`. For some reason `uv` seems to prefer the latest version of `securesystemslib` over `tuf` which causes the issue.

Adding the constraint forces the correct resolution.

Reverse dependency graph:
```
securesystemslib==1.0.0
├── sigstore==1.0.0 [requires: securesystemslib]
│   └── aiogithubapi==23.11.0 [requires: sigstore<2]
└── tuf==3.1.1 [requires: securesystemslib>=0.26.0]
    └── sigstore==1.0.0 [requires: tuf>=2.0.0]
        └── aiogithubapi==23.11.0 [requires: sigstore<2]
```

With constraint
```
securesystemslib==0.31.0
├── sigstore==1.0.0 [requires: securesystemslib]
│   └── aiogithubapi==23.11.0 [requires: sigstore<2]
└── tuf==4.0.0 [requires: securesystemslib>=0.26.0,<0.32.0]
    └── sigstore==1.0.0 [requires: tuf>=2.0.0]
        └── aiogithubapi==23.11.0 [requires: sigstore<2]
```

https://github.com/secure-systems-lab/securesystemslib/blob/v1.0.0/CHANGELOG.md#securesystemslib-v100
https://github.com/theupdateframework/python-tuf/releases/tag/v4.0.0

Failing workflow: https://github.com/home-assistant/core/actions/runs/8923946566/job/24510216051
```
...
venv/lib/python3.12/site-packages/tuf/api/metadata.py:59: in <module>
    from securesystemslib.util import persist_temp_file
E   ModuleNotFoundError: No module named 'securesystemslib.util'
=========================== short test summary info ============================
ERROR tests/components/github - ModuleNotFoundError: No module named 'securesystemslib.util'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
