### PR TITLE
Reduce API calls to fetch Habitica tasks

### DIFF
--- a/homeassistant/components/habitica/coordinator.py
+++ b/homeassistant/components/habitica/coordinator.py
@@ -47,9 +47,7 @@ class HabiticaDataUpdateCoordinator(DataUpdateCoordinator[HabiticaData]):
 
         try:
             user_response = await self.api.user.get(userFields=",".join(user_fields))
-            tasks_response = []
-            for task_type in ("todos", "dailys", "habits", "rewards"):
-                tasks_response.extend(await self.api.tasks.user.get(type=task_type))
+            tasks_response = await self.api.tasks.user.get()
         except ClientResponseError as error:
             raise UpdateFailed(f"Error communicating with API: {error}") from error
 

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -13,7 +13,6 @@ from homeassistant.components.habitica.const import (
     EVENT_API_CALL_SUCCESS,
     SERVICE_API_CALL,
 )
-from homeassistant.components.habitica.sensor import TASKS_TYPES
 from homeassistant.const import ATTR_NAME
 from homeassistant.core import HomeAssistant
 
@@ -73,20 +72,21 @@ def common_requests(aioclient_mock):
             }
         },
     )
-    for n_tasks, task_type in enumerate(TASKS_TYPES.keys(), start=1):
-        aioclient_mock.get(
-            f"https://habitica.com/api/v3/tasks/user?type={task_type}",
-            json={
-                "data": [
-                    {
-                        "text": f"this is a mock {task_type} #{task}",
-                        "id": f"{task}",
-                        "type": TASKS_TYPES[task_type].path[0],
-                    }
-                    for task in range(n_tasks)
-                ]
-            },
-        )
+
+    aioclient_mock.get(
+        "https://habitica.com/api/v3/tasks/user",
+        json={
+            "data": [
+                {
+                    "text": f"this is a mock {task} #{i}",
+                    "id": f"{i}",
+                    "type": task,
+                    "completed": False,
+                }
+                for i, task in enumerate(("habit", "daily", "todo", "reward"), start=1)
+            ]
+        },
+    )
 
     aioclient_mock.post(
         "https://habitica.com/api/v3/tasks/user",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


Follow-up PR to:

* #116378 

Habitipy 0.3.1 fixes a bug, that prevented to call the tasks api endpoint without task_type parameter. Now tasks can be fetched with a single request instead of 4.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
