### PR TITLE
Add service to openai integration to use openai vision 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -984,8 +984,8 @@ build.json @home-assistant/supervisor
 /tests/components/onvif/ @hunterjm
 /homeassistant/components/open_meteo/ @frenck
 /tests/components/open_meteo/ @frenck
-/homeassistant/components/openai_conversation/ @balloob
-/tests/components/openai_conversation/ @balloob
+/homeassistant/components/openai_conversation/ @balloob @tlanfer
+/tests/components/openai_conversation/ @balloob @tlanfer
 /homeassistant/components/openerz/ @misialq
 /tests/components/openerz/ @misialq
 /homeassistant/components/openexchangerates/ @MartinHjelmare

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -34,3 +34,21 @@ CONF_TOP_P = "top_p"
 DEFAULT_TOP_P = 1
 CONF_TEMPERATURE = "temperature"
 DEFAULT_TEMPERATURE = 0.5
+
+
+DEFAULT_IMAGE_DESCRIPTION_PROMPT = """
+Describe what is happening in this image. Do not describe the scenery.
+
+Provide the response in JSON format, according to this example:
+{
+  "summary": "A man walking with a dog towards the door",
+  "description": "A man walking along a path in a front yard is looking at his phone. He is being followed by a black dog",
+  "people": 1,
+}
+
+The field "summary" should be a very brief summary of things happening in this image.
+The field "description" can be more verbose, providing more context of the actions done by creatures in the image.
+The field "people" should describe how many humans are visible in the picture.
+
+Do not provide anything else other than the JSON object.
+"""

--- a/homeassistant/components/openai_conversation/icons.json
+++ b/homeassistant/components/openai_conversation/icons.json
@@ -1,5 +1,6 @@
 {
   "services": {
-    "generate_image": "mdi:image-sync"
+    "generate_image": "mdi:image-sync",
+    "describe_image": "mdi:image-search"
   }
 }

--- a/homeassistant/components/openai_conversation/manifest.json
+++ b/homeassistant/components/openai_conversation/manifest.json
@@ -2,7 +2,7 @@
   "domain": "openai_conversation",
   "name": "OpenAI Conversation",
   "after_dependencies": ["assist_pipeline"],
-  "codeowners": ["@balloob"],
+  "codeowners": ["@balloob", "@tlanfer"],
   "config_flow": true,
   "dependencies": ["conversation"],
   "documentation": "https://www.home-assistant.io/integrations/openai_conversation",

--- a/homeassistant/components/openai_conversation/services.yaml
+++ b/homeassistant/components/openai_conversation/services.yaml
@@ -38,3 +38,32 @@ generate_image:
           options:
             - "vivid"
             - "natural"
+
+describe_image:
+  fields:
+    config_entry:
+      required: true
+      selector:
+        config_entry:
+          integration: openai_conversation
+    camera:
+      required: true
+      selector:
+        entity:
+          domain: camera
+    prompt:
+      required: false
+      example: "Describe what is happening in the picture"
+      default: "Describe what is happening in the picture"
+      selector:
+        text:
+          multiline: true
+    detail:
+      required: true
+      example: "low"
+      default: "low"
+      selector:
+        select:
+          options:
+            - "low"
+            - "high"

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -53,6 +53,29 @@
           "description": "The style of the generated image"
         }
       }
+    },
+    "describe_image": {
+      "name": "Describe image",
+      "description": "Analyze a camera image and ask questions about it",
+      "fields": {
+        "config_entry": {
+          "name": "Config Entry",
+          "description": "The config entry to use for this service"
+        },
+        "camera": {
+          "name": "Camera",
+          "description": "The camera to take an image from"
+        },
+        "prompt": {
+          "name": "Custom Prompt",
+          "description": "Customize the prompt for OpenAI. You can ask OpenAI to return JSON content.",
+          "example": "Count the number of birds"
+        },
+        "detail": {
+          "name": "Detail",
+          "description": "Level of detail to request from OpenAI. High detail will use significantly more tokens."
+        }
+      }
     }
   },
   "issues": {

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -136,12 +136,10 @@ async def test_describe_image_service_response_text(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_init_component,
-    service_data,
-    expected_args,
+    #    service_data,
+    #    expected_args,
 ) -> None:
     """Test describe image service for text responses."""
-    service_data["config_entry"] = mock_config_entry.entry_id
-    expected_args["model"] = "gpt-4-turbo"
 
     with patch(
         "openai.resources.chat.completions.create",
@@ -152,14 +150,14 @@ async def test_describe_image_service_response_text(
         response = await hass.services.async_call(
             "openai_conversation",
             "describe_image",
-            service_data,
+            {"config_entry": mock_config_entry.entry_id},
             blocking=True,
             return_response=True,
         )
 
     assert response == {"description": "A person walking along a path"}
     assert len(mock_create.mock_calls) == 1
-    assert mock_create.mock_calls[0][2] == expected_args
+    assert mock_create.mock_calls[0][2] == {"model": "gpt-4-turbo"}
 
 
 async def test_describe_image_service_response_json(
@@ -192,7 +190,7 @@ async def test_describe_image_service_response_json(
         response = await hass.services.async_call(
             "openai_conversation",
             "describe_image",
-            service_data,
+            {"config_entry": mock_config_entry.entry_id},
             blocking=True,
             return_response=True,
         )
@@ -203,7 +201,7 @@ async def test_describe_image_service_response_json(
         "items": ["dog", "cat", "human"],
     }
     assert len(mock_create.mock_calls) == 1
-    assert mock_create.mock_calls[0][2] == expected_args
+    assert mock_create.mock_calls[0][2] == {"model": "gpt-4-turbo"}
 
 
 @pytest.mark.usefixtures("mock_init_component")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
OpenAI provides a lot of interesting features. One feature thats quite interesting for home automation scenarios is the [Vision API](https://platform.openai.com/docs/guides/vision), which lets clients provide images and ask OpenAI questions about it.
I extended the existing openai_conversation integrations which so far only provides a service for image generation. I added an additional service, which takes a camera entity as an input and uses OpenAI to analyze it. 
One usecase for this would using OpenAI to find out if the person at your front door is a delivery person, some children, or a group of dogs.
This is obviously very much inspired by [AmbleGPT](https://github.com/mhaowork/amblegpt), which does basically the same thing, except better (using several frames and providing more context). The difference being that using my provided change lets you integrate it into arbitrary automations easily.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- OpenAI vision api: https://platform.openai.com/docs/guides/vision
- AmbleGPT: https://github.com/mhaowork/amblegpt

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/32683

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
