### PR TITLE
Use `MockConfigEntry` in hue tests

### DIFF
--- a/tests/components/hue/test_services.py
+++ b/tests/components/hue/test_services.py
@@ -2,7 +2,6 @@
 
 from unittest.mock import patch
 
-from homeassistant import config_entries
 from homeassistant.components import hue
 from homeassistant.components.hue import bridge
 from homeassistant.components.hue.const import (
@@ -12,6 +11,8 @@ from homeassistant.components.hue.const import (
 from homeassistant.core import HomeAssistant
 
 from .conftest import setup_bridge, setup_component
+
+from tests.common import MockConfigEntry
 
 GROUP_RESPONSE = {
     "group_1": {
@@ -49,11 +50,8 @@ SCENE_RESPONSE = {
 
 async def test_hue_activate_scene(hass: HomeAssistant, mock_api_v1) -> None:
     """Test successful hue_activate_scene."""
-    config_entry = config_entries.ConfigEntry(
-        version=1,
-        minor_version=1,
+    config_entry = MockConfigEntry(
         domain=hue.DOMAIN,
-        title="Mock Title",
         data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
         source="test",
         options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
@@ -87,11 +85,8 @@ async def test_hue_activate_scene(hass: HomeAssistant, mock_api_v1) -> None:
 
 async def test_hue_activate_scene_transition(hass: HomeAssistant, mock_api_v1) -> None:
     """Test successful hue_activate_scene with transition."""
-    config_entry = config_entries.ConfigEntry(
-        version=1,
-        minor_version=1,
+    config_entry = MockConfigEntry(
         domain=hue.DOMAIN,
-        title="Mock Title",
         data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
         source="test",
         options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
@@ -127,11 +122,8 @@ async def test_hue_activate_scene_group_not_found(
     hass: HomeAssistant, mock_api_v1
 ) -> None:
     """Test failed hue_activate_scene due to missing group."""
-    config_entry = config_entries.ConfigEntry(
-        version=1,
-        minor_version=1,
+    config_entry = MockConfigEntry(
         domain=hue.DOMAIN,
-        title="Mock Title",
         data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
         source="test",
         options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},
@@ -162,11 +154,8 @@ async def test_hue_activate_scene_scene_not_found(
     hass: HomeAssistant, mock_api_v1
 ) -> None:
     """Test failed hue_activate_scene due to missing scene."""
-    config_entry = config_entries.ConfigEntry(
-        version=1,
-        minor_version=1,
+    config_entry = MockConfigEntry(
         domain=hue.DOMAIN,
-        title="Mock Title",
         data={"host": "1.2.3.4", "api_key": "mock-api-key", "api_version": 1},
         source="test",
         options={CONF_ALLOW_HUE_GROUPS: True, CONF_ALLOW_UNREACHABLE: False},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `MockConfigEntry` in hue tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
