### PR TITLE
Fix flakey sonos test teardown

### DIFF
--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -213,6 +213,8 @@ async def test_async_poll_manual_hosts_1(
             not in caplog.text
         )
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
 
 async def test_async_poll_manual_hosts_2(
     hass: HomeAssistant,
@@ -236,6 +238,8 @@ async def test_async_poll_manual_hosts_2(
             f"Could not get visible Sonos devices from {soco_2.ip_address}"
             in caplog.text
         )
+
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 async def test_async_poll_manual_hosts_3(
@@ -261,6 +265,8 @@ async def test_async_poll_manual_hosts_3(
             in caplog.text
         )
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
 
 async def test_async_poll_manual_hosts_4(
     hass: HomeAssistant,
@@ -284,6 +290,8 @@ async def test_async_poll_manual_hosts_4(
             f"Could not get visible Sonos devices from {soco_2.ip_address}"
             not in caplog.text
         )
+
+    await hass.async_block_till_done(wait_background_tasks=True)
 
 
 class SpeakerActivity:
@@ -348,6 +356,8 @@ async def test_async_poll_manual_hosts_5(
             assert "Activity on Living Room" in caplog.text
             assert "Activity on Bedroom" in caplog.text
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
 
 async def test_async_poll_manual_hosts_6(
     hass: HomeAssistant,
@@ -386,6 +396,8 @@ async def test_async_poll_manual_hosts_6(
             assert speaker_1_activity.call_count == 0
             assert speaker_2_activity.call_count == 0
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
 
 async def test_async_poll_manual_hosts_7(
     hass: HomeAssistant,
@@ -413,6 +425,8 @@ async def test_async_poll_manual_hosts_7(
     assert "media_player.garage" in entity_registry.entities
     assert "media_player.studio" in entity_registry.entities
 
+    await hass.async_block_till_done(wait_background_tasks=True)
+
 
 async def test_async_poll_manual_hosts_8(
     hass: HomeAssistant,
@@ -439,3 +453,4 @@ async def test_async_poll_manual_hosts_8(
     assert "media_player.basement" in entity_registry.entities
     assert "media_player.garage" in entity_registry.entities
     assert "media_player.studio" in entity_registry.entities
+    await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/actions/runs/9039805087/job/24843300480?pr=117214


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
