### PR TITLE
Rename wemo coordinator module

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -20,8 +20,8 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.async_ import gather_with_limited_concurrency
 
 from .const import DOMAIN
+from .coordinator import DeviceCoordinator, async_register_device
 from .models import WemoConfigEntryData, WemoData, async_wemo_data
-from .wemo_device import DeviceCoordinator, async_register_device
 
 # Max number of devices to initialize at once. This limit is in place to
 # avoid tying up too many executor threads with WeMo device setup.

--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -8,8 +8,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import async_wemo_dispatcher_connect
+from .coordinator import DeviceCoordinator
 from .entity import WemoBinaryStateEntity, WemoEntity
-from .wemo_device import DeviceCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/wemo/config_flow.py
+++ b/homeassistant/components/wemo/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
 
 from .const import DOMAIN
-from .wemo_device import Options, OptionsValidationError
+from .coordinator import Options, OptionsValidationError
 
 
 async def _async_has_devices(hass: HomeAssistant) -> bool:

--- a/homeassistant/components/wemo/coordinator.py
+++ b/homeassistant/components/wemo/coordinator.py
@@ -88,7 +88,7 @@ class Options:
             )
 
 
-class DeviceCoordinator(DataUpdateCoordinator[None]):  # pylint: disable=hass-enforce-coordinator-module
+class DeviceCoordinator(DataUpdateCoordinator[None]):
     """Home Assistant wrapper for a pyWeMo device."""
 
     options: Options | None = None

--- a/homeassistant/components/wemo/device_trigger.py
+++ b/homeassistant/components/wemo/device_trigger.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN as WEMO_DOMAIN, WEMO_SUBSCRIPTION_EVENT
-from .wemo_device import async_get_coordinator
+from .coordinator import async_get_coordinator
 
 TRIGGER_TYPES = {EVENT_TYPE_LONG_PRESS}
 

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -11,7 +11,7 @@ from pywemo.exceptions import ActionException
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .wemo_device import DeviceCoordinator
+from .coordinator import DeviceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -22,8 +22,8 @@ from homeassistant.util.scaling import int_states_in_range
 
 from . import async_wemo_dispatcher_connect
 from .const import SERVICE_RESET_FILTER_LIFE, SERVICE_SET_HUMIDITY
+from .coordinator import DeviceCoordinator
 from .entity import WemoBinaryStateEntity
-from .wemo_device import DeviceCoordinator
 
 SCAN_INTERVAL = timedelta(seconds=10)
 PARALLEL_UPDATES = 0

--- a/homeassistant/components/wemo/light.py
+++ b/homeassistant/components/wemo/light.py
@@ -23,8 +23,8 @@ import homeassistant.util.color as color_util
 
 from . import async_wemo_dispatcher_connect
 from .const import DOMAIN as WEMO_DOMAIN
+from .coordinator import DeviceCoordinator
 from .entity import WemoBinaryStateEntity, WemoEntity
-from .wemo_device import DeviceCoordinator
 
 # The WEMO_ constants below come from pywemo itself
 WEMO_OFF = 0

--- a/homeassistant/components/wemo/models.py
+++ b/homeassistant/components/wemo/models.py
@@ -12,7 +12,7 @@ from .const import DOMAIN
 
 if TYPE_CHECKING:  # Avoid circular dependencies.
     from . import HostPortTuple, WemoDiscovery, WemoDispatcher
-    from .wemo_device import DeviceCoordinator
+    from .coordinator import DeviceCoordinator
 
 
 @dataclass

--- a/homeassistant/components/wemo/sensor.py
+++ b/homeassistant/components/wemo/sensor.py
@@ -19,8 +19,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from . import async_wemo_dispatcher_connect
+from .coordinator import DeviceCoordinator
 from .entity import WemoEntity
-from .wemo_device import DeviceCoordinator
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/wemo/switch.py
+++ b/homeassistant/components/wemo/switch.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import async_wemo_dispatcher_connect
+from .coordinator import DeviceCoordinator
 from .entity import WemoBinaryStateEntity
-from .wemo_device import DeviceCoordinator
 
 SCAN_INTERVAL = timedelta(seconds=10)
 PARALLEL_UPDATES = 0

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -7,7 +7,7 @@ import asyncio
 import threading
 
 from homeassistant.components.homeassistant import DOMAIN as HA_DOMAIN
-from homeassistant.components.wemo import wemo_device
+from homeassistant.components.wemo.coordinator import async_get_coordinator
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -94,7 +94,7 @@ async def test_async_update_locked_callback_and_update(
     When a state update is received via a callback from the device at the same time
     as hass is calling `async_update`, verify that only one of the updates proceeds.
     """
-    coordinator = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    coordinator = async_get_coordinator(hass, wemo_entity.device_id)
     await async_setup_component(hass, HA_DOMAIN, {})
     callback = _perform_registry_callback(coordinator)
     update = _perform_async_update(coordinator)
@@ -105,7 +105,7 @@ async def test_async_update_locked_multiple_updates(
     hass: HomeAssistant, pywemo_device, wemo_entity
 ) -> None:
     """Test that two hass async_update state updates do not proceed at the same time."""
-    coordinator = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    coordinator = async_get_coordinator(hass, wemo_entity.device_id)
     await async_setup_component(hass, HA_DOMAIN, {})
     update = _perform_async_update(coordinator)
     await _async_multiple_call_helper(hass, pywemo_device, update, update)
@@ -115,7 +115,7 @@ async def test_async_update_locked_multiple_callbacks(
     hass: HomeAssistant, pywemo_device, wemo_entity
 ) -> None:
     """Test that two device callback state updates do not proceed at the same time."""
-    coordinator = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    coordinator = async_get_coordinator(hass, wemo_entity.device_id)
     await async_setup_component(hass, HA_DOMAIN, {})
     callback = _perform_registry_callback(coordinator)
     await _async_multiple_call_helper(hass, pywemo_device, callback, callback)

--- a/tests/components/wemo/test_config_flow.py
+++ b/tests/components/wemo/test_config_flow.py
@@ -3,7 +3,7 @@
 from dataclasses import asdict
 
 from homeassistant.components.wemo.const import DOMAIN
-from homeassistant.components.wemo.wemo_device import Options
+from homeassistant.components.wemo.coordinator import Options
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType

--- a/tests/components/wemo/test_wemo_device.py
+++ b/tests/components/wemo/test_wemo_device.py
@@ -10,7 +10,7 @@ from pywemo.exceptions import ActionException, PyWeMoException
 from pywemo.subscribe import EVENT_TYPE_LONG_PRESS
 
 from homeassistant import runner
-from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, wemo_device
+from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, coordinator
 from homeassistant.components.wemo.const import DOMAIN, WEMO_SUBSCRIPTION_EVENT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -50,7 +50,7 @@ async def test_async_register_device_longpress_fails(
         await hass.async_block_till_done()
     device_entries = list(device_registry.devices.values())
     assert len(device_entries) == 1
-    device = wemo_device.async_get_coordinator(hass, device_entries[0].id)
+    device = coordinator.async_get_coordinator(hass, device_entries[0].id)
     assert device.supports_long_press is False
 
 
@@ -58,7 +58,7 @@ async def test_long_press_event(
     hass: HomeAssistant, pywemo_registry, wemo_entity
 ) -> None:
     """Device fires a long press event."""
-    device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    device = coordinator.async_get_coordinator(hass, wemo_entity.device_id)
     got_event = asyncio.Event()
     event_data = {}
 
@@ -93,7 +93,7 @@ async def test_subscription_callback(
     hass: HomeAssistant, pywemo_registry, wemo_entity
 ) -> None:
     """Device processes a registry subscription callback."""
-    device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    device = coordinator.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = False
 
     got_callback = asyncio.Event()
@@ -117,7 +117,7 @@ async def test_subscription_update_action_exception(
     hass: HomeAssistant, pywemo_device, wemo_entity
 ) -> None:
     """Device handles ActionException on get_state properly."""
-    device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    device = coordinator.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = True
 
     pywemo_device.subscription_update.return_value = False
@@ -137,7 +137,7 @@ async def test_subscription_update_exception(
     hass: HomeAssistant, pywemo_device, wemo_entity
 ) -> None:
     """Device handles Exception on get_state properly."""
-    device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    device = coordinator.async_get_coordinator(hass, wemo_entity.device_id)
     device.last_update_success = True
 
     pywemo_device.subscription_update.return_value = False
@@ -157,7 +157,7 @@ async def test_async_update_data_subscribed(
     hass: HomeAssistant, pywemo_registry, pywemo_device, wemo_entity
 ) -> None:
     """No update happens when the device is subscribed."""
-    device = wemo_device.async_get_coordinator(hass, wemo_entity.device_id)
+    device = coordinator.async_get_coordinator(hass, wemo_entity.device_id)
     pywemo_registry.is_subscribed.return_value = True
     pywemo_device.get_state.reset_mock()
     await device._async_update_data()
@@ -197,7 +197,7 @@ async def test_options_enable_subscription_false(
     assert hass.config_entries.async_update_entry(
         config_entry,
         options=asdict(
-            wemo_device.Options(enable_subscription=False, enable_long_press=False)
+            coordinator.Options(enable_subscription=False, enable_long_press=False)
         ),
     )
     await hass.async_block_till_done()
@@ -208,7 +208,7 @@ async def test_options_enable_long_press_false(hass, pywemo_device, wemo_entity)
     """Test setting Options.enable_long_press = False."""
     config_entry = hass.config_entries.async_get_entry(wemo_entity.config_entry_id)
     assert hass.config_entries.async_update_entry(
-        config_entry, options=asdict(wemo_device.Options(enable_long_press=False))
+        config_entry, options=asdict(coordinator.Options(enable_long_press=False))
     )
     await hass.async_block_till_done()
     pywemo_device.remove_long_press_virtual_device.assert_called_once_with()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
