### PR TITLE
Avoid duplicate data fetch during Synologs DSM setup

### DIFF
--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -86,12 +86,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     coordinator_central = SynologyDSMCentralUpdateCoordinator(hass, entry, api)
-    await coordinator_central.async_config_entry_first_refresh()
 
     available_apis = api.dsm.apis
 
-    # The central coordinator needs to be refreshed first since
-    # the next two rely on data from it
     coordinator_cameras: SynologyDSMCameraUpdateCoordinator | None = None
     if api.surveillance_station is not None:
         coordinator_cameras = SynologyDSMCameraUpdateCoordinator(hass, entry, api)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
we already setup the api in 

https://github.com/home-assistant/core/blob/f5394dc3a3d023b3cb22dafc8d8435679fcda408/homeassistant/components/synology_dsm/__init__.py#L66-L69

so the first data fetch of the central coordinator is not needed and just leads to a duplicated fetch of all data at startup

#### prior this change:
```
2024-05-05 08:53:31.194 INFO (MainThread) [homeassistant.setup] Setting up synology_dsm
2024-05-05 08:53:32.106 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] State of Surveillance_station during setup of '21B0R2RQ4TNT0': False
2024-05-05 08:53:32.200 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable security api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable photos api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable storage api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable upgrade api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable system api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable utilisation api updates for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Start data update for '21B0R2RQ4TNT0'
2024-05-05 08:53:32.201 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Entities not added yet, fetch all for '21B0R2RQ4TNT0'
2024-05-05 08:53:39.273 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Start data update for '21B0R2RQ4TNT0'
2024-05-05 08:53:39.273 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Entities not added yet, fetch all for '21B0R2RQ4TNT0'
2024-05-05 08:53:40.497 DEBUG (MainThread) [homeassistant.components.synology_dsm.coordinator] Finished fetching 192.168.100.200 SynologyDSMCentralUpdateCoordinator data in 1.224 seconds (success: True)
```
![image](https://github.com/home-assistant/core/assets/35783820/b1671f6d-97b5-4a14-b57a-ad9a682a065a)


#### with this change
```
2024-05-05 09:10:07.376 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] State of Surveillance_station during setup of '21B0R2RQ4TNT0': False
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable security api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable photos api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable storage api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable upgrade api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable system api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Enable utilisation api updates for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Start data update for '21B0R2RQ4TNT0'
2024-05-05 09:10:07.476 DEBUG (MainThread) [homeassistant.components.synology_dsm.common] Entities not added yet, fetch all for '21B0R2RQ4TNT0'
```
![image](https://github.com/home-assistant/core/assets/35783820/f87d4fee-0639-44da-afe9-497cd2bfff26)


cc @bdraco 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #116755
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
