### PR TITLE
Switch out aiohttp-isal for aiohttp-fast-zlib to make isal optional

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -693,6 +693,7 @@ build.json @home-assistant/supervisor
 /tests/components/iqvia/ @bachya
 /homeassistant/components/irish_rail_transport/ @ttroy50
 /homeassistant/components/isal/ @bdraco
+/tests/components/isal/ @bdraco
 /homeassistant/components/islamic_prayer_times/ @engrbm87 @cpfair
 /tests/components/islamic_prayer_times/ @engrbm87 @cpfair
 /homeassistant/components/iss/ @DurgNomis-drol

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -692,6 +692,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/iqvia/ @bachya
 /tests/components/iqvia/ @bachya
 /homeassistant/components/irish_rail_transport/ @ttroy50
+/homeassistant/components/isal/ @bdraco
 /homeassistant/components/islamic_prayer_times/ @engrbm87 @cpfair
 /tests/components/islamic_prayer_times/ @engrbm87 @cpfair
 /homeassistant/components/iss/ @DurgNomis-drol

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -21,7 +21,7 @@ from aiohttp.typedefs import JSONDecoder, StrOrURL
 from aiohttp.web_exceptions import HTTPMovedPermanently, HTTPRedirection
 from aiohttp.web_protocol import RequestHandler
 from aiohttp_fast_url_dispatcher import FastUrlDispatcher, attach_fast_url_dispatcher
-from aiohttp_isal import enable_isal
+import aiohttp_fast_zlib
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -201,7 +201,7 @@ class ApiConfig:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HTTP API and debug interface."""
-    enable_isal()
+    aiohttp_fast_zlib.enable()
 
     conf: ConfData | None = config.get(DOMAIN)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -21,7 +21,6 @@ from aiohttp.typedefs import JSONDecoder, StrOrURL
 from aiohttp.web_exceptions import HTTPMovedPermanently, HTTPRedirection
 from aiohttp.web_protocol import RequestHandler
 from aiohttp_fast_url_dispatcher import FastUrlDispatcher, attach_fast_url_dispatcher
-import aiohttp_fast_zlib
 from cryptography import x509
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -54,6 +53,7 @@ from homeassistant.helpers.http import (
     HomeAssistantView,
     current_request,
 )
+from homeassistant.helpers.importlib import async_import_module
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
@@ -201,7 +201,9 @@ class ApiConfig:
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HTTP API and debug interface."""
-    aiohttp_fast_zlib.enable()
+    # Late import to ensure isal is updated before
+    # we import aiohttp_fast_zlib
+    (await async_import_module(hass, "aiohttp_fast_zlib")).enable()
 
     conf: ConfData | None = config.get(DOMAIN)
 

--- a/homeassistant/components/http/manifest.json
+++ b/homeassistant/components/http/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "http",
   "name": "HTTP",
+  "after_dependencies": ["isal"],
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/http",
   "integration_type": "system",

--- a/homeassistant/components/isal/__init__.py
+++ b/homeassistant/components/isal/__init__.py
@@ -1,0 +1,20 @@
+"""The isal integration."""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+DOMAIN = "isal"
+
+CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up up isal.
+
+    This integration is only used so that isal can be an optional
+    dep for aiohttp-fast-zlib.
+    """
+    return True

--- a/homeassistant/components/isal/manifest.json
+++ b/homeassistant/components/isal/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "isal",
+  "name": "Intelligent Storage Acceleration",
+  "documentation": "https://www.home-assistant.io/integrations/http",
+  "codeowners": ["@bdraco"],
+  "integration_type": "system",
+  "quality_scale": "internal",
+  "requirements": "isal==1.6.1"
+}

--- a/homeassistant/components/isal/manifest.json
+++ b/homeassistant/components/isal/manifest.json
@@ -5,5 +5,5 @@
   "codeowners": ["@bdraco"],
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": "isal==1.6.1"
+  "requirements": ["isal==1.6.1"]
 }

--- a/homeassistant/components/isal/manifest.json
+++ b/homeassistant/components/isal/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "isal",
   "name": "Intelligent Storage Acceleration",
-  "documentation": "https://www.home-assistant.io/integrations/http",
+  "documentation": "https://www.home-assistant.io/integrations/isal",
   "codeowners": ["@bdraco"],
   "integration_type": "system",
   "quality_scale": "internal",

--- a/homeassistant/components/isal/manifest.json
+++ b/homeassistant/components/isal/manifest.json
@@ -1,9 +1,10 @@
 {
   "domain": "isal",
   "name": "Intelligent Storage Acceleration",
-  "documentation": "https://www.home-assistant.io/integrations/isal",
   "codeowners": ["@bdraco"],
+  "documentation": "https://www.home-assistant.io/integrations/isal",
   "integration_type": "system",
+  "iot_class": "local_polling",
   "quality_scale": "internal",
   "requirements": ["isal==1.6.1"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodhcpwatcher==1.0.0
 aiodiscover==2.1.0
 aiodns==3.2.0
 aiohttp-fast-url-dispatcher==0.3.0
-aiohttp-isal==0.3.1
+aiohttp-fast-zlib==0.1.0
 aiohttp==3.9.5
 aiohttp_cors==0.7.0
 aiohttp_session==2.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies    = [
     "aiohttp_cors==0.7.0",
     "aiohttp_session==2.12.0",
     "aiohttp-fast-url-dispatcher==0.3.0",
-    "aiohttp-isal==0.3.1",
+    "aiohttp-fast-zlib==0.1.0",
     "astral==2.2",
     "async-interrupt==1.1.1",
     "attrs==23.2.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ aiohttp==3.9.5
 aiohttp_cors==0.7.0
 aiohttp_session==2.12.0
 aiohttp-fast-url-dispatcher==0.3.0
-aiohttp-isal==0.3.1
+aiohttp-fast-zlib==0.1.0
 astral==2.2
 async-interrupt==1.1.1
 attrs==23.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1160,6 +1160,9 @@ intellifire4py==2.2.2
 # homeassistant.components.iperf3
 iperf3==0.1.11
 
+# homeassistant.components.isal
+isal==1.6.1
+
 # homeassistant.components.gogogate2
 ismartgate==5.0.1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -941,6 +941,9 @@ insteon-frontend-home-assistant==0.5.0
 # homeassistant.components.intellifire
 intellifire4py==2.2.2
 
+# homeassistant.components.isal
+isal==1.6.1
+
 # homeassistant.components.gogogate2
 ismartgate==5.0.1
 

--- a/tests/components/isal/__init__.py
+++ b/tests/components/isal/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Bluetooth Adapters integration."""

--- a/tests/components/isal/__init__.py
+++ b/tests/components/isal/__init__.py
@@ -1,1 +1,1 @@
-"""Tests for the Bluetooth Adapters integration."""
+"""Tests for the Intelligent Storage Acceleration integration."""

--- a/tests/components/isal/test_init.py
+++ b/tests/components/isal/test_init.py
@@ -1,0 +1,10 @@
+"""Test the Bluetooth Adapters setup."""
+
+from homeassistant.components.isal import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+async def test_setup(hass: HomeAssistant) -> None:
+    """Ensure we can setup."""
+    assert await async_setup_component(hass, DOMAIN, {})

--- a/tests/components/isal/test_init.py
+++ b/tests/components/isal/test_init.py
@@ -1,4 +1,4 @@
-"""Test the Bluetooth Adapters setup."""
+"""Test the Intelligent Storage Acceleration setup."""
 
 from homeassistant.components.isal import DOMAIN
 from homeassistant.core import HomeAssistant

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -591,7 +591,7 @@ async def test_discovery_requirements_mqtt(hass: HomeAssistant) -> None:
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "mqtt_comp")
 
-    assert len(mock_process.mock_calls) == 1
+    assert len(mock_process.mock_calls) == 2
     assert mock_process.mock_calls[0][1][1] == mqtt.requirements
 
 
@@ -608,12 +608,13 @@ async def test_discovery_requirements_ssdp(hass: HomeAssistant) -> None:
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "ssdp_comp")
 
-    assert len(mock_process.mock_calls) == 3
+    assert len(mock_process.mock_calls) == 4
     assert mock_process.mock_calls[0][1][1] == ssdp.requirements
     assert {
         mock_process.mock_calls[1][1][0],
         mock_process.mock_calls[2][1][0],
-    } == {"network", "recorder"}
+        mock_process.mock_calls[3][1][0],
+    } == {"network", "recorder", "isal"}
 
 
 @pytest.mark.parametrize(
@@ -637,7 +638,7 @@ async def test_discovery_requirements_zeroconf(
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "comp")
 
-    assert len(mock_process.mock_calls) == 3
+    assert len(mock_process.mock_calls) == 4
     assert mock_process.mock_calls[0][1][1] == zeroconf.requirements
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A new library https://github.com/bdraco/aiohttp-fast-zlib / https://pypi.org/project/aiohttp-fast-zlib/ has been created which will only use `isal` if it is installed, and than degrade gracefully to use `zlib_ng`, and finally base `zlib` if `zlib_ng` is not available.

`aiohttp-isal` does not work on core installs where the system has 32bit userland and a 64bit kernel because it cannot build correctly, and we have no way to detect this configuration or handle it with dep specifiers: https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers. Additionally there may be some core installs on obscure systems that have trouble building wheels. 

**This does not affect containers or common systems since we have wheels available and isal already publishes wheels for most common systems https://pypi.org/project/isal/#files**.  

I had originally gone with an approach in https://github.com/home-assistant/core/pull/116811, but that required restoring the complexity in CI that we removed in #115767 so I threw that away and implemented as integration to avoid that complexity.

[Intelligent Storage Acceleration](https://github.com/intel/isa-l), is used for accelerating [`aiohttp`](https://github.com/aio-libs/aiohttp) since it can [speed up](https://github.com/pycompression/python-isal/tree/develop/benchmark_scripts) compression as much as 5x. Its how we are able to deliver fast backups in `supervisor`. Currently core install backups do not use `isal` yet.  Long term we would like to be able to use `isal` for core backups as well.

Configuration of this integration only applies to core install types. Container-based installs already have `isal` pre-installed since its included in requirements in the `isal` integration, and `aiohttp-fast-zlib` will see its available and automatically use it, and no action is required.

For core installs, `isal` can be installed from `pypi` or the `isal` integration can manually be added to `configuration.yaml` to keep `isal` up to date if wheels are available for the system.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #116681
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32588

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
