### PR TITLE
Add data point type option to `knx.telegram` trigger

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -83,8 +83,6 @@ DATA_HASS_CONFIG: Final = "knx_hass_config"
 ATTR_COUNTER: Final = "counter"
 ATTR_SOURCE: Final = "source"
 
-# dispatcher signal for KNX interface device triggers
-SIGNAL_KNX_TELEGRAM_DICT: Final = "knx_telegram_dict"
 
 type AsyncMessageCallbackType = Callable[[Telegram], Awaitable[None]]
 type MessageCallbackType = Callable[[Telegram], None]

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -16,12 +16,16 @@ from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.storage import Store
 import homeassistant.util.dt as dt_util
+from homeassistant.util.signal_type import SignalType
 
-from .const import DOMAIN, SIGNAL_KNX_TELEGRAM_DICT
+from .const import DOMAIN
 from .project import KNXProject
 
 STORAGE_VERSION: Final = 1
 STORAGE_KEY: Final = f"{DOMAIN}/telegrams_history.json"
+
+# dispatcher signal for KNX interface device triggers
+SIGNAL_KNX_TELEGRAM: SignalType[Telegram, TelegramDict] = SignalType("knx_telegram")
 
 
 class DecodedTelegramPayload(TypedDict):
@@ -95,9 +99,7 @@ class Telegrams:
         """Handle incoming and outgoing telegrams from xknx."""
         telegram_dict = self.telegram_to_dict(telegram)
         self.recent_telegrams.append(telegram_dict)
-        async_dispatcher_send(
-            self.hass, SIGNAL_KNX_TELEGRAM_DICT, telegram, telegram_dict
-        )
+        async_dispatcher_send(self.hass, SIGNAL_KNX_TELEGRAM, telegram, telegram_dict)
         for job in self._jobs:
             self.hass.async_run_hass_job(job, telegram_dict)
 

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from typing import Final, TypedDict
 
 from xknx import XKNX
+from xknx.dpt import DPTArray, DPTBase, DPTBinary
 from xknx.exceptions import XKNXException
 from xknx.telegram import Telegram
 from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
@@ -23,23 +24,28 @@ STORAGE_VERSION: Final = 1
 STORAGE_KEY: Final = f"{DOMAIN}/telegrams_history.json"
 
 
-class TelegramDict(TypedDict):
+class DecodedTelegramPayload(TypedDict):
+    """Decoded payload value and metadata."""
+
+    dpt_main: int | None
+    dpt_sub: int | None
+    dpt_name: str | None
+    unit: str | None
+    value: str | int | float | bool | None
+
+
+class TelegramDict(DecodedTelegramPayload):
     """Represent a Telegram as a dict."""
 
     # this has to be in sync with the frontend implementation
     destination: str
     destination_name: str
     direction: str
-    dpt_main: int | None
-    dpt_sub: int | None
-    dpt_name: str | None
     payload: int | tuple[int, ...] | None
     source: str
     source_name: str
     telegramtype: str
     timestamp: str  # ISO format
-    unit: str | None
-    value: str | int | float | bool | None
 
 
 class Telegrams:
@@ -89,7 +95,9 @@ class Telegrams:
         """Handle incoming and outgoing telegrams from xknx."""
         telegram_dict = self.telegram_to_dict(telegram)
         self.recent_telegrams.append(telegram_dict)
-        async_dispatcher_send(self.hass, SIGNAL_KNX_TELEGRAM_DICT, telegram_dict)
+        async_dispatcher_send(
+            self.hass, SIGNAL_KNX_TELEGRAM_DICT, telegram, telegram_dict
+        )
         for job in self._jobs:
             self.hass.async_run_hass_job(job, telegram_dict)
 
@@ -112,14 +120,10 @@ class Telegrams:
     def telegram_to_dict(self, telegram: Telegram) -> TelegramDict:
         """Convert a Telegram to a dict."""
         dst_name = ""
-        dpt_main = None
-        dpt_sub = None
-        dpt_name = None
         payload_data: int | tuple[int, ...] | None = None
         src_name = ""
         transcoder = None
-        unit = None
-        value: str | int | float | bool | None = None
+        decoded_payload: DecodedTelegramPayload | None = None
 
         if (
             ga_info := self.project.group_addresses.get(
@@ -137,27 +141,44 @@ class Telegrams:
         if isinstance(telegram.payload, (GroupValueWrite, GroupValueResponse)):
             payload_data = telegram.payload.value.value
             if transcoder is not None:
-                try:
-                    value = transcoder.from_knx(telegram.payload.value)
-                    dpt_main = transcoder.dpt_main_number
-                    dpt_sub = transcoder.dpt_sub_number
-                    dpt_name = transcoder.value_type
-                    unit = transcoder.unit
-                except XKNXException:
-                    value = "Error decoding value"
+                decoded_payload = decode_telegram_payload(
+                    payload=telegram.payload.value, transcoder=transcoder
+                )
 
         return TelegramDict(
             destination=f"{telegram.destination_address}",
             destination_name=dst_name,
             direction=telegram.direction.value,
-            dpt_main=dpt_main,
-            dpt_sub=dpt_sub,
-            dpt_name=dpt_name,
+            dpt_main=decoded_payload["dpt_main"]
+            if decoded_payload is not None
+            else None,
+            dpt_sub=decoded_payload["dpt_sub"] if decoded_payload is not None else None,
+            dpt_name=decoded_payload["dpt_name"]
+            if decoded_payload is not None
+            else None,
             payload=payload_data,
             source=f"{telegram.source_address}",
             source_name=src_name,
             telegramtype=telegram.payload.__class__.__name__,
             timestamp=dt_util.now().isoformat(),
-            unit=unit,
-            value=value,
+            unit=decoded_payload["unit"] if decoded_payload is not None else None,
+            value=decoded_payload["value"] if decoded_payload is not None else None,
         )
+
+
+def decode_telegram_payload(
+    payload: DPTArray | DPTBinary, transcoder: type[DPTBase]
+) -> DecodedTelegramPayload:
+    """Decode the payload of a KNX telegram."""
+    try:
+        value = transcoder.from_knx(payload)
+    except XKNXException:
+        value = "Error decoding value"
+
+    return DecodedTelegramPayload(
+        dpt_main=transcoder.dpt_main_number,
+        dpt_sub=transcoder.dpt_sub_number,
+        dpt_name=transcoder.value_type,
+        unit=transcoder.unit,
+        value=value,
+    )

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -3,7 +3,10 @@
 from typing import Final
 
 import voluptuous as vol
+from xknx.dpt import DPTBase
+from xknx.telegram import Telegram, TelegramDirection
 from xknx.telegram.address import DeviceGroupAddress, parse_device_group_address
+from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
@@ -14,13 +17,15 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, SIGNAL_KNX_TELEGRAM_DICT
 from .schema import ga_validator
-from .telegrams import TelegramDict
+from .telegrams import TelegramDict, decode_telegram_payload
+from .validation import sensor_type_validator
 
 TRIGGER_TELEGRAM: Final = "telegram"
 
 PLATFORM_TYPE_TRIGGER_TELEGRAM: Final = f"{DOMAIN}.{TRIGGER_TELEGRAM}"
 
 CONF_KNX_DESTINATION: Final = "destination"
+CONF_KNX_DPT: Final = "dpt"
 CONF_KNX_GROUP_VALUE_WRITE: Final = "group_value_write"
 CONF_KNX_GROUP_VALUE_READ: Final = "group_value_read"
 CONF_KNX_GROUP_VALUE_RESPONSE: Final = "group_value_response"
@@ -39,6 +44,7 @@ TELEGRAM_TRIGGER_SCHEMA: Final = {
         cv.ensure_list,
         [ga_validator],
     ),
+    vol.Optional(CONF_KNX_DPT, default=None): vol.Any(sensor_type_validator, None),
     **TELEGRAM_TRIGGER_OPTIONS,
 }
 
@@ -61,38 +67,50 @@ async def async_attach_trigger(
     dst_addresses: list[DeviceGroupAddress] = [
         parse_device_group_address(address) for address in _addresses
     ]
+    _transcoder = config.get(CONF_KNX_DPT)
+    trigger_transcoder = DPTBase.parse_transcoder(_transcoder) if _transcoder else None
+
     job = HassJob(action, f"KNX trigger {trigger_info}")
     trigger_data = trigger_info["trigger_data"]
 
     @callback
-    def async_call_trigger_action(telegram: TelegramDict) -> None:
+    def async_call_trigger_action(
+        telegram: Telegram, telegram_dict: TelegramDict
+    ) -> None:
         """Filter Telegram and call trigger action."""
-        if telegram["telegramtype"] == "GroupValueWrite":
+        telegram_type = telegram.payload.__class__
+        if telegram_type is GroupValueWrite:
             if config[CONF_KNX_GROUP_VALUE_WRITE] is False:
                 return
-        elif telegram["telegramtype"] == "GroupValueResponse":
+        elif telegram_type is GroupValueResponse:
             if config[CONF_KNX_GROUP_VALUE_RESPONSE] is False:
                 return
-        elif telegram["telegramtype"] == "GroupValueRead":
+        elif telegram_type is GroupValueRead:
             if config[CONF_KNX_GROUP_VALUE_READ] is False:
                 return
 
-        if telegram["direction"] == "Incoming":
+        if telegram.direction is TelegramDirection.INCOMING:
             if config[CONF_KNX_INCOMING] is False:
                 return
         elif config[CONF_KNX_OUTGOING] is False:
             return
 
-        if (
-            dst_addresses
-            and parse_device_group_address(telegram["destination"]) not in dst_addresses
-        ):
+        if dst_addresses and telegram.destination_address not in dst_addresses:
             return
 
-        hass.async_run_hass_job(
-            job,
-            {"trigger": {**trigger_data, **telegram}},
-        )
+        if trigger_transcoder is not None and (
+            telegram_type in (GroupValueWrite, GroupValueResponse)
+        ):
+            decoded_payload = decode_telegram_payload(
+                payload=telegram.payload.value,  # type: ignore[union-attr]  # checked via telegram_type
+                transcoder=trigger_transcoder,  # type: ignore[type-abstract]  # parse_transcoder don't return abstract classes
+            )
+            # overwrite decoded payload values in telegram_dict
+            telegram_trigger_data = {**trigger_data, **telegram_dict, **decoded_payload}
+        else:
+            telegram_trigger_data = {**trigger_data, **telegram_dict}
+
+        hass.async_run_hass_job(job, {"trigger": telegram_trigger_data})
 
     return async_dispatcher_connect(
         hass,

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -25,7 +25,7 @@ TRIGGER_TELEGRAM: Final = "telegram"
 PLATFORM_TYPE_TRIGGER_TELEGRAM: Final = f"{DOMAIN}.{TRIGGER_TELEGRAM}"
 
 CONF_KNX_DESTINATION: Final = "destination"
-CONF_KNX_DPT: Final = "dpt"
+CONF_KNX_TYPE: Final = "type"
 CONF_KNX_GROUP_VALUE_WRITE: Final = "group_value_write"
 CONF_KNX_GROUP_VALUE_READ: Final = "group_value_read"
 CONF_KNX_GROUP_VALUE_RESPONSE: Final = "group_value_response"
@@ -44,7 +44,7 @@ TELEGRAM_TRIGGER_SCHEMA: Final = {
         cv.ensure_list,
         [ga_validator],
     ),
-    vol.Optional(CONF_KNX_DPT, default=None): vol.Any(sensor_type_validator, None),
+    vol.Optional(CONF_KNX_TYPE, default=None): vol.Any(sensor_type_validator, None),
     **TELEGRAM_TRIGGER_OPTIONS,
 }
 
@@ -67,7 +67,7 @@ async def async_attach_trigger(
     dst_addresses: list[DeviceGroupAddress] = [
         parse_device_group_address(address) for address in _addresses
     ]
-    _transcoder = config.get(CONF_KNX_DPT)
+    _transcoder = config.get(CONF_KNX_TYPE)
     trigger_transcoder = DPTBase.parse_transcoder(_transcoder) if _transcoder else None
 
     job = HassJob(action, f"KNX trigger {trigger_info}")

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -77,14 +77,14 @@ async def async_attach_trigger(
         telegram: Telegram, telegram_dict: TelegramDict
     ) -> None:
         """Filter Telegram and call trigger action."""
-        telegram_type = telegram.payload.__class__
-        if telegram_type is GroupValueWrite:
+        payload_apci = type(telegram.payload)
+        if payload_apci is GroupValueWrite:
             if config[CONF_KNX_GROUP_VALUE_WRITE] is False:
                 return
-        elif telegram_type is GroupValueResponse:
+        elif payload_apci is GroupValueResponse:
             if config[CONF_KNX_GROUP_VALUE_RESPONSE] is False:
                 return
-        elif telegram_type is GroupValueRead:
+        elif payload_apci is GroupValueRead:
             if config[CONF_KNX_GROUP_VALUE_READ] is False:
                 return
 
@@ -98,10 +98,10 @@ async def async_attach_trigger(
             return
 
         if trigger_transcoder is not None and (
-            telegram_type in (GroupValueWrite, GroupValueResponse)
+            payload_apci in (GroupValueWrite, GroupValueResponse)
         ):
             decoded_payload = decode_telegram_payload(
-                payload=telegram.payload.value,  # type: ignore[union-attr]  # checked via telegram_type
+                payload=telegram.payload.value,  # type: ignore[union-attr]  # checked via payload_apci
                 transcoder=trigger_transcoder,  # type: ignore[type-abstract]  # parse_transcoder don't return abstract classes
             )
             # overwrite decoded payload values in telegram_dict

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -15,9 +15,9 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, SIGNAL_KNX_TELEGRAM_DICT
+from .const import DOMAIN
 from .schema import ga_validator
-from .telegrams import TelegramDict, decode_telegram_payload
+from .telegrams import SIGNAL_KNX_TELEGRAM, TelegramDict, decode_telegram_payload
 from .validation import sensor_type_validator
 
 TRIGGER_TELEGRAM: Final = "telegram"
@@ -113,6 +113,6 @@ async def async_attach_trigger(
 
     return async_dispatcher_connect(
         hass,
-        signal=SIGNAL_KNX_TELEGRAM_DICT,
+        signal=SIGNAL_KNX_TELEGRAM,
         target=async_call_trigger_action,
     )

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -8,7 +8,7 @@ from xknx.telegram import Telegram, TelegramDirection
 from xknx.telegram.address import DeviceGroupAddress, parse_device_group_address
 from xknx.telegram.apci import GroupValueRead, GroupValueResponse, GroupValueWrite
 
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import CONF_PLATFORM, CONF_TYPE
 from homeassistant.core import CALLBACK_TYPE, HassJob, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -25,7 +25,6 @@ TRIGGER_TELEGRAM: Final = "telegram"
 PLATFORM_TYPE_TRIGGER_TELEGRAM: Final = f"{DOMAIN}.{TRIGGER_TELEGRAM}"
 
 CONF_KNX_DESTINATION: Final = "destination"
-CONF_KNX_TYPE: Final = "type"
 CONF_KNX_GROUP_VALUE_WRITE: Final = "group_value_write"
 CONF_KNX_GROUP_VALUE_READ: Final = "group_value_read"
 CONF_KNX_GROUP_VALUE_RESPONSE: Final = "group_value_response"
@@ -44,13 +43,13 @@ TELEGRAM_TRIGGER_SCHEMA: Final = {
         cv.ensure_list,
         [ga_validator],
     ),
-    vol.Optional(CONF_KNX_TYPE, default=None): vol.Any(sensor_type_validator, None),
     **TELEGRAM_TRIGGER_OPTIONS,
 }
-
+# TRIGGER_SCHEMA is exclusive to triggers, the above are used in device triggers too
 TRIGGER_SCHEMA = cv.TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_PLATFORM): PLATFORM_TYPE_TRIGGER_TELEGRAM,
+        vol.Optional(CONF_TYPE, default=None): vol.Any(sensor_type_validator, None),
         **TELEGRAM_TRIGGER_SCHEMA,
     }
 )
@@ -67,7 +66,7 @@ async def async_attach_trigger(
     dst_addresses: list[DeviceGroupAddress] = [
         parse_device_group_address(address) for address in _addresses
     ]
-    _transcoder = config.get(CONF_KNX_TYPE)
+    _transcoder = config.get(CONF_TYPE)
     trigger_transcoder = DPTBase.parse_transcoder(_transcoder) if _transcoder else None
 
     job = HassJob(action, f"KNX trigger {trigger_info}")

--- a/homeassistant/components/knx/trigger.py
+++ b/homeassistant/components/knx/trigger.py
@@ -97,8 +97,10 @@ async def async_attach_trigger(
         if dst_addresses and telegram.destination_address not in dst_addresses:
             return
 
-        if trigger_transcoder is not None and (
-            payload_apci in (GroupValueWrite, GroupValueResponse)
+        if (
+            trigger_transcoder is not None
+            and payload_apci in (GroupValueWrite, GroupValueResponse)
+            and trigger_transcoder.value_type != telegram_dict["dpt_name"]
         ):
             decoded_payload = decode_telegram_payload(
                 payload=telegram.payload.value,  # type: ignore[union-attr]  # checked via payload_apci

--- a/tests/components/knx/test_trigger.py
+++ b/tests/components/knx/test_trigger.py
@@ -96,11 +96,11 @@ async def test_telegram_trigger(
 
 
 @pytest.mark.parametrize(
-    ("payload", "dpt_option", "expected_value", "expected_unit"),
+    ("payload", "type_option", "expected_value", "expected_unit"),
     [
-        ((0x4C,), {"dpt": "percent"}, 30, "%"),
+        ((0x4C,), {"type": "percent"}, 30, "%"),
         ((0x03,), {}, None, None),  # "dpt" omitted defaults to None
-        ((0x0C, 0x1A), {"dpt": "temperature"}, 21.00, "°C"),
+        ((0x0C, 0x1A), {"type": "temperature"}, 21.00, "°C"),
     ],
 )
 async def test_telegram_trigger_dpt_option(
@@ -108,11 +108,11 @@ async def test_telegram_trigger_dpt_option(
     calls: list[ServiceCall],
     knx: KNXTestKit,
     payload: tuple[int, ...],
-    dpt_option: dict[str, bool],
+    type_option: dict[str, bool],
     expected_value: int | None,
     expected_unit: str | None,
 ) -> None:
-    """Test telegram trigger dpt option."""
+    """Test telegram trigger type option."""
     await knx.setup_integration({})
     assert await async_setup_component(
         hass,
@@ -123,7 +123,7 @@ async def test_telegram_trigger_dpt_option(
                 {
                     "trigger": {
                         "platform": "knx.telegram",
-                        **dpt_option,
+                        **type_option,
                     },
                     "action": {
                         "service": "test.automation",

--- a/tests/components/knx/test_trigger.py
+++ b/tests/components/knx/test_trigger.py
@@ -144,6 +144,14 @@ async def test_telegram_trigger_dpt_option(
     assert test_call.data["trigger"]["value"] == expected_value
     assert test_call.data["trigger"]["unit"] == expected_unit
 
+    await knx.receive_read("0/0/1")
+
+    assert len(calls) == 1
+    test_call = calls.pop()
+    assert test_call.data["catch_all"] == "telegram - 0/0/1"
+    assert test_call.data["trigger"]["value"] is None
+    assert test_call.data["trigger"]["unit"] is None
+
 
 @pytest.mark.parametrize(
     "group_value_options",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add data point type option to `knx.telegram` trigger so the trigger can decode data even if no project file data exists. 

This is also useful for blueprint creators - who can't know if the blueprint users have their project files parsed.

The `type` key accepts value type strings or numeric KNX-DPT-identifiers just like `knx.send` service or the sensor entity configuration do. If omitted (or `None`) and project file data is available, this data will be used to determine the type.

The new interface for the trigger is
```yaml
trigger:
  - platform: knx.telegram
    destination:  # list of group addresses (optional - if omitted every telegram would fire the trigger)
      - "1/2/3"
    type: percent  # (optional - default: None)  <-- this is new
    group_value_write: true  # (optional - default: true)
    group_value_response: true  # (optional - default: true)
    group_value_read: true  # (optional - default: true)
    incoming: true  # (optional - default: true)
    outgoing: true  # (optional - default: true)
```

The change also makes it possible to use identity checks instead of dict-lookup-string-comparisons and we don't need to reparse the destination address for all telegrams.
Also `SignalType` is now used to have type safe dispatcher calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/107592
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32782

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
