### PR TITLE
Revert "Bump opower to 0.4.5 and use new account.id"

### DIFF
--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -86,7 +86,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
         # Because Opower provides historical usage/cost with a delay of a couple of days
         # we need to insert data into statistics.
         await self._insert_statistics()
-        return {forecast.account.id: forecast for forecast in forecasts}
+        return {forecast.account.utility_account_id: forecast for forecast in forecasts}
 
     async def _insert_statistics(self) -> None:
         """Insert Opower statistics."""
@@ -97,7 +97,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
                     account.meter_type.name.lower(),
                     # Some utilities like AEP have "-" in their account id.
                     # Replace it with "_" to avoid "Invalid statistic_id"
-                    account.id.replace("-", "_"),
+                    account.utility_account_id.replace("-", "_"),
                 )
             )
             cost_statistic_id = f"{DOMAIN}:{id_prefix}_energy_cost"
@@ -161,7 +161,7 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, Forecast]]):
 
             name_prefix = (
                 f"Opower {self.api.utility.subdomain()} "
-                f"{account.meter_type.name.lower()} {account.id}"
+                f"{account.meter_type.name.lower()} {account.utility_account_id}"
             )
             cost_metadata = StatisticMetaData(
                 has_mean=False,

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/opower",
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
-  "requirements": ["opower==0.4.5"]
+  "requirements": ["opower==0.4.4"]
 }

--- a/homeassistant/components/opower/sensor.py
+++ b/homeassistant/components/opower/sensor.py
@@ -159,10 +159,10 @@ async def async_setup_entry(
     entities: list[OpowerSensor] = []
     forecasts = coordinator.data.values()
     for forecast in forecasts:
-        device_id = f"{coordinator.api.utility.subdomain()}_{forecast.account.id}"
+        device_id = f"{coordinator.api.utility.subdomain()}_{forecast.account.utility_account_id}"
         device = DeviceInfo(
             identifiers={(DOMAIN, device_id)},
-            name=f"{forecast.account.meter_type.name} account {forecast.account.id}",
+            name=f"{forecast.account.meter_type.name} account {forecast.account.utility_account_id}",
             manufacturer="Opower",
             model=coordinator.api.utility.name(),
             entry_type=DeviceEntryType.SERVICE,
@@ -182,7 +182,7 @@ async def async_setup_entry(
             OpowerSensor(
                 coordinator,
                 sensor,
-                forecast.account.id,
+                forecast.account.utility_account_id,
                 device,
                 device_id,
             )
@@ -201,7 +201,7 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self,
         coordinator: OpowerCoordinator,
         description: OpowerEntityDescription,
-        id: str,
+        utility_account_id: str,
         device: DeviceInfo,
         device_id: str,
     ) -> None:
@@ -210,11 +210,13 @@ class OpowerSensor(CoordinatorEntity[OpowerCoordinator], SensorEntity):
         self.entity_description = description
         self._attr_unique_id = f"{device_id}_{description.key}"
         self._attr_device_info = device
-        self.id = id
+        self.utility_account_id = utility_account_id
 
     @property
     def native_value(self) -> StateType:
         """Return the state."""
         if self.coordinator.data is not None:
-            return self.entity_description.value_fn(self.coordinator.data[self.id])
+            return self.entity_description.value_fn(
+                self.coordinator.data[self.utility_account_id]
+            )
         return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1495,7 +1495,7 @@ openwrt-luci-rpc==1.1.17
 openwrt-ubus-rpc==0.0.2
 
 # homeassistant.components.opower
-opower==0.4.5
+opower==0.4.4
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1195,7 +1195,7 @@ openhomedevice==2.2.0
 openwebifpy==4.2.4
 
 # homeassistant.components.opower
-opower==0.4.5
+opower==0.4.4
 
 # homeassistant.components.oralb
 oralb-ble==0.17.6


### PR DESCRIPTION
Reverts home-assistant/core#117330

This reverts the above PR which bumped the opower library version from 0.4.4 to 0.4.5 (https://github.com/tronikos/opower/releases/tag/v0.4.5). Its intention was a bugfix to allow for cases where there are multiple meters on a single account.

However, I did miss something in this review (as pointed out to me by @emontnemery in Discord); the result of this PR / change is that an entity's unique ID is no longer stable. So if meters are added to an account (or removed), the unique ID may change (and thus entities become orphaned).

This was also commented on the PR here: <https://github.com/home-assistant/core/pull/117330#issuecomment-2109859772>

Not sure why, but I completely missed that comment and agree with it. Therefore, I'm reverting this PR.

/CC @tronikos @c0mputerguru

