### PR TITLE
Fix nws blocking startup

### DIFF
--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import datetime
+from functools import partial
 import logging
 
 from pynws import SimpleNWS, call_with_retry
@@ -63,44 +64,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
-        async def update_observation() -> None:
-            """Retrieve recent observations."""
-            await call_with_retry(
-                nws_data.update_observation,
-                retry_interval,
-                retry_stop,
-                start_time=utcnow() - UPDATE_TIME_PERIOD,
-            )
-
-        return update_observation
+        return partial(
+            call_with_retry,
+            nws_data.update_observation,
+            retry_interval,
+            retry_stop,
+            start_time=utcnow() - UPDATE_TIME_PERIOD,
+        )
 
     def async_setup_update_forecast(
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
-        async def update_forecast() -> None:
-            """Retrieve twice-daily forecsat."""
-            await call_with_retry(
-                nws_data.update_forecast,
-                retry_interval,
-                retry_stop,
-            )
-
-        return update_forecast
+        return partial(
+            call_with_retry,
+            nws_data.update_forecast,
+            retry_interval,
+            retry_stop,
+        )
 
     def async_setup_update_forecast_hourly(
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
-        async def update_forecast_hourly() -> None:
-            """Retrieve hourly forecast."""
-            await call_with_retry(
-                nws_data.update_forecast_hourly,
-                retry_interval,
-                retry_stop,
-            )
-
-        return update_forecast_hourly
+        return partial(
+            call_with_retry,
+            nws_data.update_forecast_hourly,
+            retry_interval,
+            retry_stop,
+        )
 
     # Don't use retries in setup
     coordinator_observation = TimestampDataUpdateCoordinator(

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -59,7 +59,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     nws_data = SimpleNWS(latitude, longitude, api_key, client_session)
     await nws_data.set_station(station)
 
-    def setup_update_observation(
+    def async_setup_update_observation(
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -64,13 +64,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
-        return partial(
-            call_with_retry,
-            nws_data.update_observation,
-            retry_interval,
-            retry_stop,
-            start_time=utcnow() - UPDATE_TIME_PERIOD,
-        )
+        async def update_observation() -> None:
+            """Retrieve recent observations."""
+            await call_with_retry(
+                nws_data.update_observation,
+                retry_interval,
+                retry_stop,
+                start_time=utcnow() - UPDATE_TIME_PERIOD,
+            )
+
+        return update_observation
 
     def async_setup_update_forecast(
         retry_interval: datetime.timedelta | float,

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -60,7 +60,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await nws_data.set_station(station)
 
     def setup_update_observation(
-        retry_interval, retry_stop
+        retry_interval: datetime.timedelta | float,
+        retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
         async def update_observation() -> None:
             """Retrieve recent observations."""
@@ -74,7 +75,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return update_observation
 
     def setup_update_forecast(
-        retry_interval, retry_stop
+        retry_interval: datetime.timedelta | float,
+        retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
         async def update_forecast() -> None:
             """Retrieve twice-daily forecsat."""
@@ -87,7 +89,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         return update_forecast
 
     def setup_update_forecast_hourly(
-        retry_interval, retry_stop
+        retry_interval: datetime.timedelta | float,
+        retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
         async def update_forecast_hourly() -> None:
             """Retrieve hourly forecast."""

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -74,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return update_observation
 
-    def setup_update_forecast(
+    def async_setup_update_forecast(
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
@@ -88,7 +88,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return update_forecast
 
-    def setup_update_forecast_hourly(
+    def async_setup_update_forecast_hourly(
         retry_interval: datetime.timedelta | float,
         retry_stop: datetime.timedelta | float,
     ) -> Callable[[], Awaitable[None]]:
@@ -107,7 +107,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"NWS observation station {station}",
-        update_method=setup_update_observation(0, 0),
+        update_method=async_setup_update_observation(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -118,7 +118,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"NWS forecast station {station}",
-        update_method=setup_update_forecast(0, 0),
+        update_method=async_setup_update_forecast(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -129,7 +129,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"NWS forecast hourly station {station}",
-        update_method=setup_update_forecast_hourly(0, 0),
+        update_method=async_setup_update_forecast_hourly(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -149,13 +149,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator_forecast_hourly.async_refresh()
 
     # Use retries
-    coordinator_observation.update_method = setup_update_observation(
+    coordinator_observation.update_method = async_setup_update_observation(
         RETRY_INTERVAL, RETRY_STOP
     )
-    coordinator_forecast.update_method = setup_update_forecast(
+    coordinator_forecast.update_method = async_setup_update_forecast(
         RETRY_INTERVAL, RETRY_STOP
     )
-    coordinator_forecast_hourly.update_method = setup_update_forecast_hourly(
+    coordinator_forecast_hourly.update_method = async_setup_update_forecast_hourly(
         RETRY_INTERVAL, RETRY_STOP
     )
 

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 import datetime
 import logging
@@ -58,36 +59,52 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     nws_data = SimpleNWS(latitude, longitude, api_key, client_session)
     await nws_data.set_station(station)
 
-    async def update_observation() -> None:
-        """Retrieve recent observations."""
-        await call_with_retry(
-            nws_data.update_observation,
-            RETRY_INTERVAL,
-            RETRY_STOP,
-            start_time=utcnow() - UPDATE_TIME_PERIOD,
-        )
+    def setup_update_observation(
+        retry_interval, retry_stop
+    ) -> Callable[[], Awaitable[None]]:
+        async def update_observation() -> None:
+            """Retrieve recent observations."""
+            await call_with_retry(
+                nws_data.update_observation,
+                retry_interval,
+                retry_stop,
+                start_time=utcnow() - UPDATE_TIME_PERIOD,
+            )
 
-    async def update_forecast() -> None:
-        """Retrieve twice-daily forecsat."""
-        await call_with_retry(
-            nws_data.update_forecast,
-            RETRY_INTERVAL,
-            RETRY_STOP,
-        )
+        return update_observation
 
-    async def update_forecast_hourly() -> None:
-        """Retrieve hourly forecast."""
-        await call_with_retry(
-            nws_data.update_forecast_hourly,
-            RETRY_INTERVAL,
-            RETRY_STOP,
-        )
+    def setup_update_forecast(
+        retry_interval, retry_stop
+    ) -> Callable[[], Awaitable[None]]:
+        async def update_forecast() -> None:
+            """Retrieve twice-daily forecsat."""
+            await call_with_retry(
+                nws_data.update_forecast,
+                retry_interval,
+                retry_stop,
+            )
 
+        return update_forecast
+
+    def setup_update_forecast_hourly(
+        retry_interval, retry_stop
+    ) -> Callable[[], Awaitable[None]]:
+        async def update_forecast_hourly() -> None:
+            """Retrieve hourly forecast."""
+            await call_with_retry(
+                nws_data.update_forecast_hourly,
+                retry_interval,
+                retry_stop,
+            )
+
+        return update_forecast_hourly
+
+    # Don't use retries in setup
     coordinator_observation = TimestampDataUpdateCoordinator(
         hass,
         _LOGGER,
         name=f"NWS observation station {station}",
-        update_method=update_observation,
+        update_method=setup_update_observation(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -98,7 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"NWS forecast station {station}",
-        update_method=update_forecast,
+        update_method=setup_update_forecast(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -109,7 +126,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         _LOGGER,
         name=f"NWS forecast hourly station {station}",
-        update_method=update_forecast_hourly,
+        update_method=setup_update_forecast_hourly(0, 0),
         update_interval=DEFAULT_SCAN_INTERVAL,
         request_refresh_debouncer=debounce.Debouncer(
             hass, _LOGGER, cooldown=DEBOUNCE_TIME, immediate=True
@@ -127,6 +144,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await coordinator_observation.async_refresh()
     await coordinator_forecast.async_refresh()
     await coordinator_forecast_hourly.async_refresh()
+
+    # Use retries
+    coordinator_observation.update_method = setup_update_observation(
+        RETRY_INTERVAL, RETRY_STOP
+    )
+    coordinator_forecast.update_method = setup_update_forecast(
+        RETRY_INTERVAL, RETRY_STOP
+    )
+    coordinator_forecast_hourly.update_method = setup_update_forecast_hourly(
+        RETRY_INTERVAL, RETRY_STOP
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 


### PR DESCRIPTION
## Proposed change
This PR fixes startup blocking introduced by #115857.

Coordinators are first setup to do no retrying within the entry setup.  Then the update method is updated to include retries after that.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
