### PR TITLE
Allow templates for enabling conditions

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -227,16 +227,25 @@ async def async_from_config(
         factory = platform.async_condition_from_config
 
     # Check if condition is not enabled
-    if not config.get(CONF_ENABLED, True):
+    if CONF_ENABLED in config:
+        enabled = config[CONF_ENABLED]
+        if isinstance(enabled, Template):
+            try:
+                enabled = enabled.async_render(limited=True)
+            except TemplateError as err:
+                raise HomeAssistantError(
+                    f"Error rendering condition enabled template: {err}"
+                ) from err
+        if not enabled:
 
-        @trace_condition_function
-        def disabled_condition(
-            hass: HomeAssistant, variables: TemplateVarsType = None
-        ) -> bool | None:
-            """Condition not enabled, will act as if it didn't exist."""
-            return None
+            @trace_condition_function
+            def disabled_condition(
+                hass: HomeAssistant, variables: TemplateVarsType = None
+            ) -> bool | None:
+                """Condition not enabled, will act as if it didn't exist."""
+                return None
 
-        return disabled_condition
+            return disabled_condition
 
     # Check for partials to properly determine if coroutine function
     check_factory = factory

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1356,7 +1356,7 @@ NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
 
 CONDITION_BASE_SCHEMA = {
     vol.Optional(CONF_ALIAS): string,
-    vol.Optional(CONF_ENABLED): boolean,
+    vol.Optional(CONF_ENABLED): vol.Any(boolean, template_complex),
 }
 
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1356,7 +1356,7 @@ NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
 
 CONDITION_BASE_SCHEMA = {
     vol.Optional(CONF_ALIAS): string,
-    vol.Optional(CONF_ENABLED): vol.Any(boolean, template_complex),
+    vol.Optional(CONF_ENABLED): vol.Any(boolean, template),
 }
 
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -3382,10 +3382,36 @@ async def test_platform_async_validate_condition_config(hass: HomeAssistant) -> 
         device_automation_validate_condition_mock.assert_awaited()
 
 
-async def test_disabled_condition(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize("enabled_value", [True, "{{ 1 == 1 }}"])
+async def test_enabled_condition(
+    hass: HomeAssistant, enabled_value: bool | str
+) -> None:
+    """Test an explicitly enabled condition."""
+    config = {
+        "enabled": enabled_value,
+        "condition": "state",
+        "entity_id": "binary_sensor.test",
+        "state": "on",
+    }
+    config = cv.CONDITION_SCHEMA(config)
+    config = await condition.async_validate_condition_config(hass, config)
+    test = await condition.async_from_config(hass, config)
+
+    hass.states.async_set("binary_sensor.test", "on")
+    assert test(hass) is True
+
+    # Still passes, condition is not enabled
+    hass.states.async_set("binary_sensor.test", "off")
+    assert test(hass) is False
+
+
+@pytest.mark.parametrize("enabled_value", [False, "{{ 1 == 9 }}"])
+async def test_disabled_condition(
+    hass: HomeAssistant, enabled_value: bool | str
+) -> None:
     """Test a disabled condition returns none."""
     config = {
-        "enabled": False,
+        "enabled": enabled_value,
         "condition": "state",
         "entity_id": "binary_sensor.test",
         "state": "on",
@@ -3400,6 +3426,21 @@ async def test_disabled_condition(hass: HomeAssistant) -> None:
     # Still passes, condition is not enabled
     hass.states.async_set("binary_sensor.test", "off")
     assert test(hass) is None
+
+
+async def test_condition_enabled_template_limited(hass: HomeAssistant) -> None:
+    """Test conditions enabled template raises for non-limited template uses."""
+    config = {
+        "enabled": "{{ states('sensor.limited') }}",
+        "condition": "state",
+        "entity_id": "binary_sensor.test",
+        "state": "on",
+    }
+    config = cv.CONDITION_SCHEMA(config)
+    config = await condition.async_validate_condition_config(hass, config)
+
+    with pytest.raises(HomeAssistantError):
+        await condition.async_from_config(hass, config)
 
 
 async def test_and_condition_with_disabled_condition(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow limited templates for enabling automation conditions. This will be useful to enable / disable specific conditions based on blueprint input values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
  - https://github.com/home-assistant/architecture/discussions/1066
  - https://github.com/home-assistant/core/pull/114458
  - https://github.com/home-assistant/core/pull/117049
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32771

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
