### PR TITLE
Don't prioritize "name" slot if it's a wildcard in default conversation agent

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -418,7 +418,9 @@ class DefaultAgent(ConversationEntity):
         language: str,
     ) -> RecognizeResult | None:
         """Search intents for a match to user input."""
-        maybe_result: RecognizeResult | None = None
+        name_result: RecognizeResult | None = None
+        best_results: list[RecognizeResult] = []
+        best_text_chunks_matched: int | None = None
         for result in recognize_all(
             user_input.text,
             lang_intents.intents,
@@ -426,18 +428,33 @@ class DefaultAgent(ConversationEntity):
             intent_context=intent_context,
             language=language,
         ):
-            if "name" in result.entities:
-                return result
+            if ("name" in result.entities) and (
+                not result.entities["name"].is_wildcard
+            ):
+                name_result = result
 
-            # Keep looking in case an entity has the same name
-            maybe_result = result
+            if (best_text_chunks_matched is None) or (
+                result.text_chunks_matched > best_text_chunks_matched
+            ):
+                # Only overwrite if more literal text was matched.
+                # This causes wildcards to match last.
+                best_results = [result]
+                best_text_chunks_matched = result.text_chunks_matched
+            elif result.text_chunks_matched == best_text_chunks_matched:
+                # Accumulate results with the same number of literal text matched.
+                # We will resolve the ambiguity below.
+                best_results.append(result)
 
-        if maybe_result is not None:
+        if name_result is not None:
+            # Prioritize matches with entity names above area names
+            return name_result
+
+        if best_results:
             # Successful strict match
-            return maybe_result
+            return best_results[0]
 
         # Try again with missing entities enabled
-        best_num_unmatched_entities = 0
+        maybe_result: RecognizeResult | None = None
         for result in recognize_all(
             user_input.text,
             lang_intents.intents,

--- a/homeassistant/components/conversation/http.py
+++ b/homeassistant/components/conversation/http.py
@@ -311,9 +311,9 @@ def _get_debug_targets(
 
 def _get_unmatched_slots(
     result: RecognizeResult,
-) -> dict[str, str | int]:
+) -> dict[str, str | int | float]:
     """Return a dict of unmatched text/range slot entities."""
-    unmatched_slots: dict[str, str | int] = {}
+    unmatched_slots: dict[str, str | int | float] = {}
     for entity in result.unmatched_entities_list:
         if isinstance(entity, UnmatchedTextEntity):
             if entity.text == MISSING_ENTITY:

--- a/homeassistant/components/conversation/manifest.json
+++ b/homeassistant/components/conversation/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/conversation",
   "integration_type": "system",
   "quality_scale": "internal",
-  "requirements": ["hassil==1.6.1", "home-assistant-intents==2024.4.24"]
+  "requirements": ["hassil==1.7.1", "home-assistant-intents==2024.4.24"]
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -30,7 +30,7 @@ ha-av==10.1.1
 ha-ffmpeg==3.2.0
 habluetooth==3.0.1
 hass-nabucasa==0.78.0
-hassil==1.6.1
+hassil==1.7.1
 home-assistant-bluetooth==1.12.0
 home-assistant-frontend==20240501.1
 home-assistant-intents==2024.4.24

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1047,7 +1047,7 @@ hass-nabucasa==0.78.0
 hass-splunk==0.1.1
 
 # homeassistant.components.conversation
-hassil==1.6.1
+hassil==1.7.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.8

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -858,7 +858,7 @@ habluetooth==3.0.1
 hass-nabucasa==0.78.0
 
 # homeassistant.components.conversation
-hassil==1.6.1
+hassil==1.7.1
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.8

--- a/tests/testing_config/custom_sentences/en/beer.yaml
+++ b/tests/testing_config/custom_sentences/en/beer.yaml
@@ -4,8 +4,14 @@ intents:
     data:
       - sentences:
           - "I'd like to order a {beer_style} [please]"
+  OrderFood:
+    data:
+      - sentences:
+          - "I'd like to order {food_name:name} [please]"
 lists:
   beer_style:
     values:
       - "stout"
       - "lager"
+  food_name:
+    wildcard: true


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default conversation agent will prioritize matches that contain entity names automatically (identified by the `name` slot). When the source of the `name` slot is a wildcard, however, this causes matches with more literal text to be skipped.

For example: "cancel 5 minute timer" will produce a match with `name` = `5 minute` instead of `minutes` = 5 in:

```yaml
HassCancelTimer:
  data:
    - sentences:
        - "cancel {minutes} minute timer"
        - "cancel {timer_name:name} timer"

lists:
  timer_name:
    wildcard: true
```

This PR ensures that the "best" match has the most literal text (text that is not part of a list or wildcard). If a "name" slot is present, but **not** a wildcard, it is still prioritized.

A bump to hassil was required to fix a bug where wildcard entities were not being reported as such in the match results.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
