### PR TITLE
Allow older vehicles to sleep in Teslemetry

### DIFF
--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -1,11 +1,12 @@
 """Teslemetry Data Coordinator."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from tesla_fleet_api import EnergySpecific, VehicleSpecific
 from tesla_fleet_api.const import VehicleDataEndpoint
 from tesla_fleet_api.exceptions import (
+    Forbidden,
     InvalidToken,
     SubscriptionRequired,
     TeslaFleetError,
@@ -19,6 +20,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import LOGGER, TeslemetryState
 
 VEHICLE_INTERVAL = timedelta(seconds=30)
+VEHICLE_WAIT = timedelta(minutes=15)
 ENERGY_LIVE_INTERVAL = timedelta(seconds=30)
 ENERGY_INFO_INTERVAL = timedelta(seconds=30)
 
@@ -49,6 +51,8 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Class to manage fetching data from the Teslemetry API."""
 
     updated_once: bool
+    pre2021: bool
+    last_active: datetime
 
     def __init__(
         self, hass: HomeAssistant, api: VehicleSpecific, product: dict
@@ -63,20 +67,41 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api = api
         self.data = flatten(product)
         self.updated_once = False
+        self.pre2021 = product["vin"][9] <= "L"
+        self.last_active = datetime.now()
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Update vehicle data using Teslemetry API."""
+
+        self.update_interval = VEHICLE_INTERVAL
+
         try:
             data = (await self.api.vehicle_data(endpoints=ENDPOINTS))["response"]
         except VehicleOffline:
             self.data["state"] = TeslemetryState.OFFLINE
             return self.data
-        except InvalidToken as e:
-            raise ConfigEntryAuthFailed from e
-        except SubscriptionRequired as e:
+        except (InvalidToken, Forbidden, SubscriptionRequired) as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
+
+        if self.pre2021 and data["state"] == TeslemetryState.ONLINE:
+            # Handle pre-2021 vehicles which cannot sleep by themselves
+            if (
+                data["charge_state"].get("charging_state") == "Charging"
+                or data["vehicle_state"].get("is_user_present")
+                or data["vehicle_state"].get("sentry_mode")
+            ):
+                # Vehicle is active, reset timer
+                self.last_active = datetime.now()
+            else:
+                elapsed = datetime.now() - self.last_active
+                if elapsed > timedelta(minutes=20):
+                    # Vehicle didn't sleep, try again in 15 minutes
+                    self.last_active = datetime.now()
+                elif elapsed > timedelta(minutes=15):
+                    # Let vehicle go to sleep now
+                    self.update_interval = VEHICLE_WAIT
 
         self.updated_once = True
         return flatten(data)
@@ -102,9 +127,7 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
 
         try:
             data = (await self.api.live_status())["response"]
-        except InvalidToken as e:
-            raise ConfigEntryAuthFailed from e
-        except SubscriptionRequired as e:
+        except (InvalidToken, Forbidden, SubscriptionRequired) as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
@@ -114,6 +137,7 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
             wc["din"]: wc for wc in (data.get("wall_connectors") or [])
         }
 
+        self.updated_once = True
         return data
 
 
@@ -138,11 +162,10 @@ class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
 
         try:
             data = (await self.api.site_info())["response"]
-        except InvalidToken as e:
-            raise ConfigEntryAuthFailed from e
-        except SubscriptionRequired as e:
+        except (InvalidToken, Forbidden, SubscriptionRequired) as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
+        self.updated_once = True
         return flatten(data)

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -67,7 +67,6 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api = api
         self.data = flatten(product)
         self.updated_once = False
-        self.pre2021 = product["vin"][9] <= "L"
         self.last_active = datetime.now()
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -87,6 +87,8 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
+        self.updated_once = True
+
         if self.api.pre2021 and data["state"] == TeslemetryState.ONLINE:
             # Handle pre-2021 vehicles which cannot sleep by themselves
             if (

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -80,7 +80,9 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except VehicleOffline:
             self.data["state"] = TeslemetryState.OFFLINE
             return self.data
-        except (InvalidToken, Forbidden, SubscriptionRequired) as e:
+        except InvalidToken as e:
+            raise ConfigEntryAuthFailed from e
+        except SubscriptionRequired as e:
             raise ConfigEntryAuthFailed from e
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -85,7 +85,7 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
-        if self.pre2021 and data["state"] == TeslemetryState.ONLINE:
+        if self.api.pre2021 and data["state"] == TeslemetryState.ONLINE:
             # Handle pre-2021 vehicles which cannot sleep by themselves
             if (
                 data["charge_state"].get("charging_state") == "Charging"

--- a/homeassistant/components/teslemetry/coordinator.py
+++ b/homeassistant/components/teslemetry/coordinator.py
@@ -103,7 +103,6 @@ class TeslemetryVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     # Let vehicle go to sleep now
                     self.update_interval = VEHICLE_WAIT
 
-        self.updated_once = True
         return flatten(data)
 
 
@@ -137,7 +136,6 @@ class TeslemetryEnergySiteLiveCoordinator(DataUpdateCoordinator[dict[str, Any]])
             wc["din"]: wc for wc in (data.get("wall_connectors") or [])
         }
 
-        self.updated_once = True
         return data
 
 
@@ -167,5 +165,4 @@ class TeslemetryEnergySiteInfoCoordinator(DataUpdateCoordinator[dict[str, Any]])
         except TeslaFleetError as e:
             raise UpdateFailed(e.message) from e
 
-        self.updated_once = True
         return flatten(data)

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.4.9"]
+  "requirements": ["tesla-fleet-api==0.5.7"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.5.9"]
+  "requirements": ["tesla-fleet-api==0.5.11"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.5.7"]
+  "requirements": ["tesla-fleet-api==0.5.8"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.5.8"]
+  "requirements": ["tesla-fleet-api==0.5.9"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==0.5.11"]
+  "requirements": ["tesla-fleet-api==0.5.12"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2704,7 +2704,7 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.11
+tesla-fleet-api==0.5.12
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2704,7 +2704,7 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.8
+tesla-fleet-api==0.5.9
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2704,7 +2704,7 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.9
+tesla-fleet-api==0.5.11
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2704,7 +2704,7 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.7
+tesla-fleet-api==0.5.8
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2704,7 +2704,7 @@ temperusb==1.6.1
 # tensorflow==2.5.0
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.4.9
+tesla-fleet-api==0.5.7
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.9
+tesla-fleet-api==0.5.11
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.4.9
+tesla-fleet-api==0.5.7
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.7
+tesla-fleet-api==0.5.8
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.8
+tesla-fleet-api==0.5.9
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2096,7 +2096,7 @@ temescal==0.5
 temperusb==1.6.1
 
 # homeassistant.components.teslemetry
-tesla-fleet-api==0.5.11
+tesla-fleet-api==0.5.12
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.2

--- a/tests/components/teslemetry/fixtures/products.json
+++ b/tests/components/teslemetry/fixtures/products.json
@@ -4,7 +4,7 @@
       "id": 1234,
       "user_id": 1234,
       "vehicle_id": 1234,
-      "vin": "VINVINVIN",
+      "vin": "LRW3F7EK4KC700000",
       "color": null,
       "access_type": "OWNER",
       "display_name": "Test",

--- a/tests/components/teslemetry/fixtures/products.json
+++ b/tests/components/teslemetry/fixtures/products.json
@@ -4,7 +4,7 @@
       "id": 1234,
       "user_id": 1234,
       "vehicle_id": 1234,
-      "vin": "LRW3F7EK4KC700000",
+      "vin": "LRWXF7EK4KC700000",
       "color": null,
       "access_type": "OWNER",
       "display_name": "Test",

--- a/tests/components/teslemetry/fixtures/vehicle_data.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "VINVINVIN",
+    "vin": "LRW3F7EK4KC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {

--- a/tests/components/teslemetry/fixtures/vehicle_data.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "LRW3F7EK4KC700000",
+    "vin": "LRWXF7EK4KC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {

--- a/tests/components/teslemetry/fixtures/vehicle_data_alt.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data_alt.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "LRW3F7EK4KC700000",
+    "vin": "LRWXF7EK4KC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {

--- a/tests/components/teslemetry/fixtures/vehicle_data_alt.json
+++ b/tests/components/teslemetry/fixtures/vehicle_data_alt.json
@@ -3,7 +3,7 @@
     "id": 1234,
     "user_id": 1234,
     "vehicle_id": 1234,
-    "vin": "VINVINVIN",
+    "vin": "LRW3F7EK4KC700000",
     "color": null,
     "access_type": "OWNER",
     "granular_access": {
@@ -201,7 +201,7 @@
       "feature_bitmask": "fbdffbff,187f",
       "fp_window": 1,
       "ft": 1,
-      "is_user_present": false,
+      "is_user_present": true,
       "locked": false,
       "media_info": {
         "audio_volume": 2.6667,

--- a/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
+++ b/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
@@ -166,7 +166,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_heater_on',
-    'unique_id': 'VINVINVIN-charge_state_battery_heater_on',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_heater_on',
     'unit_of_measurement': None,
   })
 # ---
@@ -181,7 +181,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_cabin_overheat_protection_actively_cooling-entry]
@@ -213,7 +213,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_cabin_overheat_protection_actively_cooling',
-    'unique_id': 'VINVINVIN-climate_state_cabin_overheat_protection_actively_cooling',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_cabin_overheat_protection_actively_cooling',
     'unit_of_measurement': None,
   })
 # ---
@@ -228,7 +228,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_charge_cable-entry]
@@ -260,7 +260,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_conn_charge_cable',
-    'unique_id': 'VINVINVIN-charge_state_conn_charge_cable',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_conn_charge_cable',
     'unit_of_measurement': None,
   })
 # ---
@@ -275,7 +275,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_charger_has_multiple_phases-entry]
@@ -307,7 +307,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_phases',
-    'unique_id': 'VINVINVIN-charge_state_charger_phases',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_phases',
     'unit_of_measurement': None,
   })
 # ---
@@ -353,7 +353,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_dashcam_state',
-    'unique_id': 'VINVINVIN-vehicle_state_dashcam_state',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_dashcam_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -400,7 +400,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_df',
-    'unique_id': 'VINVINVIN-vehicle_state_df',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_df',
     'unit_of_measurement': None,
   })
 # ---
@@ -415,7 +415,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_driver_window-entry]
@@ -447,7 +447,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_fd_window',
-    'unique_id': 'VINVINVIN-vehicle_state_fd_window',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_fd_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -462,7 +462,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_passenger_door-entry]
@@ -494,7 +494,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_pf',
-    'unique_id': 'VINVINVIN-vehicle_state_pf',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_pf',
     'unit_of_measurement': None,
   })
 # ---
@@ -509,7 +509,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_passenger_window-entry]
@@ -541,7 +541,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_fp_window',
-    'unique_id': 'VINVINVIN-vehicle_state_fp_window',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_fp_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -588,7 +588,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_is_preconditioning',
-    'unique_id': 'VINVINVIN-climate_state_is_preconditioning',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_is_preconditioning',
     'unit_of_measurement': None,
   })
 # ---
@@ -602,7 +602,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_preconditioning_enabled-entry]
@@ -634,7 +634,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_preconditioning_enabled',
-    'unique_id': 'VINVINVIN-charge_state_preconditioning_enabled',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_preconditioning_enabled',
     'unit_of_measurement': None,
   })
 # ---
@@ -680,7 +680,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_dr',
-    'unique_id': 'VINVINVIN-vehicle_state_dr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_dr',
     'unit_of_measurement': None,
   })
 # ---
@@ -695,7 +695,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_driver_window-entry]
@@ -727,7 +727,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rd_window',
-    'unique_id': 'VINVINVIN-vehicle_state_rd_window',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rd_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -742,7 +742,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_passenger_door-entry]
@@ -774,7 +774,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_pr',
-    'unique_id': 'VINVINVIN-vehicle_state_pr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_pr',
     'unit_of_measurement': None,
   })
 # ---
@@ -789,7 +789,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_passenger_window-entry]
@@ -821,7 +821,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rp_window',
-    'unique_id': 'VINVINVIN-vehicle_state_rp_window',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rp_window',
     'unit_of_measurement': None,
   })
 # ---
@@ -868,7 +868,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_scheduled_charging_pending',
-    'unique_id': 'VINVINVIN-charge_state_scheduled_charging_pending',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_scheduled_charging_pending',
     'unit_of_measurement': None,
   })
 # ---
@@ -882,7 +882,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_status-entry]
@@ -914,7 +914,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'state',
-    'unique_id': 'VINVINVIN-state',
+    'unique_id': 'LRWXF7EK4KC700000-state',
     'unit_of_measurement': None,
   })
 # ---
@@ -929,7 +929,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_front_left-entry]
@@ -961,7 +961,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_fl',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_soft_warning_fl',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_fl',
     'unit_of_measurement': None,
   })
 # ---
@@ -976,7 +976,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_front_right-entry]
@@ -1008,7 +1008,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_fr',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_soft_warning_fr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_fr',
     'unit_of_measurement': None,
   })
 # ---
@@ -1023,7 +1023,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_rear_left-entry]
@@ -1055,7 +1055,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_rl',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_soft_warning_rl',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_rl',
     'unit_of_measurement': None,
   })
 # ---
@@ -1070,7 +1070,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_rear_right-entry]
@@ -1102,7 +1102,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_soft_warning_rr',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_soft_warning_rr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_soft_warning_rr',
     'unit_of_measurement': None,
   })
 # ---
@@ -1117,7 +1117,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_trip_charging-entry]
@@ -1149,7 +1149,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_trip_charging',
-    'unique_id': 'VINVINVIN-charge_state_trip_charging',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_trip_charging',
     'unit_of_measurement': None,
   })
 # ---
@@ -1163,7 +1163,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_user_present-entry]
@@ -1195,7 +1195,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_is_user_present',
-    'unique_id': 'VINVINVIN-vehicle_state_is_user_present',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_is_user_present',
     'unit_of_measurement': None,
   })
 # ---
@@ -1263,7 +1263,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_cabin_overheat_protection_actively_cooling-statealt]
@@ -1277,7 +1277,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_charge_cable-statealt]
@@ -1291,7 +1291,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_charger_has_multiple_phases-statealt]
@@ -1332,7 +1332,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_driver_window-statealt]
@@ -1346,7 +1346,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_passenger_door-statealt]
@@ -1360,7 +1360,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_passenger_window-statealt]
@@ -1387,7 +1387,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_preconditioning_enabled-statealt]
@@ -1414,7 +1414,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_driver_window-statealt]
@@ -1428,7 +1428,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_passenger_door-statealt]
@@ -1442,7 +1442,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_passenger_window-statealt]
@@ -1469,7 +1469,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_status-statealt]
@@ -1483,7 +1483,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_front_left-statealt]
@@ -1497,7 +1497,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_front_right-statealt]
@@ -1511,7 +1511,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_rear_left-statealt]
@@ -1525,7 +1525,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_rear_right-statealt]
@@ -1539,7 +1539,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_trip_charging-statealt]
@@ -1552,7 +1552,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'unknown',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_user_present-statealt]

--- a/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
+++ b/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
@@ -181,7 +181,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_cabin_overheat_protection_actively_cooling-entry]
@@ -228,7 +228,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_charge_cable-entry]
@@ -275,7 +275,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_charger_has_multiple_phases-entry]
@@ -415,7 +415,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_driver_window-entry]
@@ -462,7 +462,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_passenger_door-entry]
@@ -509,7 +509,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_front_passenger_window-entry]
@@ -602,7 +602,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_preconditioning_enabled-entry]
@@ -695,7 +695,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_driver_window-entry]
@@ -742,7 +742,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_passenger_door-entry]
@@ -789,7 +789,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_rear_passenger_window-entry]
@@ -882,7 +882,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_status-entry]
@@ -929,7 +929,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_front_left-entry]
@@ -976,7 +976,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_front_right-entry]
@@ -1023,7 +1023,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_rear_left-entry]
@@ -1070,7 +1070,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_tire_pressure_warning_rear_right-entry]
@@ -1117,7 +1117,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_trip_charging-entry]
@@ -1163,7 +1163,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor[binary_sensor.test_user_present-entry]
@@ -1263,7 +1263,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_cabin_overheat_protection_actively_cooling-statealt]
@@ -1277,7 +1277,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_charge_cable-statealt]
@@ -1291,7 +1291,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_charger_has_multiple_phases-statealt]
@@ -1332,7 +1332,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_driver_window-statealt]
@@ -1346,7 +1346,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_passenger_door-statealt]
@@ -1360,7 +1360,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_front_passenger_window-statealt]
@@ -1387,7 +1387,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_preconditioning_enabled-statealt]
@@ -1414,7 +1414,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_driver_window-statealt]
@@ -1428,7 +1428,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_passenger_door-statealt]
@@ -1442,7 +1442,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_rear_passenger_window-statealt]
@@ -1469,7 +1469,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_status-statealt]
@@ -1483,7 +1483,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_front_left-statealt]
@@ -1497,7 +1497,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_front_right-statealt]
@@ -1511,7 +1511,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_rear_left-statealt]
@@ -1525,7 +1525,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_tire_pressure_warning_rear_right-statealt]
@@ -1539,7 +1539,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_trip_charging-statealt]
@@ -1552,7 +1552,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_binary_sensor_refresh[binary_sensor.test_user_present-statealt]

--- a/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
+++ b/tests/components/teslemetry/snapshots/test_binary_sensors.ambr
@@ -1566,6 +1566,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_button.ambr
+++ b/tests/components/teslemetry/snapshots/test_button.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'flash_lights',
-    'unique_id': 'VINVINVIN-flash_lights',
+    'unique_id': 'LRWXF7EK4KC700000-flash_lights',
     'unit_of_measurement': None,
   })
 # ---
@@ -74,7 +74,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'homelink',
-    'unique_id': 'VINVINVIN-homelink',
+    'unique_id': 'LRWXF7EK4KC700000-homelink',
     'unit_of_measurement': None,
   })
 # ---
@@ -120,7 +120,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'honk',
-    'unique_id': 'VINVINVIN-honk',
+    'unique_id': 'LRWXF7EK4KC700000-honk',
     'unit_of_measurement': None,
   })
 # ---
@@ -166,7 +166,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'enable_keyless_driving',
-    'unique_id': 'VINVINVIN-enable_keyless_driving',
+    'unique_id': 'LRWXF7EK4KC700000-enable_keyless_driving',
     'unit_of_measurement': None,
   })
 # ---
@@ -212,7 +212,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'boombox',
-    'unique_id': 'VINVINVIN-boombox',
+    'unique_id': 'LRWXF7EK4KC700000-boombox',
     'unit_of_measurement': None,
   })
 # ---
@@ -258,7 +258,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'wake',
-    'unique_id': 'VINVINVIN-wake',
+    'unique_id': 'LRWXF7EK4KC700000-wake',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_climate.ambr
+++ b/tests/components/teslemetry/snapshots/test_climate.ambr
@@ -41,7 +41,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'VINVINVIN-driver_temp',
+    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -116,7 +116,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'VINVINVIN-driver_temp',
+    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -191,7 +191,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'VINVINVIN-driver_temp',
+    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_climate.ambr
+++ b/tests/components/teslemetry/snapshots/test_climate.ambr
@@ -41,7 +41,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
+    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -116,7 +116,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
+    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---
@@ -191,7 +191,7 @@
     'previous_unique_id': None,
     'supported_features': <ClimateEntityFeature: 401>,
     'translation_key': <TeslemetryClimateSide.DRIVER: 'driver_temp'>,
-    'unique_id': 'LRW3F7EK4KC700000-driver_temp',
+    'unique_id': 'LRWXF7EK4KC700000-driver_temp',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_cover.ambr
+++ b/tests/components/teslemetry/snapshots/test_cover.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'VINVINVIN-charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -76,7 +76,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 1>,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'VINVINVIN-vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -124,7 +124,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'VINVINVIN-vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -172,7 +172,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'windows',
-    'unique_id': 'VINVINVIN-windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
     'unit_of_measurement': None,
   })
 # ---
@@ -220,7 +220,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'VINVINVIN-charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -268,7 +268,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 1>,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'VINVINVIN-vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -316,7 +316,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'VINVINVIN-vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -364,7 +364,7 @@
     'previous_unique_id': None,
     'supported_features': <CoverEntityFeature: 3>,
     'translation_key': 'windows',
-    'unique_id': 'VINVINVIN-windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
     'unit_of_measurement': None,
   })
 # ---
@@ -412,7 +412,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_port_door_open',
-    'unique_id': 'VINVINVIN-charge_state_charge_port_door_open',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_door_open',
     'unit_of_measurement': None,
   })
 # ---
@@ -460,7 +460,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_ft',
-    'unique_id': 'VINVINVIN-vehicle_state_ft',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_ft',
     'unit_of_measurement': None,
   })
 # ---
@@ -508,7 +508,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_rt',
-    'unique_id': 'VINVINVIN-vehicle_state_rt',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_rt',
     'unit_of_measurement': None,
   })
 # ---
@@ -556,7 +556,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'windows',
-    'unique_id': 'VINVINVIN-windows',
+    'unique_id': 'LRWXF7EK4KC700000-windows',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_device_tracker.ambr
+++ b/tests/components/teslemetry/snapshots/test_device_tracker.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'location',
-    'unique_id': 'VINVINVIN-location',
+    'unique_id': 'LRWXF7EK4KC700000-location',
     'unit_of_measurement': None,
   })
 # ---
@@ -78,7 +78,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'route',
-    'unique_id': 'VINVINVIN-route',
+    'unique_id': 'LRWXF7EK4KC700000-route',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_init.ambr
+++ b/tests/components/teslemetry/snapshots/test_init.ambr
@@ -29,7 +29,7 @@
     'via_device_id': None,
   })
 # ---
-# name: test_devices[{('teslemetry', 'VINVINVIN')}]
+# name: test_devices[{('teslemetry', 'LRWXF7EK4KC700000')}]
   DeviceRegistryEntrySnapshot({
     'area_id': None,
     'config_entries': <ANY>,
@@ -43,17 +43,17 @@
     'identifiers': set({
       tuple(
         'teslemetry',
-        'VINVINVIN',
+        'LRWXF7EK4KC700000',
       ),
     }),
     'is_new': False,
     'labels': set({
     }),
     'manufacturer': 'Tesla',
-    'model': None,
+    'model': 'Model X',
     'name': 'Test',
     'name_by_user': None,
-    'serial_number': 'VINVINVIN',
+    'serial_number': 'LRWXF7EK4KC700000',
     'suggested_area': None,
     'sw_version': None,
     'via_device_id': None,

--- a/tests/components/teslemetry/snapshots/test_lock.ambr
+++ b/tests/components/teslemetry/snapshots/test_lock.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_port_latch',
-    'unique_id': 'VINVINVIN-charge_state_charge_port_latch',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_port_latch',
     'unit_of_measurement': None,
   })
 # ---
@@ -75,7 +75,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_locked',
-    'unique_id': 'VINVINVIN-vehicle_state_locked',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_locked',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_media_player.ambr
+++ b/tests/components/teslemetry/snapshots/test_media_player.ambr
@@ -29,7 +29,7 @@
     'previous_unique_id': None,
     'supported_features': <MediaPlayerEntityFeature: 16437>,
     'translation_key': 'media',
-    'unique_id': 'VINVINVIN-media',
+    'unique_id': 'LRWXF7EK4KC700000-media',
     'unit_of_measurement': None,
   })
 # ---
@@ -107,7 +107,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'media',
-    'unique_id': 'VINVINVIN-media',
+    'unique_id': 'LRWXF7EK4KC700000-media',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_number.ambr
+++ b/tests/components/teslemetry/snapshots/test_number.ambr
@@ -149,7 +149,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_current_request',
-    'unique_id': 'VINVINVIN-charge_state_charge_current_request',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_current_request',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -206,7 +206,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_limit_soc',
-    'unique_id': 'VINVINVIN-charge_state_charge_limit_soc',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_limit_soc',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_select.ambr
+++ b/tests/components/teslemetry/snapshots/test_select.ambr
@@ -149,7 +149,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_left',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_left',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -208,7 +208,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_right',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_right',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -267,7 +267,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_center',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_rear_center',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_center',
     'unit_of_measurement': None,
   })
 # ---
@@ -326,7 +326,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_left',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_rear_left',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -385,7 +385,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_rear_right',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_rear_right',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_rear_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -444,7 +444,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_third_row_left',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_third_row_left',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_third_row_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -503,7 +503,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_seat_heater_third_row_right',
-    'unique_id': 'VINVINVIN-climate_state_seat_heater_third_row_right',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_seat_heater_third_row_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -561,7 +561,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_steering_wheel_heat_level',
-    'unique_id': 'VINVINVIN-climate_state_steering_wheel_heat_level',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_steering_wheel_heat_level',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -867,7 +867,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_level',
-    'unique_id': 'VINVINVIN-charge_state_battery_level',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_battery_level',
     'unit_of_measurement': '%',
   })
 # ---
@@ -940,7 +940,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_range',
-    'unique_id': 'VINVINVIN-charge_state_battery_range',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1005,7 +1005,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_conn_charge_cable',
-    'unique_id': 'VINVINVIN-charge_state_conn_charge_cable',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_conn_charge_cable',
     'unit_of_measurement': None,
   })
 # ---
@@ -1069,7 +1069,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_energy_added',
-    'unique_id': 'VINVINVIN-charge_state_charge_energy_added',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charge_energy_added',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
@@ -1139,7 +1139,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_rate',
-    'unique_id': 'VINVINVIN-charge_state_charge_rate',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charge_rate',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -1206,7 +1206,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_actual_current',
-    'unique_id': 'VINVINVIN-charge_state_charger_actual_current',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_actual_current',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1273,7 +1273,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_power',
-    'unique_id': 'VINVINVIN-charge_state_charger_power',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -1340,7 +1340,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_voltage',
-    'unique_id': 'VINVINVIN-charge_state_charger_voltage',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1414,7 +1414,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'VINVINVIN-charge_state_charging_state',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -1496,7 +1496,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_miles_to_arrival',
-    'unique_id': 'VINVINVIN-drive_state_active_route_miles_to_arrival',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_miles_to_arrival',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1566,7 +1566,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_driver_temp_setting',
-    'unique_id': 'VINVINVIN-climate_state_driver_temp_setting',
+    'unique_id': 'LRW3F7EK4KC700000-climate_state_driver_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1639,7 +1639,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_est_battery_range',
-    'unique_id': 'VINVINVIN-charge_state_est_battery_range',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_est_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1704,7 +1704,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_fast_charger_type',
-    'unique_id': 'VINVINVIN-charge_state_fast_charger_type',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_fast_charger_type',
     'unit_of_measurement': None,
   })
 # ---
@@ -1771,7 +1771,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_ideal_battery_range',
-    'unique_id': 'VINVINVIN-charge_state_ideal_battery_range',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_ideal_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1841,7 +1841,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_inside_temp',
-    'unique_id': 'VINVINVIN-climate_state_inside_temp',
+    'unique_id': 'LRW3F7EK4KC700000-climate_state_inside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1914,7 +1914,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_odometer',
-    'unique_id': 'VINVINVIN-vehicle_state_odometer',
+    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_odometer',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1984,7 +1984,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_outside_temp',
-    'unique_id': 'VINVINVIN-climate_state_outside_temp',
+    'unique_id': 'LRW3F7EK4KC700000-climate_state_outside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2054,7 +2054,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_passenger_temp_setting',
-    'unique_id': 'VINVINVIN-climate_state_passenger_temp_setting',
+    'unique_id': 'LRW3F7EK4KC700000-climate_state_passenger_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2121,7 +2121,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_power',
-    'unique_id': 'VINVINVIN-drive_state_power',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -2193,7 +2193,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_shift_state',
-    'unique_id': 'VINVINVIN-drive_state_shift_state',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_shift_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -2271,7 +2271,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_speed',
-    'unique_id': 'VINVINVIN-drive_state_speed',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_speed',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -2338,7 +2338,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_energy_at_arrival',
-    'unique_id': 'VINVINVIN-drive_state_active_route_energy_at_arrival',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_energy_at_arrival',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2403,7 +2403,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_minutes_to_arrival',
-    'unique_id': 'VINVINVIN-drive_state_active_route_minutes_to_arrival',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_minutes_to_arrival',
     'unit_of_measurement': None,
   })
 # ---
@@ -2464,7 +2464,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_minutes_to_full_charge',
-    'unique_id': 'VINVINVIN-charge_state_minutes_to_full_charge',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_minutes_to_full_charge',
     'unit_of_measurement': None,
   })
 # ---
@@ -2533,7 +2533,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fl',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_pressure_fl',
+    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_fl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2606,7 +2606,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fr',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_pressure_fr',
+    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_fr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2679,7 +2679,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rl',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_pressure_rl',
+    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_rl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2752,7 +2752,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rr',
-    'unique_id': 'VINVINVIN-vehicle_state_tpms_pressure_rr',
+    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_rr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2819,7 +2819,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_traffic_minutes_delay',
-    'unique_id': 'VINVINVIN-drive_state_active_route_traffic_minutes_delay',
+    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_traffic_minutes_delay',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -2886,7 +2886,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_usable_battery_level',
-    'unique_id': 'VINVINVIN-charge_state_usable_battery_level',
+    'unique_id': 'LRW3F7EK4KC700000-charge_state_usable_battery_level',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_sensor.ambr
+++ b/tests/components/teslemetry/snapshots/test_sensor.ambr
@@ -867,7 +867,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_level',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_battery_level',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_level',
     'unit_of_measurement': '%',
   })
 # ---
@@ -940,7 +940,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_battery_range',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_battery_range',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1005,7 +1005,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_conn_charge_cable',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_conn_charge_cable',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_conn_charge_cable',
     'unit_of_measurement': None,
   })
 # ---
@@ -1069,7 +1069,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_energy_added',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charge_energy_added',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_energy_added',
     'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
   })
 # ---
@@ -1139,7 +1139,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charge_rate',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charge_rate',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charge_rate',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -1206,7 +1206,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_actual_current',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_actual_current',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_actual_current',
     'unit_of_measurement': <UnitOfElectricCurrent.AMPERE: 'A'>,
   })
 # ---
@@ -1273,7 +1273,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_power',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_power',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -1340,7 +1340,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charger_voltage',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charger_voltage',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charger_voltage',
     'unit_of_measurement': <UnitOfElectricPotential.VOLT: 'V'>,
   })
 # ---
@@ -1414,7 +1414,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_charging_state',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_charging_state',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_charging_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -1496,7 +1496,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_miles_to_arrival',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_miles_to_arrival',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_miles_to_arrival',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1566,7 +1566,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_driver_temp_setting',
-    'unique_id': 'LRW3F7EK4KC700000-climate_state_driver_temp_setting',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_driver_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1639,7 +1639,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_est_battery_range',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_est_battery_range',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_est_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1704,7 +1704,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_fast_charger_type',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_fast_charger_type',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_fast_charger_type',
     'unit_of_measurement': None,
   })
 # ---
@@ -1771,7 +1771,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_ideal_battery_range',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_ideal_battery_range',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_ideal_battery_range',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1841,7 +1841,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_inside_temp',
-    'unique_id': 'LRW3F7EK4KC700000-climate_state_inside_temp',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_inside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -1914,7 +1914,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_odometer',
-    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_odometer',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_odometer',
     'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
@@ -1984,7 +1984,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_outside_temp',
-    'unique_id': 'LRW3F7EK4KC700000-climate_state_outside_temp',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_outside_temp',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2054,7 +2054,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_passenger_temp_setting',
-    'unique_id': 'LRW3F7EK4KC700000-climate_state_passenger_temp_setting',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_passenger_temp_setting',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
@@ -2121,7 +2121,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_power',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_power',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_power',
     'unit_of_measurement': <UnitOfPower.KILO_WATT: 'kW'>,
   })
 # ---
@@ -2193,7 +2193,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_shift_state',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_shift_state',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_shift_state',
     'unit_of_measurement': None,
   })
 # ---
@@ -2271,7 +2271,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_speed',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_speed',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_speed',
     'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
   })
 # ---
@@ -2338,7 +2338,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_energy_at_arrival',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_energy_at_arrival',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_energy_at_arrival',
     'unit_of_measurement': '%',
   })
 # ---
@@ -2403,7 +2403,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_minutes_to_arrival',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_minutes_to_arrival',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_minutes_to_arrival',
     'unit_of_measurement': None,
   })
 # ---
@@ -2464,7 +2464,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_minutes_to_full_charge',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_minutes_to_full_charge',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_minutes_to_full_charge',
     'unit_of_measurement': None,
   })
 # ---
@@ -2533,7 +2533,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fl',
-    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_fl',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_fl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2606,7 +2606,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_fr',
-    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_fr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_fr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2679,7 +2679,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rl',
-    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_rl',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_rl',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2752,7 +2752,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_tpms_pressure_rr',
-    'unique_id': 'LRW3F7EK4KC700000-vehicle_state_tpms_pressure_rr',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_tpms_pressure_rr',
     'unit_of_measurement': <UnitOfPressure.PSI: 'psi'>,
   })
 # ---
@@ -2819,7 +2819,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'drive_state_active_route_traffic_minutes_delay',
-    'unique_id': 'LRW3F7EK4KC700000-drive_state_active_route_traffic_minutes_delay',
+    'unique_id': 'LRWXF7EK4KC700000-drive_state_active_route_traffic_minutes_delay',
     'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
   })
 # ---
@@ -2886,7 +2886,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_usable_battery_level',
-    'unique_id': 'LRW3F7EK4KC700000-charge_state_usable_battery_level',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_usable_battery_level',
     'unit_of_measurement': '%',
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_switch.ambr
+++ b/tests/components/teslemetry/snapshots/test_switch.ambr
@@ -122,7 +122,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_seat_climate_left',
-    'unique_id': 'VINVINVIN-climate_state_auto_seat_climate_left',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_seat_climate_left',
     'unit_of_measurement': None,
   })
 # ---
@@ -169,7 +169,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_seat_climate_right',
-    'unique_id': 'VINVINVIN-climate_state_auto_seat_climate_right',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_seat_climate_right',
     'unit_of_measurement': None,
   })
 # ---
@@ -216,7 +216,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_auto_steering_wheel_heat',
-    'unique_id': 'VINVINVIN-climate_state_auto_steering_wheel_heat',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_auto_steering_wheel_heat',
     'unit_of_measurement': None,
   })
 # ---
@@ -263,7 +263,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'charge_state_user_charge_enable_request',
-    'unique_id': 'VINVINVIN-charge_state_user_charge_enable_request',
+    'unique_id': 'LRWXF7EK4KC700000-charge_state_user_charge_enable_request',
     'unit_of_measurement': None,
   })
 # ---
@@ -310,7 +310,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'climate_state_defrost_mode',
-    'unique_id': 'VINVINVIN-climate_state_defrost_mode',
+    'unique_id': 'LRWXF7EK4KC700000-climate_state_defrost_mode',
     'unit_of_measurement': None,
   })
 # ---
@@ -357,7 +357,7 @@
     'previous_unique_id': None,
     'supported_features': 0,
     'translation_key': 'vehicle_state_sentry_mode',
-    'unique_id': 'VINVINVIN-vehicle_state_sentry_mode',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_sentry_mode',
     'unit_of_measurement': None,
   })
 # ---

--- a/tests/components/teslemetry/snapshots/test_update.ambr
+++ b/tests/components/teslemetry/snapshots/test_update.ambr
@@ -28,7 +28,7 @@
     'previous_unique_id': None,
     'supported_features': <UpdateEntityFeature: 5>,
     'translation_key': 'vehicle_state_software_update_status',
-    'unique_id': 'VINVINVIN-vehicle_state_software_update_status',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_software_update_status',
     'unit_of_measurement': None,
   })
 # ---
@@ -84,7 +84,7 @@
     'previous_unique_id': None,
     'supported_features': <UpdateEntityFeature: 4>,
     'translation_key': 'vehicle_state_software_update_status',
-    'unique_id': 'VINVINVIN-vehicle_state_software_update_status',
+    'unique_id': 'LRWXF7EK4KC700000-vehicle_state_software_update_status',
     'unit_of_measurement': None,
   })
 # ---


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tesla vehicles manufactured before 2021 cannot sleep if they are polled by API constantly. This PR adds logic to the coordinator to introduce a 15 minute wait after 15 minutes in inactivity. This 15 minute break is enough time to let the vehicle sleep, and then the coordinator can revert back to frequent polling so it knows when the vehicle wakes up.

The age of the vehicle is determined the 10th character of the VIN, as this is a code for the year it was manufactured.

Library bump: https://github.com/Teslemetry/python-tesla-fleet-api/compare/v0.4.9...v0.5.12

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
