### PR TITLE
fix UnboundLocalError on modified_statistic_ids in compile_statistics

### DIFF
--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -488,7 +488,7 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
     # Define modified_statistic_ids outside of the "with" statement as context managers
     # with exception suppressing prevent defining the value of the local variable, yet
     # the flow continues
-    modified_statistic_ids = None
+    modified_statistic_ids: set[str] | None = None
 
     # Return if we already have 5-minute statistics for the requested period
     with session_scope(

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -485,6 +485,11 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
 
     The actual calculation is delegated to the platforms.
     """
+    # Define modified_statistic_ids outside of the "with" statement as context managers
+    # with exception suppressing prevent defining the value of the local variable, yet
+    # the flow continues
+    modified_statistic_ids = None
+
     # Return if we already have 5-minute statistics for the requested period
     with session_scope(
         session=instance.get_session(),
@@ -496,17 +501,13 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
             instance, session, start, fire_events
         )
 
-        if modified_statistic_ids:
-            # In the rare case that we have modified statistic_ids, we reload the modified
-            # statistics meta data into the cache in a fresh session to ensure that the
-            # cache is up to date and future calls to get statistics meta data will
-            # not have to hit the database again.
-            with session_scope(
-                session=instance.get_session(), read_only=True
-            ) as session:
-                instance.statistics_meta_manager.get_many(
-                    session, modified_statistic_ids
-                )
+    if modified_statistic_ids:
+        # In the rare case that we have modified statistic_ids, we reload the modified
+        # statistics meta data into the cache in a fresh session to ensure that the
+        # cache is up to date and future calls to get statistics meta data will
+        # not have to hit the database again.
+        with session_scope(session=instance.get_session(), read_only=True) as session:
+            instance.statistics_meta_manager.get_many(session, modified_statistic_ids)
 
     return True
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -485,6 +485,11 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
 
     The actual calculation is delegated to the platforms.
     """
+    # Define modified_statistic_ids outside of the "with" statement as context managers
+    # with exception suppressing prevent defining the value of the local variable, yet
+    # the flow continues
+    modified_statistic_ids = None
+
     # Return if we already have 5-minute statistics for the requested period
     with session_scope(
         session=instance.get_session(),

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -485,9 +485,9 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
 
     The actual calculation is delegated to the platforms.
     """
-    # Define modified_statistic_ids outside of the "with" statement as context managers
-    # with exception suppressing prevent defining the value of the local variable, yet
-    # the flow continues
+    # Define modified_statistic_ids outside of the "with" statement as
+    # filter_unique_constraint_integrity_error may raise an exception
+    # which would prevent the variable from being defined.
     modified_statistic_ids: set[str] | None = None
 
     # Return if we already have 5-minute statistics for the requested period

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -485,11 +485,6 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
 
     The actual calculation is delegated to the platforms.
     """
-    # Define modified_statistic_ids outside of the "with" statement as context managers
-    # with exception suppressing prevent defining the value of the local variable, yet
-    # the flow continues
-    modified_statistic_ids = None
-
     # Return if we already have 5-minute statistics for the requested period
     with session_scope(
         session=instance.get_session(),
@@ -501,13 +496,17 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
             instance, session, start, fire_events
         )
 
-    if modified_statistic_ids:
-        # In the rare case that we have modified statistic_ids, we reload the modified
-        # statistics meta data into the cache in a fresh session to ensure that the
-        # cache is up to date and future calls to get statistics meta data will
-        # not have to hit the database again.
-        with session_scope(session=instance.get_session(), read_only=True) as session:
-            instance.statistics_meta_manager.get_many(session, modified_statistic_ids)
+        if modified_statistic_ids:
+            # In the rare case that we have modified statistic_ids, we reload the modified
+            # statistics meta data into the cache in a fresh session to ensure that the
+            # cache is up to date and future calls to get statistics meta data will
+            # not have to hit the database again.
+            with session_scope(
+                session=instance.get_session(), read_only=True
+            ) as session:
+                instance.statistics_meta_manager.get_many(
+                    session, modified_statistic_ids
+                )
 
     return True
 

--- a/homeassistant/components/recorder/statistics.py
+++ b/homeassistant/components/recorder/statistics.py
@@ -486,8 +486,9 @@ def compile_statistics(instance: Recorder, start: datetime, fire_events: bool) -
     The actual calculation is delegated to the platforms.
     """
     # Define modified_statistic_ids outside of the "with" statement as
-    # filter_unique_constraint_integrity_error may raise an exception
-    # which would prevent the variable from being defined.
+    # _compile_statistics may raise and be trapped by
+    # filter_unique_constraint_integrity_error which would make
+    # modified_statistic_ids unbound.
     modified_statistic_ids: set[str] | None = None
 
     # Return if we already have 5-minute statistics for the requested period


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR suppresses an UnboundLocalError that occurs when an exception that occurs in the `with` statement
is suppressed by the context manager:

```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/recorder/core.py", line 902, in _guarded_process_one_task_or_event_or_recover
    self._process_one_task_or_event_or_recover(task)
  File "/usr/src/homeassistant/homeassistant/components/recorder/core.py", line 922, in _process_one_task_or_event_or_recover
    return task.run(self)
           ^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/recorder/tasks.py", line 166, in run
    if statistics.compile_statistics(instance, self.start, self.fire_events):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/recorder/util.py", line 646, in wrapper
    return job(instance, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/recorder/statistics.py", line 499, in compile_statistics
    if modified_statistic_ids:
       ^^^^^^^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'modified_statistic_ids' where it is not associated with a value
```

This was apparently introduced by https://github.com/home-assistant/core/pull/112718/files#diff-7dd2c3612718f829e43c0afeb9659ec0d0b0d50fa0094091664646bdbf8e813eR66

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
