### PR TITLE
Migrate bluetooth to use the singleton helper

### DIFF
--- a/homeassistant/components/bluetooth/__init__.py
+++ b/homeassistant/components/bluetooth/__init__.py
@@ -51,8 +51,9 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.issue_registry import async_delete_issue
 from homeassistant.loader import async_get_bluetooth
 
-from . import models, passive_update_processor
+from . import passive_update_processor
 from .api import (
+    _get_manager,
     async_address_present,
     async_ble_device_from_address,
     async_discovered_service_info,
@@ -76,7 +77,6 @@ from .const import (
     CONF_ADAPTER,
     CONF_DETAILS,
     CONF_PASSIVE,
-    DATA_MANAGER,
     DOMAIN,
     FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS,
     LINUX_FIRMWARE_LOAD_FALLBACK_SECONDS,
@@ -230,10 +230,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, integration_matcher, bluetooth_adapters, bluetooth_storage, slot_manager
     )
     set_manager(manager)
-
     await storage_setup_task
     await manager.async_setup()
-    hass.data[DATA_MANAGER] = models.MANAGER = manager
 
     hass.async_create_background_task(
         _async_start_adapter_discovery(hass, manager, bluetooth_adapters),
@@ -314,7 +312,7 @@ async def async_update_device(
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry for a bluetooth scanner."""
-    manager: HomeAssistantBluetoothManager = hass.data[DATA_MANAGER]
+    manager = _get_manager(hass)
     address = entry.unique_id
     assert address is not None
     adapter = await manager.async_get_adapter_from_address_or_recover(address)

--- a/homeassistant/components/bluetooth/api.py
+++ b/homeassistant/components/bluetooth/api.py
@@ -15,10 +15,12 @@ from habluetooth import (
     BluetoothScannerDevice,
     BluetoothScanningMode,
     HaBleakScannerWrapper,
+    get_manager,
 )
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback as hass_callback
+from homeassistant.helpers.singleton import singleton
 
 from .const import DATA_MANAGER
 from .manager import HomeAssistantBluetoothManager
@@ -29,9 +31,10 @@ if TYPE_CHECKING:
     from bleak.backends.device import BLEDevice
 
 
+@singleton(DATA_MANAGER)
 def _get_manager(hass: HomeAssistant) -> HomeAssistantBluetoothManager:
     """Get the bluetooth manager."""
-    return cast(HomeAssistantBluetoothManager, hass.data[DATA_MANAGER])
+    return cast(HomeAssistantBluetoothManager, get_manager())
 
 
 @hass_callback
@@ -68,8 +71,6 @@ def async_discovered_service_info(
     hass: HomeAssistant, connectable: bool = True
 ) -> Iterable[BluetoothServiceInfoBleak]:
     """Return the discovered devices list."""
-    if DATA_MANAGER not in hass.data:
-        return []
     return _get_manager(hass).async_discovered_service_info(connectable)
 
 
@@ -78,8 +79,6 @@ def async_last_service_info(
     hass: HomeAssistant, address: str, connectable: bool = True
 ) -> BluetoothServiceInfoBleak | None:
     """Return the last service info for an address."""
-    if DATA_MANAGER not in hass.data:
-        return None
     return _get_manager(hass).async_last_service_info(address, connectable)
 
 
@@ -88,8 +87,6 @@ def async_ble_device_from_address(
     hass: HomeAssistant, address: str, connectable: bool = True
 ) -> BLEDevice | None:
     """Return BLEDevice for an address if its present."""
-    if DATA_MANAGER not in hass.data:
-        return None
     return _get_manager(hass).async_ble_device_from_address(address, connectable)
 
 
@@ -106,8 +103,6 @@ def async_address_present(
     hass: HomeAssistant, address: str, connectable: bool = True
 ) -> bool:
     """Check if an address is present in the bluetooth device list."""
-    if DATA_MANAGER not in hass.data:
-        return False
     return _get_manager(hass).async_address_present(address, connectable)
 
 

--- a/homeassistant/components/bluetooth/config_flow.py
+++ b/homeassistant/components/bluetooth/config_flow.py
@@ -14,6 +14,7 @@ from bluetooth_adapters import (
     adapter_model,
     get_adapters,
 )
+from habluetooth import get_manager
 import voluptuous as vol
 
 from homeassistant.components import onboarding
@@ -25,7 +26,6 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from . import models
 from .const import CONF_ADAPTER, CONF_DETAILS, CONF_PASSIVE, DOMAIN
 from .util import adapter_title
 
@@ -185,4 +185,4 @@ class BluetoothConfigFlow(ConfigFlow, domain=DOMAIN):
     @callback
     def async_supports_options_flow(cls, config_entry: ConfigEntry) -> bool:
         """Return options flow support for this handler."""
-        return bool(models.MANAGER and models.MANAGER.supports_passive_scan)
+        return bool((manager := get_manager()) and manager.supports_passive_scan)

--- a/homeassistant/components/bluetooth/models.py
+++ b/homeassistant/components/bluetooth/models.py
@@ -4,16 +4,8 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from enum import Enum
-from typing import TYPE_CHECKING
 
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
-
-if TYPE_CHECKING:
-    from .manager import HomeAssistantBluetoothManager
-
-
-MANAGER: HomeAssistantBluetoothManager | None = None
-
 
 BluetoothChange = Enum("BluetoothChange", "ADVERTISEMENT")
 BluetoothCallback = Callable[[BluetoothServiceInfoBleak, BluetoothChange], None]

--- a/tests/components/bluetooth/test_init.py
+++ b/tests/components/bluetooth/test_init.py
@@ -8,7 +8,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 from bleak import BleakError
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 from bluetooth_adapters import DEFAULT_ADDRESS
-from habluetooth import scanner
+from habluetooth import scanner, set_manager
 from habluetooth.wrappers import HaBleakScannerWrapper
 import pytest
 
@@ -1154,6 +1154,7 @@ async def test_async_discovered_device_api(
 ) -> None:
     """Test the async_discovered_device API."""
     mock_bt = []
+    set_manager(None)
     with (
         patch(
             "homeassistant.components.bluetooth.async_get_bluetooth",
@@ -1169,8 +1170,10 @@ async def test_async_discovered_device_api(
             },
         ),
     ):
-        assert not bluetooth.async_discovered_service_info(hass)
-        assert not bluetooth.async_address_present(hass, "44:44:22:22:11:22")
+        with pytest.raises(RuntimeError, match="BluetoothManager has not been set"):
+            assert not bluetooth.async_discovered_service_info(hass)
+        with pytest.raises(RuntimeError, match="BluetoothManager has not been set"):
+            assert not bluetooth.async_address_present(hass, "44:44:22:22:11:22")
         await async_setup_with_default_adapter(hass)
 
         with patch.object(hass.config_entries.flow, "async_init"):
@@ -2744,6 +2747,7 @@ async def test_async_ble_device_from_address(
     hass: HomeAssistant, mock_bleak_scanner_start: MagicMock, macos_adapter: None
 ) -> None:
     """Test the async_ble_device_from_address api."""
+    set_manager(None)
     mock_bt = []
     with (
         patch(
@@ -2760,11 +2764,15 @@ async def test_async_ble_device_from_address(
             },
         ),
     ):
-        assert not bluetooth.async_discovered_service_info(hass)
-        assert not bluetooth.async_address_present(hass, "44:44:22:22:11:22")
-        assert (
-            bluetooth.async_ble_device_from_address(hass, "44:44:33:11:23:45") is None
-        )
+        with pytest.raises(RuntimeError, match="BluetoothManager has not been set"):
+            assert not bluetooth.async_discovered_service_info(hass)
+        with pytest.raises(RuntimeError, match="BluetoothManager has not been set"):
+            assert not bluetooth.async_address_present(hass, "44:44:22:22:11:22")
+        with pytest.raises(RuntimeError, match="BluetoothManager has not been set"):
+            assert (
+                bluetooth.async_ble_device_from_address(hass, "44:44:33:11:23:45")
+                is None
+            )
 
         await async_setup_with_default_adapter(hass)
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate bluetooth to use the singleton helper

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
