### PR TITLE
Remove "device_id" slot from timers

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -335,18 +335,13 @@ class DefaultAgent(ConversationEntity):
         assert lang_intents is not None
 
         # Slot values to pass to the intent
-        slots: dict[str, Any] = {}
-
-        # Automatically add device id
-        if user_input.device_id is not None:
-            slots["device_id"] = user_input.device_id
-
-        # Add entities from match
-        for entity in result.entities_list:
-            slots[entity.name] = {
+        slots: dict[str, Any] = {
+            entity.name: {
                 "value": entity.value,
                 "text": entity.text or entity.value,
             }
+            for entity in result.entities_list
+        }
 
         try:
             intent_response = await intent.async_handle(

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -65,9 +65,9 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
         intent.INTENT_START_TIMER,
         {
             "name": {"value": timer_name},
-            "device_id": {"value": device_id},
             "seconds": {"value": 0},
         },
+        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -118,11 +118,11 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_START_TIMER,
         {
-            "device_id": {"value": device_id},
             "hours": {"value": 1},
             "minutes": {"value": 2},
             "seconds": {"value": 3},
         },
+        device_id=device_id,
     )
 
     async with asyncio.timeout(1):
@@ -154,12 +154,12 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_START_TIMER,
         {
-            "device_id": {"value": device_id},
             "name": {"value": timer_name},
             "hours": {"value": 1},
             "minutes": {"value": 2},
             "seconds": {"value": 3},
         },
+        device_id=device_id,
     )
 
     async with asyncio.timeout(1):
@@ -225,12 +225,12 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_START_TIMER,
         {
-            "device_id": {"value": device_id},
             "name": {"value": timer_name},
             "hours": {"value": 1},
             "minutes": {"value": 2},
             "seconds": {"value": 3},
         },
+        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -244,7 +244,6 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_INCREASE_TIMER,
         {
-            "device_id": {"value": device_id},
             "start_hours": {"value": 1},
             "start_minutes": {"value": 2},
             "start_seconds": {"value": 3},
@@ -252,6 +251,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
             "minutes": {"value": 5},
             "seconds": {"value": 30},
         },
+        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -321,12 +321,12 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_START_TIMER,
         {
-            "device_id": {"value": device_id},
             "name": {"value": timer_name},
             "hours": {"value": 1},
             "minutes": {"value": 2},
             "seconds": {"value": 3},
         },
+        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -340,12 +340,12 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
         "test",
         intent.INTENT_DECREASE_TIMER,
         {
-            "device_id": {"value": device_id},
             "start_hours": {"value": 1},
             "start_minutes": {"value": 2},
             "start_seconds": {"value": 3},
             "seconds": {"value": 30},
         },
+        device_id=device_id,
     )
 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
@@ -535,7 +535,8 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {"device_id": {"value": device_alice_study.id}, "minutes": {"value": 3}},
+        {"minutes": {"value": 3}},
+        device_id=device_alice_study.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -544,16 +545,14 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {"device_id": {"value": device_bob_kitchen_1.id}, "minutes": {"value": 3}},
+        {"minutes": {"value": 3}},
+        device_id=device_bob_kitchen_1.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
     # Alice should hear her timer listed first
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_TIMER_STATUS,
-        {"device_id": {"value": device_alice_study.id}},
+        hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_alice_study.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
@@ -563,10 +562,7 @@ async def test_disambiguation(
 
     # Bob should hear his timer listed first
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_TIMER_STATUS,
-        {"device_id": {"value": device_bob_kitchen_1.id}},
+        hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_bob_kitchen_1.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
@@ -589,10 +585,7 @@ async def test_disambiguation(
 
     # Alice: cancel my timer
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_alice_study.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_alice_study.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -606,10 +599,7 @@ async def test_disambiguation(
 
     # Cancel Bob's timer
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_bob_kitchen_1.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_bob_kitchen_1.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -645,7 +635,8 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {"device_id": {"value": device_alice_study.id}, "minutes": {"value": 3}},
+        {"minutes": {"value": 3}},
+        device_id=device_alice_study.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -654,10 +645,8 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {
-            "device_id": {"value": device_alice_bedroom.id},
-            "minutes": {"value": 3},
-        },
+        {"minutes": {"value": 3}},
+        device_id=device_alice_bedroom.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -666,7 +655,8 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {"device_id": {"value": device_bob_kitchen_1.id}, "minutes": {"value": 3}},
+        {"minutes": {"value": 3}},
+        device_id=device_bob_kitchen_1.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -675,17 +665,15 @@ async def test_disambiguation(
         hass,
         "test",
         intent.INTENT_START_TIMER,
-        {"device_id": {"value": device_bob_living_room.id}, "minutes": {"value": 3}},
+        {"minutes": {"value": 3}},
+        device_id=device_bob_living_room.id,
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
     # Alice should hear the timer in her area first, then on her floor, then
     # elsewhere.
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_TIMER_STATUS,
-        {"device_id": {"value": device_alice_study.id}},
+        hass, "test", intent.INTENT_TIMER_STATUS, {}, device_id=device_alice_study.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
@@ -699,10 +687,7 @@ async def test_disambiguation(
     cancelled_event.clear()
     timer_info = None
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_alice_study.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_alice_study.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -727,10 +712,7 @@ async def test_disambiguation(
     cancelled_event.clear()
     timer_info = None
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_alice_study.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_alice_study.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -756,10 +738,7 @@ async def test_disambiguation(
     cancelled_event.clear()
     timer_info = None
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_bob_kitchen_2.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_bob_kitchen_2.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 
@@ -774,10 +753,7 @@ async def test_disambiguation(
     cancelled_event.clear()
     timer_info = None
     result = await intent.async_handle(
-        hass,
-        "test",
-        intent.INTENT_CANCEL_TIMER,
-        {"device_id": {"value": device_bob_kitchen_2.id}},
+        hass, "test", intent.INTENT_CANCEL_TIMER, {}, device_id=device_bob_kitchen_2.id
     )
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Intent handlers now receive `device_id`, so the "device_id" intent slot is no longer necessary.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
