### PR TITLE
Enable open protection in the event loop

### DIFF
--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -1,5 +1,6 @@
 """Block blocking calls being done in asyncio."""
 
+import builtins
 from contextlib import suppress
 from http.client import HTTPConnection
 import importlib
@@ -45,11 +46,11 @@ def enable() -> None:
         time.sleep, strict=False, check_allowed=_check_sleep_call_allowed
     )
 
-    # Currently disabled. pytz doing I/O when getting timezone.
-    # Prevent files being opened inside the event loop
-    # builtins.open = protect_loop(builtins.open)
-
     if not _IN_TESTS:
+        # Prevent files being opened inside the event loop
+        builtins.open = protect_loop(  # type: ignore[assignment]
+            builtins.open, strict_core=False, strict=False
+        )
         # unittest uses `importlib.import_module` to do mocking
         # so we cannot protect it if we are running tests
         importlib.import_module = protect_loop(

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -67,6 +67,7 @@ def enable() -> None:
             strict_core=False,
             strict=False,
             check_allowed=_check_file_allowed,
+            loop_thread_id=loop_thread_id,
         )
         # unittest uses `importlib.import_module` to do mocking
         # so we cannot protect it if we are running tests

--- a/homeassistant/block_async_io.py
+++ b/homeassistant/block_async_io.py
@@ -24,9 +24,9 @@ def _check_import_call_allowed(mapped_args: dict[str, Any]) -> bool:
 
 def _check_file_allowed(mapped_args: dict[str, Any]) -> bool:
     # If the file is in /proc we can ignore it.
-    return bool(
-        (args := mapped_args.get("args")) and args[0].startswith(ALLOWED_FILE_PREFIXES)
-    )
+    args = mapped_args["args"]
+    path = args[0] if type(args[0]) is str else str(args[0])  # noqa: E721
+    return path.startswith(ALLOWED_FILE_PREFIXES)
 
 
 def _check_sleep_call_allowed(mapped_args: dict[str, Any]) -> bool:

--- a/tests/test_block_async_io.py
+++ b/tests/test_block_async_io.py
@@ -2,7 +2,9 @@
 
 import contextlib
 import importlib
+from pathlib import Path, PurePosixPath
 import time
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -214,5 +216,22 @@ async def test_protect_open(caplog: pytest.LogCaptureFixture) -> None:
     block_async_io.enable()
     with contextlib.suppress(FileNotFoundError):
         open("/config/data_not_exist").close()
+
+    assert "Detected blocking call to open with args" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/config/data_not_exist",
+        Path("/config/data_not_exist"),
+        PurePosixPath("/config/data_not_exist"),
+    ],
+)
+async def test_protect_open_path(path: Any, caplog: pytest.LogCaptureFixture) -> None:
+    """Test opening a file by path in the event loop logs."""
+    block_async_io.enable()
+    with contextlib.suppress(FileNotFoundError):
+        open(path).close()
 
     assert "Detected blocking call to open with args" in caplog.text


### PR DESCRIPTION
~~needs https://github.com/home-assistant/core/pull/117295~~

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable open protection (log only, not strict) in the event loop.  We did not do this before because pytz opened the zoneinfo files all the time. Since `pytz` is no longer used in HA as timezone support was added to stdlib in cpython 3.9, we can now start logging opens that happen in the event loop. There may be integrations that are still using `pytz` in libraries that need to support 3.8, however they should be updated since 3.8 will go end of life in just a few months. 
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
