### PR TITLE
Split homeassistant_alerts constants and coordinator

### DIFF
--- a/homeassistant/components/homeassistant_alerts/const.py
+++ b/homeassistant/components/homeassistant_alerts/const.py
@@ -1,7 +1,5 @@
 """Constants for the Home Assistant alerts integration."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 
 import aiohttp

--- a/homeassistant/components/homeassistant_alerts/const.py
+++ b/homeassistant/components/homeassistant_alerts/const.py
@@ -1,0 +1,13 @@
+"""Constants for the Home Assistant alerts integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import aiohttp
+
+COMPONENT_LOADED_COOLDOWN = 30
+DOMAIN = "homeassistant_alerts"
+UPDATE_INTERVAL = timedelta(hours=3)
+
+REQUEST_TIMEOUT = aiohttp.ClientTimeout(total=30)

--- a/homeassistant/components/homeassistant_alerts/coordinator.py
+++ b/homeassistant/components/homeassistant_alerts/coordinator.py
@@ -1,7 +1,5 @@
 """Coordinator for the Home Assistant alerts integration."""
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 

--- a/homeassistant/components/homeassistant_alerts/coordinator.py
+++ b/homeassistant/components/homeassistant_alerts/coordinator.py
@@ -1,0 +1,113 @@
+"""Coordinator for the Home Assistant alerts integration."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+from awesomeversion import AwesomeVersion, AwesomeVersionStrategy
+
+from homeassistant.components.hassio import get_supervisor_info, is_hassio
+from homeassistant.const import __version__
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN, REQUEST_TIMEOUT, UPDATE_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class IntegrationAlert:
+    """Issue Registry Entry."""
+
+    alert_id: str
+    integration: str
+    filename: str
+    date_updated: str | None
+
+    @property
+    def issue_id(self) -> str:
+        """Return the issue id."""
+        return f"{self.filename}_{self.integration}"
+
+
+class AlertUpdateCoordinator(DataUpdateCoordinator[dict[str, IntegrationAlert]]):
+    """Data fetcher for HA Alerts."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the data updater."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=UPDATE_INTERVAL,
+        )
+        self.ha_version = AwesomeVersion(
+            __version__,
+            ensure_strategy=AwesomeVersionStrategy.CALVER,
+        )
+        self.supervisor = is_hassio(self.hass)
+
+    async def _async_update_data(self) -> dict[str, IntegrationAlert]:
+        response = await async_get_clientsession(self.hass).get(
+            "https://alerts.home-assistant.io/alerts.json",
+            timeout=REQUEST_TIMEOUT,
+        )
+        alerts = await response.json()
+
+        result = {}
+
+        for alert in alerts:
+            if "integrations" not in alert:
+                continue
+
+            if "homeassistant" in alert:
+                if "affected_from_version" in alert["homeassistant"]:
+                    affected_from_version = AwesomeVersion(
+                        alert["homeassistant"]["affected_from_version"],
+                    )
+                    if self.ha_version < affected_from_version:
+                        continue
+                if "resolved_in_version" in alert["homeassistant"]:
+                    resolved_in_version = AwesomeVersion(
+                        alert["homeassistant"]["resolved_in_version"],
+                    )
+                    if self.ha_version >= resolved_in_version:
+                        continue
+
+            if self.supervisor and "supervisor" in alert:
+                if (supervisor_info := get_supervisor_info(self.hass)) is None:
+                    continue
+
+                if "affected_from_version" in alert["supervisor"]:
+                    affected_from_version = AwesomeVersion(
+                        alert["supervisor"]["affected_from_version"],
+                    )
+                    if supervisor_info["version"] < affected_from_version:
+                        continue
+                if "resolved_in_version" in alert["supervisor"]:
+                    resolved_in_version = AwesomeVersion(
+                        alert["supervisor"]["resolved_in_version"],
+                    )
+                    if supervisor_info["version"] >= resolved_in_version:
+                        continue
+
+            for integration in alert["integrations"]:
+                if "package" not in integration:
+                    continue
+
+                if integration["package"] not in self.hass.config.components:
+                    continue
+
+                integration_alert = IntegrationAlert(
+                    alert_id=alert["id"],
+                    integration=integration["package"],
+                    filename=alert["filename"],
+                    date_updated=alert.get("updated"),
+                )
+
+                result[integration_alert.issue_id] = integration_alert
+
+        return result

--- a/tests/components/homeassistant_alerts/test_init.py
+++ b/tests/components/homeassistant_alerts/test_init.py
@@ -10,7 +10,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 from pytest_unordered import unordered
 
-from homeassistant.components.homeassistant_alerts import (
+from homeassistant.components.homeassistant_alerts.const import (
     COMPONENT_LOADED_COOLDOWN,
     DOMAIN,
     UPDATE_INTERVAL,
@@ -134,15 +134,15 @@ async def test_alerts(
 
     with (
         patch(
-            "homeassistant.components.homeassistant_alerts.__version__",
+            "homeassistant.components.homeassistant_alerts.coordinator.__version__",
             ha_version,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.is_hassio",
+            "homeassistant.components.homeassistant_alerts.coordinator.is_hassio",
             return_value=supervisor_info is not None,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.get_supervisor_info",
+            "homeassistant.components.homeassistant_alerts.coordinator.get_supervisor_info",
             return_value=supervisor_info,
         ),
     ):
@@ -317,15 +317,15 @@ async def test_alerts_refreshed_on_component_load(
 
     with (
         patch(
-            "homeassistant.components.homeassistant_alerts.__version__",
+            "homeassistant.components.homeassistant_alerts.coordinator.__version__",
             ha_version,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.is_hassio",
+            "homeassistant.components.homeassistant_alerts.coordinator.is_hassio",
             return_value=supervisor_info is not None,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.get_supervisor_info",
+            "homeassistant.components.homeassistant_alerts.coordinator.get_supervisor_info",
             return_value=supervisor_info,
         ),
     ):
@@ -361,15 +361,15 @@ async def test_alerts_refreshed_on_component_load(
 
     with (
         patch(
-            "homeassistant.components.homeassistant_alerts.__version__",
+            "homeassistant.components.homeassistant_alerts.coordinator.__version__",
             ha_version,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.is_hassio",
+            "homeassistant.components.homeassistant_alerts.coordinator.is_hassio",
             return_value=supervisor_info is not None,
         ),
         patch(
-            "homeassistant.components.homeassistant_alerts.get_supervisor_info",
+            "homeassistant.components.homeassistant_alerts.coordinator.get_supervisor_info",
             return_value=supervisor_info,
         ),
     ):
@@ -456,7 +456,7 @@ async def test_bad_alerts(
         hass.config.components.add(domain)
 
     with patch(
-        "homeassistant.components.homeassistant_alerts.__version__",
+        "homeassistant.components.homeassistant_alerts.coordinator.__version__",
         ha_version,
     ):
         assert await async_setup_component(hass, DOMAIN, {})
@@ -615,7 +615,7 @@ async def test_alerts_change(
         hass.config.components.add(domain)
 
     with patch(
-        "homeassistant.components.homeassistant_alerts.__version__",
+        "homeassistant.components.homeassistant_alerts.coordinator.__version__",
         ha_version,
     ):
         assert await async_setup_component(hass, DOMAIN, {})


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
