### PR TITLE
Use ConfigEntry runtime_data in TwenteMilieu

### DIFF
--- a/homeassistant/components/twentemilieu/__init__.py
+++ b/homeassistant/components/twentemilieu/__init__.py
@@ -23,6 +23,9 @@ SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_ID): cv.string})
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
 
+TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator[dict[WasteType, list[date]]]
+TwenteMilieuConfigEntry = ConfigEntry[TwenteMilieuDataUpdateCoordinator]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Twente Milieu from a config entry."""
@@ -34,14 +37,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         session=session,
     )
 
-    coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]] = (
-        DataUpdateCoordinator(
-            hass,
-            LOGGER,
-            name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
-            update_method=twentemilieu.update,
-        )
+    coordinator: TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name=DOMAIN,
+        update_interval=SCAN_INTERVAL,
+        update_method=twentemilieu.update,
     )
     await coordinator.async_config_entry_first_refresh()
 
@@ -51,7 +52,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, unique_id=str(entry.data[CONF_ID])
         )
 
-    hass.data.setdefault(DOMAIN, {})[entry.data[CONF_ID]] = coordinator
+    entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
@@ -59,7 +60,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload Twente Milieu config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        del hass.data[DOMAIN][entry.data[CONF_ID]]
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/twentemilieu/calendar.py
+++ b/homeassistant/components/twentemilieu/calendar.py
@@ -2,30 +2,26 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
-
-from twentemilieu import WasteType
+from datetime import datetime, timedelta
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import homeassistant.util.dt as dt_util
 
-from .const import DOMAIN, WASTE_TYPE_TO_DESCRIPTION
+from . import TwenteMilieuConfigEntry
+from .const import WASTE_TYPE_TO_DESCRIPTION
 from .entity import TwenteMilieuEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TwenteMilieuConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Twente Milieu calendar based on a config entry."""
-    coordinator = hass.data[DOMAIN][entry.data[CONF_ID]]
-    async_add_entities([TwenteMilieuCalendar(coordinator, entry)])
+    async_add_entities([TwenteMilieuCalendar(entry)])
 
 
 class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
@@ -35,13 +31,9 @@ class TwenteMilieuCalendar(TwenteMilieuEntity, CalendarEntity):
     _attr_name = None
     _attr_translation_key = "calendar"
 
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]],
-        entry: ConfigEntry,
-    ) -> None:
+    def __init__(self, entry: TwenteMilieuConfigEntry) -> None:
         """Initialize the Twente Milieu entity."""
-        super().__init__(coordinator, entry)
+        super().__init__(entry)
         self._attr_unique_id = str(entry.data[CONF_ID])
         self._event: CalendarEvent | None = None
 

--- a/homeassistant/components/twentemilieu/diagnostics.py
+++ b/homeassistant/components/twentemilieu/diagnostics.py
@@ -2,29 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import date
 from typing import Any
 
-from twentemilieu import WasteType
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-
-from .const import DOMAIN
 
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]] = hass.data[DOMAIN][
-        entry.data[CONF_ID]
-    ]
     return {
         f"WasteType.{waste_type.name}": [
             waste_date.isoformat() for waste_date in waste_dates
         ]
-        for waste_type, waste_dates in coordinator.data.items()
+        for waste_type, waste_dates in entry.runtime_data.data.items()
     }

--- a/homeassistant/components/twentemilieu/entity.py
+++ b/homeassistant/components/twentemilieu/entity.py
@@ -2,36 +2,24 @@
 
 from __future__ import annotations
 
-from datetime import date
-
-from twentemilieu import WasteType
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import TwenteMilieuDataUpdateCoordinator
 from .const import DOMAIN
 
 
-class TwenteMilieuEntity(
-    CoordinatorEntity[DataUpdateCoordinator[dict[WasteType, list[date]]]], Entity
-):
+class TwenteMilieuEntity(CoordinatorEntity[TwenteMilieuDataUpdateCoordinator], Entity):
     """Defines a Twente Milieu entity."""
 
     _attr_has_entity_name = True
 
-    def __init__(
-        self,
-        coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]],
-        entry: ConfigEntry,
-    ) -> None:
+    def __init__(self, entry: ConfigEntry) -> None:
         """Initialize the Twente Milieu entity."""
-        super().__init__(coordinator=coordinator)
+        super().__init__(coordinator=entry.runtime_data)
         self._attr_device_info = DeviceInfo(
             configuration_url="https://www.twentemilieu.nl",
             entry_type=DeviceEntryType.SERVICE,

--- a/homeassistant/components/twentemilieu/sensor.py
+++ b/homeassistant/components/twentemilieu/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 from .entity import TwenteMilieuEntity
@@ -69,9 +68,8 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Twente Milieu sensor based on a config entry."""
-    coordinator = hass.data[DOMAIN][entry.data[CONF_ID]]
     async_add_entities(
-        TwenteMilieuSensor(coordinator, description, entry) for description in SENSORS
+        TwenteMilieuSensor(entry, description) for description in SENSORS
     )
 
 
@@ -82,12 +80,11 @@ class TwenteMilieuSensor(TwenteMilieuEntity, SensorEntity):
 
     def __init__(
         self,
-        coordinator: DataUpdateCoordinator[dict[WasteType, list[date]]],
-        description: TwenteMilieuSensorDescription,
         entry: ConfigEntry,
+        description: TwenteMilieuSensorDescription,
     ) -> None:
         """Initialize the Twente Milieu entity."""
-        super().__init__(coordinator, entry)
+        super().__init__(entry)
         self.entity_description = description
         self._attr_unique_id = f"{DOMAIN}_{entry.data[CONF_ID]}_{description.key}"
 

--- a/tests/components/twentemilieu/test_init.py
+++ b/tests/components/twentemilieu/test_init.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from homeassistant.components.twentemilieu.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -26,7 +25,6 @@ async def test_load_unload_config_entry(
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert not hass.data.get(DOMAIN)
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SSIA, moves the Twente Milieu integration to use the `runtime_data` attribute of the `ConfigEntry` instead of `hass.data`.

Cleans up quite a bit of typing and imports.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
