### PR TITLE
Support run any apps in the Android TV Remote `play_media` service

### DIFF
--- a/homeassistant/components/androidtv_remote/media_player.py
+++ b/homeassistant/components/androidtv_remote/media_player.py
@@ -180,6 +180,10 @@ class AndroidTVRemoteMediaPlayerEntity(AndroidTVRemoteBaseEntity, MediaPlayerEnt
             self._send_launch_app_command(media_id)
             return
 
+        if media_type == MediaType.APP:
+            self._send_launch_app_command(f"market://launch?id={media_id}")
+            return
+
         raise ValueError(f"Invalid media type: {media_type}")
 
     async def _send_key_commands(

--- a/homeassistant/components/androidtv_remote/media_player.py
+++ b/homeassistant/components/androidtv_remote/media_player.py
@@ -176,12 +176,8 @@ class AndroidTVRemoteMediaPlayerEntity(AndroidTVRemoteBaseEntity, MediaPlayerEnt
             await self._channel_set_task
             return
 
-        if media_type == MediaType.URL:
+        if media_type in [MediaType.URL, MediaType.APP]:
             self._send_launch_app_command(media_id)
-            return
-
-        if media_type == MediaType.APP:
-            self._send_launch_app_command(f"market://launch?id={media_id}")
             return
 
         raise ValueError(f"Invalid media type: {media_type}")

--- a/tests/components/androidtv_remote/test_media_player.py
+++ b/tests/components/androidtv_remote/test_media_player.py
@@ -277,9 +277,7 @@ async def test_media_player_play_media(
         },
         blocking=True,
     )
-    mock_api.send_launch_app_command.assert_called_with(
-        "market://launch?id=tv.twitch.android.app"
-    )
+    mock_api.send_launch_app_command.assert_called_with("tv.twitch.android.app")
 
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/androidtv_remote/test_media_player.py
+++ b/tests/components/androidtv_remote/test_media_player.py
@@ -267,6 +267,20 @@ async def test_media_player_play_media(
     )
     mock_api.send_launch_app_command.assert_called_with("https://www.youtube.com")
 
+    await hass.services.async_call(
+        "media_player",
+        "play_media",
+        {
+            "entity_id": MEDIA_PLAYER_ENTITY,
+            "media_content_type": "app",
+            "media_content_id": "tv.twitch.android.app",
+        },
+        blocking=True,
+    )
+    mock_api.send_launch_app_command.assert_called_with(
+        "market://launch?id=tv.twitch.android.app"
+    )
+
     with pytest.raises(ValueError):
         await hass.services.async_call(
             "media_player",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a shortcut to run any apps by package name in the Android TV Remote `play_media` service:
```yaml
# Launch the YouTube app
service: media_player.play_media
data:
  media_content_type: app
  media_content_id: com.google.android.youtube.tv
target:
  entity_id: media_player.living_room_tv
```

Thanks to @albaintor for a founded workaround.

Depends on https://github.com/home-assistant/core/pull/116906

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32602

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
