### PR TITLE
Migrate baf to use config entry runtime_data

### DIFF
--- a/homeassistant/components/baf/__init__.py
+++ b/homeassistant/components/baf/__init__.py
@@ -13,8 +13,11 @@ from homeassistant.const import CONF_IP_ADDRESS, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
-from .const import DOMAIN, QUERY_INTERVAL, RUN_TIMEOUT
+from .const import QUERY_INTERVAL, RUN_TIMEOUT
 from .models import BAFData
+
+BAFConfigEntry = ConfigEntry[BAFData]
+
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
@@ -27,7 +30,7 @@ PLATFORMS: list[Platform] = [
 ]
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: BAFConfigEntry) -> bool:
     """Set up Big Ass Fans from a config entry."""
     ip_address = entry.data[CONF_IP_ADDRESS]
 
@@ -46,16 +49,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         run_future.cancel()
         raise ConfigEntryNotReady(f"Timed out connecting to {ip_address}") from ex
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = BAFData(device, run_future)
+    entry.runtime_data = BAFData(device, run_future)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: BAFConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        data: BAFData = hass.data[DOMAIN].pop(entry.entry_id)
-        data.run_future.cancel()
+        entry.runtime_data.run_future.cancel()
 
     return unload_ok

--- a/homeassistant/components/baf/__init__.py
+++ b/homeassistant/components/baf/__init__.py
@@ -10,7 +10,7 @@ from aiobafi6.exceptions import DeviceUUIDMismatchError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import QUERY_INTERVAL, RUN_TIMEOUT
@@ -48,8 +48,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: BAFConfigEntry) -> bool:
         run_future.cancel()
         raise ConfigEntryNotReady(f"Timed out connecting to {ip_address}") from ex
 
+    @callback
+    def _async_cancel_run() -> None:
+        run_future.cancel()
+
     entry.runtime_data = device
-    entry.async_on_unload(run_future.cancel)
+    entry.async_on_unload(_async_cancel_run)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/baf/binary_sensor.py
+++ b/homeassistant/components/baf/binary_sensor.py
@@ -8,7 +8,6 @@ from typing import cast
 
 from aiobafi6 import Device
 
-from homeassistant import config_entries
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -17,9 +16,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import BAFConfigEntry
 from .entity import BAFEntity
-from .models import BAFData
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -42,12 +40,11 @@ OCCUPANCY_SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF binary sensors."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    device = data.device
+    device = entry.runtime_data.device
     sensors_descriptions: list[BAFBinarySensorDescription] = []
     if device.has_occupancy:
         sensors_descriptions.extend(OCCUPANCY_SENSORS)

--- a/homeassistant/components/baf/binary_sensor.py
+++ b/homeassistant/components/baf/binary_sensor.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF binary sensors."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     sensors_descriptions: list[BAFBinarySensorDescription] = []
     if device.has_occupancy:
         sensors_descriptions.extend(OCCUPANCY_SENSORS)

--- a/homeassistant/components/baf/climate.py
+++ b/homeassistant/components/baf/climate.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant import config_entries
 from homeassistant.components.climate import (
     ClimateEntity,
     ClimateEntityFeature,
@@ -15,20 +14,19 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import BAFConfigEntry
 from .entity import BAFEntity
-from .models import BAFData
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan auto comfort."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    if data.device.has_fan and data.device.has_auto_comfort:
-        async_add_entities([BAFAutoComfort(data.device)])
+    device = entry.runtime_data.device
+    if device.has_fan and device.has_auto_comfort:
+        async_add_entities([BAFAutoComfort(device)])
 
 
 class BAFAutoComfort(BAFEntity, ClimateEntity):

--- a/homeassistant/components/baf/climate.py
+++ b/homeassistant/components/baf/climate.py
@@ -24,7 +24,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan auto comfort."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     if device.has_fan and device.has_auto_comfort:
         async_add_entities([BAFAutoComfort(device)])
 

--- a/homeassistant/components/baf/fan.py
+++ b/homeassistant/components/baf/fan.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from aiobafi6 import OffOnAuto
 
-from homeassistant import config_entries
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
@@ -21,20 +20,20 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from .const import DOMAIN, PRESET_MODE_AUTO, SPEED_COUNT, SPEED_RANGE
+from . import BAFConfigEntry
+from .const import PRESET_MODE_AUTO, SPEED_COUNT, SPEED_RANGE
 from .entity import BAFEntity
-from .models import BAFData
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up SenseME fans."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    if data.device.has_fan:
-        async_add_entities([BAFFan(data.device)])
+    device = entry.runtime_data.device
+    if device.has_fan:
+        async_add_entities([BAFFan(device)])
 
 
 class BAFFan(BAFEntity, FanEntity):

--- a/homeassistant/components/baf/fan.py
+++ b/homeassistant/components/baf/fan.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up SenseME fans."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     if device.has_fan:
         async_add_entities([BAFFan(device)])
 

--- a/homeassistant/components/baf/light.py
+++ b/homeassistant/components/baf/light.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF lights."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     if device.has_light:
         klass = BAFFanLight if device.has_fan else BAFStandaloneLight
         async_add_entities([klass(device)])

--- a/homeassistant/components/baf/light.py
+++ b/homeassistant/components/baf/light.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from aiobafi6 import Device, OffOnAuto
 
-from homeassistant import config_entries
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -20,21 +19,20 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin,
 )
 
-from .const import DOMAIN
+from . import BAFConfigEntry
 from .entity import BAFEntity
-from .models import BAFData
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF lights."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    if data.device.has_light:
-        klass = BAFFanLight if data.device.has_fan else BAFStandaloneLight
-        async_add_entities([klass(data.device)])
+    device = entry.runtime_data.device
+    if device.has_light:
+        klass = BAFFanLight if device.has_fan else BAFStandaloneLight
+        async_add_entities([klass(device)])
 
 
 class BAFLight(BAFEntity, LightEntity):

--- a/homeassistant/components/baf/models.py
+++ b/homeassistant/components/baf/models.py
@@ -2,18 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
-
-from aiobafi6 import Device
-
-
-@dataclass
-class BAFData:
-    """Data for the baf integration."""
-
-    device: Device
-    run_future: asyncio.Future
 
 
 @dataclass

--- a/homeassistant/components/baf/number.py
+++ b/homeassistant/components/baf/number.py
@@ -119,7 +119,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF numbers."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     descriptions: list[BAFNumberDescription] = []
     if device.has_fan:
         descriptions.extend(FAN_NUMBER_DESCRIPTIONS)

--- a/homeassistant/components/baf/number.py
+++ b/homeassistant/components/baf/number.py
@@ -8,7 +8,6 @@ from typing import cast
 
 from aiobafi6 import Device
 
-from homeassistant import config_entries
 from homeassistant.components.number import (
     NumberEntity,
     NumberEntityDescription,
@@ -18,9 +17,9 @@ from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, HALF_DAY_SECS, ONE_DAY_SECS, ONE_MIN_SECS, SPEED_RANGE
+from . import BAFConfigEntry
+from .const import HALF_DAY_SECS, ONE_DAY_SECS, ONE_MIN_SECS, SPEED_RANGE
 from .entity import BAFEntity
-from .models import BAFData
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -116,12 +115,11 @@ LIGHT_NUMBER_DESCRIPTIONS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF numbers."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    device = data.device
+    device = entry.runtime_data.device
     descriptions: list[BAFNumberDescription] = []
     if device.has_fan:
         descriptions.extend(FAN_NUMBER_DESCRIPTIONS)

--- a/homeassistant/components/baf/sensor.py
+++ b/homeassistant/components/baf/sensor.py
@@ -96,7 +96,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan sensors."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     sensors_descriptions: list[BAFSensorDescription] = [
         description
         for description in DEFINED_ONLY_SENSORS

--- a/homeassistant/components/baf/sensor.py
+++ b/homeassistant/components/baf/sensor.py
@@ -8,7 +8,6 @@ from typing import cast
 
 from aiobafi6 import Device
 
-from homeassistant import config_entries
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -24,9 +23,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import BAFConfigEntry
 from .entity import BAFEntity
-from .models import BAFData
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -94,12 +92,11 @@ FAN_SENSORS = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan sensors."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    device = data.device
+    device = entry.runtime_data.device
     sensors_descriptions: list[BAFSensorDescription] = [
         description
         for description in DEFINED_ONLY_SENSORS

--- a/homeassistant/components/baf/switch.py
+++ b/homeassistant/components/baf/switch.py
@@ -8,15 +8,13 @@ from typing import Any, cast
 
 from aiobafi6 import Device
 
-from homeassistant import config_entries
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import BAFConfigEntry
 from .entity import BAFEntity
-from .models import BAFData
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -104,12 +102,11 @@ LIGHT_SWITCHES = [
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: config_entries.ConfigEntry,
+    entry: BAFConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan switches."""
-    data: BAFData = hass.data[DOMAIN][entry.entry_id]
-    device = data.device
+    device = entry.runtime_data.device
     descriptions: list[BAFSwitchDescription] = []
     descriptions.extend(BASE_SWITCHES)
     if device.has_fan:

--- a/homeassistant/components/baf/switch.py
+++ b/homeassistant/components/baf/switch.py
@@ -106,7 +106,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up BAF fan switches."""
-    device = entry.runtime_data.device
+    device = entry.runtime_data
     descriptions: list[BAFSwitchDescription] = []
     descriptions.extend(BASE_SWITCHES)
     if device.has_fan:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate baf to use config entry runtime_data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
