### PR TITLE
New integration: Change device type of a binary sensor

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -180,6 +180,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/binary_sensor/ @home-assistant/core
 /tests/components/binary_sensor/ @home-assistant/core
 /homeassistant/components/binary_sensor_as_x/ @home-assistant/core @tetele
+/tests/components/binary_sensor_as_x/ @home-assistant/core @tetele
 /homeassistant/components/bizkaibus/ @UgaitzEtxebarria
 /homeassistant/components/blebox/ @bbx-a @riokuu @swistakm
 /tests/components/blebox/ @bbx-a @riokuu @swistakm

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -179,6 +179,7 @@ build.json @home-assistant/supervisor
 /homeassistant/components/beewi_smartclim/ @alemuro
 /homeassistant/components/binary_sensor/ @home-assistant/core
 /tests/components/binary_sensor/ @home-assistant/core
+/homeassistant/components/binary_sensor_as_x/ @home-assistant/core @tetele
 /homeassistant/components/bizkaibus/ @UgaitzEtxebarria
 /homeassistant/components/blebox/ @bbx-a @riokuu @swistakm
 /tests/components/blebox/ @bbx-a @riokuu @swistakm

--- a/homeassistant/components/binary_sensor_as_x/__init__.py
+++ b/homeassistant/components/binary_sensor_as_x/__init__.py
@@ -1,0 +1,175 @@
+"""Component to wrap binary_sensor entities in entities of other domains."""
+
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components.homeassistant import exposed_entities
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ENTITY_ID
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.event import async_track_entity_registry_updated_event
+
+from .const import CONF_TARGET_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@callback
+def async_add_to_device(
+    hass: HomeAssistant, entry: ConfigEntry, entity_id: str
+) -> str | None:
+    """Add our config entry to the tracked entity's device."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    device_id = None
+
+    if (
+        not (wrapped_binary_sensor := registry.async_get(entity_id))
+        or not (device_id := wrapped_binary_sensor.device_id)
+        or not (device_registry.async_get(device_id))
+    ):
+        return device_id
+
+    device_registry.async_update_device(device_id, add_config_entry_id=entry.entry_id)
+
+    return device_id
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    try:
+        entity_id = er.async_validate_entity_id(registry, entry.options[CONF_ENTITY_ID])
+    except vol.Invalid:
+        # The entity is identified by an unknown entity registry ID
+        _LOGGER.error(
+            "Failed to setup binary_sensor_as_x for unknown entity %s",
+            entry.options[CONF_ENTITY_ID],
+        )
+        return False
+
+    async def async_registry_updated(
+        event: Event[er.EventEntityRegistryUpdatedData],
+    ) -> None:
+        """Handle entity registry update."""
+        data = event.data
+        if data["action"] == "remove":
+            await hass.config_entries.async_remove(entry.entry_id)
+
+        if data["action"] != "update":
+            return
+
+        if "entity_id" in data["changes"]:
+            # Entity_id changed, reload the config entry
+            await hass.config_entries.async_reload(entry.entry_id)
+
+        if device_id and "device_id" in data["changes"]:
+            # If the tracked binary sensor is no longer in the device, remove our config entry
+            # from the device
+            if (
+                not (entity_entry := registry.async_get(data[CONF_ENTITY_ID]))
+                or not device_registry.async_get(device_id)
+                or entity_entry.device_id == device_id
+            ):
+                # No need to do any cleanup
+                return
+
+            device_registry.async_update_device(
+                device_id, remove_config_entry_id=entry.entry_id
+            )
+
+    entry.async_on_unload(
+        async_track_entity_registry_updated_event(
+            hass, entity_id, async_registry_updated
+        )
+    )
+    entry.async_on_unload(entry.add_update_listener(config_entry_update_listener))
+
+    device_id = async_add_to_device(hass, entry, entity_id)
+
+    await hass.config_entries.async_forward_entry_setups(
+        entry, (entry.options[CONF_TARGET_DOMAIN],)
+    )
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old entry."""
+    _LOGGER.debug(
+        "Migrating from version %s.%s", config_entry.version, config_entry.minor_version
+    )
+
+    if config_entry.version > 1:
+        # This means the user has downgraded from a future version
+        return False
+    if config_entry.version == 1:
+        options = {**config_entry.options}
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, minor_version=2
+        )
+
+    _LOGGER.debug(
+        "Migration to version %s.%s successful",
+        config_entry.version,
+        config_entry.minor_version,
+    )
+
+    return True
+
+
+async def config_entry_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update listener, called when the config entry options are changed."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(
+        entry, (entry.options[CONF_TARGET_DOMAIN],)
+    )
+
+
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Unload a config entry.
+
+    This will unhide the wrapped entity and restore assistant expose settings.
+    """
+    registry = er.async_get(hass)
+    try:
+        binary_sensor_entity_id = er.async_validate_entity_id(
+            registry, entry.options[CONF_ENTITY_ID]
+        )
+    except vol.Invalid:
+        # The source entity has been removed from the entity registry
+        return
+
+    if not (binary_sensor_entity_entry := registry.async_get(binary_sensor_entity_id)):
+        return
+
+    # Unhide the wrapped entity
+    if binary_sensor_entity_entry.hidden_by == er.RegistryEntryHider.INTEGRATION:
+        registry.async_update_entity(binary_sensor_entity_id, hidden_by=None)
+
+    binary_sensor_as_x_entries = er.async_entries_for_config_entry(
+        registry, entry.entry_id
+    )
+    if not binary_sensor_as_x_entries:
+        return
+
+    binary_sensor_as_x_entry = binary_sensor_as_x_entries[0]
+
+    # Restore assistant expose settings
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, binary_sensor_as_x_entry.entity_id
+    )
+    for assistant, settings in expose_settings.items():
+        if (should_expose := settings.get("should_expose")) is None:
+            continue
+        exposed_entities.async_expose_entity(
+            hass, assistant, binary_sensor_entity_id, should_expose
+        )

--- a/homeassistant/components/binary_sensor_as_x/__init__.py
+++ b/homeassistant/components/binary_sensor_as_x/__init__.py
@@ -107,10 +107,10 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     if config_entry.version > 1:
         # This means the user has downgraded from a future version
         return False
-    if config_entry.version == 1:
+    if config_entry.version <= 1:
         options = {**config_entry.options}
         hass.config_entries.async_update_entry(
-            config_entry, options=options, minor_version=2
+            config_entry, options=options, version=1, minor_version=0
         )
 
     _LOGGER.debug(

--- a/homeassistant/components/binary_sensor_as_x/config_flow.py
+++ b/homeassistant/components/binary_sensor_as_x/config_flow.py
@@ -1,0 +1,58 @@
+"""Config flow for Binary sensor as X integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_ENTITY_ID, Platform
+from homeassistant.helpers import entity_registry as er, selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+    wrapped_entity_config_entry_title,
+)
+
+from .const import CONF_TARGET_DOMAIN, DOMAIN
+
+TARGET_DOMAIN_OPTIONS = [
+    selector.SelectOptionDict(value=Platform.COVER, label="Cover"),
+]
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(
+        vol.Schema(
+            {
+                vol.Required(CONF_ENTITY_ID): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain=Platform.BINARY_SENSOR),
+                ),
+                vol.Required(CONF_TARGET_DOMAIN): selector.SelectSelector(
+                    selector.SelectSelectorConfig(options=TARGET_DOMAIN_OPTIONS),
+                ),
+            }
+        )
+    )
+}
+
+
+class BinarySensorAsXConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a config flow for Binary sensor as X."""
+
+    config_flow = CONFIG_FLOW
+
+    VERSION = 1
+    MINOR_VERSION = 0
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title and hide the wrapped entity if registered."""
+        # Hide the wrapped entry if registered
+        registry = er.async_get(self.hass)
+        entity_entry = registry.async_get(options[CONF_ENTITY_ID])
+        if entity_entry is not None and not entity_entry.hidden:
+            registry.async_update_entity(
+                options[CONF_ENTITY_ID], hidden_by=er.RegistryEntryHider.INTEGRATION
+            )
+
+        return wrapped_entity_config_entry_title(self.hass, options[CONF_ENTITY_ID])

--- a/homeassistant/components/binary_sensor_as_x/const.py
+++ b/homeassistant/components/binary_sensor_as_x/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Binary sensor as X integration."""
+
+from typing import Final
+
+DOMAIN: Final = "binary_sensor_as_x"
+
+CONF_TARGET_DOMAIN: Final = "target_domain"

--- a/homeassistant/components/binary_sensor_as_x/cover.py
+++ b/homeassistant/components/binary_sensor_as_x/cover.py
@@ -1,0 +1,62 @@
+"""Cover support for binary_sensor entities."""
+
+from __future__ import annotations
+
+from homeassistant.components.cover import (
+    DOMAIN as COVER_DOMAIN,
+    CoverDeviceClass,
+    CoverEntity,
+    CoverEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_ENTITY_ID, STATE_ON
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .entity import BaseDeviceClassEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Initialize Cover Binary sensor config entry."""
+    registry = er.async_get(hass)
+    entity_id = er.async_validate_entity_id(
+        registry, config_entry.options[CONF_ENTITY_ID]
+    )
+
+    async_add_entities(
+        [
+            CoverBinarySensor(
+                hass,
+                config_entry.title,
+                COVER_DOMAIN,
+                entity_id,
+                config_entry.entry_id,
+            )
+        ]
+    )
+
+
+class CoverBinarySensor(BaseDeviceClassEntity, CoverEntity):
+    """Represents a Binary sensor as a Cover."""
+
+    _attr_supported_features = CoverEntityFeature(0)
+    _accepted_device_classes = CoverDeviceClass
+
+    @callback
+    def async_state_changed_listener(
+        self, event: Event[EventStateChangedData] | None = None
+    ) -> None:
+        """Handle child updates."""
+        super().async_state_changed_listener(event)
+        if (
+            not self.available
+            or (state := self.hass.states.get(self._binary_sensor_entity_id)) is None
+        ):
+            return
+
+        self._attr_is_closed = state.state != STATE_ON

--- a/homeassistant/components/binary_sensor_as_x/entity.py
+++ b/homeassistant/components/binary_sensor_as_x/entity.py
@@ -1,0 +1,173 @@
+"""Base entity for the Binary sensor as X integration."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from homeassistant.components.homeassistant import exposed_entities
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity, get_device_class
+from homeassistant.helpers.event import async_track_state_change_event
+
+from .const import DOMAIN as BINARY_SENSOR_AS_X_DOMAIN
+
+
+class BaseEntity(Entity):
+    """Represents a Binary sensor as an X."""
+
+    _attr_should_poll = False
+    _is_new_entity: bool
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry_title: str,
+        domain: str,
+        binary_sensor_entity_id: str,
+        unique_id: str,
+    ) -> None:
+        """Initialize Binary sensor as an X."""
+        registry = er.async_get(hass)
+        device_registry = dr.async_get(hass)
+        wrapped_binary_sensor = registry.async_get(binary_sensor_entity_id)
+        device_id = wrapped_binary_sensor.device_id if wrapped_binary_sensor else None
+        entity_category = (
+            wrapped_binary_sensor.entity_category if wrapped_binary_sensor else None
+        )
+        has_entity_name = (
+            wrapped_binary_sensor.has_entity_name if wrapped_binary_sensor else False
+        )
+
+        name: str | None = config_entry_title
+        if wrapped_binary_sensor:
+            name = wrapped_binary_sensor.original_name
+
+        self._device_id = device_id
+        if device_id and (device := device_registry.async_get(device_id)):
+            self._attr_device_info = DeviceInfo(
+                connections=device.connections,
+                identifiers=device.identifiers,
+            )
+        self._attr_entity_category = entity_category
+        self._attr_has_entity_name = has_entity_name
+        self._attr_name = name
+        self._attr_unique_id = unique_id
+        self._binary_sensor_entity_id = binary_sensor_entity_id
+
+        self._is_new_entity = (
+            registry.async_get_entity_id(domain, BINARY_SENSOR_AS_X_DOMAIN, unique_id)
+            is None
+        )
+
+    @callback
+    def async_state_changed_listener(
+        self, event: Event[EventStateChangedData] | None = None
+    ) -> None:
+        """Handle child updates."""
+        if (
+            state := self.hass.states.get(self._binary_sensor_entity_id)
+        ) is None or state.state == STATE_UNAVAILABLE:
+            self._attr_available = False
+            return
+
+        self._attr_available = True
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks and copy the wrapped entity's custom name if set."""
+
+        @callback
+        def _async_state_changed_listener(
+            event: Event[EventStateChangedData] | None = None,
+        ) -> None:
+            """Handle child updates."""
+            self.async_state_changed_listener(event)
+            self.async_write_ha_state()
+
+        self.async_on_remove(
+            async_track_state_change_event(
+                self.hass,
+                [self._binary_sensor_entity_id],
+                _async_state_changed_listener,
+            )
+        )
+
+        # Call once on adding
+        _async_state_changed_listener()
+
+        # Update entity options
+        registry = er.async_get(self.hass)
+        if registry.async_get(self.entity_id) is not None:
+            registry.async_update_entity_options(
+                self.entity_id,
+                BINARY_SENSOR_AS_X_DOMAIN,
+                self.async_generate_entity_options(),
+            )
+
+        if not self._is_new_entity or not (
+            wrapped_binary_sensor := registry.async_get(self._binary_sensor_entity_id)
+        ):
+            return
+
+        def copy_custom_name(wrapped_binary_sensor: er.RegistryEntry) -> None:
+            """Copy the name set by user from the wrapped entity."""
+            if wrapped_binary_sensor.name is None:
+                return
+            registry.async_update_entity(
+                self.entity_id, name=wrapped_binary_sensor.name
+            )
+
+        def copy_expose_settings() -> None:
+            """Copy assistant expose settings from the wrapped entity.
+
+            Also unexpose the wrapped entity if exposed.
+            """
+            expose_settings = exposed_entities.async_get_entity_settings(
+                self.hass, self._binary_sensor_entity_id
+            )
+            for assistant, settings in expose_settings.items():
+                if (should_expose := settings.get("should_expose")) is None:
+                    continue
+                exposed_entities.async_expose_entity(
+                    self.hass, assistant, self.entity_id, should_expose
+                )
+                exposed_entities.async_expose_entity(
+                    self.hass, assistant, self._binary_sensor_entity_id, False
+                )
+
+        copy_custom_name(wrapped_binary_sensor)
+        copy_expose_settings()
+
+    @callback
+    def async_generate_entity_options(self) -> dict[str, Any]:
+        """Generate entity options."""
+        return {"entity_id": self._binary_sensor_entity_id, "invert": False}
+
+
+class BaseDeviceClassEntity(BaseEntity):
+    """Represents a Binary sensor as X where the device_class is important."""
+
+    _accepted_device_classes: type[StrEnum] | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry_title: str,
+        domain: str,
+        binary_sensor_entity_id: str,
+        unique_id: str,
+    ) -> None:
+        """Initialize Binary sensor as an X and inherit device_class."""
+        super().__init__(
+            hass, config_entry_title, domain, binary_sensor_entity_id, unique_id
+        )
+
+        if device_class := get_device_class(hass, binary_sensor_entity_id):
+            if (
+                not self._accepted_device_classes
+                or device_class in self._accepted_device_classes
+            ):
+                self._attr_device_class = device_class

--- a/homeassistant/components/binary_sensor_as_x/manifest.json
+++ b/homeassistant/components/binary_sensor_as_x/manifest.json
@@ -1,0 +1,10 @@
+{
+  "domain": "binary_sensor_as_x",
+  "name": "Change device type of a binary sensor",
+  "codeowners": ["@home-assistant/core", "@tetele"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/binary_sensor_as_x",
+  "integration_type": "helper",
+  "iot_class": "calculated",
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/binary_sensor_as_x/strings.json
+++ b/homeassistant/components/binary_sensor_as_x/strings.json
@@ -1,0 +1,14 @@
+{
+  "title": "Change device type of a binary sensor",
+  "config": {
+    "step": {
+      "user": {
+        "description": "Pick a binary sensor that you want to show up in Home Assistant as a cover. The original binary sensor will be hidden.",
+        "data": {
+          "entity_id": "Binary sensor",
+          "target_domain": "New Type"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -5,6 +5,7 @@ To update, run python3 -m script.hassfest
 
 FLOWS = {
     "helper": [
+        "binary_sensor_as_x",
         "derivative",
         "group",
         "integration",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7109,6 +7109,11 @@
     }
   },
   "helper": {
+    "binary_sensor_as_x": {
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "calculated"
+    },
     "counter": {
       "integration_type": "helper",
       "config_flow": false
@@ -7208,6 +7213,7 @@
   "translated_name": [
     "alert",
     "aurora",
+    "binary_sensor_as_x",
     "cert_expiry",
     "counter",
     "cpuspeed",

--- a/tests/components/binary_sensor_as_x/__init__.py
+++ b/tests/components/binary_sensor_as_x/__init__.py
@@ -1,0 +1,14 @@
+"""The tests for Binary sensor as X platforms."""
+
+from homeassistant.const import STATE_CLOSED, STATE_OFF, STATE_ON, STATE_OPEN, Platform
+
+PLATFORMS_TO_TEST = (Platform.COVER,)
+
+STATE_MAP = {
+    False: {
+        Platform.COVER: {STATE_ON: STATE_OPEN, STATE_OFF: STATE_CLOSED},
+    },
+    True: {
+        Platform.COVER: {STATE_ON: STATE_CLOSED, STATE_OFF: STATE_OPEN},
+    },
+}

--- a/tests/components/binary_sensor_as_x/conftest.py
+++ b/tests/components/binary_sensor_as_x/conftest.py
@@ -1,0 +1,27 @@
+"""Fixtures for the Binary sensor as X integration tests."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+
+@pytest.fixture(autouse=True)
+async def setup_homeassistant(hass: HomeAssistant):
+    """Set up the homeassistant integration."""
+    await async_setup_component(hass, "homeassistant", {})
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Mock setting up a config entry."""
+    with patch(
+        "homeassistant.components.binary_sensor_as_x.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        yield mock_setup

--- a/tests/components/binary_sensor_as_x/test_config_flow.py
+++ b/tests/components/binary_sensor_as_x/test_config_flow.py
@@ -1,0 +1,113 @@
+"""Test the Binary sensor as X config flow."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from homeassistant import config_entries
+from homeassistant.components.binary_sensor_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+
+from . import PLATFORMS_TO_TEST
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_config_flow(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test the config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITY_ID: "binary_sensor.basement",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "basement"
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_ENTITY_ID: "binary_sensor.basement",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "binary_sensor.basement",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+
+
+@pytest.mark.parametrize(
+    ("hidden_by_before", "hidden_by_after"),
+    [
+        (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
+        (None, er.RegistryEntryHider.INTEGRATION),
+    ],
+)
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_config_flow_registered_entity(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    mock_setup_entry: AsyncMock,
+    hidden_by_before: er.RegistryEntryHider | None,
+    hidden_by_after: er.RegistryEntryHider,
+) -> None:
+    """Test the config flow hides a registered entity."""
+    registry = er.async_get(hass)
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique", suggested_object_id="basement"
+    )
+    assert binary_sensor_entity_entry.entity_id == "binary_sensor.basement"
+    registry.async_update_entity("binary_sensor.basement", hidden_by=hidden_by_before)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] is None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENTITY_ID: "binary_sensor.basement",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "basement"
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_ENTITY_ID: "binary_sensor.basement",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.data == {}
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "binary_sensor.basement",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+
+    binary_sensor_entity_entry = registry.async_get("binary_sensor.basement")
+    assert binary_sensor_entity_entry.hidden_by == hidden_by_after

--- a/tests/components/binary_sensor_as_x/test_cover.py
+++ b/tests/components/binary_sensor_as_x/test_cover.py
@@ -1,0 +1,60 @@
+"""Tests for the Binary sensor as X Cover platform."""
+
+from homeassistant.components.binary_sensor_as_x.config_flow import (
+    BinarySensorAsXConfigFlowHandler,
+)
+from homeassistant.components.binary_sensor_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.const import CONF_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_default_state(hass: HomeAssistant) -> None:
+    """Test cover binary sensor default state."""
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.test",
+            CONF_TARGET_DOMAIN: Platform.COVER,
+        },
+        title="Bedroom Door",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.bedroom_door")
+    assert state is not None
+    assert state.state == "unavailable"
+    assert state.attributes["supported_features"] == 0
+
+
+async def test_device_class(hass: HomeAssistant) -> None:
+    """Test cover binary sensor default state."""
+    hass.states.async_set("binary_sensor.test", "on", {"device_class": "door"})
+    await hass.async_block_till_done()
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.test",
+            CONF_TARGET_DOMAIN: Platform.COVER,
+        },
+        title="Bedroom Door",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("cover.bedroom_door")
+    assert state is not None
+    assert state.state == "open"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["device_class"] == "door"

--- a/tests/components/binary_sensor_as_x/test_init.py
+++ b/tests/components/binary_sensor_as_x/test_init.py
@@ -1,0 +1,1016 @@
+"""Tests for the Binary sensor as X."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.binary_sensor_as_x.config_flow import (
+    BinarySensorAsXConfigFlowHandler,
+)
+from homeassistant.components.binary_sensor_as_x.const import CONF_TARGET_DOMAIN, DOMAIN
+from homeassistant.components.homeassistant import exposed_entities
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    CONF_ENTITY_ID,
+    STATE_CLOSED,
+    STATE_OFF,
+    STATE_ON,
+    STATE_OPEN,
+    EntityCategory,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from . import PLATFORMS_TO_TEST
+
+from tests.common import MockConfigEntry
+
+EXPOSE_SETTINGS = {
+    "cloud.alexa": True,
+    "cloud.google_assistant": False,
+    "conversation": True,
+}
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_config_entry_unregistered_uuid(
+    hass: HomeAssistant, target_domain: str
+) -> None:
+    """Test binary sensor setup from config entry with unknown entity registry id."""
+    fake_uuid = "a266a680b608c32770e6c45bfe6b8411"
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: fake_uuid,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 0
+
+
+@pytest.mark.parametrize(
+    ("target_domain", "state_on", "state_off"),
+    [
+        (Platform.COVER, STATE_OPEN, STATE_CLOSED),
+    ],
+)
+async def test_entity_registry_events(
+    hass: HomeAssistant, target_domain: str, state_on: str, state_off: str
+) -> None:
+    """Test entity registry events are tracked."""
+    registry = er.async_get(hass)
+    registry_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique", original_name="ABC"
+    )
+    binary_sensor_entity_id = registry_entry.entity_id
+    hass.states.async_set(binary_sensor_entity_id, STATE_ON)
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: registry_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc").state == state_on
+
+    # Change entity_id
+    new_binary_sensor_entity_id = f"{binary_sensor_entity_id}_new"
+    registry.async_update_entity(
+        binary_sensor_entity_id, new_entity_id=new_binary_sensor_entity_id
+    )
+    hass.states.async_set(new_binary_sensor_entity_id, STATE_OFF)
+    await hass.async_block_till_done()
+
+    # Check tracking the new entity_id
+    await hass.async_block_till_done()
+    assert hass.states.get(f"{target_domain}.abc").state == state_off
+
+    # The old entity_id should no longer be tracked
+    hass.states.async_set(binary_sensor_entity_id, STATE_ON)
+    await hass.async_block_till_done()
+    assert hass.states.get(f"{target_domain}.abc").state == state_off
+
+    # Check changing name does not reload the config entry
+    with patch(
+        "homeassistant.components.binary_sensor_as_x.async_unload_entry",
+    ) as mock_setup_entry:
+        registry.async_update_entity(new_binary_sensor_entity_id, name="New name")
+        await hass.async_block_till_done()
+    mock_setup_entry.assert_not_called()
+
+    # Check removing the entity removes the config entry
+    registry.async_remove(new_binary_sensor_entity_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc") is None
+    assert registry.async_get(f"{target_domain}.abc") is None
+    assert len(hass.config_entries.async_entries("binary_sensor_as_x")) == 0
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_device_registry_config_entry_1(
+    hass: HomeAssistant, target_domain: str
+) -> None:
+    """Test we add our config entry to the tracked binary_sensor's device."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    binary_sensor_config_entry = MockConfigEntry()
+    binary_sensor_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    binary_sensor_entity_entry = entity_registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        config_entry=binary_sensor_config_entry,
+        device_id=device_entry.id,
+        original_name="ABC",
+    )
+    # Add another config entry to the same device
+    device_registry.async_update_device(
+        device_entry.id, add_config_entry_id=MockConfigEntry().entry_id
+    )
+
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+
+    device_entry = device_registry.async_get(device_entry.id)
+    assert binary_sensor_as_x_config_entry.entry_id in device_entry.config_entries
+
+    # Remove the wrapped binary_sensor's config entry from the device
+    device_registry.async_update_device(
+        device_entry.id, remove_config_entry_id=binary_sensor_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+    # Check that the binary_sensor_as_x config entry is removed from the device
+    device_entry = device_registry.async_get(device_entry.id)
+    assert binary_sensor_as_x_config_entry.entry_id not in device_entry.config_entries
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_device_registry_config_entry_2(
+    hass: HomeAssistant, target_domain: str
+) -> None:
+    """Test we add our config entry to the tracked binary_sensor's device."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    binary_sensor_config_entry = MockConfigEntry()
+    binary_sensor_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    binary_sensor_entity_entry = entity_registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        config_entry=binary_sensor_config_entry,
+        device_id=device_entry.id,
+        original_name="ABC",
+    )
+
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+
+    device_entry = device_registry.async_get(device_entry.id)
+    assert binary_sensor_as_x_config_entry.entry_id in device_entry.config_entries
+
+    # Remove the wrapped binary_sensor from the device
+    entity_registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id, device_id=None
+    )
+    await hass.async_block_till_done()
+    # Check that the binary_sensor_as_x config entry is removed from the device
+    device_entry = device_registry.async_get(device_entry.id)
+    assert binary_sensor_as_x_config_entry.entry_id not in device_entry.config_entries
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_config_entry_entity_id(
+    hass: HomeAssistant, target_domain: Platform
+) -> None:
+    """Test binary sensor setup from config entry with entity id."""
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.abc",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert DOMAIN in hass.config.components
+
+    state = hass.states.get(f"{target_domain}.abc")
+    assert state
+    assert state.state == "unavailable"
+    # Name copied from config entry title
+    assert state.name == "ABC"
+
+    # Check the light is added to the entity registry
+    registry = er.async_get(hass)
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+    assert entity_entry.unique_id == config_entry.entry_id
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_config_entry_uuid(hass: HomeAssistant, target_domain: Platform) -> None:
+    """Test binary sensor setup from config entry with entity registry id."""
+    registry = er.async_get(hass)
+    registry_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique", original_name="ABC"
+    )
+
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: registry_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(f"{target_domain}.abc")
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_device(hass: HomeAssistant, target_domain: Platform) -> None:
+    """Test the entity is added to the wrapped entity's device."""
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    test_config_entry = MockConfigEntry()
+    test_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=test_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    binary_sensor_entity_entry = entity_registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        device_id=device_entry.id,
+        original_name="ABC",
+    )
+
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = entity_registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_setup_and_remove_config_entry(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test removing a config entry."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are present
+    assert hass.states.get(f"{target_domain}.abc") is not None
+    assert registry.async_get(f"{target_domain}.abc") is not None
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    # Check the state and entity registry entry are removed
+    assert hass.states.get(f"{target_domain}.abc") is None
+    assert registry.async_get(f"{target_domain}.abc") is None
+
+
+@pytest.mark.parametrize(
+    ("hidden_by_before", "hidden_by_after"),
+    [
+        (er.RegistryEntryHider.USER, er.RegistryEntryHider.USER),
+        (er.RegistryEntryHider.INTEGRATION, None),
+    ],
+)
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_reset_hidden_by(
+    hass: HomeAssistant,
+    target_domain: Platform,
+    hidden_by_before: er.RegistryEntryHider | None,
+    hidden_by_after: er.RegistryEntryHider,
+) -> None:
+    """Test removing a config entry resets hidden by."""
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique"
+    )
+    registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id, hidden_by=hidden_by_before
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    # Check hidden by is reset
+    binary_sensor_entity_entry = registry.async_get(
+        binary_sensor_entity_entry.entity_id
+    )
+    assert binary_sensor_entity_entry.hidden_by == hidden_by_after
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_entity_category_inheritance(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the entity category is inherited from source device."""
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique", original_name="ABC"
+    )
+    registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id, entity_category=EntityCategory.CONFIG
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+    assert entity_entry.entity_category is EntityCategory.CONFIG
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_entity_options(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the source entity is stored as an entity option."""
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor", "test", "unique", original_name="ABC"
+    )
+    registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id, entity_category=EntityCategory.CONFIG
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+    assert entity_entry.options == {
+        DOMAIN: {"entity_id": binary_sensor_entity_entry.entity_id},
+    }
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_entity_name(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the source entity has entity_name set to True."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    binary_sensor_config_entry = MockConfigEntry()
+    binary_sensor_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        name="Device name",
+    )
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        device_id=device_entry.id,
+        has_entity_name=True,
+    )
+    binary_sensor_entity_entry = registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id,
+        config_entry_id=binary_sensor_config_entry.entry_id,
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.device_name")
+    assert entity_entry
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+    assert entity_entry.has_entity_name is True
+    assert entity_entry.name is None
+    assert entity_entry.original_name is None
+    assert entity_entry.options == {
+        DOMAIN: {"entity_id": binary_sensor_entity_entry.entity_id}
+    }
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_custom_name_1(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the source entity has a custom name."""
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    binary_sensor_config_entry = MockConfigEntry()
+    binary_sensor_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        name="Device name",
+    )
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        device_id=device_entry.id,
+        has_entity_name=True,
+        original_name="Original entity name",
+    )
+    binary_sensor_entity_entry = registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id,
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        name="Custom entity name",
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(
+        f"{target_domain}.device_name_original_entity_name"
+    )
+    assert entity_entry
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+    assert entity_entry.has_entity_name is True
+    assert entity_entry.name == "Custom entity name"
+    assert entity_entry.original_name == "Original entity name"
+    assert entity_entry.options == {
+        DOMAIN: {"entity_id": binary_sensor_entity_entry.entity_id}
+    }
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_custom_name_2(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test the source entity has a custom name.
+
+    This tests the custom name is only copied from the source device when the
+    binary_sensor_as_x config entry is setup the first time.
+    """
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+
+    binary_sensor_config_entry = MockConfigEntry()
+    binary_sensor_config_entry.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        name="Device name",
+    )
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        device_id=device_entry.id,
+        has_entity_name=True,
+        original_name="Original entity name",
+    )
+    binary_sensor_entity_entry = registry.async_update_entity(
+        binary_sensor_entity_entry.entity_id,
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        name="New custom entity name",
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    # Register the binary_sensor as x entity in the entity registry, this means
+    # the entity has been setup before
+    binary_sensor_as_x_entity_entry = registry.async_get_or_create(
+        target_domain,
+        "binary_sensor_as_x",
+        binary_sensor_as_x_config_entry.entry_id,
+        suggested_object_id="device_name_original_entity_name",
+    )
+    binary_sensor_as_x_entity_entry = registry.async_update_entity(
+        binary_sensor_as_x_entity_entry.entity_id,
+        config_entry_id=binary_sensor_config_entry.entry_id,
+        name="Old custom entity name",
+    )
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(
+        f"{target_domain}.device_name_original_entity_name"
+    )
+    assert entity_entry
+    assert entity_entry.entity_id == binary_sensor_as_x_entity_entry.entity_id
+    assert entity_entry.device_id == binary_sensor_entity_entry.device_id
+    assert entity_entry.has_entity_name is True
+    assert entity_entry.name == "Old custom entity name"
+    assert entity_entry.original_name == "Original entity name"
+    assert entity_entry.options == {
+        DOMAIN: {"entity_id": binary_sensor_entity_entry.entity_id}
+    }
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_import_expose_settings_1(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test importing assistant expose settings."""
+    await async_setup_component(hass, "homeassistant", {})
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        original_name="ABC",
+    )
+    for assistant, should_expose in EXPOSE_SETTINGS.items():
+        exposed_entities.async_expose_entity(
+            hass, assistant, binary_sensor_entity_entry.entity_id, should_expose
+        )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+
+    # Check binary_sensor_as_x expose settings were copied from the binary_sensor
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, entity_entry.entity_id
+    )
+    for assistant in EXPOSE_SETTINGS:
+        assert expose_settings[assistant]["should_expose"] == EXPOSE_SETTINGS[assistant]
+
+    # Check the binary_sensor is no longer exposed
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, binary_sensor_entity_entry.entity_id
+    )
+    for assistant in EXPOSE_SETTINGS:
+        assert expose_settings[assistant]["should_expose"] is False
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_import_expose_settings_2(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test importing assistant expose settings.
+
+    This tests the expose settings are only copied from the source device when the
+    binary_sensor_as_x config entry is setup the first time.
+    """
+
+    await async_setup_component(hass, "homeassistant", {})
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        original_name="ABC",
+    )
+    for assistant, should_expose in EXPOSE_SETTINGS.items():
+        exposed_entities.async_expose_entity(
+            hass, assistant, binary_sensor_entity_entry.entity_id, should_expose
+        )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    # Register the binary_sensor as x entity in the entity registry, this means
+    # the entity has been setup before
+    binary_sensor_as_x_entity_entry = registry.async_get_or_create(
+        target_domain,
+        "binary_sensor_as_x",
+        binary_sensor_as_x_config_entry.entry_id,
+        suggested_object_id="abc",
+    )
+    for assistant, should_expose in EXPOSE_SETTINGS.items():
+        exposed_entities.async_expose_entity(
+            hass,
+            assistant,
+            binary_sensor_as_x_entity_entry.entity_id,
+            not should_expose,
+        )
+
+    assert await hass.config_entries.async_setup(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    entity_entry = registry.async_get(f"{target_domain}.abc")
+    assert entity_entry
+
+    # Check binary_sensor_as_x expose settings were not copied from the binary_sensor
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, entity_entry.entity_id
+    )
+    for assistant in EXPOSE_SETTINGS:
+        assert (
+            expose_settings[assistant]["should_expose"]
+            is not EXPOSE_SETTINGS[assistant]
+        )
+
+    # Check the binary_sensor settings were not modified
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, binary_sensor_entity_entry.entity_id
+    )
+    for assistant in EXPOSE_SETTINGS:
+        assert expose_settings[assistant]["should_expose"] == EXPOSE_SETTINGS[assistant]
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_restore_expose_settings(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test removing a config entry restores assistant expose settings."""
+    await async_setup_component(hass, "homeassistant", {})
+    registry = er.async_get(hass)
+
+    binary_sensor_entity_entry = registry.async_get_or_create(
+        "binary_sensor",
+        "test",
+        "unique",
+        original_name="ABC",
+    )
+
+    # Add the config entry
+    binary_sensor_as_x_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: binary_sensor_entity_entry.id,
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=BinarySensorAsXConfigFlowHandler.VERSION,
+        minor_version=BinarySensorAsXConfigFlowHandler.MINOR_VERSION,
+    )
+    binary_sensor_as_x_config_entry.add_to_hass(hass)
+
+    # Register the binary_sensor as x entity
+    binary_sensor_as_x_entity_entry = registry.async_get_or_create(
+        target_domain,
+        "binary_sensor_as_x",
+        binary_sensor_as_x_config_entry.entry_id,
+        config_entry=binary_sensor_as_x_config_entry,
+        suggested_object_id="abc",
+    )
+    for assistant, should_expose in EXPOSE_SETTINGS.items():
+        exposed_entities.async_expose_entity(
+            hass, assistant, binary_sensor_as_x_entity_entry.entity_id, should_expose
+        )
+
+    # Remove the config entry
+    assert await hass.config_entries.async_remove(
+        binary_sensor_as_x_config_entry.entry_id
+    )
+    await hass.async_block_till_done()
+
+    # Check the binary_sensor expose settings were restored
+    expose_settings = exposed_entities.async_get_entity_settings(
+        hass, binary_sensor_entity_entry.entity_id
+    )
+    for assistant in EXPOSE_SETTINGS:
+        assert expose_settings[assistant]["should_expose"] == EXPOSE_SETTINGS[assistant]
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_migrate(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test migration."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=0,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check migration was successful and added invert option
+    assert config_entry.state is ConfigEntryState.LOADED
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "binary_sensor.test",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert config_entry.version == BinarySensorAsXConfigFlowHandler.VERSION
+    assert config_entry.minor_version == BinarySensorAsXConfigFlowHandler.MINOR_VERSION
+
+    # Check the state and entity registry entry are present
+    assert hass.states.get(f"{target_domain}.abc") is not None
+    assert registry.async_get(f"{target_domain}.abc") is not None
+
+
+@pytest.mark.parametrize("target_domain", PLATFORMS_TO_TEST)
+async def test_migrate_from_future(
+    hass: HomeAssistant,
+    target_domain: Platform,
+) -> None:
+    """Test migration."""
+    registry = er.async_get(hass)
+
+    # Setup the config entry
+    config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            CONF_ENTITY_ID: "binary_sensor.test",
+            CONF_TARGET_DOMAIN: target_domain,
+        },
+        title="ABC",
+        version=2,
+        minor_version=1,
+    )
+    config_entry.add_to_hass(hass)
+    assert not await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Check migration was not successful and did not add invert option
+    assert config_entry.state is ConfigEntryState.MIGRATION_ERROR
+    assert config_entry.options == {
+        CONF_ENTITY_ID: "binary_sensor.test",
+        CONF_TARGET_DOMAIN: target_domain,
+    }
+    assert config_entry.version == 2
+    assert config_entry.minor_version == 1
+
+    # Check the state and entity registry entry are not present
+    assert hass.states.get(f"{target_domain}.abc") is None
+    assert registry.async_get(f"{target_domain}.abc") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A new integration similar to `switch_as_x`, but for `binary_sensor`s. The motivation is described here https://github.com/home-assistant/architecture/discussions/1084

This helper integration takes a `binary_sensor` as an input and creates a new `cover` entity (just state reporting, no actuation possible, of course) which reflects the state.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/1084 https://github.com/home-assistant/intents/discussions/2168
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
