### PR TITLE
Move philips_js coordinator to separate module

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1028,6 +1028,7 @@ omit =
     homeassistant/components/permobil/entity.py
     homeassistant/components/permobil/sensor.py
     homeassistant/components/philips_js/__init__.py
+    homeassistant/components/philips_js/coordinator.py
     homeassistant/components/philips_js/light.py
     homeassistant/components/philips_js/media_player.py
     homeassistant/components/philips_js/remote.py

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -2,18 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Mapping
-from datetime import timedelta
 import logging
-from typing import Any
 
-from haphilipsjs import (
-    AutenticationFailure,
-    ConnectionFailure,
-    GeneralFailure,
-    PhilipsTV,
-)
+from haphilipsjs import PhilipsTV
 from haphilipsjs.typing import SystemType
 
 from homeassistant.config_entries import ConfigEntry
@@ -24,13 +15,10 @@ from homeassistant.const import (
     CONF_USERNAME,
     Platform,
 )
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.core import HomeAssistant
 
-from .const import CONF_ALLOW_NOTIFY, CONF_SYSTEM, DOMAIN
+from .const import CONF_SYSTEM
+from .coordinator import PhilipsTVDataUpdateCoordinator
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -42,7 +30,7 @@ PLATFORMS = [
 
 LOGGER = logging.getLogger(__name__)
 
-PhilipsTVConfigEntry = ConfigEntry["PhilipsTVDataUpdateCoordinator"]
+PhilipsTVConfigEntry = ConfigEntry[PhilipsTVDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -> bool:
@@ -81,115 +69,3 @@ async def async_update_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -
 async def async_unload_entry(hass: HomeAssistant, entry: PhilipsTVConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):  # pylint: disable=hass-enforce-coordinator-module
-    """Coordinator to update data."""
-
-    config_entry: ConfigEntry
-
-    def __init__(
-        self, hass: HomeAssistant, api: PhilipsTV, options: Mapping[str, Any]
-    ) -> None:
-        """Set up the coordinator."""
-        self.api = api
-        self.options = options
-        self._notify_future: asyncio.Task | None = None
-
-        super().__init__(
-            hass,
-            LOGGER,
-            name=DOMAIN,
-            update_interval=timedelta(seconds=30),
-            request_refresh_debouncer=Debouncer(
-                hass, LOGGER, cooldown=2.0, immediate=False
-            ),
-        )
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            identifiers={
-                (DOMAIN, self.unique_id),
-            },
-            manufacturer="Philips",
-            model=self.system.get("model"),
-            name=self.system["name"],
-            sw_version=self.system.get("softwareversion"),
-        )
-
-    @property
-    def system(self) -> SystemType:
-        """Return the system descriptor."""
-        if self.api.system:
-            return self.api.system
-        return self.config_entry.data[CONF_SYSTEM]
-
-    @property
-    def unique_id(self) -> str:
-        """Return the system descriptor."""
-        entry = self.config_entry
-        if entry.unique_id:
-            return entry.unique_id
-        assert entry.entry_id
-        return entry.entry_id
-
-    @property
-    def _notify_wanted(self):
-        """Return if the notify feature should be active.
-
-        We only run it when TV is considered fully on. When powerstate is in standby, the TV
-        will go in low power states and seemingly break the http server in odd ways.
-        """
-        return (
-            self.api.on
-            and self.api.powerstate == "On"
-            and self.api.notify_change_supported
-            and self.options.get(CONF_ALLOW_NOTIFY, False)
-        )
-
-    async def _notify_task(self):
-        while self._notify_wanted:
-            try:
-                res = await self.api.notifyChange(130)
-            except (ConnectionFailure, AutenticationFailure):
-                res = None
-
-            if res:
-                self.async_set_updated_data(None)
-            elif res is None:
-                LOGGER.debug("Aborting notify due to unexpected return")
-                break
-
-    @callback
-    def _async_notify_stop(self):
-        if self._notify_future:
-            self._notify_future.cancel()
-            self._notify_future = None
-
-    @callback
-    def _async_notify_schedule(self):
-        if self._notify_future and not self._notify_future.done():
-            return
-
-        if self._notify_wanted:
-            self._notify_future = asyncio.create_task(self._notify_task())
-
-    @callback
-    def _unschedule_refresh(self) -> None:
-        """Remove data update."""
-        super()._unschedule_refresh()
-        self._async_notify_stop()
-
-    async def _async_update_data(self):
-        """Fetch the latest data from the source."""
-        try:
-            await self.api.update()
-            self._async_notify_schedule()
-        except ConnectionFailure:
-            pass
-        except AutenticationFailure as exception:
-            raise ConfigEntryAuthFailed(str(exception)) from exception
-        except GeneralFailure as exception:
-            raise UpdateFailed(str(exception)) from exception

--- a/homeassistant/components/philips_js/binary_sensor.py
+++ b/homeassistant/components/philips_js/binary_sensor.py
@@ -13,7 +13,8 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
+from . import PhilipsTVConfigEntry
+from .coordinator import PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 

--- a/homeassistant/components/philips_js/coordinator.py
+++ b/homeassistant/components/philips_js/coordinator.py
@@ -1,0 +1,140 @@
+"""Coordinator for the Philips TV integration."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from datetime import timedelta
+import logging
+from typing import Any
+
+from haphilipsjs import (
+    AutenticationFailure,
+    ConnectionFailure,
+    GeneralFailure,
+    PhilipsTV,
+)
+from haphilipsjs.typing import SystemType
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.debounce import Debouncer
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CONF_ALLOW_NOTIFY, CONF_SYSTEM, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator to update data."""
+
+    config_entry: ConfigEntry
+
+    def __init__(
+        self, hass: HomeAssistant, api: PhilipsTV, options: Mapping[str, Any]
+    ) -> None:
+        """Set up the coordinator."""
+        self.api = api
+        self.options = options
+        self._notify_future: asyncio.Task | None = None
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(seconds=30),
+            request_refresh_debouncer=Debouncer(
+                hass, _LOGGER, cooldown=2.0, immediate=False
+            ),
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info."""
+        return DeviceInfo(
+            identifiers={
+                (DOMAIN, self.unique_id),
+            },
+            manufacturer="Philips",
+            model=self.system.get("model"),
+            name=self.system["name"],
+            sw_version=self.system.get("softwareversion"),
+        )
+
+    @property
+    def system(self) -> SystemType:
+        """Return the system descriptor."""
+        if self.api.system:
+            return self.api.system
+        return self.config_entry.data[CONF_SYSTEM]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the system descriptor."""
+        entry = self.config_entry
+        if entry.unique_id:
+            return entry.unique_id
+        assert entry.entry_id
+        return entry.entry_id
+
+    @property
+    def _notify_wanted(self):
+        """Return if the notify feature should be active.
+
+        We only run it when TV is considered fully on. When powerstate is in standby, the TV
+        will go in low power states and seemingly break the http server in odd ways.
+        """
+        return (
+            self.api.on
+            and self.api.powerstate == "On"
+            and self.api.notify_change_supported
+            and self.options.get(CONF_ALLOW_NOTIFY, False)
+        )
+
+    async def _notify_task(self):
+        while self._notify_wanted:
+            try:
+                res = await self.api.notifyChange(130)
+            except (ConnectionFailure, AutenticationFailure):
+                res = None
+
+            if res:
+                self.async_set_updated_data(None)
+            elif res is None:
+                _LOGGER.debug("Aborting notify due to unexpected return")
+                break
+
+    @callback
+    def _async_notify_stop(self):
+        if self._notify_future:
+            self._notify_future.cancel()
+            self._notify_future = None
+
+    @callback
+    def _async_notify_schedule(self):
+        if self._notify_future and not self._notify_future.done():
+            return
+
+        if self._notify_wanted:
+            self._notify_future = asyncio.create_task(self._notify_task())
+
+    @callback
+    def _unschedule_refresh(self) -> None:
+        """Remove data update."""
+        super()._unschedule_refresh()
+        self._async_notify_stop()
+
+    async def _async_update_data(self):
+        """Fetch the latest data from the source."""
+        try:
+            await self.api.update()
+            self._async_notify_schedule()
+        except ConnectionFailure:
+            pass
+        except AutenticationFailure as exception:
+            raise ConfigEntryAuthFailed(str(exception)) from exception
+        except GeneralFailure as exception:
+            raise UpdateFailed(str(exception)) from exception

--- a/homeassistant/components/philips_js/entity.py
+++ b/homeassistant/components/philips_js/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import PhilipsTVDataUpdateCoordinator
+from .coordinator import PhilipsTVDataUpdateCoordinator
 
 
 class PhilipsJsEntity(CoordinatorEntity[PhilipsTVDataUpdateCoordinator]):

--- a/homeassistant/components/philips_js/light.py
+++ b/homeassistant/components/philips_js/light.py
@@ -21,7 +21,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.color import color_hsv_to_RGB, color_RGB_to_hsv
 
-from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
+from . import PhilipsTVConfigEntry
+from .coordinator import PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 EFFECT_PARTITION = ": "

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -21,7 +21,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
-from . import LOGGER as _LOGGER, PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
+from . import LOGGER as _LOGGER, PhilipsTVConfigEntry
+from .coordinator import PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
 

--- a/homeassistant/components/philips_js/remote.py
+++ b/homeassistant/components/philips_js/remote.py
@@ -16,7 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
-from . import LOGGER, PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
+from . import LOGGER, PhilipsTVConfigEntry
+from .coordinator import PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
 

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -8,7 +8,8 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
+from . import PhilipsTVConfigEntry
+from .coordinator import PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 
 HUE_POWER_OFF = "Off"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
