### PR TITLE
Support reconfigure flow in Brother integration

### DIFF
--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -19,11 +19,11 @@ from .const import DOMAIN, PRINTER_TYPES
 
 DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_HOST, default=""): str,
+        vol.Required(CONF_HOST): str,
         vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
     }
 )
-RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_HOST, default=""): str})
+RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 
 
 async def validate_input(
@@ -176,10 +176,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 self.hass.config_entries.async_update_entry(
                     self.entry,
-                    data={
-                        CONF_HOST: user_input[CONF_HOST],
-                        CONF_TYPE: self.entry.data[CONF_TYPE],
-                    },
+                    data=self.entry.data | {CONF_HOST: user_input[CONF_HOST]},
                 )
                 await self.hass.config_entries.async_reload(self.entry.entry_id)
                 return self.async_abort(reason="reconfigure_successful")
@@ -188,7 +185,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure_confirm",
             data_schema=self.add_suggested_values_to_schema(
                 data_schema=RECONFIGURE_SCHEMA,
-                suggested_values=self.entry.data,
+                suggested_values=self.entry.data | (user_input or {}),
             ),
             description_placeholders={"printer_name": self.entry.title},
             errors=errors,

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -168,11 +168,9 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "cannot_connect"
             except SnmpError:
                 errors["base"] = "snmp_error"
-            except UnsupportedModelError:
-                return self.async_abort(reason="unsupported_model")
             else:
                 if serial.lower() != self.entry.unique_id:
-                    return self.async_abort(reason="not_the_same_device")
+                    return self.async_abort(reason="another_device")
 
                 self.hass.config_entries.async_update_entry(
                     self.entry,

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -191,6 +191,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_HOST, default=self.host): str,
                 }
             ),
+            description_placeholders={"printer_name": self.entry.title},
             errors=errors,
         )
 

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -23,6 +23,7 @@ DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_TYPE, default="laser"): vol.In(PRINTER_TYPES),
     }
 )
+RECONFIGURE_SCHEMA = vol.Schema({vol.Required(CONF_HOST, default=""): str})
 
 
 async def validate_input(
@@ -184,10 +185,9 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="reconfigure_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=self.host): str,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=RECONFIGURE_SCHEMA,
+                suggested_values=self.entry.data,
             ),
             description_placeholders={"printer_name": self.entry.title},
             errors=errors,

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -149,7 +149,6 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
         if TYPE_CHECKING:
             assert entry is not None
 
-        self.host = entry.data[CONF_HOST]
         self.entry = entry
 
         return await self.async_step_reconfigure_confirm()

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -161,7 +161,7 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             try:
-                await validate_input(self.hass, user_input)
+                _, serial = await validate_input(self.hass, user_input)
             except InvalidHost:
                 errors[CONF_HOST] = "wrong_host"
             except (ConnectionError, TimeoutError):
@@ -171,6 +171,9 @@ class BrotherConfigFlow(ConfigFlow, domain=DOMAIN):
             except UnsupportedModelError:
                 return self.async_abort(reason="unsupported_model")
             else:
+                if serial.lower() != self.entry.unique_id:
+                    return self.async_abort(reason="not_the_same_device")
+
                 self.hass.config_entries.async_update_entry(
                     self.entry,
                     data={

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -36,7 +36,8 @@
     "abort": {
       "unsupported_model": "This printer model is not supported.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "another_device": "The IP address or hostname of another Brother printer was used."
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "another_device": "Re-configuration was unsuccessful, the IP address or hostname of another Brother printer was used."
     }
   },
   "entity": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -36,7 +36,7 @@
     "abort": {
       "unsupported_model": "This printer model is not supported.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "not_the_same_device": "The IP address of another Brother printer was used."
+      "another_device": "The IP address of another Brother printer was used."
     }
   },
   "entity": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -19,7 +19,7 @@
         }
       },
       "reconfigure_confirm": {
-        "description": "Update your configuration information.",
+        "description": "Update your configuration information for {printer_name}.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -35,7 +35,8 @@
     },
     "abort": {
       "unsupported_model": "This printer model is not supported.",
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "not_the_same_device": "The IP address of another Brother printer was used."
     }
   },
   "entity": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -17,6 +17,15 @@
         "data": {
           "type": "[%key:component::brother::config::step::user::data::type%]"
         }
+      },
+      "reconfigure_confirm": {
+        "description": "Update your configuration information.",
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::brother::config::step::user::data_description::host%]"
+        }
       }
     },
     "error": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -31,13 +31,13 @@
     "error": {
       "wrong_host": "Invalid hostname or IP address.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "snmp_error": "SNMP server turned off or printer not supported."
+      "snmp_error": "SNMP server turned off or printer not supported.",
+      "another_device": "The IP address or hostname of another Brother printer was used."
     },
     "abort": {
       "unsupported_model": "This printer model is not supported.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
-      "another_device": "Re-configuration was unsuccessful, the IP address or hostname of another Brother printer was used."
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     }
   },
   "entity": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -19,7 +19,7 @@
         }
       },
       "reconfigure_confirm": {
-        "description": "Update your configuration information for {printer_name}.",
+        "description": "Update configuration for {printer_name}.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         },
@@ -36,7 +36,7 @@
     "abort": {
       "unsupported_model": "This printer model is not supported.",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "another_device": "The IP address of another Brother printer was used."
+      "another_device": "The IP address or hostname of another Brother printer was used."
     }
   },
   "entity": {

--- a/tests/components/brother/conftest.py
+++ b/tests/components/brother/conftest.py
@@ -87,7 +87,16 @@ def mock_setup_entry() -> Generator[AsyncMock]:
 
 
 @pytest.fixture
-def mock_brother_client() -> Generator[AsyncMock]:
+def mock_unload_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_unload_entry."""
+    with patch(
+        "homeassistant.components.brother.async_unload_entry", return_value=True
+    ) as mock_unload_entry:
+        yield mock_unload_entry
+
+
+@pytest.fixture
+def mock_brother_client() -> Generator[AsyncMock, None, None]:
     """Mock Brother client."""
     with (
         patch("homeassistant.components.brother.Brother", autospec=True) as mock_client,

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -22,7 +22,6 @@ from . import init_integration
 from tests.common import MockConfigEntry
 
 CONFIG = {CONF_HOST: "127.0.0.1", CONF_TYPE: "laser"}
-PRINTER_DATA = json.loads(load_fixture("printer_data.json", "brother"))
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -257,6 +256,8 @@ async def test_zeroconf_confirm_create_entry(
 
 async def test_reconfigure_successful(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
     """Test starting a reconfigure flow."""
+    await init_integration(hass, mock_config_entry)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
@@ -269,17 +270,10 @@ async def test_reconfigure_successful(hass: HomeAssistant, mock_brother_client: 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm"
 
-    with (
-        patch("brother.Brother.initialize"),
-        patch(
-            "brother.Brother._get_data",
-            return_value=PRINTER_DATA,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_HOST: "10.10.10.10"},
-        )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "10.10.10.10"},
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -301,6 +295,8 @@ async def test_reconfigure_not_successful(
     hass: HomeAssistant, exc: Exception, base_error: str, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry
 ) -> None:
     """Test starting a reconfigure flow but no connection found."""
+    await init_integration(hass, mock_config_entry)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
@@ -313,30 +309,23 @@ async def test_reconfigure_not_successful(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm"
 
-    with (
-        patch("brother.Brother.initialize"),
-        patch("brother.Brother._get_data", side_effect=exc),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_HOST: "10.10.10.10"},
-        )
+    mock_brother_client.async_update.side_effect = exc
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "10.10.10.10"},
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm"
     assert result["errors"] == {"base": base_error}
 
-    with (
-        patch("brother.Brother.initialize"),
-        patch(
-            "brother.Brother._get_data",
-            return_value=PRINTER_DATA,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_HOST: "10.10.10.10"},
-        )
+    mock_brother_client.async_update.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "10.10.10.10"},
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_successful"
@@ -348,6 +337,8 @@ async def test_reconfigure_not_successful(
 
 async def test_reconfigure_invalid_hostname(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
     """Test starting a reconfigure flow but no connection found."""
+    await init_integration(hass, mock_config_entry)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
@@ -370,31 +361,28 @@ async def test_reconfigure_invalid_hostname(hass: HomeAssistant, mock_brother_cl
     assert result["errors"] == {CONF_HOST: "wrong_host"}
 
 
-async def test_reconfigure_not_the_same_device(hass: HomeAssistant) -> None:
+async def test_reconfigure_not_the_same_device(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
     """Test starting the reconfiguration process, but with a different printer."""
+    await init_integration(hass, mock_config_entry)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={
             "source": SOURCE_RECONFIGURE,
             "entry_id": mock_config_entry.entry_id,
         },
-        data=entry.data,
+        data=mock_config_entry.data,
     )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reconfigure_confirm"
 
-    with (
-        patch("brother.Brother.initialize"),
-        patch(
-            "brother.Brother._get_data",
-            return_value=PRINTER_DATA,
-        ),
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={CONF_HOST: "10.10.10.10"},
-        )
+    mock_brother_client.serial = "9876543210"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "10.10.10.10"},
+    )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "another_device"

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -8,7 +8,11 @@ import pytest
 
 from homeassistant.components import zeroconf
 from homeassistant.components.brother.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF
+from homeassistant.config_entries import (
+    SOURCE_RECONFIGURE,
+    SOURCE_USER,
+    SOURCE_ZEROCONF,
+)
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -18,6 +22,7 @@ from . import init_integration
 from tests.common import MockConfigEntry
 
 CONFIG = {CONF_HOST: "127.0.0.1", CONF_TYPE: "laser"}
+PRINTER_DATA = json.loads(load_fixture("printer_data.json", "brother"))
 
 pytestmark = pytest.mark.usefixtures("mock_setup_entry")
 
@@ -248,3 +253,148 @@ async def test_zeroconf_confirm_create_entry(
     assert result["title"] == "HL-L2340DW 0123456789"
     assert result["data"][CONF_HOST] == "127.0.0.1"
     assert result["data"][CONF_TYPE] == "laser"
+
+
+async def test_reconfigure_successful(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
+    """Test starting a reconfigure flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    with (
+        patch("brother.Brother.initialize"),
+        patch(
+            "brother.Brother._get_data",
+            return_value=PRINTER_DATA,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "10.10.10.10"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == {
+        CONF_HOST: "10.10.10.10",
+        CONF_TYPE: "laser",
+    }
+
+
+@pytest.mark.parametrize(
+    ("exc", "base_error"),
+    [
+        (ConnectionError, "cannot_connect"),
+        (TimeoutError, "cannot_connect"),
+        (SnmpError("error"), "snmp_error"),
+    ],
+)
+async def test_reconfigure_not_successful(
+    hass: HomeAssistant, exc: Exception, base_error: str, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test starting a reconfigure flow but no connection found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    with (
+        patch("brother.Brother.initialize"),
+        patch("brother.Brother._get_data", side_effect=exc),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "10.10.10.10"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+    assert result["errors"] == {"base": base_error}
+
+    with (
+        patch("brother.Brother.initialize"),
+        patch(
+            "brother.Brother._get_data",
+            return_value=PRINTER_DATA,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "10.10.10.10"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == {
+        CONF_HOST: "10.10.10.10",
+        CONF_TYPE: "laser",
+    }
+
+
+async def test_reconfigure_invalid_hostname(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
+    """Test starting a reconfigure flow but no connection found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=mock_config_entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "invalid/hostname"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+    assert result["errors"] == {CONF_HOST: "wrong_host"}
+
+
+async def test_reconfigure_not_the_same_device(hass: HomeAssistant) -> None:
+    """Test starting the reconfiguration process, but with a different printer."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        },
+        data=entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+
+    with (
+        patch("brother.Brother.initialize"),
+        patch(
+            "brother.Brother._get_data",
+            return_value=PRINTER_DATA,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "10.10.10.10"},
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "another_device"

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -23,7 +23,7 @@ from tests.common import MockConfigEntry
 
 CONFIG = {CONF_HOST: "127.0.0.1", CONF_TYPE: "laser"}
 
-pytestmark = pytest.mark.usefixtures("mock_setup_entry")
+pytestmark = pytest.mark.usefixtures("mock_setup_entry", "mock_unload_entry")
 
 
 async def test_show_form(hass: HomeAssistant) -> None:

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -400,5 +400,6 @@ async def test_reconfigure_not_the_same_device(
         user_input={CONF_HOST: "10.10.10.10"},
     )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "another_device"
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure_confirm"
+    assert result["errors"] == {"base": "another_device"}

--- a/tests/components/brother/test_config_flow.py
+++ b/tests/components/brother/test_config_flow.py
@@ -254,7 +254,11 @@ async def test_zeroconf_confirm_create_entry(
     assert result["data"][CONF_TYPE] == "laser"
 
 
-async def test_reconfigure_successful(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
+async def test_reconfigure_successful(
+    hass: HomeAssistant,
+    mock_brother_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test starting a reconfigure flow."""
     await init_integration(hass, mock_config_entry)
 
@@ -292,7 +296,11 @@ async def test_reconfigure_successful(hass: HomeAssistant, mock_brother_client: 
     ],
 )
 async def test_reconfigure_not_successful(
-    hass: HomeAssistant, exc: Exception, base_error: str, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry
+    hass: HomeAssistant,
+    exc: Exception,
+    base_error: str,
+    mock_brother_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test starting a reconfigure flow but no connection found."""
     await init_integration(hass, mock_config_entry)
@@ -335,7 +343,11 @@ async def test_reconfigure_not_successful(
     }
 
 
-async def test_reconfigure_invalid_hostname(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
+async def test_reconfigure_invalid_hostname(
+    hass: HomeAssistant,
+    mock_brother_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test starting a reconfigure flow but no connection found."""
     await init_integration(hass, mock_config_entry)
 
@@ -361,7 +373,11 @@ async def test_reconfigure_invalid_hostname(hass: HomeAssistant, mock_brother_cl
     assert result["errors"] == {CONF_HOST: "wrong_host"}
 
 
-async def test_reconfigure_not_the_same_device(hass: HomeAssistant, mock_brother_client: AsyncMock, mock_config_entry: MockConfigEntry) -> None:
+async def test_reconfigure_not_the_same_device(
+    hass: HomeAssistant,
+    mock_brother_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
     """Test starting the reconfiguration process, but with a different printer."""
     await init_integration(hass, mock_config_entry)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a reconfigure flow that allows to change the IP address of a previously configured printer.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
