### PR TITLE
Bump opower to 0.4.5 and use new account.id

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -86,7 +86,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         # Because Opower provides historical usage/cost with a delay of a couple of days
         # we need to insert data into statistics.
         await self._insert_statistics()
-        return {forecast.account.utility_account_id: forecast for forecast in forecasts}
+        return {forecast.account.id: forecast for forecast in forecasts}
 
     async def _insert_statistics(self) -> None:
         """Insert Opower statistics."""
@@ -97,7 +97,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                     account.meter_type.name.lower(),
                     # Some utilities like AEP have "-" in their account id.
                     # Replace it with "_" to avoid "Invalid statistic_id"
-                    account.utility_account_id.replace("-", "_"),
+                    account.id.replace("-", "_"),
                 )
             )
             cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
@@ -161,7 +161,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
             name_prefix = (
                 f"Opower {self.api.utility.subdomain()} "
-                f"{account.meter_type.name.lower()} {account.utility_account_id}"
+                f"{account.meter_type.name.lower()} {account.id}"
             )
             cost_metadata = StatisticMetaData(
                 has_mean=False,

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.4.4"]
+  "requirements": ["opower==0.4.5"]
 }

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -159,10 +159,10 @@ async def async_setup_entry(
     entities: list[OpowerSensor] = []
     forecasts = coordinator.data.values()
     for forecast in forecasts:
-        device_id = f"{coordinator.api.utility.subdomain()}_{forecast.account.utility_account_id}"
+        device_id = f"{coordinator.api.utility.subdomain()}_{forecast.account.id}"
         device = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
-            name=f"{forecast.account.meter_type.name} account {forecast.account.utility_account_id}",
+            name=f"{forecast.account.meter_type.name} account {forecast.account.id}",
             manufacturer="Opower",
             model=coordinator.api.utility.name(),
             entry_type=DeviceEntryType.SERVICE,
@@ -182,7 +182,7 @@ async def async_setup_entry(
             OpowerSensor(
                 coordinator,
                 sensor,
-                forecast.account.utility_account_id,
+                forecast.account.id,
                 device,
                 device_id,
             )
@@ -201,7 +201,7 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self,
         coordinator: OpowerCoordinator,
         description: OpowerEntityDescription,
-        utility_account_id: str,
+        id: str,
         device: DeviceInfo,
         device_id: str,
     ) -> None:
@@ -210,13 +210,11 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self.entity_description = description
         self._attr_unique_id = f"{device_id}_{description.key}"
         self._attr_device_info = device
-        self.utility_account_id = utility_account_id
+        self.id = id
 
     @property
     def native_value(self) -> StateType:
         """Return the state."""
         if self.coordinator.data is not None:
-            return self.entity_description.value_fn(
-                self.coordinator.data[self.utility_account_id]
-            )
+            return self.entity_description.value_fn(self.coordinator.data[self.id])
         return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1492,7 +1492,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.4.4
+opower==0.4.5
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1192,7 +1192,7 @@ openhomedevice==2.2.0
 openwebifpy==4.2.4
 
 # homeassistant.components.opower
-opower==0.4.4
+opower==0.4.5
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bumping opower library version from 0.4.4 to 0.4.5 (https://github.com/tronikos/opower/releases/tag/v0.4.5).  Doing so allows a bugfix for the case where there are multiple meters on a single account.
Full diff: https://github.com/tronikos/opower/compare/v0.4.4...v0.4.5

If you have multiple meters for a single account, currently you only get data for 1 meter, and which one is non-deterministic.  With this change, if there are multiple meters for a single account, a unique identifier for the meter will be used instead of the account number in the name and ID of the sensors and statistics. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #108260
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/30974

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
