### PR TITLE
Move prusalink coordinators to separate module

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -2,15 +2,8 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-import asyncio
-from datetime import timedelta
-import logging
-from time import monotonic
-from typing import TypeVar
-
-from pyprusalink import JobInfo, LegacyPrinterStatus, PrinterStatus, PrusaLink
-from pyprusalink.types import InvalidAuth, PrusaLinkError
+from pyprusalink import PrusaLink
+from pyprusalink.types import InvalidAuth
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -20,22 +13,23 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .config_flow import ConfigFlow
 from .const import DOMAIN
+from .coordinator import (
+    JobUpdateCoordinator,
+    LegacyStatusCoordinator,
+    PrusaLinkUpdateCoordinator,
+    StatusCoordinator,
+)
 
 PLATFORMS: list[Platform] = [Platform.BUTTON, Platform.CAMERA, Platform.SENSOR]
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -127,78 +121,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
-
-
-class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):  # pylint: disable=hass-enforce-coordinator-module
-    """Update coordinator for the printer."""
-
-    config_entry: ConfigEntry
-    expect_change_until = 0.0
-
-    def __init__(self, hass: HomeAssistant, api: PrusaLink) -> None:
-        """Initialize the update coordinator."""
-        self.api = api
-
-        super().__init__(
-            hass, _LOGGER, name=DOMAIN, update_interval=self._get_update_interval(None)
-        )
-
-    async def _async_update_data(self) -> T:
-        """Update the data."""
-        try:
-            async with asyncio.timeout(5):
-                data = await self._fetch_data()
-        except InvalidAuth:
-            raise UpdateFailed("Invalid authentication") from None
-        except PrusaLinkError as err:
-            raise UpdateFailed(str(err)) from err
-
-        self.update_interval = self._get_update_interval(data)
-        return data
-
-    @abstractmethod
-    async def _fetch_data(self) -> T:
-        """Fetch the actual data."""
-        raise NotImplementedError
-
-    @callback
-    def expect_change(self) -> None:
-        """Expect a change."""
-        self.expect_change_until = monotonic() + 30
-
-    def _get_update_interval(self, data: T) -> timedelta:
-        """Get new update interval."""
-        if self.expect_change_until > monotonic():
-            return timedelta(seconds=5)
-
-        return timedelta(seconds=30)
-
-
-class StatusCoordinator(PrusaLinkUpdateCoordinator[PrinterStatus]):  # pylint: disable=hass-enforce-coordinator-module
-    """Printer update coordinator."""
-
-    async def _fetch_data(self) -> PrinterStatus:
-        """Fetch the printer data."""
-        return await self.api.get_status()
-
-
-class LegacyStatusCoordinator(PrusaLinkUpdateCoordinator[LegacyPrinterStatus]):  # pylint: disable=hass-enforce-coordinator-module
-    """Printer legacy update coordinator."""
-
-    async def _fetch_data(self) -> LegacyPrinterStatus:
-        """Fetch the printer data."""
-        return await self.api.get_legacy_printer()
-
-
-class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo]):  # pylint: disable=hass-enforce-coordinator-module
-    """Job update coordinator."""
-
-    async def _fetch_data(self) -> JobInfo:
-        """Fetch the printer data."""
-        return await self.api.get_job()
 
 
 class PrusaLinkEntity(CoordinatorEntity[PrusaLinkUpdateCoordinator]):

--- a/homeassistant/components/prusalink/button.py
+++ b/homeassistant/components/prusalink/button.py
@@ -15,7 +15,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, PrusaLinkEntity, PrusaLinkUpdateCoordinator
+from . import PrusaLinkEntity
+from .const import DOMAIN
+from .coordinator import PrusaLinkUpdateCoordinator
 
 T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
 

--- a/homeassistant/components/prusalink/camera.py
+++ b/homeassistant/components/prusalink/camera.py
@@ -9,7 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import DOMAIN, JobUpdateCoordinator, PrusaLinkEntity
+from . import PrusaLinkEntity
+from .const import DOMAIN
+from .coordinator import JobUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -1,0 +1,93 @@
+"""Coordinators for the PrusaLink integration."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+import asyncio
+from datetime import timedelta
+import logging
+from time import monotonic
+from typing import TypeVar
+
+from pyprusalink import JobInfo, LegacyPrinterStatus, PrinterStatus, PrusaLink
+from pyprusalink.types import InvalidAuth, PrusaLinkError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
+
+
+class PrusaLinkUpdateCoordinator(DataUpdateCoordinator[T], ABC):
+    """Update coordinator for the printer."""
+
+    config_entry: ConfigEntry
+    expect_change_until = 0.0
+
+    def __init__(self, hass: HomeAssistant, api: PrusaLink) -> None:
+        """Initialize the update coordinator."""
+        self.api = api
+
+        super().__init__(
+            hass, _LOGGER, name=DOMAIN, update_interval=self._get_update_interval(None)
+        )
+
+    async def _async_update_data(self) -> T:
+        """Update the data."""
+        try:
+            async with asyncio.timeout(5):
+                data = await self._fetch_data()
+        except InvalidAuth:
+            raise UpdateFailed("Invalid authentication") from None
+        except PrusaLinkError as err:
+            raise UpdateFailed(str(err)) from err
+
+        self.update_interval = self._get_update_interval(data)
+        return data
+
+    @abstractmethod
+    async def _fetch_data(self) -> T:
+        """Fetch the actual data."""
+        raise NotImplementedError
+
+    @callback
+    def expect_change(self) -> None:
+        """Expect a change."""
+        self.expect_change_until = monotonic() + 30
+
+    def _get_update_interval(self, data: T) -> timedelta:
+        """Get new update interval."""
+        if self.expect_change_until > monotonic():
+            return timedelta(seconds=5)
+
+        return timedelta(seconds=30)
+
+
+class StatusCoordinator(PrusaLinkUpdateCoordinator[PrinterStatus]):
+    """Printer update coordinator."""
+
+    async def _fetch_data(self) -> PrinterStatus:
+        """Fetch the printer data."""
+        return await self.api.get_status()
+
+
+class LegacyStatusCoordinator(PrusaLinkUpdateCoordinator[LegacyPrinterStatus]):
+    """Printer legacy update coordinator."""
+
+    async def _fetch_data(self) -> LegacyPrinterStatus:
+        """Fetch the printer data."""
+        return await self.api.get_legacy_printer()
+
+
+class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo]):
+    """Job update coordinator."""
+
+    async def _fetch_data(self) -> JobInfo:
+        """Fetch the printer data."""
+        return await self.api.get_job()

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -29,7 +29,9 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import utcnow
 from homeassistant.util.variance import ignore_variance
 
-from . import DOMAIN, PrusaLinkEntity, PrusaLinkUpdateCoordinator
+from . import PrusaLinkEntity
+from .const import DOMAIN
+from .coordinator import PrusaLinkUpdateCoordinator
 
 T = TypeVar("T", PrinterStatus, LegacyPrinterStatus, JobInfo)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
