### PR TITLE
Bump aioautomower to 2024.5.0

### DIFF
--- a/homeassistant/components/husqvarna_automower/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower/lawn_mower.py
@@ -83,7 +83,7 @@ class AutomowerLawnMowerEntity(AutomowerControlEntity, LawnMowerEntity):
     async def async_start_mowing(self) -> None:
         """Resume schedule."""
         try:
-            await self.coordinator.api.resume_schedule(self.mower_id)
+            await self.coordinator.api.commands.resume_schedule(self.mower_id)
         except ApiException as exception:
             raise HomeAssistantError(
                 f"Command couldn't be sent to the command queue: {exception}"
@@ -92,7 +92,7 @@ class AutomowerLawnMowerEntity(AutomowerControlEntity, LawnMowerEntity):
     async def async_pause(self) -> None:
         """Pauses the mower."""
         try:
-            await self.coordinator.api.pause_mowing(self.mower_id)
+            await self.coordinator.api.commands.pause_mowing(self.mower_id)
         except ApiException as exception:
             raise HomeAssistantError(
                 f"Command couldn't be sent to the command queue: {exception}"
@@ -101,7 +101,7 @@ class AutomowerLawnMowerEntity(AutomowerControlEntity, LawnMowerEntity):
     async def async_dock(self) -> None:
         """Parks the mower until next schedule."""
         try:
-            await self.coordinator.api.park_until_next_schedule(self.mower_id)
+            await self.coordinator.api.commands.park_until_next_schedule(self.mower_id)
         except ApiException as exception:
             raise HomeAssistantError(
                 f"Command couldn't be sent to the command queue: {exception}"

--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/husqvarna_automower",
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
-  "requirements": ["aioautomower==2024.4.4"]
+  "requirements": ["aioautomower==2024.5.0"]
 }

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -58,6 +58,15 @@ async def async_set_work_area_cutting_height(
     await coordinator.async_request_refresh()
 
 
+async def async_set_cutting_height(
+    session: AutomowerSession,
+    mower_id: str,
+    cheight: float,
+) -> None:
+    """Set cutting height."""
+    await session.commands.set_cutting_height(mower_id, int(cheight))
+
+
 @dataclass(frozen=True, kw_only=True)
 class AutomowerNumberEntityDescription(NumberEntityDescription):
     """Describes Automower number entity."""
@@ -77,9 +86,7 @@ NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
         native_max_value=9,
         exists_fn=lambda data: data.cutting_height is not None,
         value_fn=_async_get_cutting_height,
-        set_value_fn=lambda session,
-        mower_id,
-        cheight: session.commands.set_cutting_height(mower_id, int(cheight)),
+        set_value_fn=async_set_cutting_height,
     ),
 )
 

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -49,7 +49,7 @@ async def async_set_work_area_cutting_height(
     work_area_id: int,
 ) -> None:
     """Set cutting height for work area."""
-    await coordinator.api.set_cutting_height_workarea(
+    await coordinator.api.commands.set_cutting_height_workarea(
         mower_id, int(cheight), work_area_id
     )
     # As there are no updates from the websocket regarding work area changes,
@@ -77,9 +77,9 @@ NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
         native_max_value=9,
         exists_fn=lambda data: data.cutting_height is not None,
         value_fn=_async_get_cutting_height,
-        set_value_fn=lambda session, mower_id, cheight: session.set_cutting_height(
-            mower_id, int(cheight)
-        ),
+        set_value_fn=lambda session,
+        mower_id,
+        cheight: session.commands.set_cutting_height(mower_id, int(cheight)),
     ),
 )
 

--- a/homeassistant/components/husqvarna_automower/select.py
+++ b/homeassistant/components/husqvarna_automower/select.py
@@ -64,7 +64,7 @@ class AutomowerSelectEntity(AutomowerControlEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         try:
-            await self.coordinator.api.set_headlight_mode(
+            await self.coordinator.api.commands.set_headlight_mode(
                 self.mower_id, cast(HeadlightModes, option.upper())
             )
         except ApiException as exception:

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -78,7 +78,7 @@ class AutomowerSwitchEntity(AutomowerControlEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
         try:
-            await self.coordinator.api.park_until_further_notice(self.mower_id)
+            await self.coordinator.api.commands.park_until_further_notice(self.mower_id)
         except ApiException as exception:
             raise HomeAssistantError(
                 f"Command couldn't be sent to the command queue: {exception}"
@@ -87,7 +87,7 @@ class AutomowerSwitchEntity(AutomowerControlEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
         try:
-            await self.coordinator.api.resume_schedule(self.mower_id)
+            await self.coordinator.api.commands.resume_schedule(self.mower_id)
         except ApiException as exception:
             raise HomeAssistantError(
                 f"Command couldn't be sent to the command queue: {exception}"

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -75,7 +75,6 @@ class LocalCalendarEntity(CalendarEntity):
         self._event: CalendarEvent | None = None
         self._attr_name = name
         self._attr_unique_id = unique_id
-        _LOGGER.debug(calendar)
 
     @property
     def event(self) -> CalendarEvent | None:
@@ -86,7 +85,6 @@ class LocalCalendarEntity(CalendarEntity):
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
-        _LOGGER.debug("self._caledar: %s", self._calendar)
         events = self._calendar.timeline_tz(start_date.tzinfo).overlapping(
             start_date,
             end_date,
@@ -164,7 +162,6 @@ def _parse_event(event: dict[str, Any]) -> Event:
     """Parse an ical event from a home assistant event dictionary."""
     if rrule := event.get(EVENT_RRULE):
         event[EVENT_RRULE] = Recur.from_rrule(rrule)
-        _LOGGER.debug("Parsed RRULE: %s", event[EVENT_RRULE])
 
     # This function is called with new events created in the local timezone,
     # however ical library does not properly return recurrence_ids for

--- a/homeassistant/components/local_calendar/calendar.py
+++ b/homeassistant/components/local_calendar/calendar.py
@@ -75,6 +75,7 @@ class LocalCalendarEntity(CalendarEntity):
         self._event: CalendarEvent | None = None
         self._attr_name = name
         self._attr_unique_id = unique_id
+        _LOGGER.debug(calendar)
 
     @property
     def event(self) -> CalendarEvent | None:
@@ -85,6 +86,7 @@ class LocalCalendarEntity(CalendarEntity):
         self, hass: HomeAssistant, start_date: datetime, end_date: datetime
     ) -> list[CalendarEvent]:
         """Get all events in a specific time frame."""
+        _LOGGER.debug("self._caledar: %s", self._calendar)
         events = self._calendar.timeline_tz(start_date.tzinfo).overlapping(
             start_date,
             end_date,
@@ -162,6 +164,7 @@ def _parse_event(event: dict[str, Any]) -> Event:
     """Parse an ical event from a home assistant event dictionary."""
     if rrule := event.get(EVENT_RRULE):
         event[EVENT_RRULE] = Recur.from_rrule(rrule)
+        _LOGGER.debug("Parsed RRULE: %s", event[EVENT_RRULE])
 
     # This function is called with new events created in the local timezone,
     # however ical library does not properly return recurrence_ids for

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -204,7 +204,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.4.4
+aioautomower==2024.5.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -183,7 +183,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.4.4
+aioautomower==2024.5.0
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.0.0

--- a/tests/components/husqvarna_automower/conftest.py
+++ b/tests/components/husqvarna_automower/conftest.py
@@ -90,5 +90,7 @@ def mock_automower_client() -> Generator[AsyncMock, None, None]:
             return ClientWebSocketResponse
 
         client.auth = AsyncMock(side_effect=websocket_connect)
+        client.commands = AsyncMock()
+        client.commands.set_cutting_height = AsyncMock()
 
         yield client

--- a/tests/components/husqvarna_automower/conftest.py
+++ b/tests/components/husqvarna_automower/conftest.py
@@ -91,6 +91,5 @@ def mock_automower_client() -> Generator[AsyncMock, None, None]:
 
         client.auth = AsyncMock(side_effect=websocket_connect)
         client.commands = AsyncMock()
-        client.commands.set_cutting_height = AsyncMock()
 
         yield client

--- a/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
@@ -5,6 +5,22 @@
       'battery_percent': 100,
     }),
     'calendar': dict({
+      'events': list([
+        dict({
+          'end': '2024-05-07T00:00:00+00:00',
+          'rrule': 'FREQ=WEEKLY;BYDAY=MO,WE,FR',
+          'start': '2024-05-06T19:00:00+00:00',
+          'uid': '1140_300_MO,WE,FR',
+          'work_area_id': None,
+        }),
+        dict({
+          'end': '2024-05-07T08:00:00+00:00',
+          'rrule': 'FREQ=WEEKLY;BYDAY=TU,TH,SA',
+          'start': '2024-05-07T00:00:00+00:00',
+          'uid': '0_480_TU,TH,SA',
+          'work_area_id': None,
+        }),
+      ]),
       'tasks': list([
         dict({
           'duration': 300,

--- a/tests/components/husqvarna_automower/test_lawn_mower.py
+++ b/tests/components/husqvarna_automower/test_lawn_mower.py
@@ -71,9 +71,9 @@ async def test_lawn_mower_commands(
     """Test lawn_mower commands."""
     await setup_integration(hass, mock_config_entry)
 
-    getattr(mock_automower_client, aioautomower_command).side_effect = ApiException(
-        "Test error"
-    )
+    getattr(
+        mock_automower_client.commands, aioautomower_command
+    ).side_effect = ApiException("Test error")
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(

--- a/tests/components/husqvarna_automower/test_number.py
+++ b/tests/components/husqvarna_automower/test_number.py
@@ -35,7 +35,7 @@ async def test_number_commands(
         service_data={"value": "3"},
         blocking=True,
     )
-    mocked_method = mock_automower_client.set_cutting_height
+    mocked_method = mock_automower_client.commands.set_cutting_height
     assert len(mocked_method.mock_calls) == 1
 
     mocked_method.side_effect = ApiException("Test error")
@@ -68,7 +68,9 @@ async def test_number_workarea_commands(
     values[TEST_MOWER_ID].work_areas[123456].cutting_height = 75
     mock_automower_client.get_status.return_value = values
     mocked_method = AsyncMock()
-    setattr(mock_automower_client, "set_cutting_height_workarea", mocked_method)
+    setattr(
+        mock_automower_client.commands, "set_cutting_height_workarea", mocked_method
+    )
     await hass.services.async_call(
         domain="number",
         service="set_value",

--- a/tests/components/husqvarna_automower/test_select.py
+++ b/tests/components/husqvarna_automower/test_select.py
@@ -81,7 +81,7 @@ async def test_select_commands(
         },
         blocking=True,
     )
-    mocked_method = mock_automower_client.set_headlight_mode
+    mocked_method = mock_automower_client.commands.set_headlight_mode
     assert len(mocked_method.mock_calls) == 1
 
     mocked_method.side_effect = ApiException("Test error")

--- a/tests/components/husqvarna_automower/test_switch.py
+++ b/tests/components/husqvarna_automower/test_switch.py
@@ -76,7 +76,7 @@ async def test_switch_commands(
         service_data={"entity_id": "switch.test_mower_1_enable_schedule"},
         blocking=True,
     )
-    mocked_method = getattr(mock_automower_client, aioautomower_command)
+    mocked_method = getattr(mock_automower_client.commands, aioautomower_command)
     assert len(mocked_method.mock_calls) == 1
 
     mocked_method.side_effect = ApiException("Test error")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the new version of the library the mower commands were moved in a separate class for better clarity
Also a new calendar event was added -> Can be addressed in another PR
rn: https://github.com/Thomas55555/aioautomower/releases/tag/2024.5.0
diff: https://github.com/Thomas55555/aioautomower/compare/2024.4.4...2024.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
