### PR TITLE
Bump youless_api to  1.1.1

### DIFF
--- a/homeassistant/components/youless/manifest.json
+++ b/homeassistant/components/youless/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/youless",
   "iot_class": "local_polling",
   "loggers": ["youless_api"],
-  "requirements": ["youless-api==1.0.1"]
+  "requirements": ["youless-api==1.1.1"]
 }

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -42,6 +42,7 @@ async def async_setup_entry(
 
     async_add_entities(
         [
+            WaterSensor(coordinator, device),
             GasSensor(coordinator, device),
             EnergyMeterSensor(
                 coordinator, device, "low", SensorStateClass.TOTAL_INCREASING
@@ -108,6 +109,27 @@ class YoulessBaseSensor(
     def available(self) -> bool:
         """Return a flag to indicate the sensor not being available."""
         return super().available and self.get_sensor is not None
+
+
+class WaterSensor(YoulessBaseSensor):
+    """The Youless Water sensor."""
+
+    _attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+    _attr_device_class = SensorDeviceClass.WATER
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self, coordinator: DataUpdateCoordinator[YoulessAPI], device: str
+    ) -> None:
+        """Instantiate a Water sensor."""
+        super().__init__(coordinator, device, "water", "Water meter", "water")
+        self._attr_name = "Water usage"
+        self._attr_icon = "mdi:water"
+
+    @property
+    def get_sensor(self) -> YoulessSensor | None:
+        """Get the sensor for providing the value."""
+        return self.coordinator.data.water_meter
 
 
 class GasSensor(YoulessBaseSensor):

--- a/homeassistant/components/youless/sensor.py
+++ b/homeassistant/components/youless/sensor.py
@@ -42,7 +42,6 @@ async def async_setup_entry(
 
     async_add_entities(
         [
-            WaterSensor(coordinator, device),
             GasSensor(coordinator, device),
             EnergyMeterSensor(
                 coordinator, device, "low", SensorStateClass.TOTAL_INCREASING
@@ -109,27 +108,6 @@ class YoulessBaseSensor(
     def available(self) -> bool:
         """Return a flag to indicate the sensor not being available."""
         return super().available and self.get_sensor is not None
-
-
-class WaterSensor(YoulessBaseSensor):
-    """The Youless Water sensor."""
-
-    _attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
-    _attr_device_class = SensorDeviceClass.WATER
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
-
-    def __init__(
-        self, coordinator: DataUpdateCoordinator[YoulessAPI], device: str
-    ) -> None:
-        """Instantiate a Water sensor."""
-        super().__init__(coordinator, device, "water", "Water meter", "water")
-        self._attr_name = "Water usage"
-        self._attr_icon = "mdi:water"
-
-    @property
-    def get_sensor(self) -> YoulessSensor | None:
-        """Get the sensor for providing the value."""
-        return self.coordinator.data.water_meter
 
 
 class GasSensor(YoulessBaseSensor):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2920,7 +2920,7 @@ yeelightsunflower==0.0.10
 yolink-api==0.4.4
 
 # homeassistant.components.youless
-youless-api==1.0.1
+youless-api==1.1.1
 
 # homeassistant.components.youtube
 youtubeaio==1.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2270,7 +2270,7 @@ yeelight==0.7.14
 yolink-api==0.4.4
 
 # homeassistant.components.youless
-youless-api==1.0.1
+youless-api==1.1.1
 
 # homeassistant.components.youtube
 youtubeaio==1.1.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps the version of youless_api to 1.1.1 as requiered by PR https://github.com/home-assistant/core/pull/117452
Link to the comparison of both releases: https://github.com/gjong/youless-python-bridge/compare/1.0.1...1.1.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
