### PR TITLE
Add open and opening state support to MQTT lock

### DIFF
--- a/homeassistant/components/mqtt/lock.py
+++ b/homeassistant/components/mqtt/lock.py
@@ -31,6 +31,8 @@ from .const import (
     CONF_PAYLOAD_RESET,
     CONF_QOS,
     CONF_RETAIN,
+    CONF_STATE_OPEN,
+    CONF_STATE_OPENING,
     CONF_STATE_TOPIC,
 )
 from .debug_info import log_messages
@@ -56,6 +58,7 @@ CONF_PAYLOAD_OPEN = "payload_open"
 
 CONF_STATE_LOCKED = "state_locked"
 CONF_STATE_LOCKING = "state_locking"
+
 CONF_STATE_UNLOCKED = "state_unlocked"
 CONF_STATE_UNLOCKING = "state_unlocking"
 CONF_STATE_JAMMED = "state_jammed"
@@ -67,6 +70,8 @@ DEFAULT_PAYLOAD_OPEN = "OPEN"
 DEFAULT_PAYLOAD_RESET = "None"
 DEFAULT_STATE_LOCKED = "LOCKED"
 DEFAULT_STATE_LOCKING = "LOCKING"
+DEFAULT_STATE_OPEN = "OPEN"
+DEFAULT_STATE_OPENING = "OPENING"
 DEFAULT_STATE_UNLOCKED = "UNLOCKED"
 DEFAULT_STATE_UNLOCKING = "UNLOCKING"
 DEFAULT_STATE_JAMMED = "JAMMED"
@@ -90,6 +95,8 @@ PLATFORM_SCHEMA_MODERN = MQTT_RW_SCHEMA.extend(
         vol.Optional(CONF_STATE_JAMMED, default=DEFAULT_STATE_JAMMED): cv.string,
         vol.Optional(CONF_STATE_LOCKED, default=DEFAULT_STATE_LOCKED): cv.string,
         vol.Optional(CONF_STATE_LOCKING, default=DEFAULT_STATE_LOCKING): cv.string,
+        vol.Optional(CONF_STATE_OPEN, default=DEFAULT_STATE_OPEN): cv.string,
+        vol.Optional(CONF_STATE_OPENING, default=DEFAULT_STATE_OPENING): cv.string,
         vol.Optional(CONF_STATE_UNLOCKED, default=DEFAULT_STATE_UNLOCKED): cv.string,
         vol.Optional(CONF_STATE_UNLOCKING, default=DEFAULT_STATE_UNLOCKING): cv.string,
         vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
@@ -102,6 +109,8 @@ STATE_CONFIG_KEYS = [
     CONF_STATE_JAMMED,
     CONF_STATE_LOCKED,
     CONF_STATE_LOCKING,
+    CONF_STATE_OPEN,
+    CONF_STATE_OPENING,
     CONF_STATE_UNLOCKED,
     CONF_STATE_UNLOCKING,
 ]
@@ -189,6 +198,8 @@ class MqttLock(MqttEntity, LockEntity):
                 "_attr_is_jammed",
                 "_attr_is_locked",
                 "_attr_is_locking",
+                "_attr_is_open",
+                "_attr_is_opening",
                 "_attr_is_unlocking",
             },
         )
@@ -202,6 +213,8 @@ class MqttLock(MqttEntity, LockEntity):
             elif payload in self._valid_states:
                 self._attr_is_locked = payload == self._config[CONF_STATE_LOCKED]
                 self._attr_is_locking = payload == self._config[CONF_STATE_LOCKING]
+                self._attr_is_open = payload == self._config[CONF_STATE_OPEN]
+                self._attr_is_opening = payload == self._config[CONF_STATE_OPENING]
                 self._attr_is_unlocking = payload == self._config[CONF_STATE_UNLOCKING]
                 self._attr_is_jammed = payload == self._config[CONF_STATE_JAMMED]
 
@@ -286,5 +299,5 @@ class MqttLock(MqttEntity, LockEntity):
         )
         if self._optimistic:
             # Optimistically assume that the lock unlocks when opened.
-            self._attr_is_locked = False
+            self._attr_is_open = True
             self.async_write_ha_state()

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -13,6 +13,8 @@ from homeassistant.components.lock import (
     STATE_JAMMED,
     STATE_LOCKED,
     STATE_LOCKING,
+    STATE_OPEN,
+    STATE_OPENING,
     STATE_UNLOCKED,
     STATE_UNLOCKING,
     LockEntityFeature,
@@ -75,8 +77,10 @@ CONFIG_WITH_STATES = {
             "payload_unlock": "UNLOCK",
             "state_locked": "closed",
             "state_locking": "closing",
-            "state_unlocked": "open",
-            "state_unlocking": "opening",
+            "state_open": "open",
+            "state_opening": "opening",
+            "state_unlocked": "unlocked",
+            "state_unlocking": "unlocking",
         }
     }
 }
@@ -87,8 +91,10 @@ CONFIG_WITH_STATES = {
     [
         (CONFIG_WITH_STATES, "closed", STATE_LOCKED),
         (CONFIG_WITH_STATES, "closing", STATE_LOCKING),
-        (CONFIG_WITH_STATES, "open", STATE_UNLOCKED),
-        (CONFIG_WITH_STATES, "opening", STATE_UNLOCKING),
+        (CONFIG_WITH_STATES, "open", STATE_OPEN),
+        (CONFIG_WITH_STATES, "opening", STATE_OPENING),
+        (CONFIG_WITH_STATES, "unlocked", STATE_UNLOCKED),
+        (CONFIG_WITH_STATES, "unlocking", STATE_UNLOCKING),
     ],
 )
 async def test_controlling_state_via_topic(
@@ -117,8 +123,10 @@ async def test_controlling_state_via_topic(
     [
         (CONFIG_WITH_STATES, "closed", STATE_LOCKED),
         (CONFIG_WITH_STATES, "closing", STATE_LOCKING),
-        (CONFIG_WITH_STATES, "open", STATE_UNLOCKED),
-        (CONFIG_WITH_STATES, "opening", STATE_UNLOCKING),
+        (CONFIG_WITH_STATES, "open", STATE_OPEN),
+        (CONFIG_WITH_STATES, "opening", STATE_OPENING),
+        (CONFIG_WITH_STATES, "unlocked", STATE_UNLOCKED),
+        (CONFIG_WITH_STATES, "unlocking", STATE_UNLOCKING),
         (CONFIG_WITH_STATES, "None", STATE_UNKNOWN),
     ],
 )
@@ -168,7 +176,7 @@ async def test_controlling_non_default_state_via_topic(
                 CONFIG_WITH_STATES,
                 ({"value_template": "{{ value_json.val }}"},),
             ),
-            '{"val":"opening"}',
+            '{"val":"unlocking"}',
             STATE_UNLOCKING,
         ),
         (
@@ -178,6 +186,24 @@ async def test_controlling_non_default_state_via_topic(
                 ({"value_template": "{{ value_json.val }}"},),
             ),
             '{"val":"open"}',
+            STATE_OPEN,
+        ),
+        (
+            help_custom_config(
+                lock.DOMAIN,
+                CONFIG_WITH_STATES,
+                ({"value_template": "{{ value_json.val }}"},),
+            ),
+            '{"val":"opening"}',
+            STATE_OPENING,
+        ),
+        (
+            help_custom_config(
+                lock.DOMAIN,
+                CONFIG_WITH_STATES,
+                ({"value_template": "{{ value_json.val }}"},),
+            ),
+            '{"val":"unlocked"}',
             STATE_UNLOCKED,
         ),
         (
@@ -237,7 +263,7 @@ async def test_controlling_state_via_topic_and_json_message(
                 ({"value_template": "{{ value_json.val }}"},),
             ),
             '{"val":"open"}',
-            STATE_UNLOCKED,
+            STATE_OPEN,
         ),
         (
             help_custom_config(
@@ -246,6 +272,24 @@ async def test_controlling_state_via_topic_and_json_message(
                 ({"value_template": "{{ value_json.val }}"},),
             ),
             '{"val":"opening"}',
+            STATE_OPENING,
+        ),
+        (
+            help_custom_config(
+                lock.DOMAIN,
+                CONFIG_WITH_STATES,
+                ({"value_template": "{{ value_json.val }}"},),
+            ),
+            '{"val":"unlocked"}',
+            STATE_UNLOCKED,
+        ),
+        (
+            help_custom_config(
+                lock.DOMAIN,
+                CONFIG_WITH_STATES,
+                ({"value_template": "{{ value_json.val }}"},),
+            ),
+            '{"val":"unlocking"}',
             STATE_UNLOCKING,
         ),
     ],
@@ -483,7 +527,7 @@ async def test_sending_mqtt_commands_support_open_and_optimistic(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("lock.test")
-    assert state.state is STATE_UNLOCKED
+    assert state.state is STATE_OPEN
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 
@@ -545,7 +589,7 @@ async def test_sending_mqtt_commands_support_open_and_explicit_optimistic(
     mqtt_mock.async_publish.assert_called_once_with("command-topic", "OPEN", 0, False)
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("lock.test")
-    assert state.state is STATE_UNLOCKED
+    assert state.state is STATE_OPEN
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
MQTT Lock now supports the lock `open` and `opening` state. When a lock is used in `optimistic` mode. The the lock's state will become `open` instead of `unlocked` when an MQTT Lock is opened. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add open and opening state support to MQTT lock

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
