### PR TITLE
Migrate file integration to config entry

### DIFF
--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -1,1 +1,72 @@
 """The file component."""
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_PLATFORM, CONF_VALUE_TEMPLATE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv, discovery
+from homeassistant.helpers.template import Template
+from homeassistant.helpers.typing import ConfigType
+
+from .const import DOMAIN
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the file integration.
+
+    The file integration uses config flow for configuration.
+    But, a `file:` entry in configuration.yaml will trigger an import flow
+    if a config entry doesn't already exist.
+    """
+
+    config_data: dict[str, list[ConfigType]] = {
+        domain: [item for item in config[domain] if item.pop(CONF_PLATFORM) == DOMAIN]
+        for domain in config
+        if domain in PLATFORMS
+    }
+    # Ensure we pass the string value for a value_template
+    if Platform.SENSOR in config_data and (
+        items := [
+            item for item in config_data[Platform.SENSOR] if CONF_VALUE_TEMPLATE in item
+        ]
+    ):
+        for item in items:
+            value_template: Template = item[CONF_VALUE_TEMPLATE]
+            item[CONF_VALUE_TEMPLATE] = value_template.template
+    if not hass.config_entries.async_entries(DOMAIN):
+        # No config entry exists and configuration.yaml
+        # config exists, then trigger the import flow.
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=config_data,
+            )
+        )
+
+    # The legacy File notify.notify service is deprecated with HA Core 2024.5.0
+    # with HA Core 2024.5.0 and will be removed with HA core 2024.12.0
+    hass.async_create_task(
+        discovery.async_load_platform(
+            hass,
+            Platform.NOTIFY,
+            DOMAIN,
+            None,
+            config,
+        )
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a file component entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -1,10 +1,9 @@
 """The file component."""
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_PLATFORM, CONF_VALUE_TEMPLATE, Platform
+from homeassistant.const import CONF_PLATFORM, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, discovery
-from homeassistant.helpers.template import Template
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -15,58 +14,56 @@ PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the file integration.
+    """Set up the file integration."""
 
-    The file integration uses config flow for configuration.
-    But, a `file:` entry in configuration.yaml will trigger an import flow
-    if a config entry doesn't already exist.
-    """
+    # The legacy File notify.notify service is deprecated with HA Core 2024.5.0
+    # with HA Core 2024.5.0 and will be removed with HA core 2024.12.0
+    # The legacy service will coexist together with the new entity platform service
+    # hass.async_create_task(
+    #    discovery.async_load_platform(
+    #        hass,
+    #        Platform.NOTIFY,
+    #        DOMAIN,
+    #        None,
+    #        config,
+    #    )
+    # )
 
+    if hass.config_entries.async_entries(DOMAIN):
+        # We skip import in case we already have config entries
+        return True
+
+    # Prepare to import the YAML config into separate config entries
     config_data: dict[str, list[ConfigType]] = {
         domain: [item for item in config[domain] if item.pop(CONF_PLATFORM) == DOMAIN]
         for domain in config
         if domain in PLATFORMS
     }
-    # Ensure we pass the string value for a value_template
-    if Platform.SENSOR in config_data and (
-        items := [
-            item for item in config_data[Platform.SENSOR] if CONF_VALUE_TEMPLATE in item
-        ]
-    ):
-        for item in items:
-            value_template: Template = item[CONF_VALUE_TEMPLATE]
-            item[CONF_VALUE_TEMPLATE] = value_template.template
-    if not hass.config_entries.async_entries(DOMAIN):
-        # No config entry exists and configuration.yaml
-        # config exists, then trigger the import flow.
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=config_data,
-            )
-        )
 
-    # The legacy File notify.notify service is deprecated with HA Core 2024.5.0
-    # with HA Core 2024.5.0 and will be removed with HA core 2024.12.0
-    hass.async_create_task(
-        discovery.async_load_platform(
-            hass,
-            Platform.NOTIFY,
-            DOMAIN,
-            None,
-            config,
-        )
-    )
+    for domain, items in config_data.items():
+        for item in items:
+            item[CONF_PLATFORM] = domain
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN,
+                    context={"source": SOURCE_IMPORT},
+                    data=item,
+                )
+            )
+
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a file component entry."""
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(
+        entry, [Platform(entry.data[CONF_PLATFORM])]
+    )
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    return await hass.config_entries.async_unload_platforms(
+        entry, [entry.data[CONF_PLATFORM]]
+    )

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -3,7 +3,7 @@
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PLATFORM, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -16,19 +16,24 @@ PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the file integration."""
 
-    # The legacy File notify.notify service is deprecated with HA Core 2024.5.0
-    # with HA Core 2024.5.0 and will be removed with HA core 2024.12.0
+    # The legacy File notify.notify service is deprecated with HA Core 2024.6.0
+    # with HA Core 2024.6.0 and will be removed with HA core 2024.12.0
     # The legacy service will coexist together with the new entity platform service
-    # hass.async_create_task(
-    #    discovery.async_load_platform(
-    #        hass,
-    #        Platform.NOTIFY,
-    #        DOMAIN,
-    #        None,
-    #        config,
-    #    )
-    # )
-
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        "deprecated_yaml_notify_migration",
+        breaks_in_ha_version="2024.12",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        learn_more_url="https://www.home-assistant.io/integrations/file/",
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml_notify_migration",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "File",
+        },
+    )
     if hass.config_entries.async_entries(DOMAIN):
         # We skip import in case we already have config entries
         return True

--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -2,33 +2,38 @@
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_PLATFORM, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant
+from homeassistant.helpers import (
+    config_validation as cv,
+    discovery,
+    issue_registry as ir,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
+PLATFORMS = [Platform.SENSOR]
+
+YAML_PLATFORMS = [Platform.NOTIFY, Platform.SENSOR]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the file integration."""
 
-    # The legacy File notify.notify service is deprecated with HA Core 2024.6.0
-    # with HA Core 2024.6.0 and will be removed with HA core 2024.12.0
-    # The legacy service will coexist together with the new entity platform service
+    # The YAML config was imported with HA Core 2024.6.0 and will be removed with
+    # HA Core 2024.12
     ir.async_create_issue(
         hass,
-        DOMAIN,
-        "deprecated_yaml_notify_migration",
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
         breaks_in_ha_version="2024.12",
         is_fixable=False,
         issue_domain=DOMAIN,
         learn_more_url="https://www.home-assistant.io/integrations/file/",
         severity=ir.IssueSeverity.WARNING,
-        translation_key="deprecated_yaml_notify_migration",
+        translation_key="deprecated_yaml",
         translation_placeholders={
             "domain": DOMAIN,
             "integration_title": "File",
@@ -42,7 +47,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     config_data: dict[str, list[ConfigType]] = {
         domain: [item for item in config[domain] if item.pop(CONF_PLATFORM) == DOMAIN]
         for domain in config
-        if domain in PLATFORMS
+        if domain in YAML_PLATFORMS
     }
 
     for domain, items in config_data.items():
@@ -61,9 +66,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a file component entry."""
-    await hass.config_entries.async_forward_entry_setups(
-        entry, [Platform(entry.data[CONF_PLATFORM])]
-    )
+    if entry.data[CONF_PLATFORM] in PLATFORMS:
+        await hass.config_entries.async_forward_entry_setups(
+            entry, [Platform(entry.data[CONF_PLATFORM])]
+        )
+    else:
+        # The notify platform is not yet set up as entry, so
+        # forward setup config through discovery to ensure setup notify service.
+        # This is needed as long as the legacy service is not migrated
+        hass.async_create_task(
+            discovery.async_load_platform(
+                hass,
+                Platform.NOTIFY,
+                DOMAIN,
+                dict(entry.data),
+                {},
+            )
+        )
+
     return True
 
 

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -85,9 +85,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input:
             user_input[CONF_PLATFORM] = "notify"
-            self._async_abort_entries_match(
-                {key: user_input[key] for key in (CONF_PLATFORM, CONF_FILENAME)}
-            )
+            self._async_abort_entries_match(user_input)
             filepath: str = os.path.join(
                 self.hass.config.config_dir, user_input[CONF_FILENAME]
             )
@@ -109,9 +107,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         if user_input:
             user_input[CONF_PLATFORM] = "sensor"
-            self._async_abort_entries_match(
-                {key: user_input[key] for key in (CONF_PLATFORM, CONF_FILE_PATH)}
-            )
+            self._async_abort_entries_match(user_input)
             if not await self.validate_file_path(user_input[CONF_FILE_PATH]):
                 errors[CONF_FILE_PATH] = "not_allowed"
             else:

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -1,0 +1,1 @@
+"""Config flow for file integration."""

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -18,9 +18,6 @@ from homeassistant.const import (
 from homeassistant.helpers.selector import (
     BooleanSelector,
     BooleanSelectorConfig,
-    SelectSelector,
-    SelectSelectorConfig,
-    SelectSelectorMode,
     TemplateSelector,
     TemplateSelectorConfig,
     TextSelector,
@@ -31,18 +28,11 @@ from homeassistant.helpers.selector import (
 from .const import CONF_TIMESTAMP, DEFAULT_NAME, DOMAIN
 
 BOOLEAN_SELECTOR = BooleanSelector(BooleanSelectorConfig())
-PLATFORM_SELECTOR = SelectSelector(
-    SelectSelectorConfig(
-        options=["notify", "sensor"],
-        mode=SelectSelectorMode.DROPDOWN,
-    )
-)
 TEMPLATE_SELECTOR = TemplateSelector(TemplateSelectorConfig())
 TEXT_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 
 FILE_SENSOR_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_NAME): TEXT_SELECTOR,
         vol.Required(CONF_FILE_PATH): TEXT_SELECTOR,
         vol.Optional(CONF_VALUE_TEMPLATE): TEMPLATE_SELECTOR,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): TEXT_SELECTOR,
@@ -51,7 +41,6 @@ FILE_SENSOR_SCHEMA = vol.Schema(
 
 FILE_NOTIFY_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_NAME): TEXT_SELECTOR,
         vol.Required(CONF_FILENAME): TEXT_SELECTOR,
         vol.Optional(CONF_TIMESTAMP, default=False): BOOLEAN_SELECTOR,
     }
@@ -111,8 +100,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if not await self.validate_file_path(user_input[CONF_FILE_PATH]):
                 errors[CONF_FILE_PATH] = "not_allowed"
             else:
-                name: str = user_input.get(CONF_NAME, DEFAULT_NAME)
-                title = f"{name} [{user_input[CONF_FILE_PATH]}]"
+                title = f"{DEFAULT_NAME} [{user_input[CONF_FILE_PATH]}]"
                 return self.async_create_entry(data=user_input, title=title)
 
         return self.async_show_form(

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -33,6 +33,7 @@ TEXT_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 
 FILE_SENSOR_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_NAME): TEXT_SELECTOR,
         vol.Required(CONF_FILE_PATH): TEXT_SELECTOR,
         vol.Optional(CONF_VALUE_TEMPLATE): TEMPLATE_SELECTOR,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): TEXT_SELECTOR,

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -41,6 +41,7 @@ FILE_SENSOR_SCHEMA = vol.Schema(
 
 FILE_NOTIFY_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_NAME): TEXT_SELECTOR,
         vol.Required(CONF_FILENAME): TEXT_SELECTOR,
         vol.Optional(CONF_TIMESTAMP, default=False): BOOLEAN_SELECTOR,
     }

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -1,1 +1,49 @@
 """Config flow for file integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import (
+    CONF_FILE_PATH,
+    CONF_FILENAME,
+    CONF_NAME,
+    CONF_PLATFORM,
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_VALUE_TEMPLATE,
+    Platform,
+)
+import homeassistant.helpers.config_validation as cv
+
+from .const import DEFAULT_NAME, DOMAIN
+
+FILE_SENSOR_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_FILE_PATH): cv.isfile,
+        vol.Optional(CONF_NAME, default="File"): cv.string,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    }
+)
+
+
+class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a file config flow."""
+
+    VERSION = 1
+
+    async def async_step_import(
+        self, import_data: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Import `file`` config from configuration.yaml."""
+        assert import_data is not None
+        platform = import_data[CONF_PLATFORM]
+        name: str = import_data.get(CONF_NAME, DEFAULT_NAME)
+        file_name: str
+        if platform == Platform.NOTIFY:
+            file_name = import_data[CONF_FILENAME]
+        else:
+            file_name = import_data[CONF_FILE_PATH]
+        title = f"{name} [{file_name}]"
+        return self.async_create_entry(title=title, data=import_data)

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -112,7 +112,7 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match(
                 {key: user_input[key] for key in (CONF_PLATFORM, CONF_FILE_PATH)}
             )
-            if not await self.validate_file_path(user_input[CONF_FILENAME]):
+            if not await self.validate_file_path(user_input[CONF_FILE_PATH]):
                 errors[CONF_FILE_PATH] = "not_allowed"
             else:
                 name: str = user_input.get(CONF_NAME, DEFAULT_NAME)

--- a/homeassistant/components/file/config_flow.py
+++ b/homeassistant/components/file/config_flow.py
@@ -33,7 +33,7 @@ TEXT_SELECTOR = TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT))
 
 FILE_SENSOR_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_NAME): TEXT_SELECTOR,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): TEXT_SELECTOR,
         vol.Required(CONF_FILE_PATH): TEXT_SELECTOR,
         vol.Optional(CONF_VALUE_TEMPLATE): TEMPLATE_SELECTOR,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): TEXT_SELECTOR,
@@ -42,8 +42,8 @@ FILE_SENSOR_SCHEMA = vol.Schema(
 
 FILE_NOTIFY_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_NAME): TEXT_SELECTOR,
-        vol.Required(CONF_FILENAME): TEXT_SELECTOR,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): TEXT_SELECTOR,
+        vol.Required(CONF_FILE_PATH): TEXT_SELECTOR,
         vol.Optional(CONF_TIMESTAMP, default=False): BOOLEAN_SELECTOR,
     }
 )
@@ -77,14 +77,11 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         if user_input:
             user_input[CONF_PLATFORM] = "notify"
             self._async_abort_entries_match(user_input)
-            filepath: str = os.path.join(
-                self.hass.config.config_dir, user_input[CONF_FILENAME]
-            )
-            if not await self.validate_file_path(filepath):
-                errors[CONF_FILENAME] = "not_allowed"
+            if not await self.validate_file_path(user_input[CONF_FILE_PATH]):
+                errors[CONF_FILE_PATH] = "not_allowed"
             else:
                 name: str = user_input.get(CONF_NAME, DEFAULT_NAME)
-                title = f"{name} [{user_input[CONF_FILENAME]}]"
+                title = f"{name} [{user_input[CONF_FILE_PATH]}]"
                 return self.async_create_entry(data=user_input, title=title)
 
         return self.async_show_form(
@@ -102,7 +99,8 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if not await self.validate_file_path(user_input[CONF_FILE_PATH]):
                 errors[CONF_FILE_PATH] = "not_allowed"
             else:
-                title = f"{DEFAULT_NAME} [{user_input[CONF_FILE_PATH]}]"
+                name: str = user_input.get(CONF_NAME, DEFAULT_NAME)
+                title = f"{name} [{user_input[CONF_FILE_PATH]}]"
                 return self.async_create_entry(data=user_input, title=title)
 
         return self.async_show_form(
@@ -119,8 +117,10 @@ class FileConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         name: str = import_data.get(CONF_NAME, DEFAULT_NAME)
         file_name: str
         if platform == Platform.NOTIFY:
-            file_name = import_data[CONF_FILENAME]
+            file_name = import_data.pop(CONF_FILENAME)
+            file_path: str = os.path.join(self.hass.config.config_dir, file_name)
+            import_data[CONF_FILE_PATH] = file_path
         else:
-            file_name = import_data[CONF_FILE_PATH]
-        title = f"{name} [{file_name}]"
+            file_path = import_data[CONF_FILE_PATH]
+        title = f"{name} [{file_path}]"
         return self.async_create_entry(title=title, data=import_data)

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -6,3 +6,7 @@ CONF_TIMESTAMP = "timestamp"
 
 DEFAULT_NAME = "File"
 FILE_ICON = "mdi:file"
+
+URL_ALLOWLIST_EXT_DIRS = (
+    "https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs"
+)

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -1,9 +1,8 @@
 """Constants for the file integration."""
 
-from typing import Final
+DOMAIN = "file"
 
-DOMAIN: Final = "file"
+CONF_TIMESTAMP = "timestamp"
 
 DEFAULT_NAME = "File"
-
 FILE_ICON = "mdi:file"

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -1,0 +1,5 @@
+"""Constants for the file integration."""
+
+from typing import Final
+
+DOMAIN: Final = "file"

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -6,7 +6,3 @@ CONF_TIMESTAMP = "timestamp"
 
 DEFAULT_NAME = "File"
 FILE_ICON = "mdi:file"
-
-URL_ALLOWLIST_EXT_DIRS = (
-    "https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs"
-)

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -3,3 +3,7 @@
 from typing import Final
 
 DOMAIN: Final = "file"
+
+DEFAULT_NAME = "File"
+
+FILE_ICON = "mdi:file"

--- a/homeassistant/components/file/manifest.json
+++ b/homeassistant/components/file/manifest.json
@@ -2,6 +2,7 @@
   "domain": "file",
   "name": "File",
   "codeowners": ["@fabaff"],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/file",
   "iot_class": "local_polling",
   "requirements": ["file-read-backwards==2.0.0"]

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -21,7 +21,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_TIMESTAMP, DOMAIN, URL_ALLOWLIST_EXT_DIRS
+from .const import CONF_TIMESTAMP, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -60,15 +60,6 @@ class FileNotificationService(BaseNotificationService):
         """Send a message to a file."""
         file: TextIO
         filepath: str = os.path.join(self.hass.config.config_dir, self.filename)
-        if not self.hass.config.is_allowed_path(filepath):
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="dir_not_allowed",
-                translation_placeholders={
-                    "filename": filepath,
-                    "url": URL_ALLOWLIST_EXT_DIRS,
-                },
-            )
         try:
             with open(filepath, "a", encoding="utf8") as file:
                 if os.stat(filepath).st_size == 0:

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from typing import Any, TextIO
 
@@ -12,12 +13,20 @@ from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
     PLATFORM_SCHEMA,
     BaseNotificationService,
+    NotifyEntity,
+    NotifyEntityFeature,
 )
-from homeassistant.const import CONF_FILENAME
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_FILENAME, CONF_NAME
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
+
+from .const import FILE_ICON
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_TIMESTAMP = "timestamp"
 
@@ -27,6 +36,53 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_TIMESTAMP, default=False): cv.boolean,
     }
 )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the file sensor."""
+    config: dict[str, Any] = dict(entry.data)
+    if not await hass.async_add_executor_job(
+        hass.config.is_allowed_path, config[CONF_FILENAME]
+    ):
+        _LOGGER.error("'%s' is not an allowed directory", config[CONF_FILENAME])
+        return
+    async_add_entities([FileNotifyEntity(config)])
+
+
+class FileNotifyEntity(NotifyEntity):
+    """Implement the notification entity platform for the File service."""
+
+    _attr_icon = FILE_ICON
+    _attr_supported_features = NotifyEntityFeature.TITLE
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Initialize the service."""
+        self.filename: str = config[CONF_FILENAME]
+        self.add_timestamp: bool = config.get(CONF_TIMESTAMP, False)
+        self._attr_name = config.get(CONF_NAME, config[CONF_FILENAME])
+        self._attr_unique_id = f"notify_{config[CONF_FILENAME]}"
+
+    def send_message(self, message: str, title: str | None = None) -> None:
+        """Send a message to a file."""
+        file: TextIO
+        filepath: str = os.path.join(self.hass.config.config_dir, self.filename)
+        with open(filepath, "a", encoding="utf8") as file:
+            if os.stat(filepath).st_size == 0:
+                title = (
+                    f"{title or ATTR_TITLE_DEFAULT} notifications (Log"
+                    f" started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"
+                )
+                file.write(title)
+
+            if self.add_timestamp:
+                text = f"{dt_util.utcnow().isoformat()} {message}\n"
+            else:
+                text = f"{message}\n"
+            file.write(text)
 
 
 def get_service(

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -13,19 +13,15 @@ from homeassistant.components.notify import (
     ATTR_TITLE_DEFAULT,
     PLATFORM_SCHEMA,
     BaseNotificationService,
-    NotifyEntity,
-    NotifyEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_FILENAME, CONF_NAME
+from homeassistant.const import CONF_FILENAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from .const import CONF_TIMESTAMP, DOMAIN, FILE_ICON, URL_ALLOWLIST_EXT_DIRS
+from .const import CONF_TIMESTAMP, DOMAIN, URL_ALLOWLIST_EXT_DIRS
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -37,72 +33,17 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the file sensor."""
-    config: dict[str, Any] = dict(entry.data)
-    async_add_entities([FileNotifyEntity(config)])
-
-
-class FileNotifyEntity(NotifyEntity):
-    """Implement the notification entity platform for the File service."""
-
-    _attr_icon = FILE_ICON
-    _attr_supported_features = NotifyEntityFeature.TITLE
-
-    def __init__(self, config: dict[str, Any]) -> None:
-        """Initialize the service."""
-        self.filename: str = config[CONF_FILENAME]
-        self.add_timestamp: bool = config.get(CONF_TIMESTAMP, False)
-        self._attr_name = config.get(CONF_NAME, config[CONF_FILENAME])
-        self._attr_unique_id = f"notify_{config[CONF_FILENAME]}"
-
-    def send_message(self, message: str, title: str | None = None) -> None:
-        """Send a message to a file."""
-        file: TextIO
-        filepath: str = os.path.join(self.hass.config.config_dir, self.filename)
-        if not self.hass.config.is_allowed_path(filepath):
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="dir_not_allowed",
-                translation_placeholders={
-                    "filename": filepath,
-                    "url": URL_ALLOWLIST_EXT_DIRS,
-                },
-            )
-        try:
-            with open(filepath, "a", encoding="utf8") as file:
-                if os.stat(filepath).st_size == 0:
-                    title = (
-                        f"{title or ATTR_TITLE_DEFAULT} notifications (Log"
-                        f" started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"
-                    )
-                    file.write(title)
-
-                if self.add_timestamp:
-                    text = f"{dt_util.utcnow().isoformat()} {message}\n"
-                else:
-                    text = f"{message}\n"
-                file.write(text)
-        except Exception as exc:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="write_access_failed",
-                translation_placeholders={"filename": filepath, "exc": f"{exc!r}"},
-            ) from exc
-
-
-def get_service(
+async def async_get_service(
     hass: HomeAssistant,
     config: ConfigType,
     discovery_info: DiscoveryInfoType | None = None,
-) -> FileNotificationService:
+) -> FileNotificationService | None:
     """Get the file notification service."""
-    filename: str = config[CONF_FILENAME]
-    timestamp: bool = config[CONF_TIMESTAMP]
+    if discovery_info is None:
+        # We only set up through discovery
+        return None
+    filename: str = discovery_info[CONF_FILENAME]
+    timestamp: bool = discovery_info.get(CONF_TIMESTAMP, False)
 
     return FileNotificationService(filename, timestamp)
 

--- a/homeassistant/components/file/notify.py
+++ b/homeassistant/components/file/notify.py
@@ -45,7 +45,7 @@ async def async_get_service(
         # We only set up through discovery
         return None
     file_path: str = discovery_info[CONF_FILE_PATH]
-    timestamp: bool = discovery_info.get(CONF_TIMESTAMP, False)
+    timestamp: bool = discovery_info[CONF_TIMESTAMP]
 
     return FileNotificationService(file_path, timestamp)
 

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -9,6 +9,7 @@ from file_read_backwards import FileReadBackwards
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_FILE_PATH,
     CONF_NAME,
@@ -16,22 +17,20 @@ from homeassistant.const import (
     CONF_VALUE_TEMPLATE,
 )
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
+from .const import DEFAULT_NAME, FILE_ICON
+
 _LOGGER = logging.getLogger(__name__)
-
-DEFAULT_NAME = "File"
-
-ICON = "mdi:file"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_FILE_PATH): cv.isfile,
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.string,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     }
 )
@@ -43,25 +42,40 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
+    """Set up the file sensor from YAML.
+
+    The YAML platform config is automatically
+    imported to a config entry, this method can be removed
+    when YAML support is removed.
+    """
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the file sensor."""
+    config = dict(entry.data)
     file_path: str = config[CONF_FILE_PATH]
-    name: str = config[CONF_NAME]
+    name: str = config.get(CONF_NAME, DEFAULT_NAME)
     unit: str | None = config.get(CONF_UNIT_OF_MEASUREMENT)
-    value_template: Template | None = config.get(CONF_VALUE_TEMPLATE)
+    value_template: Template | None = None
 
-    if value_template is not None:
-        value_template.hass = hass
+    if CONF_VALUE_TEMPLATE in config:
+        value_template = Template(config[CONF_VALUE_TEMPLATE], hass)
 
-    if hass.config.is_allowed_path(file_path):
-        async_add_entities([FileSensor(name, file_path, unit, value_template)], True)
-    else:
+    if not await hass.async_add_executor_job(hass.config.is_allowed_path, file_path):
         _LOGGER.error("'%s' is not an allowed directory", file_path)
+        return
+
+    async_add_entities([FileSensor(name, file_path, unit, value_template)], True)
 
 
 class FileSensor(SensorEntity):
     """Implementation of a file sensor."""
 
-    _attr_icon = ICON
+    _attr_icon = FILE_ICON
 
     def __init__(
         self,
@@ -75,6 +89,7 @@ class FileSensor(SensorEntity):
         self._file_path = file_path
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._val_tpl = value_template
+        self._attr_unique_id = f"sensor_{file_path}"
 
     def update(self) -> None:
         """Get the latest entry from a file and updates the state."""

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.util import slugify
 
 from .const import DEFAULT_NAME, FILE_ICON
 
@@ -85,7 +86,7 @@ class FileSensor(SensorEntity):
         self._file_path = file_path
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._val_tpl = value_template
-        self._attr_unique_id = f"sensor_{file_path}"
+        self._attr_unique_id = slugify(f"sensor_{file_path}")
 
     def update(self) -> None:
         """Get the latest entry from a file and updates the state."""

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -65,10 +65,6 @@ async def async_setup_entry(
     if CONF_VALUE_TEMPLATE in config:
         value_template = Template(config[CONF_VALUE_TEMPLATE], hass)
 
-    if not await hass.async_add_executor_job(hass.config.is_allowed_path, file_path):
-        _LOGGER.error("'%s' is not an allowed directory", file_path)
-        return
-
     async_add_entities([FileSensor(name, file_path, unit, value_template)], True)
 
 

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -86,7 +86,7 @@ class FileSensor(SensorEntity):
         self._file_path = file_path
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._val_tpl = value_template
-        self._attr_unique_id = slugify(f"sensor_{file_path}")
+        self._attr_unique_id = slugify(f"{name}_{file_path}")
 
     def update(self) -> None:
         """Get the latest entry from a file and updates the state."""

--- a/homeassistant/components/file/sensor.py
+++ b/homeassistant/components/file/sensor.py
@@ -59,7 +59,7 @@ async def async_setup_entry(
     """Set up the file sensor."""
     config = dict(entry.data)
     file_path: str = config[CONF_FILE_PATH]
-    name: str = config.get(CONF_NAME, DEFAULT_NAME)
+    name: str = config[CONF_NAME]
     unit: str | None = config.get(CONF_UNIT_OF_MEASUREMENT)
     value_template: Template | None = None
 

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -1,0 +1,49 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Make a choice",
+        "menu_options": {
+          "sensor": "Set up a file based sensor",
+          "notify": "Set up a notification service"
+        }
+      },
+      "sensor": {
+        "title": "File sensor",
+        "description": "Set up a file based sensor",
+        "data": {
+          "file_path": "File path",
+          "name": "Name",
+          "value_template": "Value template",
+          "unit_of_measurement": "Unit of measurement"
+        },
+        "data_description": {
+          "file_path": "The local file path to rereive the sensor value from",
+          "name": "Name of the file based sensor",
+          "value_template": "A template to render the the sensors value based on the file content",
+          "unit_of_measurement": "Unit of measurement for the sensor"
+        }
+      },
+      "notify": {
+        "title": "Notification to file service",
+        "description": "Set up a service that allows to write notification to a file.",
+        "data": {
+          "filename": "Filename",
+          "name": "Name",
+          "timestamp": "Timestamp"
+        },
+        "data_description": {
+          "filename": "A relative file path in the hass config root to write the notification to",
+          "name": "Name of the notify service",
+          "timestamp": "Add a timestamp to the notification"
+        }
+      }
+    },
+    "error": {
+      "not_allowed": "Access to the selected file path is not allowed"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -45,5 +45,13 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
+  },
+  "exceptions": {
+    "dir_not_allowed": {
+      "message": "Access to {filename} is not allowed, make sure the [directory is allowed]({url})."
+    },
+    "write_access_failed": {
+      "message": "Write access to {filename} failed: {exc}."
+    }
   }
 }

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -53,11 +53,5 @@
     "write_access_failed": {
       "message": "Write access to {filename} failed: {exc}."
     }
-  },
-  "issues": {
-    "deprecated_yaml_notify_migration": {
-      "title": "The {integration_title} YAML configuration is being removed",
-      "description": "Configuring {integration_title} using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nNotification services are migrated to be used with the `notify.send_message` entity service. Please adjust your automations to use the new service, as the leagcy services will stop working as soon as the `{domain}` configuration is removed from your configuration.yaml file.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
-    }
   }
 }

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -12,11 +12,13 @@
         "title": "File sensor",
         "description": "Set up a file based sensor",
         "data": {
+          "name": "Name",
           "file_path": "File path",
           "value_template": "Value template",
           "unit_of_measurement": "Unit of measurement"
         },
         "data_description": {
+          "name": "Name of the file based sensor",
           "file_path": "The local file path to retrieve the sensor value from",
           "value_template": "A template to render the the sensors value based on the file content",
           "unit_of_measurement": "Unit of measurement for the sensor"

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -53,5 +53,11 @@
     "write_access_failed": {
       "message": "Write access to {filename} failed: {exc}."
     }
+  },
+  "issues": {
+    "deprecated_yaml_notify_migration": {
+      "title": "The {integration_title} YAML configuration is being removed",
+      "description": "Configuring {integration_title} using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nNotification services are migrated to be used with the `notify.send_message` entity service. Please adjust your automations to use the new service, as the leagcy services will stop working as soon as the `{domain}` configuration is removed from your configuration.yaml file.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue."
+    }
   }
 }

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -13,13 +13,11 @@
         "description": "Set up a file based sensor",
         "data": {
           "file_path": "File path",
-          "name": "Name",
           "value_template": "Value template",
           "unit_of_measurement": "Unit of measurement"
         },
         "data_description": {
-          "file_path": "The local file path to rereive the sensor value from",
-          "name": "Name of the file based sensor",
+          "file_path": "The local file path to retrieve the sensor value from",
           "value_template": "A template to render the the sensors value based on the file content",
           "unit_of_measurement": "Unit of measurement for the sensor"
         }
@@ -48,7 +46,7 @@
   },
   "exceptions": {
     "dir_not_allowed": {
-      "message": "Access to {filename} is not allowed, make sure the [directory is allowed]({url})."
+      "message": "Access to {filename} is not allowed."
     },
     "write_access_failed": {
       "message": "Write access to {filename} failed: {exc}."

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -28,8 +28,8 @@
         "title": "Notification to file service",
         "description": "Set up a service that allows to write notification to a file.",
         "data": {
-          "file_path": "File path",
-          "name": "Name",
+          "file_path": "[%key:component::file::config::step::sensor::data::file_path%]",
+          "name": "[%key:component::file::config::step::sensor::data::name%]",
           "timestamp": "Timestamp"
         },
         "data_description": {

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -28,12 +28,12 @@
         "title": "Notification to file service",
         "description": "Set up a service that allows to write notification to a file.",
         "data": {
-          "filename": "Filename",
+          "file_path": "File path",
           "name": "Name",
           "timestamp": "Timestamp"
         },
         "data_description": {
-          "filename": "A relative file path in the hass config root to write the notification to",
+          "file_path": "A local file path to write the notification to",
           "name": "Name of the notify service",
           "timestamp": "Add a timestamp to the notification"
         }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -164,6 +164,7 @@ FLOWS = {
         "faa_delays",
         "fastdotcom",
         "fibaro",
+        "file",
         "filesize",
         "fireservicerota",
         "fitbit",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1815,7 +1815,7 @@
     "file": {
       "name": "File",
       "integration_type": "hub",
-      "config_flow": false,
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "filesize": {

--- a/tests/components/file/conftest.py
+++ b/tests/components/file/conftest.py
@@ -1,0 +1,25 @@
+"""Test fixtures for file platform."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def is_allowed() -> bool:
+    """Parameterize mock_is_allowed_path, default True."""
+    return True
+
+
+@pytest.fixture
+def mock_is_allowed_path(
+    hass: HomeAssistant, is_allowed: bool
+) -> Generator[None, MagicMock]:
+    """Mock is_allowed_path method."""
+    with patch.object(
+        hass.config, "is_allowed_path", return_value=is_allowed
+    ) as allowed_path_mock:
+        yield allowed_path_mock

--- a/tests/components/file/conftest.py
+++ b/tests/components/file/conftest.py
@@ -1,11 +1,20 @@
 """Test fixtures for file platform."""
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.file.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture

--- a/tests/components/file/test_config_flow.py
+++ b/tests/components/file/test_config_flow.py
@@ -1,0 +1,147 @@
+"""Tests for the file config flow."""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.file import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG_NOTIFY = {
+    "platform": "notify",
+    "filename": "some_file",
+    "timestamp": True,
+}
+MOCK_CONFIG_SENSOR = {
+    "platform": "sensor",
+    "file_path": "some/path",
+    "value_template": "{{ value | round(1) }}",
+}
+
+pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+
+
+@pytest.mark.parametrize(
+    ("platform", "data"),
+    [("sensor", MOCK_CONFIG_SENSOR), ("notify", MOCK_CONFIG_NOTIFY)],
+)
+async def test_form(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_is_allowed_path: bool,
+    platform: str,
+    data: dict[str, Any],
+) -> None:
+    """Test we get the form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": platform},
+    )
+    await hass.async_block_till_done()
+
+    user_input = dict(data)
+    user_input.pop("platform")
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=user_input
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    assert result2["data"] == data
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("platform", "data"),
+    [("sensor", MOCK_CONFIG_SENSOR), ("notify", MOCK_CONFIG_NOTIFY)],
+)
+async def test_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_is_allowed_path: bool,
+    platform: str,
+    data: dict[str, Any],
+) -> None:
+    """Test aborting if the entry is already configured."""
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": platform},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == platform
+
+    user_input = dict(data)
+    user_input.pop("platform")
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=user_input,
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize("is_allowed", [False], ids=["not_allowed"])
+@pytest.mark.parametrize(
+    ("platform", "data"),
+    [("sensor", MOCK_CONFIG_SENSOR), ("notify", MOCK_CONFIG_NOTIFY)],
+)
+async def test_not_allowed(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_is_allowed_path: bool,
+    platform: str,
+    data: dict[str, Any],
+) -> None:
+    """Test aborting if the file path is not allowed."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.MENU
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"next_step_id": platform},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == platform
+
+    user_input = dict(data)
+    user_input.pop("platform")
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input=user_input,
+    )
+    await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.FORM
+
+    expected_error: dict[str, Any] = {
+        "notify": {"filename": "not_allowed"},
+        "sensor": {"file_path": "not_allowed"},
+    }
+    assert result2["errors"] == expected_error[platform]

--- a/tests/components/file/test_config_flow.py
+++ b/tests/components/file/test_config_flow.py
@@ -14,13 +14,15 @@ from tests.common import MockConfigEntry
 
 MOCK_CONFIG_NOTIFY = {
     "platform": "notify",
-    "filename": "some_file",
+    "file_path": "some_file",
     "timestamp": True,
+    "name": "File",
 }
 MOCK_CONFIG_SENSOR = {
     "platform": "sensor",
     "file_path": "some/path",
     "value_template": "{{ value | round(1) }}",
+    "name": "File",
 }
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
@@ -139,9 +141,4 @@ async def test_not_allowed(
     await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.FORM
-
-    expected_error: dict[str, Any] = {
-        "notify": {"filename": "not_allowed"},
-        "sensor": {"file_path": "not_allowed"},
-    }
-    assert result2["errors"] == expected_error[platform]
+    assert result2["errors"] == {"file_path": "not_allowed"}

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -1,18 +1,21 @@
 """The tests for the notify file platform."""
 
 import os
-from unittest.mock import call, mock_open, patch
+from typing import Any
+from unittest.mock import MagicMock, call, mock_open, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import notify
+from homeassistant.components.file import DOMAIN
 from homeassistant.components.notify import ATTR_TITLE_DEFAULT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component
+from tests.common import MockConfigEntry, assert_setup_component
 
 
 async def test_bad_config(hass: HomeAssistant) -> None:
@@ -25,33 +28,66 @@ async def test_bad_config(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.parametrize(
-    "timestamp",
+    ("domain", "service", "params"),
     [
-        False,
-        True,
+        (notify.DOMAIN, "test", {"message": "one, two, testing, testing"}),
+        (
+            notify.DOMAIN,
+            "send_message",
+            {"entity_id": "notify.test", "message": "one, two, testing, testing"},
+        ),
     ],
+    ids=["legacy", "entity"],
+)
+@pytest.mark.parametrize(
+    ("timestamp", "config"),
+    [
+        (
+            False,
+            {
+                "notify": [
+                    {
+                        "name": "test",
+                        "platform": "file",
+                        "filename": "mock_file",
+                        "timestamp": False,
+                    }
+                ]
+            },
+        ),
+        (
+            True,
+            {
+                "notify": [
+                    {
+                        "name": "test",
+                        "platform": "file",
+                        "filename": "mock_file",
+                        "timestamp": True,
+                    }
+                ]
+            },
+        ),
+    ],
+    ids=["no_timestamp", "timestamp"],
 )
 async def test_notify_file(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, timestamp: bool
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    timestamp: bool,
+    mock_is_allowed_path: MagicMock,
+    config: ConfigType,
+    domain: str,
+    service: str,
+    params: dict[str, str],
 ) -> None:
     """Test the notify file output."""
     filename = "mock_file"
-    message = "one, two, testing, testing"
-    with assert_setup_component(1) as handle_config:
-        assert await async_setup_component(
-            hass,
-            notify.DOMAIN,
-            {
-                "notify": {
-                    "name": "test",
-                    "platform": "file",
-                    "filename": filename,
-                    "timestamp": timestamp,
-                }
-            },
-        )
-        await hass.async_block_till_done()
-    assert handle_config[notify.DOMAIN]
+    message = params["message"]
+    assert await async_setup_component(hass, notify.DOMAIN, config)
+    await hass.async_block_till_done()
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     freezer.move_to(dt_util.utcnow())
 
@@ -66,9 +102,7 @@ async def test_notify_file(
             f"(Log started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"
         )
 
-        await hass.services.async_call(
-            "notify", "test", {"message": message}, blocking=True
-        )
+        await hass.services.async_call(domain, service, params, blocking=True)
 
         full_filename = os.path.join(hass.config.path(), filename)
         assert m_open.call_count == 1
@@ -85,3 +119,140 @@ async def test_notify_file(
                 call(title),
                 call(f"{dt_util.utcnow().isoformat()} {message}\n"),
             ]
+
+
+@pytest.mark.parametrize(
+    ("timestamp", "data"),
+    [
+        (
+            False,
+            {
+                "name": "test",
+                "platform": "notify",
+                "filename": "mock_file",
+                "timestamp": False,
+            },
+        ),
+        (
+            True,
+            {
+                "name": "test",
+                "platform": "notify",
+                "filename": "mock_file",
+                "timestamp": True,
+            },
+        ),
+    ],
+    ids=["no_timestamp", "timestamp"],
+)
+async def test_notify_file_entry_only_setup(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    timestamp: bool,
+    mock_is_allowed_path: MagicMock,
+    data: dict[str, Any],
+) -> None:
+    """Test the notify file output."""
+    filename = "mock_file"
+
+    domain = notify.DOMAIN
+    service = "send_message"
+    params = {"entity_id": "notify.test", "message": "one, two, testing, testing"}
+    message = params["message"]
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['filename']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    freezer.move_to(dt_util.utcnow())
+
+    m_open = mock_open()
+    with (
+        patch("homeassistant.components.file.notify.open", m_open, create=True),
+        patch("homeassistant.components.file.notify.os.stat") as mock_st,
+    ):
+        mock_st.return_value.st_size = 0
+        title = (
+            f"{ATTR_TITLE_DEFAULT} notifications "
+            f"(Log started: {dt_util.utcnow().isoformat()})\n{'-' * 80}\n"
+        )
+
+        await hass.services.async_call(domain, service, params, blocking=True)
+
+        full_filename = os.path.join(hass.config.path(), filename)
+        assert m_open.call_count == 1
+        assert m_open.call_args == call(full_filename, "a", encoding="utf8")
+
+        assert m_open.return_value.write.call_count == 2
+        if not timestamp:
+            assert m_open.return_value.write.call_args_list == [
+                call(title),
+                call(f"{message}\n"),
+            ]
+        else:
+            assert m_open.return_value.write.call_args_list == [
+                call(title),
+                call(f"{dt_util.utcnow().isoformat()} {message}\n"),
+            ]
+
+
+@pytest.mark.parametrize(
+    ("data", "is_allowed"),
+    [
+        (
+            {
+                "name": "test",
+                "platform": "notify",
+                "filename": "mock_file",
+                "timestamp": False,
+            },
+            False,
+        ),
+        (
+            {
+                "name": "test",
+                "platform": "notify",
+                "filename": "mock_file",
+                "timestamp": True,
+            },
+            True,
+        ),
+    ],
+    ids=["not_allowed", "allowed"],
+)
+async def test_notify_file_not_allowed_path(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_is_allowed_path: MagicMock,
+    is_allowed: bool,
+    data: dict[str, Any],
+) -> None:
+    """Test the notify file output."""
+    filename = "mock_file"
+
+    domain = notify.DOMAIN
+    service = "send_message"
+    params = {"entity_id": "notify.test", "message": "one, two, testing, testing"}
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['filename']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    freezer.move_to(dt_util.utcnow())
+
+    m_open = mock_open()
+    with (
+        patch("homeassistant.components.file.notify.open", m_open, create=True),
+        patch("homeassistant.components.file.notify.os.stat") as mock_st,
+    ):
+        mock_st.return_value.st_size = 0
+        await hass.services.async_call(domain, service, params, blocking=True)
+        os.path.join(hass.config.path(), filename)
+        call_count = {False: 0, True: 1}
+        assert m_open.call_count == call_count[is_allowed]

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -32,13 +32,8 @@ async def test_bad_config(hass: HomeAssistant) -> None:
     ("domain", "service", "params"),
     [
         (notify.DOMAIN, "test", {"message": "one, two, testing, testing"}),
-        (
-            notify.DOMAIN,
-            "send_message",
-            {"entity_id": "notify.test", "message": "one, two, testing, testing"},
-        ),
     ],
-    ids=["legacy", "entity"],
+    ids=["legacy"],
 )
 @pytest.mark.parametrize(
     ("timestamp", "config"),
@@ -242,19 +237,19 @@ async def test_legacy_notify_file_exception(
     ],
     ids=["no_timestamp", "timestamp"],
 )
-async def test_notify_file_entry_only_setup(
+async def test_legacy_notify_file_entry_only_setup(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     timestamp: bool,
     mock_is_allowed_path: MagicMock,
     data: dict[str, Any],
 ) -> None:
-    """Test the notify file output."""
+    """Test the legacy notify file output in entry only setup."""
     filename = "mock_file"
 
     domain = notify.DOMAIN
-    service = "send_message"
-    params = {"entity_id": "notify.test", "message": "one, two, testing, testing"}
+    service = "test"
+    params = {"message": "one, two, testing, testing"}
     message = params["message"]
 
     entry = MockConfigEntry(
@@ -262,6 +257,8 @@ async def test_notify_file_entry_only_setup(
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     freezer.move_to(dt_util.utcnow())
 
@@ -309,16 +306,16 @@ async def test_notify_file_entry_only_setup(
     ],
     ids=["not_allowed"],
 )
-async def test_notify_file_not_allowed_path(
+async def test_legacy_notify_file_not_allowed_path(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,
     mock_is_allowed_path: MagicMock,
     data: dict[str, Any],
 ) -> None:
-    """Test the notify file output is not allowed."""
+    """Test the legacy notify file output is not allowed."""
     domain = notify.DOMAIN
-    service = "send_message"
-    params = {"entity_id": "notify.test", "message": "one, two, testing, testing"}
+    service = "test"
+    params = {"message": "one, two, testing, testing"}
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=data, title=f"test [{data['filename']}]"
@@ -356,8 +353,8 @@ async def test_notify_file_write_access_failed(
 ) -> None:
     """Test the notify file fails."""
     domain = notify.DOMAIN
-    service = "send_message"
-    params = {"entity_id": "notify.test", "message": "one, two, testing, testing"}
+    service = "test"
+    params = {"message": "one, two, testing, testing"}
 
     entry = MockConfigEntry(
         domain=DOMAIN, data=data, title=f"test [{data['filename']}]"

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -46,7 +46,6 @@ async def test_bad_config(hass: HomeAssistant) -> None:
                         "name": "test",
                         "platform": "file",
                         "filename": "mock_file",
-                        "timestamp": False,
                     }
                 ]
             },
@@ -255,6 +254,7 @@ async def test_legacy_notify_file_entry_only_setup(
                 "name": "test",
                 "platform": "notify",
                 "file_path": "mock_file",
+                "timestamp": False,
             },
         ),
     ],
@@ -284,6 +284,7 @@ async def test_legacy_notify_file_not_allowed(
                 "name": "test",
                 "platform": "notify",
                 "file_path": "mock_file",
+                "timestamp": False,
             },
             True,
         ),

--- a/tests/components/file/test_notify.py
+++ b/tests/components/file/test_notify.py
@@ -176,7 +176,7 @@ async def test_legacy_notify_file_exception(
             {
                 "name": "test",
                 "platform": "notify",
-                "filename": "mock_file",
+                "file_path": "mock_file",
                 "timestamp": False,
             },
         ),
@@ -185,7 +185,7 @@ async def test_legacy_notify_file_exception(
             {
                 "name": "test",
                 "platform": "notify",
-                "filename": "mock_file",
+                "file_path": "mock_file",
                 "timestamp": True,
             },
         ),
@@ -208,7 +208,7 @@ async def test_legacy_notify_file_entry_only_setup(
     message = params["message"]
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data=data, title=f"test [{data['filename']}]"
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
@@ -230,9 +230,8 @@ async def test_legacy_notify_file_entry_only_setup(
 
         await hass.services.async_call(domain, service, params, blocking=True)
 
-        full_filename = os.path.join(hass.config.path(), filename)
         assert m_open.call_count == 1
-        assert m_open.call_args == call(full_filename, "a", encoding="utf8")
+        assert m_open.call_args == call(filename, "a", encoding="utf8")
 
         assert m_open.return_value.write.call_count == 2
         if not timestamp:
@@ -255,7 +254,7 @@ async def test_legacy_notify_file_entry_only_setup(
             {
                 "name": "test",
                 "platform": "notify",
-                "filename": "mock_file",
+                "file_path": "mock_file",
             },
         ),
     ],
@@ -269,7 +268,7 @@ async def test_legacy_notify_file_not_allowed(
 ) -> None:
     """Test legacy notify file output not allowed."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data=config, title=f"test [{config['filename']}]"
+        domain=DOMAIN, data=config, title=f"test [{config['file_path']}]"
     )
     entry.add_to_hass(hass)
     assert not await hass.config_entries.async_setup(entry.entry_id)
@@ -284,7 +283,7 @@ async def test_legacy_notify_file_not_allowed(
             {
                 "name": "test",
                 "platform": "notify",
-                "filename": "mock_file",
+                "file_path": "mock_file",
             },
             True,
         ),
@@ -303,7 +302,7 @@ async def test_notify_file_write_access_failed(
     params = {"message": "one, two, testing, testing"}
 
     entry = MockConfigEntry(
-        domain=DOMAIN, data=data, title=f"test [{data['filename']}]"
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
     )
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/file/test_sensor.py
+++ b/tests/components/file/test_sensor.py
@@ -1,18 +1,23 @@
 """The tests for local file sensor platform."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
+import pytest
+
+from homeassistant.components.file import DOMAIN
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import get_fixture_path
+from tests.common import MockConfigEntry, get_fixture_path
 
 
 @patch("os.path.isfile", Mock(return_value=True))
 @patch("os.access", Mock(return_value=True))
-async def test_file_value(hass: HomeAssistant) -> None:
-    """Test the File sensor."""
+async def test_file_value_yaml_setup(
+    hass: HomeAssistant, mock_is_allowed_path: MagicMock
+) -> None:
+    """Test the File sensor from YAML setup."""
     config = {
         "sensor": {
             "platform": "file",
@@ -21,9 +26,8 @@ async def test_file_value(hass: HomeAssistant) -> None:
         }
     }
 
-    with patch.object(hass.config, "is_allowed_path", return_value=True):
-        assert await async_setup_component(hass, "sensor", config)
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
 
     state = hass.states.get("sensor.file1")
     assert state.state == "21"
@@ -31,20 +35,44 @@ async def test_file_value(hass: HomeAssistant) -> None:
 
 @patch("os.path.isfile", Mock(return_value=True))
 @patch("os.access", Mock(return_value=True))
-async def test_file_value_template(hass: HomeAssistant) -> None:
-    """Test the File sensor with JSON entries."""
-    config = {
-        "sensor": {
-            "platform": "file",
-            "name": "file2",
-            "file_path": get_fixture_path("file_value_template.txt", "file"),
-            "value_template": "{{ value_json.temperature }}",
-        }
+async def test_file_value_entry_setup(
+    hass: HomeAssistant, mock_is_allowed_path: MagicMock
+) -> None:
+    """Test the File sensor from an entry setup."""
+    data = {
+        "platform": "sensor",
+        "name": "file1",
+        "file_path": get_fixture_path("file_value.txt", "file"),
     }
 
-    with patch.object(hass.config, "is_allowed_path", return_value=True):
-        assert await async_setup_component(hass, "sensor", config)
-        await hass.async_block_till_done()
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    state = hass.states.get("sensor.file1")
+    assert state.state == "21"
+
+
+@patch("os.path.isfile", Mock(return_value=True))
+@patch("os.access", Mock(return_value=True))
+async def test_file_value_template(
+    hass: HomeAssistant, mock_is_allowed_path: MagicMock
+) -> None:
+    """Test the File sensor with JSON entries."""
+    data = {
+        "platform": "sensor",
+        "name": "file2",
+        "file_path": get_fixture_path("file_value_template.txt", "file"),
+        "value_template": "{{ value_json.temperature }}",
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
 
     state = hass.states.get("sensor.file2")
     assert state.state == "26"
@@ -52,19 +80,19 @@ async def test_file_value_template(hass: HomeAssistant) -> None:
 
 @patch("os.path.isfile", Mock(return_value=True))
 @patch("os.access", Mock(return_value=True))
-async def test_file_empty(hass: HomeAssistant) -> None:
+async def test_file_empty(hass: HomeAssistant, mock_is_allowed_path: MagicMock) -> None:
     """Test the File sensor with an empty file."""
-    config = {
-        "sensor": {
-            "platform": "file",
-            "name": "file3",
-            "file_path": get_fixture_path("file_empty.txt", "file"),
-        }
+    data = {
+        "platform": "sensor",
+        "name": "file3",
+        "file_path": get_fixture_path("file_empty.txt", "file"),
     }
 
-    with patch.object(hass.config, "is_allowed_path", return_value=True):
-        assert await async_setup_component(hass, "sensor", config)
-        await hass.async_block_till_done()
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
 
     state = hass.states.get("sensor.file3")
     assert state.state == STATE_UNKNOWN
@@ -72,18 +100,21 @@ async def test_file_empty(hass: HomeAssistant) -> None:
 
 @patch("os.path.isfile", Mock(return_value=True))
 @patch("os.access", Mock(return_value=True))
-async def test_file_path_invalid(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("is_allowed", [False])
+async def test_file_path_invalid(
+    hass: HomeAssistant, mock_is_allowed_path: MagicMock
+) -> None:
     """Test the File sensor with invalid path."""
-    config = {
-        "sensor": {
-            "platform": "file",
-            "name": "file4",
-            "file_path": get_fixture_path("file_value.txt", "file"),
-        }
+    data = {
+        "platform": "sensor",
+        "name": "file4",
+        "file_path": get_fixture_path("file_value.txt", "file"),
     }
 
-    with patch.object(hass.config, "is_allowed_path", return_value=False):
-        assert await async_setup_component(hass, "sensor", config)
-        await hass.async_block_till_done()
+    entry = MockConfigEntry(
+        domain=DOMAIN, data=data, title=f"test [{data['file_path']}]"
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
 
     assert len(hass.states.async_entity_ids("sensor")) == 0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The notify services for the `file` integration now require that the file path is an allowed path.
Users should check the accessed file is in the [allowlist_external_dirs](https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs) to ensure their automation's keep working.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will:
- Migrate YAML to the config entry.
- Secure `notify` services cannot access files if they are not added to the [allowlist_external_dirs](https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs).

This PR prepares for another PR to open soon:
- Add a new `notify` entity for every `file` notify service.

### Screenshots

![afbeelding](https://github.com/home-assistant/core/assets/7188918/b8d0485d-a077-4fa0-a62f-f71df56db7fc)

Final results after https://github.com/home-assistant/core/pull/117210 and https://github.com/home-assistant/core/pull/117215:
![afbeelding](https://github.com/home-assistant/core/assets/7188918/82802748-5a1d-4209-b475-543e517288f9)

![afbeelding](https://github.com/home-assistant/core/assets/7188918/04b5acdc-aa90-4c0a-9fa1-0d302b7429a0)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32593

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
