### PR TITLE
Abort Minecraft Server config flow if device is already configured

### DIFF
--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -32,9 +32,8 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             address = user_input[CONF_ADDRESS]
 
-            # Abort config flow if device is already configured.
-            if await self._async_is_device_already_configured(address):
-                return self.async_abort(reason="already_configured")
+            # Abort config flow if service is already configured.
+            self._async_abort_entries_match({CONF_ADDRESS: address})
 
             # Prepare config entry data.
             config_data = {
@@ -65,16 +64,6 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         # Show configuration form (default form in case of no user_input,
         # form filled with user_input and eventually with errors otherwise).
         return self._show_config_form(user_input, errors)
-
-    async def _async_is_device_already_configured(self, address: str) -> bool:
-        """Check if device is already configured."""
-        config_entries = self.hass.config_entries.async_entries(DOMAIN)
-
-        for config_entry in config_entries:
-            if config_entry.data[CONF_ADDRESS] == address:
-                return True
-
-        return False
 
     def _show_config_form(
         self,

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -32,6 +32,10 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input:
             address = user_input[CONF_ADDRESS]
 
+            # Abort config flow if device is already configured.
+            if await self._async_is_device_already_configured(address):
+                return self.async_abort(reason="already_configured")
+
             # Prepare config entry data.
             config_data = {
                 CONF_NAME: user_input[CONF_NAME],
@@ -61,6 +65,16 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         # Show configuration form (default form in case of no user_input,
         # form filled with user_input and eventually with errors otherwise).
         return self._show_config_form(user_input, errors)
+
+    async def _async_is_device_already_configured(self, address: str) -> bool:
+        """Check if device is already configured."""
+        config_entries = self.hass.config_entries.async_entries(DOMAIN)
+
+        for config_entry in config_entries:
+            if config_entry.data[CONF_ADDRESS] == address:
+                return True
+
+        return False
 
     def _show_config_form(
         self,

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -10,6 +10,9 @@
         }
       }
     },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
     "error": {
       "cannot_connect": "Failed to connect to server. Please check the address and try again. If a port was provided, it must be within a valid range. If you are running a Minecraft Java Edition server, ensure that it is at least version 1.7."
     }

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -11,7 +11,7 @@
       }
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     },
     "error": {
       "cannot_connect": "Failed to connect to server. Please check the address and try again. If a port was provided, it must be within a valid range. If you are running a Minecraft Java Edition server, ensure that it is at least version 1.7."

--- a/tests/components/minecraft_server/conftest.py
+++ b/tests/components/minecraft_server/conftest.py
@@ -13,7 +13,7 @@ from tests.common import MockConfigEntry
 
 @pytest.fixture
 def java_mock_config_entry() -> MockConfigEntry:
-    """Create YouTube entry in Home Assistant."""
+    """Create Java Edition mock config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         unique_id=None,
@@ -29,7 +29,7 @@ def java_mock_config_entry() -> MockConfigEntry:
 
 @pytest.fixture
 def bedrock_mock_config_entry() -> MockConfigEntry:
-    """Create YouTube entry in Home Assistant."""
+    """Create Bedrock Edition mock config entry."""
     return MockConfigEntry(
         domain=DOMAIN,
         unique_id=None,

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -35,6 +35,44 @@ async def test_show_config_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
+async def test_device_already_configured(hass: HomeAssistant) -> None:
+    """Test config flow abort if device is already configured."""
+    with (
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
+            return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.async_status",
+            return_value=TEST_BEDROCK_STATUS_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == USER_INPUT[CONF_ADDRESS]
+        assert result["data"][CONF_NAME] == USER_INPUT[CONF_NAME]
+        assert result["data"][CONF_ADDRESS] == TEST_ADDRESS
+        assert result["data"][CONF_TYPE] == MinecraftServerType.BEDROCK_EDITION
+
+    with (
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.lookup",
+            return_value=BedrockServer(host=TEST_HOST, port=TEST_PORT),
+        ),
+        patch(
+            "homeassistant.components.minecraft_server.api.BedrockServer.async_status",
+            return_value=TEST_BEDROCK_STATUS_RESPONSE,
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT
+        )
+        assert result2["type"] is FlowResultType.ABORT
+        assert result2["reason"] == "already_configured"
+
+
 async def test_address_validation_failure(hass: HomeAssistant) -> None:
     """Test error in case of a failed connection."""
     with (

--- a/tests/components/minecraft_server/test_config_flow.py
+++ b/tests/components/minecraft_server/test_config_flow.py
@@ -37,10 +37,10 @@ async def test_show_config_form(hass: HomeAssistant) -> None:
     assert result["step_id"] == "user"
 
 
-async def test_device_already_configured(
+async def test_service_already_configured(
     hass: HomeAssistant, bedrock_mock_config_entry: MockConfigEntry
 ) -> None:
-    """Test config flow abort if device is already configured."""
+    """Test config flow abort if service is already configured."""
     bedrock_mock_config_entry.add_to_hass(hass)
 
     with (


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

Note: 
As there is no unique information available from the library/server during config flow the only possibility is to check if the entered server address is already used in one of the existing config entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n.a.
- This PR is related to issue: n.a.
- Link to documentation pull request: n.a.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
