### PR TITLE
Fix wiz test warning

### DIFF
--- a/tests/components/wiz/test_init.py
+++ b/tests/components/wiz/test_init.py
@@ -44,7 +44,7 @@ async def test_cleanup_on_shutdown(hass: HomeAssistant) -> None:
     _, entry = await async_setup_integration(hass, wizlight=bulb)
     assert entry.state is ConfigEntryState.LOADED
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
     bulb.async_close.assert_called_once()
 
 
@@ -63,7 +63,7 @@ async def test_cleanup_on_failed_first_update(hass: HomeAssistant) -> None:
         _patch_wizlight(device=bulb),
     ):
         await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
     assert entry.state is ConfigEntryState.SETUP_RETRY
     bulb.async_close.assert_called_once()
 
@@ -74,6 +74,7 @@ async def test_wrong_device_now_has_our_ip(hass: HomeAssistant) -> None:
     bulb.mac = "dddddddddddd"
     _, entry = await async_setup_integration(hass, wizlight=bulb)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_reload_on_title_change(hass: HomeAssistant) -> None:
@@ -81,12 +82,12 @@ async def test_reload_on_title_change(hass: HomeAssistant) -> None:
     bulb = _mocked_wizlight(None, None, FAKE_SOCKET)
     _, entry = await async_setup_integration(hass, wizlight=bulb)
     assert entry.state is ConfigEntryState.LOADED
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     with _patch_discovery(), _patch_wizlight(device=bulb):
         hass.config_entries.async_update_entry(entry, title="Shop Switch")
         assert entry.title == "Shop Switch"
-        await hass.async_block_till_done()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert (
         hass.states.get("switch.mock_title").attributes[ATTR_FRIENDLY_NAME]


### PR DESCRIPTION
## Proposed change
```
tests/components/wiz/test_init.py::test_reload_on_title_change
  /home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/_pytest/unraisableexception.py:80: PytestUnraisableExceptionWarning: Exception ignored in: <function wizlight.__del__ at 0x7f155bd7c680>
  
  Traceback (most recent call last):
    File "/home/runner/work/ha-core/ha-core/venv/lib/python3.12/site-packages/pywizlight/bulb.py", line 800, in __del__
      self.loop.call_soon_threadsafe(self._async_close)
    File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/asyncio/base_events.py", line 840, in call_soon_threadsafe
      self._check_closed()
    File "/opt/hostedtoolcache/Python/3.12.3/x64/lib/python3.12/asyncio/base_events.py", line 541, in _check_closed
      raise RuntimeError('Event loop is closed')
  RuntimeError: Event loop is closed
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
