### PR TITLE
Add Total Volatile Organic Compounds (tVOC) matter discovery schema

### DIFF
--- a/homeassistant/components/matter/sensor.py
+++ b/homeassistant/components/matter/sensor.py
@@ -222,6 +222,19 @@ DISCOVERY_SCHEMAS = [
     MatterDiscoverySchema(
         platform=Platform.SENSOR,
         entity_description=MatterSensorEntityDescription(
+            key="TotalVolatileOrganicCompoundsSensor",
+            native_unit_of_measurement=CONCENTRATION_PARTS_PER_MILLION,
+            device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS_PARTS,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        entity_class=MatterSensor,
+        required_attributes=(
+            clusters.TotalVolatileOrganicCompoundsConcentrationMeasurement.Attributes.MeasuredValue,
+        ),
+    ),
+    MatterDiscoverySchema(
+        platform=Platform.SENSOR,
+        entity_description=MatterSensorEntityDescription(
             key="PM1Sensor",
             native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
             device_class=SensorDeviceClass.PM1,

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -387,3 +387,7 @@ async def test_air_purifier_sensor(
     state = hass.states.get("sensor.air_purifier_vocs")
     assert state
     assert state.state == "2.0"
+    assert state.attributes["state_class"] == "measurement"
+    assert state.attributes["unit_of_measurement"] == "ppm"
+    assert state.attributes["device_class"] == "volatile_organic_compounds_parts"
+    assert state.attributes["friendly_name"] == "Air Purifier VOCs"

--- a/tests/components/matter/test_sensor.py
+++ b/tests/components/matter/test_sensor.py
@@ -84,6 +84,16 @@ async def air_quality_sensor_node_fixture(
     )
 
 
+@pytest.fixture(name="air_purifier_node")
+async def air_purifier_node_fixture(
+    hass: HomeAssistant, matter_client: MagicMock
+) -> MatterNode:
+    """Fixture for an air purifier node."""
+    return await setup_integration_with_node_fixture(
+        hass, "air-purifier", matter_client
+    )
+
+
 # This tests needs to be adjusted to remove lingering tasks
 @pytest.mark.parametrize("expected_lingering_tasks", [True])
 async def test_sensor_null_value(
@@ -333,3 +343,47 @@ async def test_air_quality_sensor(
     state = hass.states.get("sensor.lightfi_aq1_air_quality_sensor_pm10")
     assert state
     assert state.state == "50.0"
+
+
+# This tests needs to be adjusted to remove lingering tasks
+@pytest.mark.parametrize("expected_lingering_tasks", [True])
+async def test_air_purifier_sensor(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    air_purifier_node: MatterNode,
+) -> None:
+    """Test Air quality sensors are creayted for air purifier device."""
+    # Carbon Dioxide
+    state = hass.states.get("sensor.air_purifier_carbon_dioxide")
+    assert state
+    assert state.state == "2.0"
+
+    # PM1
+    state = hass.states.get("sensor.air_purifier_pm1")
+    assert state
+    assert state.state == "2.0"
+
+    # PM2.5
+    state = hass.states.get("sensor.air_purifier_pm2_5")
+    assert state
+    assert state.state == "2.0"
+
+    # PM10
+    state = hass.states.get("sensor.air_purifier_pm10")
+    assert state
+    assert state.state == "2.0"
+
+    # Temperature
+    state = hass.states.get("sensor.air_purifier_temperature")
+    assert state
+    assert state.state == "20.0"
+
+    # Humidity
+    state = hass.states.get("sensor.air_purifier_humidity")
+    assert state
+    assert state.state == "50.0"
+
+    # VOCS
+    state = hass.states.get("sensor.air_purifier_vocs")
+    assert state
+    assert state.state == "2.0"


### PR DESCRIPTION
## Proposed change

Adds a little bit of missing configuration to propagate tVOC readings from a Matter device to Home Assistant. Without this patch tVOC readings are ignored. Tested with SenseCAP indicator with indicator-matter firmware.

NOTE: Device needs to be deleted and re-added for the sensor to appear.

If this pull request is not of adequate quality, please consider this to be a feature request to add tVOC sensor to matter integration.

## Type of change

- [X] New feature (which adds functionality to an existing integration)

## Additional information

This change would also be needed for https://github.com/home-assistant/core/issues/105567

## Checklist

- [ ] The code change is tested and works locally.
  - YES
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
  - I am not familiar with HA code ecosystem enough to run tests. But the change is trivial and mechanic. I expect tests to pass.
- [ ] There is no commented out code in this PR.
  - No commented out code.
- [ ] I have followed the [development checklist][dev-checklist]
  - I have not read it.
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
  - I have not read it.
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
  - No, I don't have this installed. But formatting matches other entries in the file.
- [ ] Tests have been added to verify that the new code works.
  - No.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
  - No.