### PR TITLE
Move Brother DataUpdateCoordinator to the coordinator module

### DIFF
--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from brother import Brother, SnmpError
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -46,16 +46,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> 
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
+    loaded_entries = [
+        entry
+        for entry in hass.config_entries.async_entries(DOMAIN)
+        if entry.state == ConfigEntryState.LOADED
+    ]
     # We only want to remove the SNMP engine when unloading the last config entry
-    if (
-        unload_ok
-        and len(
-            hass.config_entries.async_entries(
-                DOMAIN, include_ignore=False, include_disabled=False
-            )
-        )
-        == 1
-    ):
+    if unload_ok and len(loaded_entries) == 1:
         hass.data[DOMAIN].pop(SNMP)
 
     return unload_ok

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -2,29 +2,23 @@
 
 from __future__ import annotations
 
-from asyncio import timeout
-from datetime import timedelta
-import logging
-
-from brother import Brother, BrotherSensors, SnmpError, UnsupportedModelError
+from brother import Brother, SnmpError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_CONFIG_ENTRY, DOMAIN, SNMP
+from .const import DOMAIN, SNMP
+from .coordinator import BrotherDataUpdateCoordinator
 from .utils import get_snmp_engine
 
 PLATFORMS = [Platform.SENSOR]
 
-SCAN_INTERVAL = timedelta(seconds=30)
-
-_LOGGER = logging.getLogger(__name__)
+BrotherConfigEntry = ConfigEntry[BrotherDataUpdateCoordinator]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Set up Brother from a config entry."""
     host = entry.data[CONF_HOST]
     printer_type = entry.data[CONF_TYPE]
@@ -40,48 +34,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = BrotherDataUpdateCoordinator(hass, brother)
     await coordinator.async_config_entry_first_refresh()
 
+    entry.runtime_data = coordinator
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(DATA_CONFIG_ENTRY, {})
-    hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id] = coordinator
-    hass.data[DOMAIN][SNMP] = snmp_engine
+    hass.data[DOMAIN] = {SNMP: snmp_engine}
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
-        hass.data[DOMAIN][DATA_CONFIG_ENTRY].pop(entry.entry_id)
-        if not hass.data[DOMAIN][DATA_CONFIG_ENTRY]:
+        # We only want to remove the SNMP engine when unloading the last config entry
+        if len(hass.config_entries.async_entries(DOMAIN)) == 1:
             hass.data[DOMAIN].pop(SNMP)
-            hass.data[DOMAIN].pop(DATA_CONFIG_ENTRY)
 
     return unload_ok
-
-
-class BrotherDataUpdateCoordinator(DataUpdateCoordinator[BrotherSensors]):  # pylint: disable=hass-enforce-coordinator-module
-    """Class to manage fetching Brother data from the printer."""
-
-    def __init__(self, hass: HomeAssistant, brother: Brother) -> None:
-        """Initialize."""
-        self.brother = brother
-
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
-        )
-
-    async def _async_update_data(self) -> BrotherSensors:
-        """Update data via library."""
-        try:
-            async with timeout(20):
-                data = await self.brother.async_update()
-        except (ConnectionError, SnmpError, UnsupportedModelError) as error:
-            raise UpdateFailed(error) from error
-        return data

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -46,9 +46,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> 
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
-    if unload_ok:
-        # We only want to remove the SNMP engine when unloading the last config entry
-        if len(hass.config_entries.async_entries(DOMAIN)) == 1:
-            hass.data[DOMAIN].pop(SNMP)
+    # We only want to remove the SNMP engine when unloading the last config entry
+    if (
+        unload_ok
+        and len(
+            hass.config_entries.async_entries(
+                DOMAIN, include_ignore=False, include_disabled=False
+            )
+        )
+        == 1
+    ):
+        hass.data[DOMAIN].pop(SNMP)
 
     return unload_ok

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -35,7 +35,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> b
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
-    hass.data.setdefault(DOMAIN, {})
     hass.data.setdefault(DOMAIN, {SNMP: snmp_engine})
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> b
 
     entry.runtime_data = coordinator
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN] = {SNMP: snmp_engine}
+    hass.data.setdefault(DOMAIN, {SNMP: snmp_engine})
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Final
-
-DATA_CONFIG_ENTRY: Final = "config_entry"
 
 DOMAIN: Final = "brother"
 
 PRINTER_TYPES: Final = ["laser", "ink"]
 
 SNMP: Final = "snmp"
+
+UPDATE_INTERVAL = timedelta(seconds=30)

--- a/homeassistant/components/brother/coordinator.py
+++ b/homeassistant/components/brother/coordinator.py
@@ -1,0 +1,37 @@
+"""Coordinator for Brother integration."""
+
+from asyncio import timeout
+import logging
+
+from brother import Brother, BrotherSensors, SnmpError, UnsupportedModelError
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, UPDATE_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BrotherDataUpdateCoordinator(DataUpdateCoordinator[BrotherSensors]):
+    """Class to manage fetching Brother data from the printer."""
+
+    def __init__(self, hass: HomeAssistant, brother: Brother) -> None:
+        """Initialize."""
+        self.brother = brother
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> BrotherSensors:
+        """Update data via library."""
+        try:
+            async with timeout(20):
+                data = await self.brother.async_update()
+        except (ConnectionError, SnmpError, UnsupportedModelError) as error:
+            raise UpdateFailed(error) from error
+        return data

--- a/homeassistant/components/brother/diagnostics.py
+++ b/homeassistant/components/brother/diagnostics.py
@@ -5,20 +5,16 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import BrotherDataUpdateCoordinator
-from .const import DATA_CONFIG_ENTRY, DOMAIN
+from . import BrotherConfigEntry
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, config_entry: ConfigEntry
+    hass: HomeAssistant, config_entry: BrotherConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: BrotherDataUpdateCoordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][
-        config_entry.entry_id
-    ]
+    coordinator = config_entry.runtime_data
 
     return {
         "info": dict(config_entry.data),

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
@@ -25,8 +24,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import BrotherDataUpdateCoordinator
-from .const import DATA_CONFIG_ENTRY, DOMAIN
+from . import BrotherConfigEntry, BrotherDataUpdateCoordinator
+from .const import DOMAIN
 
 ATTR_COUNTER = "counter"
 ATTR_REMAINING_PAGES = "remaining_pages"
@@ -318,11 +317,12 @@ SENSOR_TYPES: tuple[BrotherSensorEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: BrotherConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add Brother entities from a config_entry."""
-    coordinator = hass.data[DOMAIN][DATA_CONFIG_ENTRY][entry.entry_id]
-
+    coordinator = entry.runtime_data
     # Due to the change of the attribute name of one sensor, it is necessary to migrate
     # the unique_id to the new one.
     entity_registry = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- moves `BrotherDataUpdateCoordinator` to the coordinator module
- migrates data storage from `hass.data` to `config_entry.runtime_data`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
