### PR TITLE
Bump zwave-js-server-python to 0.56.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["zwave_js_server"],
   "quality_scale": "platinum",
-  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.55.4"],
+  "requirements": ["pyserial==3.5", "zwave-js-server-python==0.56.0"],
   "usb": [
     {
       "vid": "0658",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2971,7 +2971,7 @@ zigpy==0.64.0
 zm-py==0.5.4
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.55.4
+zwave-js-server-python==0.56.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2309,7 +2309,7 @@ zigpy-znp==0.12.1
 zigpy==0.64.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.55.4
+zwave-js-server-python==0.56.0
 
 # homeassistant.components.zwave_me
 zwave-me-ws==0.4.3

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 from http import HTTPStatus
+from io import BytesIO
 import json
 from typing import Any
 from unittest.mock import patch
@@ -3089,7 +3090,9 @@ async def test_firmware_upload_view(
             f"/api/zwave_js/firmware/upload/{device.id}", data=data
         )
 
-        update_data = NodeFirmwareUpdateData("file", bytes(10))
+        update_data = NodeFirmwareUpdateData(
+            "file", b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+        )
         for attr, value in expected_data.items():
             setattr(update_data, attr, value)
 
@@ -3129,7 +3132,9 @@ async def test_firmware_upload_view_controller(
         )
         mock_node_cmd.assert_not_called()
         assert mock_controller_cmd.call_args[0][1:2] == (
-            ControllerFirmwareUpdateData("file", bytes(10)),
+            ControllerFirmwareUpdateData(
+                "file", b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+            ),
         )
         assert mock_controller_cmd.call_args[1] == {
             "additional_user_agent_components": {"HomeAssistant": "0.0.0"},
@@ -3166,7 +3171,7 @@ async def test_firmware_upload_view_invalid_payload(
     client = await hass_client()
     resp = await client.post(
         f"/api/zwave_js/firmware/upload/{device.id}",
-        data={"wrong_key": bytes(10)},
+        data={"wrong_key": BytesIO(bytes(10))},
     )
     assert resp.status == HTTPStatus.BAD_REQUEST
 
@@ -3184,7 +3189,7 @@ async def test_firmware_upload_view_no_driver(
     aiohttp_client = await hass_client()
     resp = await aiohttp_client.post(
         f"/api/zwave_js/firmware/upload/{device.id}",
-        data={"wrong_key": bytes(10)},
+        data={"wrong_key": BytesIO(bytes(10))},
     )
     assert resp.status == HTTPStatus.NOT_FOUND
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1336,6 +1336,7 @@ async def test_get_provisioning_entries(
             "security_classes": [SecurityClass.S2_UNAUTHENTICATED],
             "requested_security_classes": None,
             "status": 0,
+            "protocol": None,
             "additional_properties": {"fake": "test"},
         }
     ]
@@ -1422,6 +1423,7 @@ async def test_parse_qr_code_string(
         "manufacturer_id": 1,
         "product_type": 1,
         "product_id": 1,
+        "protocol": None,
         "application_version": "test",
         "max_inclusion_request_interval": 1,
         "uuid": "test",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
With this release, you will need to update your `zwave-js-server` instance. You must use `zwave-js-server` 1.35.0 or greater (schema 35).
- If you use the Z-Wave JS add-on, you need at least version 0.5.0.
- If you use the Z-Wave JS UI add-on, you need at least version [3.4.2](https://github.com/hassio-addons/addon-zwave-js-ui/releases/tag/v3.4.2).
- If you use the Z-Wave JS UI Docker container, you need at least version [9.10.0](https://github.com/zwave-js/zwave-js-ui/releases/tag/v9.10.0).
- If you run your own Docker container or some other installation method, you will need to update your zwave-js-server instance to at least 1.35.0.



## Proposed change
This bump forces users to upgrade to a zwave-js-server and driver version that support long range. It also adds some new long range specific attributes. This should be a no op for existing code, and just enables us to include the necessary attributes in the `zwave_js/network_status` WS API response.

changelog: https://github.com/home-assistant-libs/zwave-js-server-python/compare/0.55.4...0.56.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
