### PR TITLE
Support Tuya AM43(Zigbee) Blind drive motor

### DIFF
--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -368,6 +368,7 @@ class DPCode(StrEnum):
     WIRELESS_ELECTRICITY = "wireless_electricity"
     WORK_MODE = "work_mode"  # Working mode
     WORK_POWER = "work_power"
+    WORK_STATE = "work_state"
 
 
 @dataclass

--- a/homeassistant/components/tuya/cover.py
+++ b/homeassistant/components/tuya/cover.py
@@ -35,6 +35,10 @@ class TuyaCoverEntityDescription(CoverEntityDescription):
     open_instruction_value: str = "open"
     close_instruction_value: str = "close"
     stop_instruction_value: str = "stop"
+    product_id: str | None = None
+    work_state: str | None = None
+    reverse: bool = True
+    set_position_open_close: bool = True
 
 
 COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
@@ -42,6 +46,18 @@ COVERS: dict[str, tuple[TuyaCoverEntityDescription, ...]] = {
     # Note: Multiple curtains isn't documented
     # https://developer.tuya.com/en/docs/iot/categorycl?id=Kaiuz1hnpo7df
     "cl": (
+        # AM43 Blind drive motor
+        # Note: Only product_id is "zah67ekd"
+        TuyaCoverEntityDescription(
+            key=DPCode.CONTROL,
+            product_id="zah67ekd",
+            current_position=DPCode.PERCENT_STATE,
+            set_position=DPCode.PERCENT_CONTROL,
+            device_class=CoverDeviceClass.BLIND,
+            work_state=DPCode.WORK_STATE,
+            reverse=False,
+            set_position_open_close=False,
+        ),
         TuyaCoverEntityDescription(
             key=DPCode.CONTROL,
             translation_key="curtain",
@@ -158,8 +174,14 @@ async def async_setup_entry(
                     TuyaCoverEntity(device, hass_data.manager, description)
                     for description in descriptions
                     if (
-                        description.key in device.function
-                        or description.key in device.status_range
+                        (
+                            description.key in device.function
+                            or description.key in device.status_range
+                        )
+                        and (
+                            description.product_id is None
+                            or description.product_id == device.product_id
+                        )
                     )
                 )
 
@@ -178,6 +200,7 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
     _current_position: IntegerTypeData | None = None
     _set_position: IntegerTypeData | None = None
     _tilt: IntegerTypeData | None = None
+    _send_position: int | None = None
     entity_description: TuyaCoverEntityDescription
 
     def __init__(
@@ -242,7 +265,9 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             return None
 
         return round(
-            self._current_position.remap_value_to(position, 0, 100, reverse=True)
+            self._current_position.remap_value_to(
+                position, 0, 100, reverse=self.entity_description.reverse
+            )
         )
 
     @property
@@ -258,6 +283,46 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             return None
 
         return round(self._tilt.remap_value_to(angle, 0, 100))
+
+    @property
+    def is_opening(self):
+        """Return if cover is opening."""
+        if self.entity_description.work_state is None:
+            return None
+
+        control = self.device.status.get(self.entity_description.key)
+        set_position = self.device.status.get(
+            self._set_position.dpcode
+            if self._send_position is None
+            else self._send_position
+        )
+        state = self.device.status.get(self.entity_description.work_state)
+
+        return (
+            control == "open"
+            and state == "opening"
+            and (set_position is None or set_position != self.current_cover_position)
+        )
+
+    @property
+    def is_closing(self):
+        """Return if cover is closing."""
+        if self.entity_description.work_state is None:
+            return None
+
+        control = self.device.status.get(self.entity_description.key)
+        set_position = self.device.status.get(
+            self._set_position.dpcode
+            if self._send_position is None
+            else self._send_position
+        )
+        state = self.device.status.get(self.entity_description.work_state)
+
+        return (
+            control == "close"
+            and state == "closing"
+            and (set_position is None or set_position != self.current_cover_position)
+        )
 
     @property
     def is_closed(self) -> bool | None:
@@ -291,14 +356,19 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
         commands: list[dict[str, str | int]] = [
             {"code": self.entity_description.key, "value": value}
         ]
-
-        if self._set_position is not None:
+        if (
+            self._set_position is not None
+            and self.entity_description.set_position_open_close
+        ):
+            self._send_position = round(
+                self._set_position.remap_value_from(
+                    100, 0, 100, reverse=self.entity_description.reverse
+                ),
+            )
             commands.append(
                 {
                     "code": self._set_position.dpcode,
-                    "value": round(
-                        self._set_position.remap_value_from(100, 0, 100, reverse=True),
-                    ),
+                    "value": self._send_position,
                 }
             )
 
@@ -316,13 +386,19 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
             {"code": self.entity_description.key, "value": value}
         ]
 
-        if self._set_position is not None:
+        if (
+            self._set_position is not None
+            and self.entity_description.set_position_open_close
+        ):
+            self._send_position = round(
+                self._set_position.remap_value_from(
+                    0, 0, 100, reverse=self.entity_description.reverse
+                ),
+            )
             commands.append(
                 {
                     "code": self._set_position.dpcode,
-                    "value": round(
-                        self._set_position.remap_value_from(0, 0, 100, reverse=True),
-                    ),
+                    "value": self._send_position,
                 }
             )
 
@@ -335,15 +411,16 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                 "Cannot set position, device doesn't provide methods to set it"
             )
 
+        self._send_position = round(
+            self._set_position.remap_value_from(
+                kwargs[ATTR_POSITION], 0, 100, reverse=self.entity_description.reverse
+            )
+        )
         self._send_command(
             [
                 {
                     "code": self._set_position.dpcode,
-                    "value": round(
-                        self._set_position.remap_value_from(
-                            kwargs[ATTR_POSITION], 0, 100, reverse=True
-                        )
-                    ),
+                    "value": self._send_position,
                 }
             ]
         )
@@ -372,7 +449,10 @@ class TuyaCoverEntity(TuyaEntity, CoverEntity):
                     "code": self._tilt.dpcode,
                     "value": round(
                         self._tilt.remap_value_from(
-                            kwargs[ATTR_TILT_POSITION], 0, 100, reverse=True
+                            kwargs[ATTR_TILT_POSITION],
+                            0,
+                            100,
+                            reverse=self.entity_description.reverse,
                         )
                     ),
                 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Support for product_id "zah67ekd"
- Addition of is_opening, is_closing properties
- Support for devices whose Open/Close status is reversed

The existing curtain settings were unstable in supporting AM43 (Zigbee), so I fixed it.

I've fixed it for backwards compatibility, but please let us know if you encounter any problems.

The following is the debug log for AM43 (Zigbee).

```log
2023-11-28 10:15:44.604 DEBUG (MainThread) [custom_components.smartlife] dpcode get device=CustomerDevice(active_time=1700483147, biz_type=18, category='cl', create_time=1700483147, icon='smart/icon/ay1520042877959dqQoX/cabc06d56803a5a189c9fff9fc78c56b.png', id='ebc769bdeae5xxxxxxxxxx', ip='', lat='xx.2500', local_key='xxxxxxxxxxxxxxxx', lon='xxx.8800', model='AM43', name='AM43-Zigbee', node_id='048727fffe4f23b7', online=True, owner_id='xxxxxxxxx', product_id='zah67ekd', product_name='AM43拉绳电机-Zigbee', status={'control': 'stop', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}, sub=True, time_zone='+09:00', uid='xxxxxxxxxxxxxxxxxxxx', update_time=1700483147, uuid='xxxxxxxxxxxxxxxx', function={'control': DeviceFunction(code='control', type='Enum', values='{"range":["open","stop","close","continue"]}'), 'percent_control': DeviceFunction(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'control_back_mode': DeviceFunction(code='control_back_mode', type='Enum', values='{"range":["forward","back"]}')}, status_range={'control': DeviceStatusRange(code='control', type='Enum', values='{"range":["open","stop","close","continue"]}'), 'percent_control': DeviceStatusRange(code='percent_control', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'percent_state': DeviceStatusRange(code='percent_state', type='Integer', values='{"unit":"%","min":0,"max":100,"scale":0,"step":1}'), 'control_back_mode': DeviceStatusRange(code='control_back_mode', type='Enum', values='{"range":["forward","back"]}'), 'work_state': DeviceStatusRange(code='work_state', type='Enum', values='{"range":["opening","closing"]}'), 'situation_set': DeviceStatusRange(code='situation_set', type='Enum', values='{"range":["fully_open","fully_close"]}'), 'fault': DeviceStatusRange(code='fault', type='Bitmap', values='{"label":["motor_fault"]}')}, support_local=True, local_strategy={1: {'value_convert': 'default', 'status_code': 'control', 'config_item': {'statusFormat': '{"control":"$"}', 'valueDesc': '{"range":["open","stop","close","continue"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 2: {'value_convert': 'default', 'status_code': 'percent_control', 'config_item': {'statusFormat': '{"percent_control":"$"}', 'valueDesc': '{"unit":"%","min":0,"max":100,"scale":0,"step":1}', 'valueType': 'Integer', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 3: {'value_convert': 'default', 'status_code': 'percent_state', 'config_item': {'statusFormat': '{"percent_state":"$"}', 'valueDesc': '{"unit":"%","min":0,"max":100,"scale":0,"step":1}', 'valueType': 'Integer', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 5: {'value_convert': 'default', 'status_code': 'control_back_mode', 'config_item': {'statusFormat': '{"control_back_mode":"$"}', 'valueDesc': '{"range":["forward","back"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 7: {'value_convert': 'default', 'status_code': 'work_state', 'config_item': {'statusFormat': '{"work_state":"$"}', 'valueDesc': '{"range":["opening","closing"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 11: {'value_convert': 'default', 'status_code': 'situation_set', 'config_item': {'statusFormat': '{"situation_set":"$"}', 'valueDesc': '{"range":["fully_open","fully_close"]}', 'valueType': 'Enum', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}, 12: {'value_convert': 'default', 'status_code': 'fault', 'config_item': {'statusFormat': '{"fault":"$"}', 'valueDesc': '{"label":["motor_fault"]}', 'valueType': 'Bitmap', 'enumMappingMap': {}, 'pid': 'zah67ekd'}}}, set_up=True) dpcode=percent_state key=status_range


2023-11-28 10:10:41.995 DEBUG (SyncWorker_7) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'open'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:10:43.995 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:10:52.555 DEBUG (SyncWorker_6) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'open'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:10:53.731 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 0, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:10:54.099 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 0, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:04.088 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:15.370 DEBUG (SyncWorker_0) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.CONTROL: 'control'>, 'value': 'close'}, {'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 0}]
2023-11-28 10:11:16.527 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:26.152 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 100, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:26.379 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 0, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:38.585 DEBUG (SyncWorker_9) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 50}]
2023-11-28 10:11:41.131 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:41.324 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:41.482 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:46.196 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'open', 'percent_control': 50, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:46.526 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:49.138 DEBUG (SyncWorker_4) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 100}]
2023-11-28 10:11:49.983 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 50, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:54.135 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device eb449b2a4186c3092d7l5s: {'control': 'stop', 'percent_control': 3, 'percent_state': 3, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:11:55.164 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 100, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:00.993 DEBUG (SyncWorker_1) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 50}]
2023-11-28 10:12:02.144 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:02.275 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:03.462 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 100, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:04.619 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device eb449b2a4186c3092d7l5s: {'control': 'stop', 'percent_control': 3, 'percent_state': 3, 'control_back_mode': 'back', 'work_state': 'opening', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:07.229 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:07.461 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:09.682 DEBUG (SyncWorker_2) [custom_components.smartlife] Sending commands for device ebc769bdeae5xxxxxxxxxx: [{'code': <DPCode.PERCENT_CONTROL: 'percent_control'>, 'value': 0}]
2023-11-28 10:12:11.400 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 49, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:16.291 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'close', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
2023-11-28 10:12:16.382 DEBUG (Thread-7 (_thread_main)) [custom_components.smartlife] Received update for device ebc769bdeae5xxxxxxxxxx: {'control': 'stop', 'percent_control': 50, 'percent_state': 0, 'control_back_mode': 'back', 'work_state': 'closing', 'situation_set': 'fully_open', 'fault': 0}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
