### PR TITLE
Store Philips TV runtime data in config entry

### DIFF
--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -42,8 +42,10 @@ PLATFORMS = [
 
 LOGGER = logging.getLogger(__name__)
 
+PhilipsTVConfigEntry = ConfigEntry["PhilipsTVDataUpdateCoordinator"]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+async def async_setup_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -> bool:
     """Set up Philips TV from a config entry."""
 
     system: SystemType | None = entry.data.get(CONF_SYSTEM)
@@ -62,8 +64,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         data = {**entry.data, CONF_SYSTEM: actual_system}
         hass.config_entries.async_update_entry(entry, data=data)
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -72,18 +73,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def async_update_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -> None:
     """Update options."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):  # pylint: disable=hass-enforce-coordinator-module

--- a/homeassistant/components/philips_js/binary_sensor.py
+++ b/homeassistant/components/philips_js/binary_sensor.py
@@ -10,12 +10,10 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 
@@ -42,13 +40,11 @@ DESCRIPTIONS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PhilipsTVConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the configuration entry."""
-    coordinator: PhilipsTVDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinator = config_entry.runtime_data
 
     if (
         coordinator.api.json_feature_supported("recordings", "List")

--- a/homeassistant/components/philips_js/diagnostics.py
+++ b/homeassistant/components/philips_js/diagnostics.py
@@ -5,11 +5,9 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import PhilipsTVConfigEntry
 
 TO_REDACT = {
     "serialnumber_encrypted",
@@ -24,10 +22,10 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: PhilipsTVConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator: PhilipsTVDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator = entry.runtime_data
     api = coordinator.api
 
     return {

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -16,14 +16,12 @@ from homeassistant.components.light import (
     LightEntity,
     LightEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import color_hsv_to_RGB, color_RGB_to_hsv
 
-from . import PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 EFFECT_PARTITION = ": "
@@ -35,11 +33,11 @@ EFFECT_EXPERT_STYLES = {"FOLLOW_AUDIO", "FOLLOW_COLOR", "Lounge light"}
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PhilipsTVConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the configuration entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities([PhilipsTVLightEntity(coordinator)])
 
 

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -16,14 +16,12 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     MediaType,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
-from . import LOGGER as _LOGGER, PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import LOGGER as _LOGGER, PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
 
@@ -49,11 +47,11 @@ def _inverted(data):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PhilipsTVConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the configuration entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities(
         [
             PhilipsTVMediaPlayer(

--- a/homeassistant/components/philips_js/remote.py
+++ b/homeassistant/components/philips_js/remote.py
@@ -12,24 +12,22 @@ from homeassistant.components.remote import (
     DEFAULT_DELAY_SECS,
     RemoteEntity,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
-from . import LOGGER, PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import LOGGER, PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PhilipsTVConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the configuration entry."""
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = config_entry.runtime_data
     async_add_entities([PhilipsTVRemote(coordinator)])
 
 

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import PhilipsTVDataUpdateCoordinator
-from .const import DOMAIN
+from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 HUE_POWER_OFF = "Off"
@@ -19,13 +17,11 @@ HUE_POWER_ON = "On"
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: PhilipsTVConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the configuration entry."""
-    coordinator: PhilipsTVDataUpdateCoordinator = hass.data[DOMAIN][
-        config_entry.entry_id
-    ]
+    coordinator = config_entry.runtime_data
 
     async_add_entities([PhilipsTVScreenSwitch(coordinator)])
 

--- a/tests/components/philips_js/snapshots/test_diagnostics.ambr
+++ b/tests/components/philips_js/snapshots/test_diagnostics.ambr
@@ -1,0 +1,100 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'data': dict({
+      'ambilight_cached': dict({
+      }),
+      'ambilight_current_configuration': None,
+      'ambilight_measured': None,
+      'ambilight_mode_raw': 'internal',
+      'ambilight_modes': list([
+        'internal',
+        'manual',
+        'expert',
+        'lounge',
+      ]),
+      'ambilight_power': 'On',
+      'ambilight_power_raw': dict({
+        'power': 'On',
+      }),
+      'ambilight_processed': None,
+      'ambilight_styles': dict({
+      }),
+      'ambilight_topology': None,
+      'application': None,
+      'applications': dict({
+      }),
+      'channel': None,
+      'channel_lists': dict({
+        'all': dict({
+          'Channel': list([
+          ]),
+          'id': 'all',
+          'installCountry': 'Poland',
+          'listType': 'MixedSources',
+          'medium': 'mixed',
+          'operator': 'None',
+          'version': 2,
+        }),
+      }),
+      'channels': dict({
+      }),
+      'context': dict({
+        'data': 'NA',
+        'level1': 'NA',
+        'level2': 'NA',
+        'level3': 'NA',
+      }),
+      'favorite_lists': dict({
+        '1': dict({
+          'channels': list([
+          ]),
+          'id': '1',
+          'medium': 'mixed',
+          'name': 'Favourites 1',
+          'type': 'MixedSources',
+          'version': '60',
+        }),
+      }),
+      'on': True,
+      'powerstate': None,
+      'screenstate': 'On',
+      'source_id': None,
+      'sources': dict({
+      }),
+      'system': dict({
+        'country': 'Sweden',
+        'menulanguage': 'English',
+        'model': 'modelname',
+        'name': 'Philips TV',
+        'serialnumber': '**REDACTED**',
+        'softwareversion': 'abcd',
+      }),
+    }),
+    'entry': dict({
+      'data': dict({
+        'api_version': 1,
+        'host': '1.1.1.1',
+        'system': dict({
+          'country': 'Sweden',
+          'menulanguage': 'English',
+          'model': 'modelname',
+          'name': 'Philips TV',
+          'serialnumber': '**REDACTED**',
+          'softwareversion': 'abcd',
+        }),
+      }),
+      'disabled_by': None,
+      'domain': 'philips_js',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'title': '**REDACTED**',
+      'unique_id': '**REDACTED**',
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/components/philips_js/test_diagnostics.py
+++ b/tests/components/philips_js/test_diagnostics.py
@@ -1,0 +1,65 @@
+"""Test the Philips TV diagnostics platform."""
+
+from unittest.mock import AsyncMock
+
+from syrupy import SnapshotAssertion
+from syrupy.filters import props
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+TV_CONTEXT = {"level1": "NA", "level2": "NA", "level3": "NA", "data": "NA"}
+TV_CHANNEL_LISTS = {
+    "all": {
+        "version": 2,
+        "id": "all",
+        "listType": "MixedSources",
+        "medium": "mixed",
+        "operator": "None",
+        "installCountry": "Poland",
+        "Channel": [],
+    }
+}
+TV_FAVORITE_LISTS = {
+    "1": {
+        "version": "60",
+        "id": "1",
+        "type": "MixedSources",
+        "medium": "mixed",
+        "name": "Favourites 1",
+        "channels": [],
+    }
+}
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    mock_tv: AsyncMock,
+) -> None:
+    """Test config entry diagnostics."""
+    mock_tv.context = TV_CONTEXT
+    mock_tv.ambilight_topology = None
+    mock_tv.ambilight_mode_raw = "internal"
+    mock_tv.ambilight_modes = ["internal", "manual", "expert", "lounge"]
+    mock_tv.ambilight_power_raw = {"power": "On"}
+    mock_tv.ambilight_power = "On"
+    mock_tv.ambilight_measured = None
+    mock_tv.ambilight_processed = None
+    mock_tv.screenstate = "On"
+    mock_tv.channel = None
+    mock_tv.channel_lists = TV_CHANNEL_LISTS
+    mock_tv.favorite_lists = TV_FAVORITE_LISTS
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_config_entry
+    )
+
+    assert result == snapshot(exclude=props("entry_id"))

--- a/tests/components/philips_js/test_diagnostics.py
+++ b/tests/components/philips_js/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from haphilipsjs.typing import ChannelListType, ContextType, FavoriteListType
 from syrupy import SnapshotAssertion
 from syrupy.filters import props
 
@@ -11,27 +12,27 @@ from tests.common import MockConfigEntry
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
-TV_CONTEXT = {"level1": "NA", "level2": "NA", "level3": "NA", "data": "NA"}
+TV_CONTEXT = ContextType(level1="NA", level2="NA", level3="NA", data="NA")
 TV_CHANNEL_LISTS = {
-    "all": {
-        "version": 2,
-        "id": "all",
-        "listType": "MixedSources",
-        "medium": "mixed",
-        "operator": "None",
-        "installCountry": "Poland",
-        "Channel": [],
-    }
+    "all": ChannelListType(
+        version=2,
+        id="all",
+        listType="MixedSources",
+        medium="mixed",
+        operator="None",
+        installCountry="Poland",
+        Channel=[],
+    )
 }
 TV_FAVORITE_LISTS = {
-    "1": {
-        "version": "60",
-        "id": "1",
-        "type": "MixedSources",
-        "medium": "mixed",
-        "name": "Favourites 1",
-        "channels": [],
-    }
+    "1": FavoriteListType(
+        version="60",
+        id="1",
+        type="MixedSources",
+        medium="mixed",
+        name="Favourites 1",
+        channels=[],
+    )
 }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- uses config entry to store runtime data
- adds tests for the diagnostics platform to make codecov happy

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
