### PR TITLE
Set the quality scale to platinum for IMGW-PIB integration

### DIFF
--- a/homeassistant/components/imgw_pib/manifest.json
+++ b/homeassistant/components/imgw_pib/manifest.json
@@ -5,5 +5,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/imgw_pib",
   "iot_class": "cloud_polling",
+  "quality_scale": "platinum",
   "requirements": ["imgw_pib==1.0.1"]
 }

--- a/tests/components/imgw_pib/test_init.py
+++ b/tests/components/imgw_pib/test_init.py
@@ -1,6 +1,6 @@
 """Test init of IMGW-PIB integration."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from imgw_pib import ApiError
 
@@ -15,13 +15,14 @@ from tests.common import MockConfigEntry
 
 async def test_config_not_ready(
     hass: HomeAssistant,
-    mock_imgw_pib_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test for setup failure if the connection to the service fails."""
-    mock_imgw_pib_client.get_hydrological_data.side_effect = ApiError("API Error")
-
-    await init_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.imgw_pib.ImgwPib.create",
+        side_effect=ApiError("API Error"),
+    ):
+        await init_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- increases test coverage
- sets the quality scale to platinum

```
---------- coverage: platform linux, python 3.12.2-final-0 -----------
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
homeassistant/components/imgw_pib/__init__.py           34      0   100%
homeassistant/components/imgw_pib/binary_sensor.py      27      0   100%
homeassistant/components/imgw_pib/config_flow.py        39      0   100%
homeassistant/components/imgw_pib/const.py               5      0   100%
homeassistant/components/imgw_pib/coordinator.py        18      0   100%
homeassistant/components/imgw_pib/diagnostics.py         8      0   100%
homeassistant/components/imgw_pib/entity.py              9      0   100%
homeassistant/components/imgw_pib/sensor.py             29      0   100%
----------------------------------------------------------------------------------
TOTAL                                                  169      0   100%
```

### Silver

- [x] Connection/configuration is handled via a component
- [x] Set an appropriate SCAN_INTERVAL (if a polling integration)
- [x] Raise PlatformNotReady if unable to connect during platform setup (if appropriate)
- [ ] Handles expiration of auth credentials - _not applicable_
- [x] Handles internet unavailable. Log a warning once when unavailable, log once when reconnected.
- [x] Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected.
- [ ] Operations like service calls and entity methods (e.g. Set HVAC Mode) have proper exception handling.  - _not applicable_
- [x] Set available property to False if appropriate
- [x] Entities have unique ID (if available)

### Gold

- [x] Configurable via config entries.
- [x] Entities have device info (if available)
- [x] Has a code owner
- [x] Entities only subscribe to updates inside async_added_to_hass and unsubscribe inside async_will_remove_from_hass 
- [x] Entities have correct device classes where appropriate 
- [x] Supports entities being disabled and leverages Entity.entity_registry_enabled_default to disable less popular entities
- [ ] If the device/service API can remove entities, the integration should make sure to clean up the entity and device registry - _not applicable_

### Platinum

- [x] Set appropriate PARALLEL_UPDATES constant
- [x] Support config entry unloading
- [x] Integration + dependency are async
- [ ] Handles expired credentials - _not applicable_

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
