### PR TITLE
Add condition to trigger template entities

### DIFF
--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -15,6 +15,7 @@ from homeassistant.config import async_log_schema_error, config_without_domain
 from homeassistant.const import CONF_BINARY_SENSORS, CONF_SENSORS, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import async_validate_conditions_config
 from homeassistant.helpers.trigger import async_validate_trigger_config
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import async_notify_setup_error
@@ -28,7 +29,7 @@ from . import (
     sensor as sensor_platform,
     weather as weather_platform,
 )
-from .const import CONF_ACTION, CONF_TRIGGER, DOMAIN
+from .const import CONF_ACTION, CONF_CONDITION, CONF_TRIGGER, DOMAIN
 
 PACKAGE_MERGE_HINT = "list"
 
@@ -36,6 +37,7 @@ CONFIG_SECTION_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_UNIQUE_ID): cv.string,
         vol.Optional(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
+        vol.Optional(CONF_CONDITION): cv.CONDITIONS_SCHEMA,
         vol.Optional(CONF_ACTION): cv.SCRIPT_SCHEMA,
         vol.Optional(NUMBER_DOMAIN): vol.All(
             cv.ensure_list, [number_platform.NUMBER_SCHEMA]
@@ -82,6 +84,11 @@ async def async_validate_config(hass: HomeAssistant, config: ConfigType) -> Conf
             if CONF_TRIGGER in cfg:
                 cfg[CONF_TRIGGER] = await async_validate_trigger_config(
                     hass, cfg[CONF_TRIGGER]
+                )
+
+            if CONF_CONDITION in cfg:
+                cfg[CONF_CONDITION] = await async_validate_conditions_config(
+                    hass, cfg[CONF_CONDITION]
                 )
         except vol.Invalid as err:
             async_log_schema_error(err, DOMAIN, cfg, hass)

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -6,6 +6,7 @@ CONF_ACTION = "action"
 CONF_AVAILABILITY_TEMPLATE = "availability_template"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_TRIGGER = "trigger"
+CONF_CONDITION = "condition"
 
 DOMAIN = "template"
 
@@ -30,6 +31,5 @@ PLATFORMS = [
 
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
-CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_PICTURE = "picture"
 CONF_OBJECT_ID = "object_id"

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -31,9 +31,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
         """Instantiate trigger data."""
         super().__init__(hass, _LOGGER, name="Trigger Update Coordinator")
         self.config = config
-        self._cond_func: Callable[[TemplateVarsType | None], bool] = (
-            lambda variables=None: True
-        )
+        self._cond_func: Callable[[TemplateVarsType | None], bool] | None = None
         self._unsub_start: Callable[[], None] | None = None
         self._unsub_trigger: Callable[[], None] | None = None
         self._script: Script | None = None
@@ -106,7 +104,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
 
     async def _setup_condition_checker(
         self,
-    ) -> Callable[[TemplateVarsType | None], bool]:
+    ) -> Callable[[TemplateVarsType | None], bool] | None:
         cond_configs = self.config[CONF_CONDITION]
         checks: list[condition.ConditionCheckerType] = []
         for cond_config in cond_configs:
@@ -114,7 +112,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
                 checks.append(await condition.async_from_config(self.hass, cond_config))
             except HomeAssistantError as ex:
                 _LOGGER.warning("Invalid condition: %s", ex)
-                self._cond_func = lambda variables=None: True
+                return None
 
         def check_conditions(variables: TemplateVarsType | None = None) -> bool:
             """AND all conditions."""
@@ -158,7 +156,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
         self._execute_update(run_variables, context)
 
     async def _check_condition(self, run_variables, context=None) -> bool:
-        condition_result = self._cond_func(run_variables)
+        condition_result = self._cond_func(run_variables) if self._cond_func else True
         if condition_result is False:
             _LOGGER.debug(
                 "Conditions not met, aborting template trigger update. Condition summary: %s",

--- a/homeassistant/components/template/coordinator.py
+++ b/homeassistant/components/template/coordinator.py
@@ -108,11 +108,7 @@ class TriggerUpdateCoordinator(DataUpdateCoordinator):
         cond_configs = self.config[CONF_CONDITION]
         checks: list[condition.ConditionCheckerType] = []
         for cond_config in cond_configs:
-            try:
-                checks.append(await condition.async_from_config(self.hass, cond_config))
-            except HomeAssistantError as ex:
-                _LOGGER.warning("Invalid condition: %s", ex)
-                return None
+            checks.append(await condition.async_from_config(self.hass, cond_config))
 
         def check_conditions(variables: TemplateVarsType | None = None) -> bool:
             """AND all conditions."""

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -1202,6 +1202,124 @@ async def test_trigger_entity(
     assert state.context is context
 
 
+@pytest.mark.parametrize(("count", "domain"), [(1, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "condition": [
+                        {
+                            "condition": "template",
+                            "value_template": "{{ trigger.event.data.beer >= 42 }}",
+                        }
+                    ],
+                    "sensor": [
+                        {
+                            "name": "Enough Name",
+                            "unique_id": "enough-id",
+                            "state": "You had enough Beer.",
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+async def test_trigger_conditional_entity(hass: HomeAssistant, start_ha) -> None:
+    """Test conditional trigger entity works."""
+    state = hass.states.get("sensor.enough_name")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    hass.bus.async_fire("test_event", {"beer": 2})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.enough_name")
+    assert state.state == STATE_UNKNOWN
+
+    hass.bus.async_fire("test_event", {"beer": 42})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.enough_name")
+    assert state.state == "You had enough Beer."
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "condition": [
+                        {
+                            "condition": "template",
+                            "value_template": "{{ trigger.event.data.beer / 0 == 'narf' }}",
+                        }
+                    ],
+                    "sensor": [
+                        {
+                            "name": "Enough Name",
+                            "unique_id": "enough-id",
+                            "state": "You had enough Beer.",
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+async def test_trigger_conditional_entity_evaluation_error(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, start_ha
+) -> None:
+    """Test trigger entity is not updated when condition evaluation fails."""
+    hass.bus.async_fire("test_event", {"beer": 1})
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.enough_name")
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+    assert "Error evaluating template trigger condition" in caplog.text
+
+
+@pytest.mark.parametrize(("count", "domain"), [(0, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "condition": [
+                        {"condition": "template", "value_template": "{{ invalid"}
+                    ],
+                    "sensor": [
+                        {
+                            "name": "Will Not Exist Name",
+                            "state": "Unimportant",
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+async def test_trigger_conditional_entity_invalid_condition(
+    hass: HomeAssistant, start_ha
+) -> None:
+    """Test trigger entity is not created when condition is invalid."""
+    state = hass.states.get("sensor.will_not_exist_name")
+    assert state is None
+
+
 @pytest.mark.parametrize(("count", "domain"), [(1, "template")])
 @pytest.mark.parametrize(
     "config",
@@ -1896,3 +2014,49 @@ async def test_trigger_action(
 
     assert len(events) == 1
     assert events[0].context.parent_id == context.id
+
+
+@pytest.mark.parametrize(("count", "domain"), [(1, template.DOMAIN)])
+@pytest.mark.parametrize(
+    "config",
+    [
+        {
+            "template": [
+                {
+                    "unique_id": "listening-test-event",
+                    "trigger": {"platform": "event", "event_type": "test_event"},
+                    "condition": [
+                        {
+                            "condition": "template",
+                            "value_template": "{{ trigger.event.data.beer >= 42 }}",
+                        }
+                    ],
+                    "action": [
+                        {"event": "test_event_by_action"},
+                    ],
+                    "sensor": [
+                        {
+                            "name": "Not That Important",
+                            "state": "Really not.",
+                        }
+                    ],
+                },
+            ],
+        },
+    ],
+)
+async def test_trigger_conditional_action(hass: HomeAssistant, start_ha) -> None:
+    """Test conditional trigger entity with an action works."""
+
+    event = "test_event_by_action"
+    events = async_capture_events(hass, event)
+
+    hass.bus.async_fire("test_event", {"beer": 1})
+    await hass.async_block_till_done()
+
+    assert len(events) == 0
+
+    hass.bus.async_fire("test_event", {"beer": 42})
+    await hass.async_block_till_done()
+
+    assert len(events) == 1


### PR DESCRIPTION
## Proposed change
Add the option to specify conditions for trigger template entities to only execute actions and entity updates if the given conditions are met.

This PR addresses these feature requests:
- https://community.home-assistant.io/t/add-condition-for-trigger-based-template-sensors/426123
- https://community.home-assistant.io/t/conditions-in-trigger-based-template-sensors/409266
- https://community.home-assistant.io/t/why-cant-we-condition-triggers-for-template-entities/467173

Documentation update PR will be created if there is a positive perspective of getting this PR merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
