### PR TITLE
Rename fritz coordinator module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -461,8 +461,6 @@ omit =
     homeassistant/components/freebox/camera.py
     homeassistant/components/freebox/home_base.py
     homeassistant/components/freebox/switch.py
-    homeassistant/components/fritz/coordinator.py
-    homeassistant/components/fritz/device_tracker.py
     homeassistant/components/fritz/services.py
     homeassistant/components/fritz/switch.py
     homeassistant/components/fritzbox_callmonitor/__init__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -461,7 +461,7 @@ omit =
     homeassistant/components/freebox/camera.py
     homeassistant/components/freebox/home_base.py
     homeassistant/components/freebox/switch.py
-    homeassistant/components/fritz/common.py
+    homeassistant/components/fritz/coordinator.py
     homeassistant/components/fritz/device_tracker.py
     homeassistant/components/fritz/services.py
     homeassistant/components/fritz/switch.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -461,6 +461,8 @@ omit =
     homeassistant/components/freebox/camera.py
     homeassistant/components/freebox/home_base.py
     homeassistant/components/freebox/switch.py
+    homeassistant/components/fritz/coordinator.py
+    homeassistant/components/fritz/device_tracker.py
     homeassistant/components/fritz/services.py
     homeassistant/components/fritz/switch.py
     homeassistant/components/fritzbox_callmonitor/__init__.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -462,7 +462,6 @@ omit =
     homeassistant/components/freebox/home_base.py
     homeassistant/components/freebox/switch.py
     homeassistant/components/fritz/coordinator.py
-    homeassistant/components/fritz/device_tracker.py
     homeassistant/components/fritz/services.py
     homeassistant/components/fritz/switch.py
     homeassistant/components/fritzbox_callmonitor/__init__.py

--- a/homeassistant/components/fritz/__init__.py
+++ b/homeassistant/components/fritz/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
-from .common import AvmWrapper, FritzData
 from .const import (
     DATA_FRITZ,
     DEFAULT_SSL,
@@ -22,6 +21,7 @@ from .const import (
     FRITZ_EXCEPTIONS,
     PLATFORMS,
 )
+from .coordinator import AvmWrapper, FritzData
 from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/fritz/binary_sensor.py
+++ b/homeassistant/components/fritz/binary_sensor.py
@@ -16,13 +16,13 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import (
+from .const import DOMAIN
+from .coordinator import (
     AvmWrapper,
     ConnectionInfo,
     FritzBoxBaseCoordinatorEntity,
     FritzEntityDescription,
 )
-from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -19,8 +19,14 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import AvmWrapper, FritzData, FritzDevice, FritzDeviceBase, _is_tracked
 from .const import BUTTON_TYPE_WOL, CONNECTION_TYPE_LAN, DATA_FRITZ, DOMAIN, MeshRoles
+from .coordinator import (
+    AvmWrapper,
+    FritzData,
+    FritzDevice,
+    FritzDeviceBase,
+    _is_tracked,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/device_tracker.py
+++ b/homeassistant/components/fritz/device_tracker.py
@@ -11,14 +11,14 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import (
+from .const import DATA_FRITZ, DOMAIN
+from .coordinator import (
     AvmWrapper,
     FritzData,
     FritzDevice,
     FritzDeviceBase,
     device_filter_out_from_trackers,
 )
-from .const import DATA_FRITZ, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/diagnostics.py
+++ b/homeassistant/components/fritz/diagnostics.py
@@ -9,8 +9,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from .common import AvmWrapper
 from .const import DOMAIN
+from .coordinator import AvmWrapper
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
 

--- a/homeassistant/components/fritz/image.py
+++ b/homeassistant/components/fritz/image.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util, slugify
 
-from .common import AvmWrapper, FritzBoxBaseEntity
 from .const import DOMAIN
+from .coordinator import AvmWrapper, FritzBoxBaseEntity
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/sensor.py
+++ b/homeassistant/components/fritz/sensor.py
@@ -27,13 +27,13 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import utcnow
 
-from .common import (
+from .const import DOMAIN, DSL_CONNECTION, UPTIME_DEVIATION
+from .coordinator import (
     AvmWrapper,
     ConnectionInfo,
     FritzBoxBaseCoordinatorEntity,
     FritzEntityDescription,
 )
-from .const import DOMAIN, DSL_CONNECTION, UPTIME_DEVIATION
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -11,7 +11,6 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service import async_extract_config_entry_ids
 
-from .common import AvmWrapper
 from .const import (
     DOMAIN,
     FRITZ_SERVICES,
@@ -20,6 +19,7 @@ from .const import (
     SERVICE_RECONNECT,
     SERVICE_SET_GUEST_WIFI_PW,
 )
+from .coordinator import AvmWrapper
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/fritz/switch.py
+++ b/homeassistant/components/fritz/switch.py
@@ -17,15 +17,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
 
-from .common import (
-    AvmWrapper,
-    FritzBoxBaseEntity,
-    FritzData,
-    FritzDevice,
-    FritzDeviceBase,
-    SwitchInfo,
-    device_filter_out_from_trackers,
-)
 from .const import (
     DATA_FRITZ,
     DOMAIN,
@@ -35,6 +26,15 @@ from .const import (
     SWITCH_TYPE_WIFINETWORK,
     WIFI_STANDARD,
     MeshRoles,
+)
+from .coordinator import (
+    AvmWrapper,
+    FritzBoxBaseEntity,
+    FritzData,
+    FritzDevice,
+    FritzDeviceBase,
+    SwitchInfo,
+    device_filter_out_from_trackers,
 )
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/fritz/update.py
+++ b/homeassistant/components/fritz/update.py
@@ -16,8 +16,12 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .common import AvmWrapper, FritzBoxBaseCoordinatorEntity, FritzEntityDescription
 from .const import DOMAIN
+from .coordinator import (
+    AvmWrapper,
+    FritzBoxBaseCoordinatorEntity,
+    FritzEntityDescription,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/fritz/conftest.py
+++ b/tests/components/fritz/conftest.py
@@ -84,7 +84,7 @@ def fc_data_mock():
 def fc_class_mock(fc_data):
     """Fixture that sets up a mocked FritzConnection class."""
     with patch(
-        "homeassistant.components.fritz.common.FritzConnection", autospec=True
+        "homeassistant.components.fritz.coordinator.FritzConnection", autospec=True
     ) as result:
         result.return_value = FritzConnectionMock(fc_data)
         yield result
@@ -94,7 +94,7 @@ def fc_class_mock(fc_data):
 def fh_class_mock():
     """Fixture that sets up a mocked FritzHosts class."""
     with patch(
-        "homeassistant.components.fritz.common.FritzHosts",
+        "homeassistant.components.fritz.coordinator.FritzHosts",
         new=FritzHosts,
     ) as result:
         result.get_mesh_topology = MagicMock(return_value=MOCK_MESH_DATA)

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -63,7 +63,7 @@ async def test_buttons(
     assert button
     assert button.state == STATE_UNKNOWN
     with patch(
-        f"homeassistant.components.fritz.common.AvmWrapper.{wrapper_method}"
+        f"homeassistant.components.fritz.coordinator.AvmWrapper.{wrapper_method}"
     ) as mock_press_action:
         await hass.services.async_call(
             BUTTON_DOMAIN,
@@ -97,7 +97,7 @@ async def test_wol_button(
     assert button
     assert button.state == STATE_UNKNOWN
     with patch(
-        "homeassistant.components.fritz.common.AvmWrapper.async_wake_on_lan"
+        "homeassistant.components.fritz.coordinator.AvmWrapper.async_wake_on_lan"
     ) as mock_press_action:
         await hass.services.async_call(
             BUTTON_DOMAIN,

--- a/tests/components/fritz/test_config_flow.py
+++ b/tests/components/fritz/test_config_flow.py
@@ -105,7 +105,7 @@ async def test_user(
             side_effect=fc_class_mock,
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch("homeassistant.components.fritz.async_setup_entry") as mock_setup_entry,
@@ -172,7 +172,7 @@ async def test_user_already_configured(
             side_effect=fc_class_mock,
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch(
@@ -323,7 +323,7 @@ async def test_reauth_successful(
             side_effect=fc_class_mock,
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch(
@@ -459,7 +459,7 @@ async def test_reconfigure_successful(
             side_effect=fc_class_mock,
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch(
@@ -522,7 +522,7 @@ async def test_reconfigure_not_successful(
             side_effect=[FritzConnectionException, fc_class_mock],
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch(
@@ -699,7 +699,7 @@ async def test_ssdp(hass: HomeAssistant, fc_class_mock, mock_get_source_ip) -> N
             side_effect=fc_class_mock,
         ),
         patch(
-            "homeassistant.components.fritz.common.FritzBoxTools._update_device_info",
+            "homeassistant.components.fritz.coordinator.FritzBoxTools._update_device_info",
             return_value=MOCK_FIRMWARE_INFO,
         ),
         patch("homeassistant.components.fritz.async_setup_entry") as mock_setup_entry,

--- a/tests/components/fritz/test_diagnostics.py
+++ b/tests/components/fritz/test_diagnostics.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from homeassistant.components.diagnostics import REDACTED
-from homeassistant.components.fritz.common import AvmWrapper
 from homeassistant.components.fritz.const import DOMAIN
+from homeassistant.components.fritz.coordinator import AvmWrapper
 from homeassistant.components.fritz.diagnostics import TO_REDACT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant

--- a/tests/components/fritz/test_init.py
+++ b/tests/components/fritz/test_init.py
@@ -76,7 +76,7 @@ async def test_setup_auth_fail(hass: HomeAssistant, error) -> None:
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.fritz.common.FritzConnection",
+        "homeassistant.components.fritz.coordinator.FritzConnection",
         side_effect=error,
     ):
         await hass.config_entries.async_setup(entry.entry_id)
@@ -96,7 +96,7 @@ async def test_setup_fail(hass: HomeAssistant, error) -> None:
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.fritz.common.FritzConnection",
+        "homeassistant.components.fritz.coordinator.FritzConnection",
         side_effect=error,
     ):
         await hass.config_entries.async_setup(entry.entry_id)

--- a/tests/components/fritz/test_update.py
+++ b/tests/components/fritz/test_update.py
@@ -104,7 +104,7 @@ async def test_available_update_can_be_installed(
     fc_class_mock().override_services({**MOCK_FB_SERVICES, **AVAILABLE_UPDATE})
 
     with patch(
-        "homeassistant.components.fritz.common.FritzBoxTools.async_trigger_firmware_update",
+        "homeassistant.components.fritz.coordinator.FritzBoxTools.async_trigger_firmware_update",
         return_value=True,
     ) as mocked_update_call:
         entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
