### PR TITLE
Improve recorder and worker thread matching in RecorderPool

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -7,7 +7,6 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import CancelledError
 import contextlib
 from datetime import datetime, timedelta
-from functools import partial
 import logging
 import queue
 import sqlite3
@@ -1416,8 +1415,9 @@ class Recorder(threading.Thread):
             MutexPool.pool_lock = threading.RLock()
             kwargs["pool_reset_on_return"] = None
         elif self.db_url.startswith(SQLITE_URL_PREFIX):
-            kwargs["poolclass"] = partial(
-                RecorderPool, self.recorder_and_worker_thread_ids
+            kwargs["poolclass"] = RecorderPool
+            kwargs["recorder_and_worker_thread_ids"] = (
+                self.recorder_and_worker_thread_ids
             )
         elif self.db_url.startswith(
             (

--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -7,6 +7,7 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import CancelledError
 import contextlib
 from datetime import datetime, timedelta
+from functools import partial
 import logging
 import queue
 import sqlite3
@@ -187,6 +188,7 @@ class Recorder(threading.Thread):
 
         self.hass = hass
         self.thread_id: int | None = None
+        self.recorder_and_worker_thread_ids: set[int] = set()
         self.auto_purge = auto_purge
         self.auto_repack = auto_repack
         self.keep_days = keep_days
@@ -294,6 +296,7 @@ class Recorder(threading.Thread):
     def async_start_executor(self) -> None:
         """Start the executor."""
         self._db_executor = DBInterruptibleThreadPoolExecutor(
+            self.recorder_and_worker_thread_ids,
             thread_name_prefix=DB_WORKER_PREFIX,
             max_workers=MAX_DB_EXECUTOR_WORKERS,
             shutdown_hook=self._shutdown_pool,
@@ -717,7 +720,10 @@ class Recorder(threading.Thread):
 
     def _run(self) -> None:
         """Start processing events to save."""
-        self.thread_id = threading.get_ident()
+        thread_id = threading.get_ident()
+        self.thread_id = thread_id
+        self.recorder_and_worker_thread_ids.add(thread_id)
+
         setup_result = self._setup_recorder()
 
         if not setup_result:
@@ -1410,7 +1416,9 @@ class Recorder(threading.Thread):
             MutexPool.pool_lock = threading.RLock()
             kwargs["pool_reset_on_return"] = None
         elif self.db_url.startswith(SQLITE_URL_PREFIX):
-            kwargs["poolclass"] = RecorderPool
+            kwargs["poolclass"] = partial(
+                RecorderPool, self.recorder_and_worker_thread_ids
+            )
         elif self.db_url.startswith(
             (
                 MARIADB_URL_PREFIX,

--- a/homeassistant/components/recorder/executor.py
+++ b/homeassistant/components/recorder/executor.py
@@ -12,9 +12,13 @@ from homeassistant.util.executor import InterruptibleThreadPoolExecutor
 
 
 def _worker_with_shutdown_hook(
-    shutdown_hook: Callable[[], None], *args: Any, **kwargs: Any
+    shutdown_hook: Callable[[], None],
+    recorder_and_worker_thread_ids: set[int],
+    *args: Any,
+    **kwargs: Any,
 ) -> None:
     """Create a worker that calls a function after its finished."""
+    recorder_and_worker_thread_ids.add(threading.get_ident())
     _worker(*args, **kwargs)
     shutdown_hook()
 
@@ -22,9 +26,12 @@ def _worker_with_shutdown_hook(
 class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
     """A database instance that will not deadlock on shutdown."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, recorder_and_worker_thread_ids: set[int], *args: Any, **kwargs: Any
+    ) -> None:
         """Init the executor with a shutdown hook support."""
         self._shutdown_hook: Callable[[], None] = kwargs.pop("shutdown_hook")
+        self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
         super().__init__(*args, **kwargs)
 
     def _adjust_thread_count(self) -> None:
@@ -54,6 +61,7 @@ class DBInterruptibleThreadPoolExecutor(InterruptibleThreadPoolExecutor):
                 target=_worker_with_shutdown_hook,
                 args=(
                     self._shutdown_hook,
+                    self.recorder_and_worker_thread_ids,
                     weakref.ref(self, weakref_cb),
                     self._work_queue,
                     self._initializer,

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -37,12 +37,18 @@ class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
     """
 
     def __init__(  # pylint: disable=super-init-not-called
-        self, recorder_and_worker_thread_ids: set[int], *args: Any, **kw: Any
+        self,
+        creator: Any,
+        recorder_and_worker_thread_ids: set[int] | None = None,
+        **kw: Any,
     ) -> None:
         """Create the pool."""
         kw["pool_size"] = POOL_SIZE
+        assert (
+            recorder_and_worker_thread_ids is not None
+        ), "recorder_and_worker_thread_ids is required"
         self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
-        SingletonThreadPool.__init__(self, *args, **kw)
+        SingletonThreadPool.__init__(self, creator, **kw)
 
     def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if threading.get_ident() in self.recorder_and_worker_thread_ids:

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -29,7 +29,7 @@ ADVISE_MSG = (
 )
 
 
-class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
+class RecorderPool(SingletonThreadPool, NullPool):
     """A hybrid of NullPool and SingletonThreadPool.
 
     When called from the creating thread or db executor acts like SingletonThreadPool
@@ -49,6 +49,22 @@ class RecorderPool(SingletonThreadPool, NullPool):  # type: ignore[misc]
         ), "recorder_and_worker_thread_ids is required"
         self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
         SingletonThreadPool.__init__(self, creator, **kw)
+
+    def recreate(self) -> "RecorderPool":
+        """Recreate the pool."""
+        self.logger.info("Pool recreating")
+        return self.__class__(
+            self._creator,
+            pool_size=self.size,
+            recycle=self._recycle,
+            echo=self.echo,
+            pre_ping=self._pre_ping,
+            logging_name=self._orig_logging_name,
+            reset_on_return=self._reset_on_return,
+            _dispatch=self.dispatch,
+            dialect=self._dialect,
+            recorder_and_worker_thread_ids=self.recorder_and_worker_thread_ids,
+        )
 
     def _do_return_conn(self, record: ConnectionPoolEntry) -> None:
         if threading.get_ident() in self.recorder_and_worker_thread_ids:

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -14,6 +14,7 @@ from unittest.mock import MagicMock, Mock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from sqlalchemy.exc import DatabaseError, OperationalError, SQLAlchemyError
+from sqlalchemy.pool import QueuePool
 
 from homeassistant.components import recorder
 from homeassistant.components.recorder import (
@@ -30,7 +31,6 @@ from homeassistant.components.recorder import (
     db_schema,
     get_instance,
     migration,
-    pool,
     statistics,
 )
 from homeassistant.components.recorder.const import (
@@ -2265,7 +2265,7 @@ async def test_connect_args_priority(hass: HomeAssistant, config_url) -> None:
         def engine_created(*args): ...
 
         def get_dialect_pool_class(self, *args):
-            return pool.RecorderPool
+            return QueuePool
 
         def initialize(*args): ...
 

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -12,20 +12,32 @@ from homeassistant.components.recorder.pool import RecorderPool
 
 async def test_recorder_pool_called_from_event_loop() -> None:
     """Test we raise an exception when calling from the event loop."""
-    engine = create_engine("sqlite://", poolclass=RecorderPool)
+    recorder_and_worker_thread_ids: set[int] = set()
+    engine = create_engine(
+        "sqlite://",
+        poolclass=RecorderPool,
+        recorder_and_worker_thread_ids=recorder_and_worker_thread_ids,
+    )
     with pytest.raises(RuntimeError):
         sessionmaker(bind=engine)().connection()
 
 
 def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
     """Test RecorderPool gives the same connection in the creating thread."""
-
-    engine = create_engine("sqlite://", poolclass=RecorderPool)
+    recorder_and_worker_thread_ids: set[int] = set()
+    engine = create_engine(
+        "sqlite://",
+        poolclass=RecorderPool,
+        recorder_and_worker_thread_ids=recorder_and_worker_thread_ids,
+    )
     get_session = sessionmaker(bind=engine)
     shutdown = False
     connections = []
+    add_thread = False
 
     def _get_connection_twice():
+        if add_thread:
+            recorder_and_worker_thread_ids.add(threading.get_ident())
         session = get_session()
         connections.append(session.connection().connection.driver_connection)
         session.close()
@@ -44,6 +56,7 @@ def test_recorder_pool(caplog: pytest.LogCaptureFixture) -> None:
     assert "accesses the database without the database executor" in caplog.text
     assert connections[0] != connections[1]
 
+    add_thread = True
     caplog.clear()
     new_thread = threading.Thread(target=_get_connection_twice, name=DB_WORKER_PREFIX)
     new_thread.start()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Previously we would look at the name of the threads. Matching threads on name is brittle because other integrations may name their thread `Recorder` or `DbWorker`. Instead we now use explicit thread ids which ensures there will never be a conflict.

Additionally `get_ident()` has a native code implementation which avoids python overhead.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
