### PR TITLE
Add access guards on file notify service

### DIFF
--- a/homeassistant/components/file/__init__.py
+++ b/homeassistant/components/file/__init__.py
@@ -1,1 +1,3 @@
 """The file component."""
+
+from .const import DOMAIN  # noqa: F401

--- a/homeassistant/components/file/const.py
+++ b/homeassistant/components/file/const.py
@@ -1,0 +1,12 @@
+"""Constants for the file integration."""
+
+DOMAIN = "file"
+
+CONF_TIMESTAMP = "timestamp"
+
+DEFAULT_NAME = "File"
+FILE_ICON = "mdi:file"
+
+URL_ALLOWLIST_EXT_DIRS = (
+    "https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs"
+)

--- a/homeassistant/components/file/strings.json
+++ b/homeassistant/components/file/strings.json
@@ -1,0 +1,10 @@
+{
+  "exceptions": {
+    "dir_not_allowed": {
+      "message": "Access to {filename} is not allowed, make sure the [directory is allowed]({url})."
+    },
+    "write_access_failed": {
+      "message": "Write access to {filename} failed: {exc}."
+    }
+  }
+}

--- a/tests/components/file/conftest.py
+++ b/tests/components/file/conftest.py
@@ -1,0 +1,25 @@
+"""Test fixtures for file platform."""
+
+from collections.abc import Generator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def is_allowed() -> bool:
+    """Parameterize mock_is_allowed_path, default True."""
+    return True
+
+
+@pytest.fixture
+def mock_is_allowed_path(
+    hass: HomeAssistant, is_allowed: bool
+) -> Generator[None, MagicMock]:
+    """Mock is_allowed_path method."""
+    with patch.object(
+        hass.config, "is_allowed_path", return_value=is_allowed
+    ) as allowed_path_mock:
+        yield allowed_path_mock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The notify services for the `file` integration now require that the file path is an allowed path.
Users should check the accessed file is in the [allowlist_external_dirs](https://www.home-assistant.io/integrations/homeassistant/#allowlist_external_dirs) to ensure their automation's keep working.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add file access and access error handling on the file notify service.

This change is part of a bigger plan to add config flow support the the file integration. ( #116861)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32654

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
