### PR TITLE
Change Ambient Network timestamp updates

### DIFF
--- a/homeassistant/components/ambient_network/coordinator.py
+++ b/homeassistant/components/ambient_network/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import API_LAST_DATA, DOMAIN, LOGGER
 from .helper import get_station_name
@@ -24,6 +25,7 @@ class AmbientNetworkDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]])
 
     config_entry: ConfigEntry
     station_name: str
+    last_measured: datetime | None = None
 
     def __init__(self, hass: HomeAssistant, api: OpenAPI) -> None:
         """Initialize the coordinator."""
@@ -47,19 +49,13 @@ class AmbientNetworkDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]])
                 f"Station '{self.config_entry.title}' did not report any data"
             )
 
-        # Eliminate data if the station hasn't been updated for a while.
-        if (created_at := last_data.get("created_at")) is None:
-            raise UpdateFailed(
-                f"Station '{self.config_entry.title}' did not report a time stamp"
-            )
-
-        # Eliminate data that has been generated more than an hour ago. The station is
-        # probably offline.
-        if int(created_at / 1000) < int(
-            (datetime.now() - timedelta(hours=1)).timestamp()
-        ):
-            raise UpdateFailed(
-                f"Station '{self.config_entry.title}' reported stale data"
+        # Some stations do not report a "created_at" or "dateutc".
+        # See https://github.com/home-assistant/core/issues/116917
+        if (ts := last_data.get("created_at")) is not None or (
+            ts := last_data.get("dateutc")
+        ) is not None:
+            self.last_measured = datetime.fromtimestamp(
+                ts / 1000, tz=dt_util.DEFAULT_TIME_ZONE
             )
 
         return cast(dict[str, Any], last_data)

--- a/homeassistant/components/ambient_network/sensor.py
+++ b/homeassistant/components/ambient_network/sensor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -293,8 +292,6 @@ async def async_setup_entry(
 class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
     """A sensor implementation for an Ambient Weather Network sensor."""
 
-    _extra_attributes: dict[str, Any] | None
-
     def __init__(
         self,
         coordinator: AmbientNetworkDataUpdateCoordinator,
@@ -303,11 +300,6 @@ class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
     ) -> None:
         """Initialize a sensor object."""
         super().__init__(coordinator, description, mac_address)
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return entity specific state attributes."""
-        return self._extra_attributes
 
     def _update_attrs(self) -> None:
         """Update sensor attributes."""
@@ -323,6 +315,6 @@ class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
         self._attr_native_value = value
 
         if self.coordinator.last_measured is not None:
-            self._extra_attributes = {"last_measured": self.coordinator.last_measured}
-        else:
-            self._extra_attributes = None
+            self._attr_extra_state_attributes = {
+                "last_measured": self.coordinator.last_measured
+            }

--- a/homeassistant/components/ambient_network/sensor.py
+++ b/homeassistant/components/ambient_network/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -292,6 +293,8 @@ async def async_setup_entry(
 class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
     """A sensor implementation for an Ambient Weather Network sensor."""
 
+    _extra_attributes: dict[str, Any] | None
+
     def __init__(
         self,
         coordinator: AmbientNetworkDataUpdateCoordinator,
@@ -299,12 +302,15 @@ class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
         mac_address: str,
     ) -> None:
         """Initialize a sensor object."""
-
         super().__init__(coordinator, description, mac_address)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return entity specific state attributes."""
+        return self._extra_attributes
 
     def _update_attrs(self) -> None:
         """Update sensor attributes."""
-
         value = self.coordinator.data.get(self.entity_description.key)
 
         # Treatments for special units.
@@ -315,3 +321,8 @@ class AmbientNetworkSensor(AmbientNetworkEntity, SensorEntity):
 
         self._attr_available = value is not None
         self._attr_native_value = value
+
+        if self.coordinator.last_measured is not None:
+            self._extra_attributes = {"last_measured": self.coordinator.last_measured}
+        else:
+            self._extra_attributes = None

--- a/tests/components/ambient_network/fixtures/device_details_response_b.json
+++ b/tests/components/ambient_network/fixtures/device_details_response_b.json
@@ -3,5 +3,8 @@
   "macAddress": "BB:BB:BB:BB:BB:BB",
   "info": {
     "name": "Station B"
+  },
+  "lastData": {
+    "tempf": 82.9
   }
 }

--- a/tests/components/ambient_network/fixtures/device_details_response_c.json
+++ b/tests/components/ambient_network/fixtures/device_details_response_c.json
@@ -3,7 +3,7 @@
   "macAddress": "CC:CC:CC:CC:CC:CC",
   "lastData": {
     "stationtype": "AMBWeatherPro_V5.0.6",
-    "dateutc": 1699474320000,
+    "dateutc": 1717687683000,
     "tempf": 82.9,
     "dewPoint": 82.0,
     "feelsLike": 85.0,

--- a/tests/components/ambient_network/fixtures/device_details_response_d.json
+++ b/tests/components/ambient_network/fixtures/device_details_response_d.json
@@ -1,0 +1,30 @@
+{
+  "_id": "dddddddddddddddddddddddddddddddd",
+  "macAddress": "DD:DD:DD:DD:DD:DD",
+  "lastData": {
+    "stationtype": "AMBWeatherPro_V5.0.6",
+    "tempf": 82.9,
+    "dewPoint": 82.0,
+    "feelsLike": 85.0,
+    "humidity": 60,
+    "windspeedmph": 8.72,
+    "windgustmph": 9.17,
+    "maxdailygust": 22.82,
+    "winddir": 11,
+    "uv": 0,
+    "solarradiation": 37.64,
+    "hourlyrainin": 0,
+    "dailyrainin": 0,
+    "weeklyrainin": 0,
+    "monthlyrainin": 0,
+    "totalrainin": 26.402,
+    "baromrelin": 29.586,
+    "baromabsin": 28.869,
+    "batt_co2": 1,
+    "type": "weather-data",
+    "tz": "America/Chicago"
+  },
+  "info": {
+    "name": "Station D"
+  }
+}

--- a/tests/components/ambient_network/snapshots/test_sensor.ambr
+++ b/tests/components/ambient_network/snapshots/test_sensor.ambr
@@ -449,57 +449,6 @@
     'state': '2023-10-30T09:45:00+00:00',
   })
 # ---
-# name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_last_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.station_a_last_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Last update',
-    'platform': 'ambient_network',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_update',
-    'unique_id': 'AA:AA:AA:AA:AA:AA_last_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_last_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by ambientnetwork.net',
-      'device_class': 'timestamp',
-      'friendly_name': 'Station A Last update',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.station_a_last_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2023-11-08T20:12:00+00:00',
-  })
-# ---
 # name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_max_daily_gust-entry]
   EntityRegistryEntrySnapshot({
     'aliases': set({
@@ -1064,7 +1013,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'pressure',
       'friendly_name': 'Station C Absolute pressure',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
     }),
@@ -1123,7 +1072,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station C Daily rain',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -1179,7 +1128,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station C Dew point',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -1235,7 +1184,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station C Feels like',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -1294,7 +1243,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation_intensity',
       'friendly_name': 'Station C Hourly rain',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
     }),
@@ -1350,7 +1299,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'humidity',
       'friendly_name': 'Station C Humidity',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -1406,7 +1355,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'irradiance',
       'friendly_name': 'Station C Irradiance',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
     }),
@@ -1457,7 +1406,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'timestamp',
       'friendly_name': 'Station C Last rain',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.station_c_last_rain',
@@ -1465,57 +1414,6 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2023-10-30T09:45:00+00:00',
-  })
-# ---
-# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_update-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': set({
-    }),
-    'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.station_c_last_update',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
-    'original_icon': None,
-    'original_name': 'Last update',
-    'platform': 'ambient_network',
-    'previous_unique_id': None,
-    'supported_features': 0,
-    'translation_key': 'last_update',
-    'unique_id': 'CC:CC:CC:CC:CC:CC_last_update',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_update-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'attribution': 'Data provided by ambientnetwork.net',
-      'device_class': 'timestamp',
-      'friendly_name': 'Station C Last update',
-      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.station_c_last_update',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '2023-11-08T20:12:00+00:00',
   })
 # ---
 # name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_max_daily_gust-entry]
@@ -1565,7 +1463,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station C Max daily gust',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
@@ -1624,7 +1522,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station C Monthly rain',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -1683,7 +1581,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'pressure',
       'friendly_name': 'Station C Relative pressure',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
     }),
@@ -1739,7 +1637,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station C Temperature',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -1794,7 +1692,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by ambientnetwork.net',
       'friendly_name': 'Station C UV index',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'index',
     }),
@@ -1853,7 +1751,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station C Weekly rain',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -1906,7 +1804,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by ambientnetwork.net',
       'friendly_name': 'Station C Wind direction',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'unit_of_measurement': '°',
     }),
     'context': <ANY>,
@@ -1964,7 +1862,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station C Wind gust',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
@@ -2023,7 +1921,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station C Wind speed',
-      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'last_measured': HAFakeDatetime(2024, 6, 6, 8, 28, 3, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),

--- a/tests/components/ambient_network/snapshots/test_sensor.ambr
+++ b/tests/components/ambient_network/snapshots/test_sensor.ambr
@@ -46,6 +46,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'pressure',
       'friendly_name': 'Station A Absolute pressure',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
     }),
@@ -104,6 +105,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station A Daily rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -159,6 +161,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station A Dew point',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -214,6 +217,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station A Feels like',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -272,6 +276,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation_intensity',
       'friendly_name': 'Station A Hourly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
     }),
@@ -327,6 +332,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'humidity',
       'friendly_name': 'Station A Humidity',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': '%',
     }),
@@ -382,6 +388,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'irradiance',
       'friendly_name': 'Station A Irradiance',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
     }),
@@ -432,6 +439,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'timestamp',
       'friendly_name': 'Station A Last rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
     }),
     'context': <ANY>,
     'entity_id': 'sensor.station_a_last_rain',
@@ -439,6 +447,57 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2023-10-30T09:45:00+00:00',
+  })
+# ---
+# name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_last_update-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_a_last_update',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last update',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_update',
+    'unique_id': 'AA:AA:AA:AA:AA:AA_last_update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_last_update-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'timestamp',
+      'friendly_name': 'Station A Last update',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_a_last_update',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-08T20:12:00+00:00',
   })
 # ---
 # name: test_sensors[AA:AA:AA:AA:AA:AA][sensor.station_a_max_daily_gust-entry]
@@ -488,6 +547,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station A Max daily gust',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
@@ -546,6 +606,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station A Monthly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -604,6 +665,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'pressure',
       'friendly_name': 'Station A Relative pressure',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
     }),
@@ -659,6 +721,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'temperature',
       'friendly_name': 'Station A Temperature',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
     }),
@@ -713,6 +776,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by ambientnetwork.net',
       'friendly_name': 'Station A UV index',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': 'index',
     }),
@@ -771,6 +835,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'precipitation',
       'friendly_name': 'Station A Weekly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.TOTAL: 'total'>,
       'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
     }),
@@ -823,6 +888,7 @@
     'attributes': ReadOnlyDict({
       'attribution': 'Data provided by ambientnetwork.net',
       'friendly_name': 'Station A Wind direction',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'unit_of_measurement': '°',
     }),
     'context': <ANY>,
@@ -880,6 +946,7 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station A Wind gust',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
@@ -938,11 +1005,1932 @@
       'attribution': 'Data provided by ambientnetwork.net',
       'device_class': 'wind_speed',
       'friendly_name': 'Station A Wind speed',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, 0, 914000, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
       'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
       'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.station_a_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.03347968',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_absolute_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_absolute_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Absolute pressure',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'absolute_pressure',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_baromabsin',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_absolute_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'pressure',
+      'friendly_name': 'Station C Absolute pressure',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_absolute_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '977.616536580043',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_daily_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_daily_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Daily rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'daily_rain',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_dailyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_daily_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station C Daily rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_daily_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_dew_point-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_dew_point',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Dew point',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'dew_point',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_dewPoint',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_dew_point-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station C Dew point',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_dew_point',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '27.7777777777778',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_feels_like-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_feels_like',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Feels like',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'feels_like',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_feelsLike',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_feels_like-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station C Feels like',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_feels_like',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '29.4444444444444',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_hourly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_hourly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'Hourly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hourly_rain',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_hourlyrainin',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_hourly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'Station C Hourly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_hourly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CC:CC:CC:CC:CC:CC_humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'humidity',
+      'friendly_name': 'Station C Humidity',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_irradiance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_irradiance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.IRRADIANCE: 'irradiance'>,
+    'original_icon': None,
+    'original_name': 'Irradiance',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CC:CC:CC:CC:CC:CC_solarradiation',
+    'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_irradiance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'irradiance',
+      'friendly_name': 'Station C Irradiance',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_irradiance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37.64',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_last_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_rain',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_lastRain',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'timestamp',
+      'friendly_name': 'Station C Last rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_last_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-10-30T09:45:00+00:00',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_update-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_last_update',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last update',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_update',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_last_update',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_last_update-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'timestamp',
+      'friendly_name': 'Station C Last update',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_last_update',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-08T20:12:00+00:00',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_max_daily_gust-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_max_daily_gust',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Max daily gust',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_daily_gust',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_maxdailygust',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_max_daily_gust-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station C Max daily gust',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_max_daily_gust',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '36.72523008',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_monthly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_monthly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Monthly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'monthly_rain',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_monthlyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_monthly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station C Monthly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_monthly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_relative_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_relative_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Relative pressure',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relative_pressure',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_baromrelin',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_relative_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'pressure',
+      'friendly_name': 'Station C Relative pressure',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_relative_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1001.89694313129',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CC:CC:CC:CC:CC:CC_tempf',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station C Temperature',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '28.2777777777778',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_uv_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_uv_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'UV index',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'uv_index',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_uv',
+    'unit_of_measurement': 'index',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_uv_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'friendly_name': 'Station C UV index',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'index',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_uv_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_weekly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_weekly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Weekly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'weekly_rain',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_weeklyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_weekly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station C Weekly rain',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_weekly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_direction-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_wind_direction',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wind direction',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wind_direction',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_winddir',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_direction-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'friendly_name': 'Station C Wind direction',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_wind_direction',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_gust-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_wind_gust',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind gust',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wind_gust',
+    'unique_id': 'CC:CC:CC:CC:CC:CC_windgustmph',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_gust-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station C Wind gust',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_wind_gust',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.75768448',
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_c_wind_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind speed',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'CC:CC:CC:CC:CC:CC_windspeedmph',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[CC:CC:CC:CC:CC:CC][sensor.station_c_wind_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station C Wind speed',
+      'last_measured': HAFakeDatetime(2023, 11, 8, 12, 12, tzinfo=zoneinfo.ZoneInfo(key='US/Pacific')),
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_c_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.03347968',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_absolute_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_absolute_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Absolute pressure',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'absolute_pressure',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_baromabsin',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_absolute_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'pressure',
+      'friendly_name': 'Station D Absolute pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_absolute_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '977.616536580043',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_daily_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_daily_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Daily rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'daily_rain',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_dailyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_daily_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station D Daily rain',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_daily_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_dew_point-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_dew_point',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Dew point',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'dew_point',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_dewPoint',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_dew_point-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station D Dew point',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_dew_point',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '27.7777777777778',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_feels_like-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_feels_like',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Feels like',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'feels_like',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_feelsLike',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_feels_like-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station D Feels like',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_feels_like',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '29.4444444444444',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_hourly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_hourly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION_INTENSITY: 'precipitation_intensity'>,
+    'original_icon': None,
+    'original_name': 'Hourly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hourly_rain',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_hourlyrainin',
+    'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_hourly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation_intensity',
+      'friendly_name': 'Station D Hourly rain',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfVolumetricFlux.MILLIMETERS_PER_HOUR: 'mm/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_hourly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'DD:DD:DD:DD:DD:DD_humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'humidity',
+      'friendly_name': 'Station D Humidity',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_irradiance-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_irradiance',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.IRRADIANCE: 'irradiance'>,
+    'original_icon': None,
+    'original_name': 'Irradiance',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'DD:DD:DD:DD:DD:DD_solarradiation',
+    'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_irradiance-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'irradiance',
+      'friendly_name': 'Station D Irradiance',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfIrradiance.WATTS_PER_SQUARE_METER: 'W/m²'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_irradiance',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '37.64',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_max_daily_gust-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_max_daily_gust',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Max daily gust',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'max_daily_gust',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_maxdailygust',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_max_daily_gust-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station D Max daily gust',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_max_daily_gust',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '36.72523008',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_monthly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_monthly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Monthly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'monthly_rain',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_monthlyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_monthly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station D Monthly rain',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_monthly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_relative_pressure-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_relative_pressure',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRESSURE: 'pressure'>,
+    'original_icon': None,
+    'original_name': 'Relative pressure',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'relative_pressure',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_baromrelin',
+    'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_relative_pressure-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'pressure',
+      'friendly_name': 'Station D Relative pressure',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfPressure.HPA: 'hPa'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_relative_pressure',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '1001.89694313129',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'DD:DD:DD:DD:DD:DD_tempf',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'temperature',
+      'friendly_name': 'Station D Temperature',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '28.2777777777778',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_uv_index-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_uv_index',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'UV index',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'uv_index',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_uv',
+    'unit_of_measurement': 'index',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_uv_index-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'friendly_name': 'Station D UV index',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': 'index',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_uv_index',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_weekly_rain-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_weekly_rain',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.PRECIPITATION: 'precipitation'>,
+    'original_icon': None,
+    'original_name': 'Weekly rain',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'weekly_rain',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_weeklyrainin',
+    'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_weekly_rain-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'precipitation',
+      'friendly_name': 'Station D Weekly rain',
+      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      'unit_of_measurement': <UnitOfLength.MILLIMETERS: 'mm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_weekly_rain',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_direction-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_wind_direction',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Wind direction',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wind_direction',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_winddir',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_direction-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'friendly_name': 'Station D Wind direction',
+      'unit_of_measurement': '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_wind_direction',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '11',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_gust-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_wind_gust',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind gust',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'wind_gust',
+    'unique_id': 'DD:DD:DD:DD:DD:DD_windgustmph',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_gust-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station D Wind gust',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_wind_gust',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '14.75768448',
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.station_d_wind_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind speed',
+    'platform': 'ambient_network',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'DD:DD:DD:DD:DD:DD_windspeedmph',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_sensors[DD:DD:DD:DD:DD:DD][sensor.station_d_wind_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'attribution': 'Data provided by ambientnetwork.net',
+      'device_class': 'wind_speed',
+      'friendly_name': 'Station D Wind speed',
+      'state_class': <SensorStateClass.MEASUREMENT: 'measurement'>,
+      'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.station_d_wind_speed',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/ambient_network/test_sensor.py
+++ b/tests/components/ambient_network/test_sensor.py
@@ -1,7 +1,7 @@
 """Test Ambient Weather Network sensors."""
 
 from datetime import datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aioambient import OpenAPI
 from aioambient.errors import RequestError
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -17,56 +18,37 @@ from .conftest import setup_platform
 from tests.common import async_fire_time_changed, snapshot_platform
 
 
-@freeze_time("2023-11-08")
-@pytest.mark.parametrize("config_entry", ["AA:AA:AA:AA:AA:AA"], indirect=True)
+@freeze_time("2023-11-9")
+@pytest.mark.parametrize(
+    "config_entry",
+    ["AA:AA:AA:AA:AA:AA", "CC:CC:CC:CC:CC:CC", "DD:DD:DD:DD:DD:DD"],
+    indirect=True,
+)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors(
     hass: HomeAssistant,
     open_api: OpenAPI,
-    aioambient,
-    config_entry,
+    aioambient: AsyncMock,
+    config_entry: ConfigEntry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test all sensors under normal operation."""
     await setup_platform(True, hass, config_entry)
-
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
-@freeze_time("2023-11-09")
-@pytest.mark.parametrize("config_entry", ["AA:AA:AA:AA:AA:AA"], indirect=True)
-async def test_sensors_with_stale_data(
-    hass: HomeAssistant, open_api: OpenAPI, aioambient, config_entry
-) -> None:
-    """Test that the sensors are not populated if the data is stale."""
-    await setup_platform(False, hass, config_entry)
-
-    sensor = hass.states.get("sensor.station_a_absolute_pressure")
-    assert sensor is None
-
-
-@freeze_time("2023-11-08")
 @pytest.mark.parametrize("config_entry", ["BB:BB:BB:BB:BB:BB"], indirect=True)
 async def test_sensors_with_no_data(
-    hass: HomeAssistant, open_api: OpenAPI, aioambient, config_entry
+    hass: HomeAssistant,
+    open_api: OpenAPI,
+    aioambient: AsyncMock,
+    config_entry: ConfigEntry,
 ) -> None:
     """Test that the sensors are not populated if the last data is absent."""
     await setup_platform(False, hass, config_entry)
 
-    sensor = hass.states.get("sensor.station_b_absolute_pressure")
-    assert sensor is None
-
-
-@freeze_time("2023-11-08")
-@pytest.mark.parametrize("config_entry", ["CC:CC:CC:CC:CC:CC"], indirect=True)
-async def test_sensors_with_no_update_time(
-    hass: HomeAssistant, open_api: OpenAPI, aioambient, config_entry
-) -> None:
-    """Test that the sensors are not populated if the update time is missing."""
-    await setup_platform(False, hass, config_entry)
-
-    sensor = hass.states.get("sensor.station_c_absolute_pressure")
+    sensor = hass.states.get("sensor.station_b_last_update")
     assert sensor is None
 
 
@@ -74,8 +56,8 @@ async def test_sensors_with_no_update_time(
 async def test_sensors_disappearing(
     hass: HomeAssistant,
     open_api: OpenAPI,
-    aioambient,
-    config_entry,
+    aioambient: AsyncMock,
+    config_entry: ConfigEntry,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that we log errors properly."""

--- a/tests/components/ambient_network/test_sensor.py
+++ b/tests/components/ambient_network/test_sensor.py
@@ -46,10 +46,11 @@ async def test_sensors_with_no_data(
     config_entry: ConfigEntry,
 ) -> None:
     """Test that the sensors are not populated if the last data is absent."""
-    await setup_platform(False, hass, config_entry)
+    await setup_platform(True, hass, config_entry)
 
-    sensor = hass.states.get("sensor.station_b_last_update")
-    assert sensor is None
+    sensor = hass.states.get("sensor.station_b_temperature")
+    assert sensor is not None
+    assert "last_measured" not in sensor.attributes
 
 
 @pytest.mark.parametrize("config_entry", ["AA:AA:AA:AA:AA:AA"], indirect=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the way we deal with weather station update times.
* Fix an issue for weather stations that don't report "created_at"
* Add a new "last_measured" sensor state attribute that reports when the weather data was last measured

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes [#116917](https://github.com/home-assistant/core/issues/116917)
- This PR is related to issue: https://github.com/home-assistant/core/issues/116917
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
