### PR TITLE
Add aseko pool live entity descriptions for known sensors

### DIFF
--- a/homeassistant/components/aseko_pool_live/binary_sensor.py
+++ b/homeassistant/components/aseko_pool_live/binary_sensor.py
@@ -31,18 +31,15 @@ class AsekoBinarySensorEntityDescription(BinarySensorEntityDescription):
 UNIT_BINARY_SENSORS: tuple[AsekoBinarySensorEntityDescription, ...] = (
     AsekoBinarySensorEntityDescription(
         key="water_flow",
-        translation_key="water_flow",
         value_fn=lambda unit: unit.water_flow,
     ),
     AsekoBinarySensorEntityDescription(
         key="has_alarm",
-        translation_key="alarm",
         value_fn=lambda unit: unit.has_alarm,
         device_class=BinarySensorDeviceClass.SAFETY,
     ),
     AsekoBinarySensorEntityDescription(
         key="has_error",
-        translation_key="error",
         value_fn=lambda unit: unit.has_error,
         device_class=BinarySensorDeviceClass.PROBLEM,
     ),
@@ -79,6 +76,7 @@ class AsekoUnitBinarySensorEntity(AsekoEntity, BinarySensorEntity):
         """Initialize the unit binary sensor."""
         super().__init__(unit, coordinator)
         self.entity_description = entity_description
+        self.translation_key = entity_description.key
         self._attr_unique_id = f"{self._unit.serial_number}_{entity_description.key}"
 
     @property

--- a/homeassistant/components/aseko_pool_live/icons.json
+++ b/homeassistant/components/aseko_pool_live/icons.json
@@ -6,8 +6,17 @@
       }
     },
     "sensor": {
+      "electrolyzer": {
+        "default": "mdi:lightning-bolt"
+      },
       "free_chlorine": {
         "default": "mdi:flask"
+      },
+      "redox": {
+        "default": "mdi:test-tube"
+      },
+      "water_level": {
+        "default": "mdi:waves"
       },
       "water_temperature": {
         "default": "mdi:coolant-temperature"

--- a/homeassistant/components/aseko_pool_live/sensor.py
+++ b/homeassistant/components/aseko_pool_live/sensor.py
@@ -29,7 +29,7 @@ class AsekoSensorEntityDescription(SensorEntityDescription):
 
 CONCENTRATION_KILOGRAMS_PER_CUBIC_METER = "kg/m³"
 CONCENTRATION_MILLIGRAMS_PER_LITER = "mg/l"
-GRAMS_PER_HOUR = "g/h"
+GRAMS_PER_HOUR = "g/hour"
 
 UNIT_SENSORS = {
     "airTemp": AsekoSensorEntityDescription(

--- a/homeassistant/components/aseko_pool_live/sensor.py
+++ b/homeassistant/components/aseko_pool_live/sensor.py
@@ -2,20 +2,85 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from aioaseko import Unit, Variable
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorEntityDescription,
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfElectricPotential, UnitOfLength, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import AsekoDataUpdateCoordinator
 from .entity import AsekoEntity
+
+
+@dataclass(frozen=True, kw_only=True)
+class AsekoSensorEntityDescription(SensorEntityDescription):
+    """Describes an Aseko binary sensor entity."""
+
+
+CONCENTRATION_KILOGRAMS_PER_CUBIC_METER = "kg/m³"
+CONCENTRATION_MILLIGRAMS_PER_LITER = "mg/l"
+GRAMS_PER_HOUR = "g/h"
+
+UNIT_SENSORS = {
+    "airTemp": AsekoSensorEntityDescription(
+        key="air_temperature",
+        translation_key="air_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    "waterTemp": AsekoSensorEntityDescription(
+        key="water_temperature",
+        translation_key="water_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+    ),
+    "ph": AsekoSensorEntityDescription(
+        key="ph",
+        translation_key="ph",
+        device_class=SensorDeviceClass.PH,
+    ),
+    "rx": AsekoSensorEntityDescription(
+        key="redox",
+        translation_key="redox",
+        device_class=SensorDeviceClass.VOLTAGE,
+        native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
+        icon="mdi:test-tube",
+    ),
+    "electrodePower": AsekoSensorEntityDescription(
+        key="electrolyzer",
+        translation_key="electrolyzer",
+        native_unit_of_measurement=GRAMS_PER_HOUR,
+        icon="mdi:lightning-bolt",
+    ),
+    "clf": AsekoSensorEntityDescription(
+        key="free_chlorine",
+        translation_key="free_chlorine",
+        native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
+        icon="mdi:test-tube",
+    ),
+    "salinity": AsekoSensorEntityDescription(
+        key="salinity",
+        translation_key="salinity",
+        native_unit_of_measurement=CONCENTRATION_KILOGRAMS_PER_CUBIC_METER,
+    ),
+    "waterLevel": AsekoSensorEntityDescription(
+        key="water_level",
+        translation_key="water_level",
+        device_class=SensorDeviceClass.DISTANCE,
+        native_unit_of_measurement=UnitOfLength.CENTIMETERS,
+        icon="mdi:waves",
+    ),
+}
 
 
 async def async_setup_entry(
@@ -47,29 +112,14 @@ class VariableSensorEntity(AsekoEntity, SensorEntity):
         super().__init__(unit, coordinator)
         self._variable = variable
 
-        translation_key = {
-            "Air temp.": "air_temperature",
-            "Cl free": "free_chlorine",
-            "Water temp.": "water_temperature",
-        }.get(self._variable.name)
-        if translation_key is not None:
-            self._attr_translation_key = translation_key
+        entity_description = UNIT_SENSORS.get(self._variable.type)
+        if entity_description is not None:
+            self.entity_description = entity_description
         else:
             self._attr_name = self._variable.name
+            self._attr_native_unit_of_measurement = self._variable.unit
 
         self._attr_unique_id = f"{self._unit.serial_number}{self._variable.type}"
-        self._attr_native_unit_of_measurement = self._variable.unit
-
-        self._attr_icon = {
-            "rx": "mdi:test-tube",
-            "waterLevel": "mdi:waves",
-        }.get(self._variable.type)
-
-        self._attr_device_class = {
-            "airTemp": SensorDeviceClass.TEMPERATURE,
-            "waterTemp": SensorDeviceClass.TEMPERATURE,
-            "ph": SensorDeviceClass.PH,
-        }.get(self._variable.type)
 
     @property
     def native_value(self) -> int | None:

--- a/homeassistant/components/aseko_pool_live/sensor.py
+++ b/homeassistant/components/aseko_pool_live/sensor.py
@@ -26,13 +26,11 @@ GRAMS_PER_HOUR = "g/hour"
 UNIT_SENSORS = {
     "airTemp": SensorEntityDescription(
         key="air_temperature",
-        translation_key="air_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
     "waterTemp": SensorEntityDescription(
         key="water_temperature",
-        translation_key="water_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
@@ -42,31 +40,26 @@ UNIT_SENSORS = {
     ),
     "rx": SensorEntityDescription(
         key="redox",
-        translation_key="redox",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
         icon="mdi:test-tube",
     ),
     "electrodePower": SensorEntityDescription(
         key="electrolyzer",
-        translation_key="electrolyzer",
         native_unit_of_measurement=GRAMS_PER_HOUR,
         icon="mdi:lightning-bolt",
     ),
     "clf": SensorEntityDescription(
         key="free_chlorine",
-        translation_key="free_chlorine",
         native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
         icon="mdi:test-tube",
     ),
     "salinity": SensorEntityDescription(
         key="salinity",
-        translation_key="salinity",
         native_unit_of_measurement=CONCENTRATION_KILOGRAMS_PER_CUBIC_METER,
     ),
     "waterLevel": SensorEntityDescription(
         key="water_level",
-        translation_key="water_level",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
         icon="mdi:waves",
@@ -106,6 +99,7 @@ class VariableSensorEntity(AsekoEntity, SensorEntity):
         entity_description = UNIT_SENSORS.get(self._variable.type)
         if entity_description is not None:
             self.entity_description = entity_description
+            self.translation_key = entity_description.key
         else:
             self._attr_name = self._variable.name
             self._attr_native_unit_of_measurement = self._variable.unit

--- a/homeassistant/components/aseko_pool_live/sensor.py
+++ b/homeassistant/components/aseko_pool_live/sensor.py
@@ -42,17 +42,14 @@ UNIT_SENSORS = {
         key="redox",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
-        icon="mdi:test-tube",
     ),
     "electrodePower": SensorEntityDescription(
         key="electrolyzer",
         native_unit_of_measurement=GRAMS_PER_HOUR,
-        icon="mdi:lightning-bolt",
     ),
     "clf": SensorEntityDescription(
         key="free_chlorine",
         native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
-        icon="mdi:test-tube",
     ),
     "salinity": SensorEntityDescription(
         key="salinity",
@@ -62,7 +59,6 @@ UNIT_SENSORS = {
         key="water_level",
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.CENTIMETERS,
-        icon="mdi:waves",
     ),
 }
 

--- a/homeassistant/components/aseko_pool_live/sensor.py
+++ b/homeassistant/components/aseko_pool_live/sensor.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-
 from aioaseko import Unit, Variable
 
 from homeassistant.components.sensor import (
@@ -21,59 +19,52 @@ from .const import DOMAIN
 from .coordinator import AsekoDataUpdateCoordinator
 from .entity import AsekoEntity
 
-
-@dataclass(frozen=True, kw_only=True)
-class AsekoSensorEntityDescription(SensorEntityDescription):
-    """Describes an Aseko binary sensor entity."""
-
-
 CONCENTRATION_KILOGRAMS_PER_CUBIC_METER = "kg/m³"
 CONCENTRATION_MILLIGRAMS_PER_LITER = "mg/l"
 GRAMS_PER_HOUR = "g/hour"
 
 UNIT_SENSORS = {
-    "airTemp": AsekoSensorEntityDescription(
+    "airTemp": SensorEntityDescription(
         key="air_temperature",
         translation_key="air_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
-    "waterTemp": AsekoSensorEntityDescription(
+    "waterTemp": SensorEntityDescription(
         key="water_temperature",
         translation_key="water_temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     ),
-    "ph": AsekoSensorEntityDescription(
+    "ph": SensorEntityDescription(
         key="ph",
-        translation_key="ph",
         device_class=SensorDeviceClass.PH,
     ),
-    "rx": AsekoSensorEntityDescription(
+    "rx": SensorEntityDescription(
         key="redox",
         translation_key="redox",
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.MILLIVOLT,
         icon="mdi:test-tube",
     ),
-    "electrodePower": AsekoSensorEntityDescription(
+    "electrodePower": SensorEntityDescription(
         key="electrolyzer",
         translation_key="electrolyzer",
         native_unit_of_measurement=GRAMS_PER_HOUR,
         icon="mdi:lightning-bolt",
     ),
-    "clf": AsekoSensorEntityDescription(
+    "clf": SensorEntityDescription(
         key="free_chlorine",
         translation_key="free_chlorine",
         native_unit_of_measurement=CONCENTRATION_MILLIGRAMS_PER_LITER,
         icon="mdi:test-tube",
     ),
-    "salinity": AsekoSensorEntityDescription(
+    "salinity": SensorEntityDescription(
         key="salinity",
         translation_key="salinity",
         native_unit_of_measurement=CONCENTRATION_KILOGRAMS_PER_CUBIC_METER,
     ),
-    "waterLevel": AsekoSensorEntityDescription(
+    "waterLevel": SensorEntityDescription(
         key="water_level",
         translation_key="water_level",
         device_class=SensorDeviceClass.DISTANCE,

--- a/homeassistant/components/aseko_pool_live/strings.json
+++ b/homeassistant/components/aseko_pool_live/strings.json
@@ -40,6 +40,18 @@
       "free_chlorine": {
         "name": "Free chlorine"
       },
+      "redox": {
+        "name": "Redox"
+      },
+      "salinity": {
+        "name": "Salinity"
+      },
+      "electrolyzer": {
+        "name": "Electrolyzer"
+      },
+      "water_level": {
+        "name": "Water level"
+      },
       "water_temperature": {
         "name": "Water temperature"
       }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Following sensors units are being changed from `None` to standard units:
- `redox`
- `salinity`

So following warnings will be presented:
- WARNING (Recorder) [homeassistant.components.sensor.recorder] The unit of sensor.test_pool_redox (mV) cannot be converted to the unit of previously compiled statistics (None). Generation of long term statistics will be suppressed unless the unit changes back to None or a compatible unit. Go to https://my.home-assistant.io/redirect/developer_statistics to fix this
- WARNING (Recorder) [homeassistant.components.sensor.recorder] The unit of sensor.test_pool_salinity (kg/m³) cannot be converted to the unit of previously compiled statistics (None). Generation of long term statistics will be suppressed unless the unit changes back to None or a compatible unit. Go to https://my.home-assistant.io/redirect/developer_statistics to fix this


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pre-configure device class & native units for Aseko Pool Live sensor entities to avoid issues like:
```
WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.test_pool_ph (<class 'homeassistant.components.aseko_pool_live.sensor.VariableSensorEntity'>) is using native unit of measurement '' which is not a valid unit for the device class ('ph') it is using; expected one of ['no unit of measurement']
```

Set translation keys for known entities.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
