### PR TITLE
Correct formatting mqtt MQTT_DISCOVERY_DONE and MQTT_DISCOVERY_UPDATED message

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -82,7 +82,7 @@ SUPPORTED_COMPONENTS = {
 }
 
 MQTT_DISCOVERY_UPDATED: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
-    "mqtt_discovery_updated_{}"
+    "mqtt_discovery_updated_{}_{}"
 )
 MQTT_DISCOVERY_NEW: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
     "mqtt_discovery_new_{}_{}"
@@ -345,7 +345,7 @@ async def async_start(  # noqa: C901
             message = f"Component has already been discovered: {component} {discovery_id}, sending update"
             async_log_discovery_origin_info(message, payload)
             async_dispatcher_send(
-                hass, MQTT_DISCOVERY_UPDATED.format(discovery_hash), payload
+                hass, MQTT_DISCOVERY_UPDATED.format(*discovery_hash), payload
             )
         elif payload:
             # Add component

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -88,7 +88,9 @@ MQTT_DISCOVERY_NEW: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
     "mqtt_discovery_new_{}_{}"
 )
 MQTT_DISCOVERY_NEW_COMPONENT = "mqtt_discovery_new_component"
-MQTT_DISCOVERY_DONE: SignalTypeFormat[Any] = SignalTypeFormat("mqtt_discovery_done_{}")
+MQTT_DISCOVERY_DONE: SignalTypeFormat[Any] = SignalTypeFormat(
+    "mqtt_discovery_done_{}_{}"
+)
 
 TOPIC_BASE = "~"
 
@@ -329,7 +331,7 @@ async def async_start(  # noqa: C901
             discovery_pending_discovered[discovery_hash] = {
                 "unsub": async_dispatcher_connect(
                     hass,
-                    MQTT_DISCOVERY_DONE.format(discovery_hash),
+                    MQTT_DISCOVERY_DONE.format(*discovery_hash),
                     discovery_done,
                 ),
                 "pending": deque([]),
@@ -356,7 +358,7 @@ async def async_start(  # noqa: C901
         else:
             # Unhandled discovery message
             async_dispatcher_send(
-                hass, MQTT_DISCOVERY_DONE.format(discovery_hash), None
+                hass, MQTT_DISCOVERY_DONE.format(*discovery_hash), None
             )
 
     discovery_topics = [

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -809,7 +809,7 @@ class MqttDiscoveryDeviceUpdate(ABC):
         discovery_hash = get_discovery_hash(discovery_data)
         self._remove_discovery_updated = async_dispatcher_connect(
             hass,
-            MQTT_DISCOVERY_UPDATED.format(discovery_hash),
+            MQTT_DISCOVERY_UPDATED.format(*discovery_hash),
             self.async_discovery_update,
         )
         config_entry.async_on_unload(self._entry_unload)
@@ -1044,7 +1044,7 @@ class MqttDiscoveryUpdate(Entity):
             set_discovery_hash(self.hass, discovery_hash)
             self._remove_discovery_updated = async_dispatcher_connect(
                 self.hass,
-                MQTT_DISCOVERY_UPDATED.format(discovery_hash),
+                MQTT_DISCOVERY_UPDATED.format(*discovery_hash),
                 discovery_callback,
             )
 

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -305,12 +305,12 @@ async def _async_discover(
     except vol.Invalid as err:
         discovery_hash = discovery_data[ATTR_DISCOVERY_HASH]
         clear_discovery_hash(hass, discovery_hash)
-        async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(discovery_hash), None)
+        async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(*discovery_hash), None)
         async_handle_schema_error(discovery_payload, err)
     except Exception:
         discovery_hash = discovery_data[ATTR_DISCOVERY_HASH]
         clear_discovery_hash(hass, discovery_hash)
-        async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(discovery_hash), None)
+        async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(*discovery_hash), None)
         raise
 
 
@@ -745,7 +745,7 @@ def get_discovery_hash(discovery_data: DiscoveryInfoType) -> tuple[str, str]:
 def send_discovery_done(hass: HomeAssistant, discovery_data: DiscoveryInfoType) -> None:
     """Acknowledge a discovery message has been handled."""
     discovery_hash = get_discovery_hash(discovery_data)
-    async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(discovery_hash), None)
+    async_dispatcher_send(hass, MQTT_DISCOVERY_DONE.format(*discovery_hash), None)
 
 
 def stop_discovery_updates(

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -15,7 +15,14 @@ from homeassistant.components.mqtt.abbreviations import (
     ABBREVIATIONS,
     DEVICE_ABBREVIATIONS,
 )
-from homeassistant.components.mqtt.discovery import async_start
+from homeassistant.components.mqtt.discovery import (
+    MQTT_DISCOVERY_DONE,
+    MQTT_DISCOVERY_NEW,
+    MQTT_DISCOVERY_NEW_COMPONENT,
+    MQTT_DISCOVERY_UPDATED,
+    MQTTDiscoveryPayload,
+    async_start,
+)
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_ON,
@@ -26,8 +33,13 @@ from homeassistant.const import (
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.setup import async_setup_component
+from homeassistant.util.signal_type import SignalTypeFormat
 
 from .test_common import help_all_subscribe_calls, help_test_unload_config_entry
 
@@ -1765,3 +1777,46 @@ async def test_update_with_bad_config_not_breaks_discovery(
 
     state = hass.states.get("sensor.sbfspot_12345")
     assert state and state.state == "new_value"
+
+
+@pytest.mark.parametrize(
+    "signal_message",
+    [
+        MQTT_DISCOVERY_NEW,
+        MQTT_DISCOVERY_NEW_COMPONENT,
+        MQTT_DISCOVERY_UPDATED,
+        MQTT_DISCOVERY_DONE,
+    ],
+)
+async def test_discovery_dispatcher_signal_type_messages(
+    hass: HomeAssistant, signal_message: SignalTypeFormat[MQTTDiscoveryPayload]
+) -> None:
+    """Test discovery dispatcher messages.
+
+    MQTT_DISCOVERY_UPDATED: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
+    "mqtt_discovery_updated_{}_{}"
+    )
+    MQTT_DISCOVERY_NEW: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
+        "mqtt_discovery_new_{}_{}"
+    )
+    MQTT_DISCOVERY_NEW_COMPONENT = "mqtt_discovery_new_component"
+    MQTT_DISCOVERY_DONE: SignalTypeFormat[Any] = SignalTypeFormat(
+        "mqtt_discovery_done_{}_{}"
+    )
+    """
+
+    domain_id_tuple = ("sensor", "very_unique")
+    test_data = {"name": "test", "state_topic": "test-topic"}
+    calls = []
+
+    def _callback(*args) -> None:
+        calls.append(*args)
+
+    unsub = async_dispatcher_connect(
+        hass, signal_message.format(*domain_id_tuple), _callback
+    )
+    async_dispatcher_send(hass, signal_message.format(*domain_id_tuple), test_data)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0] == test_data
+    unsub()

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -1791,19 +1791,7 @@ async def test_update_with_bad_config_not_breaks_discovery(
 async def test_discovery_dispatcher_signal_type_messages(
     hass: HomeAssistant, signal_message: SignalTypeFormat[MQTTDiscoveryPayload]
 ) -> None:
-    """Test discovery dispatcher messages.
-
-    MQTT_DISCOVERY_UPDATED: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
-    "mqtt_discovery_updated_{}_{}"
-    )
-    MQTT_DISCOVERY_NEW: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
-        "mqtt_discovery_new_{}_{}"
-    )
-    MQTT_DISCOVERY_NEW_COMPONENT = "mqtt_discovery_new_component"
-    MQTT_DISCOVERY_DONE: SignalTypeFormat[Any] = SignalTypeFormat(
-        "mqtt_discovery_done_{}_{}"
-    )
-    """
+    """Test discovery dispatcher messages."""
 
     domain_id_tuple = ("sensor", "very_unique")
     test_data = {"name": "test", "state_topic": "test-topic"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The MQTT_DISCOVERY_DONE message is set after an MQTT discovery is completed. The discovery hash `tuple[str, str]` was formated as a string repr of the tuple. This PR prints the 2 tuple values instead.
The same change is applied to the MQTT_DISCOVERY_UPDATED.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
