### PR TITLE
Add test for radarr update failure

### DIFF
--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -71,7 +71,6 @@ async def test_device_info(
     assert device.sw_version == "10.0.0.34882"
 
 
-@pytest.mark.freeze_time("2021-12-03 00:00:00+00:00")
 async def test_update_failed(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
@@ -90,3 +89,8 @@ async def test_update_failed(
         await hass.async_block_till_done()
         assert updater.call_count == 2
         assert hass.states.get(entity).state == STATE_UNAVAILABLE
+
+    next_update = dt_util.utcnow() + timedelta(minutes=1)
+    async_fire_time_changed(hass, next_update)
+    await hass.async_block_till_done()
+    assert hass.states.get(entity).state == "263.10"

--- a/tests/components/radarr/test_init.py
+++ b/tests/components/radarr/test_init.py
@@ -1,14 +1,21 @@
 """Test Radarr integration."""
 
+from datetime import timedelta
+from unittest.mock import patch
+
+from aiopyarr.exceptions import ArrConnectionException
 import pytest
 
 from homeassistant.components.radarr.const import DEFAULT_NAME, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+import homeassistant.util.dt as dt_util
 
 from . import create_entry, mock_connection_invalid_auth, setup_integration
 
+from tests.common import async_fire_time_changed
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
@@ -62,3 +69,24 @@ async def test_device_info(
     assert device.manufacturer == DEFAULT_NAME
     assert device.name == "Mock Title"
     assert device.sw_version == "10.0.0.34882"
+
+
+@pytest.mark.freeze_time("2021-12-03 00:00:00+00:00")
+async def test_update_failed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test coordinator updates handle failures."""
+    entry = await setup_integration(hass, aioclient_mock)
+    assert entry.state is ConfigEntryState.LOADED
+    entity = "sensor.mock_title_disk_space_downloads"
+    assert hass.states.get(entity).state == "263.10"
+
+    with patch(
+        "homeassistant.components.radarr.RadarrClient._async_request",
+        side_effect=ArrConnectionException,
+    ) as updater:
+        next_update = dt_util.utcnow() + timedelta(minutes=1)
+        async_fire_time_changed(hass, next_update)
+        await hass.async_block_till_done()
+        assert updater.call_count == 2
+        assert hass.states.get(entity).state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add test for radarr update failure. This now works after previous update interval correction.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
