### PR TITLE
Add area filter and rounded time to timers

### DIFF
--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -88,12 +88,9 @@ class TimerInfo:
         return max(0, self.seconds - seconds_running)
 
     @cached_property
-    def name_normalized(self) -> str | None:
+    def name_normalized(self) -> str:
         """Return normalized timer name."""
-        if self.name is None:
-            return None
-
-        return _normalize_name(self.name)
+        return _normalize_name(self.name or "")
 
     def cancel(self) -> None:
         """Cancel the timer."""
@@ -890,7 +887,6 @@ class TimerStatusIntentHandler(intent.IntentHandler):
                     "rounded_minutes_left": rounded_minutes,
                     "rounded_seconds_left": rounded_seconds,
                     "total_seconds_left": total_seconds,
-                    "created_at": timer.created_at,
                 }
             )
 

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -640,6 +640,55 @@ def _get_total_seconds(slots: dict[str, Any]) -> int:
     return total_seconds
 
 
+def _round_time(hours: int, minutes: int, seconds: int) -> tuple[int, int, int]:
+    """Round time to a lower precision for feedback."""
+    if hours > 0:
+        # No seconds, round up above 45 minutes and down below 15
+        rounded_hours = hours
+        rounded_seconds = 0
+        if minutes > 45:
+            # 01:50:30 -> 02:00:00
+            rounded_hours += 1
+            rounded_minutes = 0
+        elif minutes < 15:
+            # 01:10:30 -> 01:00:00
+            rounded_minutes = 0
+        else:
+            # 01:25:30 -> 01:30:00
+            rounded_minutes = 30
+    elif minutes > 0:
+        # Round up above 45 seconds, down below 15
+        rounded_hours = 0
+        rounded_minutes = minutes
+        if seconds > 45:
+            # 00:01:50 -> 00:02:00
+            rounded_minutes += 1
+            rounded_seconds = 0
+        elif seconds < 15:
+            # 00:01:10 -> 00:01:00
+            rounded_seconds = 0
+        else:
+            # 00:01:25 -> 00:01:30
+            rounded_seconds = 30
+    else:
+        # Round up above 50 seconds, exact below 10, and down to nearest 10
+        # otherwise.
+        rounded_hours = 0
+        rounded_minutes = 0
+        if seconds > 50:
+            # 00:00:55 -> 00:01:00
+            rounded_minutes = 1
+            rounded_seconds = 0
+        elif seconds < 10:
+            # 00:00:09 -> 00:00:09
+            rounded_seconds = seconds
+        else:
+            # 00:01:25 -> 00:01:20
+            rounded_seconds = seconds - (seconds % 10)
+
+    return rounded_hours, rounded_minutes, rounded_seconds
+
+
 class StartTimerIntentHandler(intent.IntentHandler):
     """Intent handler for starting a new timer."""
 
@@ -819,6 +868,11 @@ class TimerStatusIntentHandler(intent.IntentHandler):
             minutes, seconds = divmod(total_seconds, 60)
             hours, minutes = divmod(minutes, 60)
 
+            # Get lower-precision time for feedback
+            rounded_hours, rounded_minutes, rounded_seconds = _round_time(
+                hours, minutes, seconds
+            )
+
             statuses.append(
                 {
                     ATTR_ID: timer.id,
@@ -832,7 +886,11 @@ class TimerStatusIntentHandler(intent.IntentHandler):
                     "hours_left": hours,
                     "minutes_left": minutes,
                     "seconds_left": seconds,
+                    "rounded_hours_left": rounded_hours,
+                    "rounded_minutes_left": rounded_minutes,
+                    "rounded_seconds_left": rounded_seconds,
                     "total_seconds_left": total_seconds,
+                    "created_at": timer.created_at,
                 }
             )
 

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -979,3 +979,133 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
     assert result.response_type == intent.IntentResponseType.ACTION_DONE
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 0
+
+
+async def test_area_filter(
+    hass: HomeAssistant,
+    init_components,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test targeting timers by area name."""
+    entry = MockConfigEntry()
+    entry.add_to_hass(hass)
+
+    area_kitchen = area_registry.async_create("kitchen")
+    device_kitchen = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("test", "kitchen-device")},
+    )
+    device_registry.async_update_device(device_kitchen.id, area_id=area_kitchen.id)
+
+    area_living_room = area_registry.async_create("living room")
+    device_living_room = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections=set(),
+        identifiers={("test", "living_room-device")},
+    )
+    device_registry.async_update_device(
+        device_living_room.id, area_id=area_living_room.id
+    )
+
+    started_event = asyncio.Event()
+    num_timers = 3
+    num_started = 0
+
+    def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
+        nonlocal num_started
+
+        if event_type == TimerEventType.STARTED:
+            num_started += 1
+            if num_started == num_timers:
+                started_event.set()
+
+    async_register_timer_handler(hass, handle_timer)
+
+    # Start timers in different areas
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {"name": {"value": "pizza"}, "minutes": {"value": 10}},
+        device_id=device_kitchen.id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {"name": {"value": "tv"}, "minutes": {"value": 10}},
+        device_id=device_living_room.id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {"name": {"value": "media"}, "minutes": {"value": 15}},
+        device_id=device_living_room.id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    # Wait for all timers to start
+    async with asyncio.timeout(1):
+        await started_event.wait()
+
+    # No constraints returns all timers
+    result = await intent.async_handle(hass, "test", intent.INTENT_TIMER_STATUS, {})
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    timers = result.speech_slots.get("timers", [])
+    assert len(timers) == num_timers
+    assert {t.get(ATTR_NAME) for t in timers} == {"pizza", "tv", "media"}
+
+    # Filter by area (kitchen)
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_TIMER_STATUS,
+        {"area": {"value": "kitchen"}},
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    timers = result.speech_slots.get("timers", [])
+    assert len(timers) == 1
+    assert timers[0].get(ATTR_NAME) == "pizza"
+
+    # Filter by area (living room)
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_TIMER_STATUS,
+        {"area": {"value": "living room"}},
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    timers = result.speech_slots.get("timers", [])
+    assert len(timers) == 2
+    assert {t.get(ATTR_NAME) for t in timers} == {"tv", "media"}
+
+    # Filter by area + name
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_TIMER_STATUS,
+        {"area": {"value": "living room"}, "name": {"value": "tv"}},
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    timers = result.speech_slots.get("timers", [])
+    assert len(timers) == 1
+    assert timers[0].get(ATTR_NAME) == "tv"
+
+    # Filter by area + time
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_TIMER_STATUS,
+        {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+    timers = result.speech_slots.get("timers", [])
+    assert len(timers) == 1
+    assert timers[0].get(ATTR_NAME) == "media"

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -10,6 +10,7 @@ from homeassistant.components.intent.timers import (
     TimerInfo,
     TimerManager,
     TimerNotFoundError,
+    _round_time,
     async_register_timer_handler,
 )
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_NAME
@@ -1109,3 +1110,24 @@ async def test_area_filter(
     timers = result.speech_slots.get("timers", [])
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "media"
+
+
+def test_round_time() -> None:
+    """Test lower-precision time rounded."""
+
+    # hours
+    assert _round_time(1, 10, 30) == (1, 0, 0)
+    assert _round_time(1, 48, 30) == (2, 0, 0)
+    assert _round_time(2, 25, 30) == (2, 30, 0)
+
+    # minutes
+    assert _round_time(0, 1, 10) == (0, 1, 0)
+    assert _round_time(0, 1, 48) == (0, 2, 0)
+    assert _round_time(0, 2, 25) == (0, 2, 30)
+
+    # seconds
+    assert _round_time(0, 0, 6) == (0, 0, 6)
+    assert _round_time(0, 0, 15) == (0, 0, 10)
+    assert _round_time(0, 0, 48) == (0, 1, 0)
+    assert _round_time(0, 0, 25) == (0, 0, 20)
+    assert _round_time(0, 0, 35) == (0, 0, 30)

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -1128,6 +1128,6 @@ def test_round_time() -> None:
     # seconds
     assert _round_time(0, 0, 6) == (0, 0, 6)
     assert _round_time(0, 0, 15) == (0, 0, 10)
-    assert _round_time(0, 0, 48) == (0, 1, 0)
+    assert _round_time(0, 0, 58) == (0, 1, 0)
     assert _round_time(0, 0, 25) == (0, 0, 20)
     assert _round_time(0, 0, 35) == (0, 0, 30)

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -1111,6 +1111,15 @@ async def test_area_filter(
     assert len(timers) == 1
     assert timers[0].get(ATTR_NAME) == "media"
 
+    # Cancel by area + time
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_CANCEL_TIMER,
+        {"area": {"value": "living room"}, "start_minutes": {"value": 15}},
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
 
 def test_round_time() -> None:
     """Test lower-precision time rounded."""


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Adds the ability to target timers by the area of the device they were started with ("cancel kitchen timer")
- Adds "rounded" time fields timer status so less precise time left can be spoken ("5 minutes" instead of "5 minutes and 3 seconds")

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
