### PR TITLE
Add LinknLink integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -707,6 +707,8 @@ omit =
     homeassistant/components/lg_soundbar/media_player.py
     homeassistant/components/lightwave/*
     homeassistant/components/limitlessled/light.py
+    homeassistant/components/linknlink/binary_sensor.py
+    homeassistant/components/linknlink/coordinator.py
     homeassistant/components/linksys_smart/device_tracker.py
     homeassistant/components/linode/*
     homeassistant/components/linux_battery/sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -770,6 +770,8 @@ build.json @home-assistant/supervisor
 /tests/components/light/ @home-assistant/core
 /homeassistant/components/linear_garage_door/ @IceBotYT
 /tests/components/linear_garage_door/ @IceBotYT
+/homeassistant/components/linknlink/ @linknlink
+/tests/components/linknlink/ @linknlink
 /homeassistant/components/linux_battery/ @fabaff
 /homeassistant/components/litejet/ @joncar
 /tests/components/litejet/ @joncar

--- a/homeassistant/components/linknlink/__init__.py
+++ b/homeassistant/components/linknlink/__init__.py
@@ -1,0 +1,55 @@
+"""The linknlink integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_MAC
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DOMAIN, get_domains
+from .coordinator import LinknLinkCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a linknlink device from a config entry."""
+    coordinator = LinknLinkCoordinator(hass, entry.data[CONF_MAC])
+    if not await coordinator.async_setup():
+        _LOGGER.error(
+            "Unable to setup linknlink device - config=%s",
+            coordinator.config_entry.data,
+        )
+        raise ConfigEntryNotReady
+
+    unlisten = entry.add_update_listener(async_update)
+    entry.async_on_unload(unlisten)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    # Forward entry setup to related domains.
+    await hass.config_entries.async_forward_entry_setups(
+        entry, get_domains(coordinator.api.type)
+    )
+
+    return True
+
+
+async def async_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    device: LinknLinkCoordinator = hass.data[DOMAIN][entry.entry_id]
+    unload_ok = await hass.config_entries.async_unload_platforms(
+        entry, get_domains(device.api.type)
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/homeassistant/components/linknlink/__init__.py
+++ b/homeassistant/components/linknlink/__init__.py
@@ -47,9 +47,8 @@ async def async_update(hass: HomeAssistant, entry: ConfigEntry) -> None:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     device: LinknLinkCoordinator = hass.data[DOMAIN][entry.entry_id]
-    unload_ok = await hass.config_entries.async_unload_platforms(
+    if unload_ok := await hass.config_entries.async_unload_platforms(
         entry, get_domains(device.api.type)
-    )
-    if unload_ok:
+    ):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/linknlink/binary_sensor.py
+++ b/homeassistant/components/linknlink/binary_sensor.py
@@ -1,0 +1,71 @@
+"""Support for the linknlink binary sensors."""
+
+from __future__ import annotations
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import LinknLinkCoordinator
+from .entity import LinknLinkEntity
+
+BINARY_SENSOR_TYPES: tuple[BinarySensorEntityDescription, ...] = (
+    BinarySensorEntityDescription(
+        key="pir_detected",
+        device_class=BinarySensorDeviceClass.MOTION,
+    ),
+    BinarySensorEntityDescription(
+        key="doorsensor_status",
+        device_class=BinarySensorDeviceClass.DOOR,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the linknlink binary sensor."""
+
+    coordinator: LinknLinkCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    async_add_entities(
+        LinknLinkBinarySensor(coordinator, description)
+        for description in BINARY_SENSOR_TYPES
+        if description.key in coordinator.data
+    )
+
+
+class LinknLinkBinarySensor(LinknLinkEntity, BinarySensorEntity):
+    """Representation of a linknlink binary sensor."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: LinknLinkCoordinator,
+        description: BinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator)
+        if description.key in self.coordinator.data:
+            self.entity_description = description
+            self._attr_is_on = bool(self.coordinator.data[description.key])
+            self._attr_unique_id = f"{coordinator.api.mac.hex()}-{description.key}"
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle coordinator update."""
+        self._update_attr()
+        super()._handle_coordinator_update()
+
+    @callback
+    def _update_attr(self) -> None:
+        """Update attributes for sensor."""
+        self._attr_is_on = bool(self.coordinator.data[self.entity_description.key])

--- a/homeassistant/components/linknlink/binary_sensor.py
+++ b/homeassistant/components/linknlink/binary_sensor.py
@@ -8,7 +8,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -59,13 +59,7 @@ class LinknLinkBinarySensor(LinknLinkEntity, BinarySensorEntity):
             self._attr_is_on = bool(self.coordinator.data[description.key])
             self._attr_unique_id = f"{coordinator.api.mac.hex()}-{description.key}"
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
+    @property
+    def is_on(self) -> bool:
         """Handle coordinator update."""
-        self._update_attr()
-        super()._handle_coordinator_update()
-
-    @callback
-    def _update_attr(self) -> None:
-        """Update attributes for sensor."""
-        self._attr_is_on = bool(self.coordinator.data[self.entity_description.key])
+        return bool(self.coordinator.data[self.entity_description.key])

--- a/homeassistant/components/linknlink/config_flow.py
+++ b/homeassistant/components/linknlink/config_flow.py
@@ -1,0 +1,256 @@
+"""Config flow for linknlink devices."""
+
+import errno
+from functools import partial
+import logging
+import socket
+from typing import Any
+
+import linknlink as llk
+from linknlink.exceptions import (
+    AuthenticationError,
+    LinknLinkException,
+    NetworkTimeoutError,
+)
+import voluptuous as vol
+
+from homeassistant.components import dhcp
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TYPE
+from homeassistant.data_entry_flow import AbortFlow
+
+from .const import DEVICE_TYPES, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class linknlinkFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a linknlink config flow."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the linknlink flow."""
+        self.device: llk.Device = None
+
+    async def async_set_device(self, device: llk.Device, raise_on_progress=True):
+        """Define a device for the config flow."""
+        if device.type not in DEVICE_TYPES:
+            _LOGGER.error(
+                ("Unsupported device: %s"),
+                hex(device.devtype),
+            )
+            raise AbortFlow("not_supported")
+
+        await self.async_set_unique_id(
+            device.mac.hex(), raise_on_progress=raise_on_progress
+        )
+        self.device = device
+
+        self.context["title_placeholders"] = {
+            "name": device.name,
+            "model": device.model,
+            "host": device.host[0],
+        }
+
+    async def async_step_dhcp(
+        self, discovery_info: dhcp.DhcpServiceInfo
+    ) -> ConfigFlowResult:
+        """Handle dhcp discovery."""
+        host = discovery_info.ip
+        unique_id = discovery_info.macaddress.lower().replace(":", "")
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
+        try:
+            device = await self.hass.async_add_executor_job(llk.hello, host)
+
+        except NetworkTimeoutError:
+            return self.async_abort(reason="cannot_connect")
+
+        except OSError as err:
+            if err.errno == errno.ENETUNREACH:
+                return self.async_abort(reason="cannot_connect")
+            return self.async_abort(reason="unknown")
+
+        if device.type not in DEVICE_TYPES:
+            return self.async_abort(reason="not_supported")
+
+        await self.async_set_device(device)
+        return await self.async_step_auth()
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a flow initiated by the user."""
+        errors = {}
+
+        if user_input:
+            host = user_input[CONF_HOST]
+
+            try:
+                hello = partial(llk.hello, host)
+                linknlink = await self.hass.async_add_executor_job(hello)
+
+            except NetworkTimeoutError:
+                errors["base"] = "cannot_connect"
+                err_msg = "Device not found"
+
+            except OSError as err:
+                if err.errno in {errno.EINVAL, socket.EAI_NONAME}:
+                    errors["base"] = "invalid_host"
+                    err_msg = "Invalid hostname or IP address"
+                elif err.errno == errno.ENETUNREACH:
+                    errors["base"] = "cannot_connect"
+                    err_msg = str(err)
+                else:
+                    errors["base"] = "unknown"
+                    err_msg = str(err)
+
+            else:
+                await self.async_set_device(linknlink)
+                self._abort_if_unique_id_configured(
+                    updates={CONF_HOST: linknlink.host[0]}
+                )
+                return await self.async_step_auth()
+
+            _LOGGER.error("Failed to connect to the device at %s: %s", host, err_msg)
+
+        data_schema = {vol.Required(CONF_HOST): str}
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(data_schema),
+            errors=errors,
+        )
+
+    async def async_step_auth(self) -> ConfigFlowResult:
+        """Authenticate to the device."""
+        device = self.device
+        errors = {}
+
+        try:
+            await self.hass.async_add_executor_job(device.auth)
+
+        except AuthenticationError:
+            errors["base"] = "invalid_auth"
+            await self.async_set_unique_id(device.mac.hex())
+            return await self.async_step_reset(errors=errors)
+
+        except NetworkTimeoutError as err:
+            errors["base"] = "cannot_connect"
+            err_msg = str(err)
+
+        except LinknLinkException as err:
+            errors["base"] = "unknown"
+            err_msg = str(err)
+
+        except OSError as err:
+            if err.errno == errno.ENETUNREACH:
+                errors["base"] = "cannot_connect"
+                err_msg = str(err)
+            else:
+                errors["base"] = "unknown"
+                err_msg = str(err)
+
+        else:
+            await self.async_set_unique_id(device.mac.hex())
+            if device.is_locked:
+                return await self.async_step_unlock()
+            return await self.async_finish()
+
+        await self.async_set_unique_id(device.mac.hex())
+        _LOGGER.error(
+            "Failed to authenticate to the device at %s: %s", device.host[0], err_msg
+        )
+        return self.async_show_form(step_id="auth", errors=errors)
+
+    async def async_step_reset(self, user_input=None, errors=None) -> ConfigFlowResult:
+        """Guide the user to unlock the device manually.
+
+        We are unable to authenticate because the device is locked.
+        The user needs to open the LinknLink app and unlock the device.
+        """
+        device = self.device
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="reset",
+                errors=errors,
+                description_placeholders={
+                    "name": device.name,
+                    "model": device.model,
+                    "host": device.host[0],
+                },
+            )
+
+        return await self.async_step_user({CONF_HOST: device.host[0]})
+
+    async def async_step_unlock(self, user_input=None) -> ConfigFlowResult:
+        """Unlock the device.
+
+        The authentication succeeded, but the device is locked.
+        We can offer an unlock to prevent authorization errors.
+        """
+        device = self.device
+        errors = {}
+
+        if user_input is None:
+            pass
+
+        elif user_input["unlock"]:
+            try:
+                await self.hass.async_add_executor_job(device.set_lock, False)
+
+            except NetworkTimeoutError as err:
+                errors["base"] = "cannot_connect"
+                err_msg = str(err)
+
+            except LinknLinkException as err:
+                errors["base"] = "unknown"
+                err_msg = str(err)
+
+            except OSError as err:
+                if err.errno == errno.ENETUNREACH:
+                    errors["base"] = "cannot_connect"
+                    err_msg = str(err)
+                else:
+                    errors["base"] = "unknown"
+                    err_msg = str(err)
+
+            else:
+                return await self.async_finish()
+
+            _LOGGER.error(
+                "Failed to unlock the device at %s: %s", device.host[0], err_msg
+            )
+
+        else:
+            return await self.async_finish()
+
+        data_schema = {vol.Required("unlock", default=False): bool}
+        return self.async_show_form(
+            step_id="unlock",
+            errors=errors,
+            data_schema=vol.Schema(data_schema),
+            description_placeholders={
+                "name": device.name,
+                "model": device.model,
+                "host": device.host[0],
+            },
+        )
+
+    async def async_finish(self) -> ConfigFlowResult:
+        """Create config entry."""
+        device = self.device
+
+        # Abort reauthentication flow.
+        self._abort_if_unique_id_configured(updates={CONF_HOST: device.host[0]})
+
+        return self.async_create_entry(
+            title=f"{DOMAIN}-{device.mac.hex()}",
+            data={
+                CONF_HOST: device.host[0],
+                CONF_MAC: device.mac.hex(),
+                CONF_TYPE: device.devtype,
+            },
+        )

--- a/homeassistant/components/linknlink/const.py
+++ b/homeassistant/components/linknlink/const.py
@@ -1,0 +1,17 @@
+"""Constants for the linknlink integration."""
+
+from homeassistant.const import Platform
+
+DOMAIN = "linknlink"
+
+DOMAINS_AND_TYPES = {
+    Platform.BINARY_SENSOR: {"EHUB", "EMOTION"},
+}
+DEVICE_TYPES = set.union(*DOMAINS_AND_TYPES.values())
+
+DEFAULT_PORT = 80
+
+
+def get_domains(device_type: str) -> set[Platform]:
+    """Return the domains available for a device type."""
+    return {d for d, t in DOMAINS_AND_TYPES.items() if device_type in t}

--- a/homeassistant/components/linknlink/coordinator.py
+++ b/homeassistant/components/linknlink/coordinator.py
@@ -1,0 +1,140 @@
+"""LinknLink Coordinator."""
+
+from __future__ import annotations
+
+from contextlib import suppress
+from datetime import timedelta
+from functools import partial
+import logging
+from typing import Any
+
+import linknlink as llk
+from linknlink.exceptions import (
+    AuthenticationError,
+    AuthorizationError,
+    ConnectionClosedError,
+    LinknLinkException,
+    NetworkTimeoutError,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_TYPE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class LinknLinkCoordinator(DataUpdateCoordinator[dict[str, Any]]):
+    """In charge of get the data for a site."""
+
+    api: llk.Device
+    config_entry: ConfigEntry
+
+    def __init__(self, hass: HomeAssistant, mac: str) -> None:
+        """Initialize the data service."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}-{mac}",
+            update_interval=timedelta(seconds=30),
+        )
+        self.fw_version: int | None = None
+        self.authorized: bool | None = None
+
+    @property
+    def available(self) -> bool | None:
+        """Return True if the device is available."""
+        return self.authorized
+
+    def _get_firmware_version(self) -> int | None:
+        """Get firmware version."""
+        self.api.auth()
+        with suppress(LinknLinkException, OSError):
+            return self.api.get_fwversion()
+        return None
+
+    async def async_setup(self) -> bool:
+        """Set up the device and related entities."""
+        config = self.config_entry
+
+        api = llk.gendevice(
+            config.data[CONF_TYPE],
+            (config.data[CONF_HOST], DEFAULT_PORT),
+            bytes.fromhex(config.data[CONF_MAC]),
+            name=config.title,
+        )
+        self.api = api
+        try:
+            self.fw_version = await self.hass.async_add_executor_job(
+                self._get_firmware_version
+            )
+
+        except AuthenticationError:
+            await self._async_handle_auth_error()
+            return False
+
+        except (NetworkTimeoutError, OSError) as err:
+            _LOGGER.error("Failed to connect to the device [%s]: %s", api.host[0], err)
+            return False
+
+        except LinknLinkException as err:
+            _LOGGER.error(
+                "Failed to authenticate to the device at %s: %s", api.host[0], err
+            )
+            return False
+
+        self.authorized = True
+
+        return True
+
+    async def _async_handle_auth_error(self) -> None:
+        """Handle an authentication error."""
+        if self.authorized is False:
+            return
+
+        self.authorized = False
+
+        _LOGGER.error(
+            (
+                "%s (%s at %s) is locked. Click Configuration in the sidebar, "
+                "click Integrations, click Configure on the device and follow "
+                "the instructions to unlock it"
+            ),
+            self.name,
+            self.api.model,
+            self.api.host[0],
+        )
+
+    async def async_auth(self) -> bool:
+        """Authenticate to the device."""
+        try:
+            await self.hass.async_add_executor_job(self.api.auth)
+        except (LinknLinkException, OSError) as err:
+            _LOGGER.debug(
+                "Failed to authenticate to the device at %s: %s", self.api.host[0], err
+            )
+            if isinstance(err, AuthenticationError):
+                await self._async_handle_auth_error()
+            return False
+        return True
+
+    async def async_request(self, function, *args, **kwargs):
+        """Send a request to the device."""
+        request = partial(function, *args, **kwargs)
+        try:
+            return await self.hass.async_add_executor_job(request)
+        except (AuthorizationError, ConnectionClosedError):
+            if not await self.async_auth():
+                raise
+            return await self.hass.async_add_executor_job(request)
+
+    async def _async_update_data(self) -> dict[str, Any]:
+        """Fetch data from the device."""
+        try:
+            return await self.async_request(self.api.check_sensors)
+        except AttributeError as e:
+            _LOGGER.error("Failed to execute function: %s", e)
+            return {}

--- a/homeassistant/components/linknlink/entity.py
+++ b/homeassistant/components/linknlink/entity.py
@@ -1,0 +1,27 @@
+"""LinknLink Entities."""
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import LinknLinkCoordinator
+
+
+class LinknLinkEntity(CoordinatorEntity[LinknLinkCoordinator]):
+    """To manage the device info."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: LinknLinkCoordinator) -> None:
+        """Initialize coordinator entity."""
+        super().__init__(coordinator)
+        self.api = coordinator.api
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self.api.mac.hex())},
+            connections={(dr.CONNECTION_NETWORK_MAC, self.api.mac.hex())},
+            name=self.api.name,
+            manufacturer=self.api.manufacturer,
+            model=self.api.model,
+            sw_version=str(coordinator.fw_version),
+        )

--- a/homeassistant/components/linknlink/manifest.json
+++ b/homeassistant/components/linknlink/manifest.json
@@ -1,0 +1,18 @@
+{
+  "domain": "linknlink",
+  "name": "LinknLink",
+  "codeowners": ["@linknlink"],
+  "config_flow": true,
+  "dhcp": [
+    {
+      "registered_devices": true
+    },
+    {
+      "macaddress": "E04B41*"
+    }
+  ],
+  "documentation": "https://www.home-assistant.io/integrations/linknlink",
+  "iot_class": "local_polling",
+  "loggers": ["linknlink"],
+  "requirements": ["linknlink==0.1.9"]
+}

--- a/homeassistant/components/linknlink/strings.json
+++ b/homeassistant/components/linknlink/strings.json
@@ -1,0 +1,47 @@
+{
+  "config": {
+    "flow_title": "{name} ({model} at {host})",
+    "step": {
+      "user": {
+        "title": "Connect to the device",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "timeout": "Timeout"
+        }
+      },
+      "auth": {
+        "title": "Authenticate to the device"
+      },
+      "reset": {
+        "title": "Unlock the device",
+        "description": "{name} ({model} at {host}) is locked. You need to unlock the device in order to authenticate and complete the configuration. Instructions:\n1. Open the linknlink app.\n2. Click on the device.\n3. Click `...` in the upper right -> Settings.\n4. Scroll to the bottom of the page.\n5. Disable the Lock Device."
+      },
+      "unlock": {
+        "title": "Unlock the device (optional)",
+        "description": "{name} ({model} at {host}) is locked. This can lead to authentication problems in Home Assistant. Would you like to unlock it?",
+        "data": {
+          "unlock": "Yes, do it."
+        }
+      },
+      "finish": {
+        "title": "Choose a name for the device",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "not_supported": "Device not supported",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_host": "[%key:common::config_flow::error::invalid_host%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -294,6 +294,7 @@ FLOWS = {
         "lidarr",
         "lifx",
         "linear_garage_door",
+        "linknlink",
         "litejet",
         "litterrobot",
         "livisi",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -291,6 +291,14 @@ DHCP: list[dict[str, str | bool]] = [
         "registered_devices": True,
     },
     {
+        "domain": "linknlink",
+        "registered_devices": True,
+    },
+    {
+        "domain": "linknlink",
+        "macaddress": "E04B41*",
+    },
+    {
         "domain": "litterrobot",
         "hostname": "litter-robot4",
     },

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -3244,6 +3244,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "linknlink": {
+      "name": "LinknLink",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "local_polling"
+    },
     "linksys_smart": {
       "name": "Linksys Smart Wi-Fi",
       "integration_type": "hub",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1241,6 +1241,9 @@ limitlessled==1.1.3
 # homeassistant.components.linear_garage_door
 linear-garage-door==0.2.9
 
+# homeassistant.components.linknlink
+linknlink==0.1.9
+
 # homeassistant.components.linode
 linode-api==4.1.9b1
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -998,6 +998,9 @@ libsoundtouch==0.8
 # homeassistant.components.linear_garage_door
 linear-garage-door==0.2.9
 
+# homeassistant.components.linknlink
+linknlink==0.1.9
+
 # homeassistant.components.lamarzocco
 lmcloud==0.4.35
 

--- a/tests/components/linknlink/__init__.py
+++ b/tests/components/linknlink/__init__.py
@@ -1,0 +1,133 @@
+"""Tests for the LinknLnk integration."""
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.linknlink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+LINKNLINK_DEVICES = {
+    "Living Room": (
+        "192.168.2.12",
+        "ec0b12a43ba1",
+        "eHub",
+        "LinknLink",
+        "EHUB",
+        0x520B,
+        44017,
+        10,
+    ),
+    "Bedroom": (
+        "192.168.2.15",
+        "ec0b12a43bb2",
+        "eTHS",
+        "LinknLink",
+        "ETHS",
+        0xAC7C,
+        20025,
+        5,
+    ),
+    "Office": (  # Not supported.
+        "192.168.2.64",
+        "ec0b12a43bc3",
+        "eMotion",
+        "LinknLink",
+        "EMOTION",
+        0xAC7B,
+        57,
+        5,
+    ),
+    "Kitchen": (  # Not supported.
+        "192.168.2.64",
+        "ec0b12a43bc3",
+        "eMotion2",
+        "LinknLink",
+        "EMOTION2",
+        0x7777,
+        57,
+        5,
+    ),
+}
+
+
+@dataclass
+class MockSetup:
+    """Representation of a mock setup."""
+
+    api: MagicMock
+    entry: MockConfigEntry
+    factory: MagicMock
+
+
+class LinknLinkDevice:
+    """Representation of a LinknLink device."""
+
+    def __init__(
+        self, name, host, mac, model, manufacturer, type_, devtype, fwversion, timeout
+    ):
+        """Initialize the device."""
+        self.name: str = name
+        self.host: str = host
+        self.mac: str = mac
+        self.model: str = model
+        self.manufacturer: str = manufacturer
+        self.type: str = type_
+        self.devtype: int = devtype
+        self.timeout: int = timeout
+        self.fwversion: int = fwversion
+
+    async def setup_entry(self, hass: HomeAssistant, mock_api=None, mock_entry=None):
+        """Set up the device."""
+        mock_api = mock_api or self.get_mock_api()
+        mock_entry = mock_entry or self.get_mock_entry()
+        mock_entry.add_to_hass(hass)
+
+        with patch(
+            "homeassistant.components.linknlink.device.llk.gendevice",
+            return_value=mock_api,
+        ) as mock_factory:
+            await hass.config_entries.async_setup(mock_entry.entry_id)
+            await hass.async_block_till_done()
+
+        return MockSetup(mock_api, mock_entry, mock_factory)
+
+    def get_mock_api(self):
+        """Return a mock device (API)."""
+        mock_api = MagicMock()
+        mock_api.name = self.name
+        mock_api.host = (self.host, 80)
+        mock_api.mac = bytes.fromhex(self.mac)
+        mock_api.model = self.model
+        mock_api.manufacturer = self.manufacturer
+        mock_api.type = self.type
+        mock_api.devtype = self.devtype
+        mock_api.timeout = self.timeout
+        mock_api.is_locked = False
+        mock_api.auth.return_value = True
+        mock_api.get_fwversion.return_value = self.fwversion
+        return mock_api
+
+    def get_mock_entry(self):
+        """Return a mock config entry."""
+        return MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=self.mac,
+            title=self.name,
+            data=self.get_entry_data(),
+        )
+
+    def get_entry_data(self):
+        """Return entry data."""
+        return {
+            "host": self.host,
+            "mac": self.mac,
+            "type": self.devtype,
+            "timeout": self.timeout,
+        }
+
+
+def get_device(name):
+    """Get a device by name."""
+    return LinknLinkDevice(name, *LINKNLINK_DEVICES[name])

--- a/tests/components/linknlink/__init__.py
+++ b/tests/components/linknlink/__init__.py
@@ -66,7 +66,7 @@ class LinknLinkDevice:
 
     def __init__(
         self, name, host, mac, model, manufacturer, type_, devtype, fwversion, timeout
-    ):
+    ) -> None:
         """Initialize the device."""
         self.name: str = name
         self.host: str = host
@@ -78,7 +78,9 @@ class LinknLinkDevice:
         self.timeout: int = timeout
         self.fwversion: int = fwversion
 
-    async def setup_entry(self, hass: HomeAssistant, mock_api=None, mock_entry=None):
+    async def setup_entry(
+        self, hass: HomeAssistant, mock_api=None, mock_entry=None
+    ) -> MockSetup:
         """Set up the device."""
         mock_api = mock_api or self.get_mock_api()
         mock_entry = mock_entry or self.get_mock_entry()
@@ -93,7 +95,7 @@ class LinknLinkDevice:
 
         return MockSetup(mock_api, mock_entry, mock_factory)
 
-    def get_mock_api(self):
+    def get_mock_api(self) -> MagicMock:
         """Return a mock device (API)."""
         mock_api = MagicMock()
         mock_api.name = self.name

--- a/tests/components/linknlink/test_config_flow.py
+++ b/tests/components/linknlink/test_config_flow.py
@@ -1,0 +1,669 @@
+"""Test the LinknLink config flow."""
+
+import errno
+import socket
+from unittest.mock import call, patch
+
+import linknlink.exceptions as llke
+
+from homeassistant import config_entries
+from homeassistant.components import dhcp
+from homeassistant.components.linknlink.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import get_device
+
+DEVICE_HELLO = "homeassistant.components.linknlink.config_flow.llk.hello"
+DEVICE_FACTORY = "homeassistant.components.linknlink.config_flow.llk.gendevice"
+
+
+async def test_flow_user_works(hass: HomeAssistant) -> None:
+    """Test a config flow initiated by the user.
+
+    Best case scenario with no errors or locks.
+    """
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(DEVICE_HELLO, return_value=mock_api) as mock_hello:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == device.get_entry_data()
+
+    assert mock_hello.call_count == 1
+    assert mock_api.auth.call_count == 1
+
+
+async def test_flow_user_already_in_progress(hass: HomeAssistant) -> None:
+    """Test we do not accept more than one config flow per device."""
+    device = get_device("Living Room")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=device.get_mock_api()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=device.get_mock_api()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_flow_user_mac_already_configured(hass: HomeAssistant) -> None:
+    """Test we do not accept more than one config entry per device.
+
+    We need to abort the flow and update the existing entry.
+    """
+    device = get_device("Living Room")
+    mock_entry = device.get_mock_entry()
+    mock_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    device.host = "192.168.1.64"
+    device.timeout = 20
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+    assert dict(mock_entry.data) == device.get_entry_data()
+    assert mock_api.auth.call_count == 0
+
+
+async def test_flow_user_invalid_ip_address(hass: HomeAssistant) -> None:
+    """Test we handle an invalid IP address in the user step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, side_effect=OSError(errno.EINVAL, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "0.0.0.1"},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_host"}
+
+
+async def test_flow_user_invalid_hostname(hass: HomeAssistant) -> None:
+    """Test we handle an invalid hostname in the user step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, side_effect=OSError(socket.EAI_NONAME, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "pancakemaster.local"},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_host"}
+
+
+async def test_flow_user_device_not_found(hass: HomeAssistant) -> None:
+    """Test we handle a device not found in the user step."""
+    device = get_device("Living Room")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, side_effect=llke.NetworkTimeoutError()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_user_device_not_supported(hass: HomeAssistant) -> None:
+    """Test we handle a device not supported in the user step."""
+    device = get_device("Kitchen")
+    mock_api = device.get_mock_api()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_supported"
+
+
+async def test_flow_user_network_unreachable(hass: HomeAssistant) -> None:
+    """Test we handle a network unreachable in the user step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, side_effect=OSError(errno.ENETUNREACH, None)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "192.168.1.32"},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_user_os_error(hass: HomeAssistant) -> None:
+    """Test we handle an OS error in the user step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, side_effect=OSError()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "192.168.1.32"},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_flow_auth_authentication_error(hass: HomeAssistant) -> None:
+    """Test we handle an authentication error in the auth step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = llke.AuthenticationError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reset"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_flow_auth_network_timeout(hass: HomeAssistant) -> None:
+    """Test we handle a network timeout in the auth step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = llke.NetworkTimeoutError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "auth"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_auth_firmware_error(hass: HomeAssistant) -> None:
+    """Test we handle a firmware error in the auth step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = llke.LinknLinkException()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "auth"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_flow_auth_network_unreachable(hass: HomeAssistant) -> None:
+    """Test we handle a network unreachable in the auth step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = OSError(errno.ENETUNREACH, None)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "auth"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_auth_os_error(hass: HomeAssistant) -> None:
+    """Test we handle an OS error in the auth step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = OSError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "auth"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_flow_reset_works(hass: HomeAssistant) -> None:
+    """Test we finish a config flow after a manual unlock."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.auth.side_effect = llke.AuthenticationError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    with patch(DEVICE_HELLO, return_value=device.get_mock_api()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == device.get_entry_data()
+
+
+async def test_flow_unlock_works(hass: HomeAssistant) -> None:
+    """Test we finish a config flow with an unlock request."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "unlock"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": True},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == device.get_entry_data()
+
+    assert mock_api.set_lock.call_args == call(False)
+    assert mock_api.set_lock.call_count == 1
+
+
+async def test_flow_unlock_network_timeout(hass: HomeAssistant) -> None:
+    """Test we handle a network timeout in the unlock step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+    mock_api.set_lock.side_effect = llke.NetworkTimeoutError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": True},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "unlock"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_unlock_firmware_error(hass: HomeAssistant) -> None:
+    """Test we handle a firmware error in the unlock step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+    mock_api.set_lock.side_effect = llke.LinknLinkException
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": True},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "unlock"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_flow_unlock_network_unreachable(hass: HomeAssistant) -> None:
+    """Test we handle a network unreachable in the unlock step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+    mock_api.set_lock.side_effect = OSError(errno.ENETUNREACH, None)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": True},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "unlock"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_flow_unlock_os_error(hass: HomeAssistant) -> None:
+    """Test we handle an OS error in the unlock step."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+    mock_api.set_lock.side_effect = OSError()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": True},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "unlock"
+    assert result["errors"] == {"base": "unknown"}
+
+
+async def test_flow_do_not_unlock(hass: HomeAssistant) -> None:
+    """Test we do not unlock the device if the user does not want to."""
+    device = get_device("Living Room")
+    mock_api = device.get_mock_api()
+    mock_api.is_locked = True
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": device.host, "timeout": device.timeout},
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"unlock": False},
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == device.get_entry_data()
+
+    assert mock_api.set_lock.call_count == 0
+
+
+async def test_dhcp_can_finish(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow can finish right away."""
+
+    device = get_device("Living Room")
+    device.host = "1.2.3.4"
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="1.2.3.4",
+                macaddress=dr.format_mac(device.mac),
+            ),
+        )
+        await hass.async_block_till_done()
+
+    await hass.async_block_till_done()
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == f"linknlink-{device.mac}"
+    assert result["data"] == {
+        "host": "1.2.3.4",
+        "mac": "ec0b12a43ba1",
+        "timeout": 10,
+        "type": 21003,
+    }
+
+
+async def test_dhcp_fails_to_connect(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow that fails to connect."""
+
+    with patch(DEVICE_HELLO, side_effect=llke.NetworkTimeoutError()):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="1.2.3.4",
+                macaddress="34:ea:34:b4:3b:5a",
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_unreachable(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow that fails to connect."""
+
+    with patch(DEVICE_HELLO, side_effect=OSError(errno.ENETUNREACH, None)):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="1.2.3.4",
+                macaddress="34:ea:34:b4:3b:5a",
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_dhcp_connect_unknown_error(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow that fails to connect with an OSError."""
+
+    with patch(DEVICE_HELLO, side_effect=OSError()):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="1.2.3.4",
+                macaddress="34:ea:34:b4:3b:5a",
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "unknown"
+
+
+async def test_dhcp_device_not_supported(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow that fails because the device is not supported."""
+
+    device = get_device("Kitchen")
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip=device.host,
+                macaddress=dr.format_mac(device.mac),
+            ),
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_supported"
+
+
+async def test_dhcp_already_exists(hass: HomeAssistant) -> None:
+    """Test DHCP discovery flow that fails to connect."""
+
+    device = get_device("Living Room")
+    mock_entry = device.get_mock_entry()
+    mock_entry.add_to_hass(hass)
+    device.host = "1.2.3.4"
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="1.2.3.4",
+                macaddress="34:ea:34:b4:3b:5a",
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_dhcp_updates_host(hass: HomeAssistant) -> None:
+    """Test DHCP updates host."""
+
+    device = get_device("Living Room")
+    device.host = "1.2.3.4"
+    mock_entry = device.get_mock_entry()
+    mock_entry.add_to_hass(hass)
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_HELLO, return_value=mock_api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=dhcp.DhcpServiceInfo(
+                hostname="linknlink",
+                ip="4.5.6.7",
+                macaddress="ec:0b:12:a4:3b:a1",
+            ),
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert mock_entry.data["host"] == "4.5.6.7"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Adding support for LinknLink eHub and eMotion Devices.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Our company has recently received a lot of requests for integration into ha, hoping to work with ha to provide a better user experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/29881

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
