### PR TITLE
Move p1_monitor coordinator to separate module

### DIFF
--- a/homeassistant/components/p1_monitor/__init__.py
+++ b/homeassistant/components/p1_monitor/__init__.py
@@ -2,34 +2,13 @@
 
 from __future__ import annotations
 
-from typing import TypedDict
-
-from p1monitor import (
-    P1Monitor,
-    P1MonitorConnectionError,
-    P1MonitorNoDataError,
-    Phases,
-    Settings,
-    SmartMeter,
-    WaterMeter,
-)
-
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import (
-    DOMAIN,
-    LOGGER,
-    SCAN_INTERVAL,
-    SERVICE_PHASES,
-    SERVICE_SETTINGS,
-    SERVICE_SMARTMETER,
-    SERVICE_WATERMETER,
-)
+from .const import DOMAIN
+from .coordinator import P1MonitorDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
@@ -57,55 +36,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok:
         del hass.data[DOMAIN][entry.entry_id]
     return unload_ok
-
-
-class P1MonitorData(TypedDict):
-    """Class for defining data in dict."""
-
-    smartmeter: SmartMeter
-    phases: Phases
-    settings: Settings
-    watermeter: WaterMeter | None
-
-
-class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):  # pylint: disable=hass-enforce-coordinator-module
-    """Class to manage fetching P1 Monitor data from single endpoint."""
-
-    config_entry: ConfigEntry
-    has_water_meter: bool | None = None
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-    ) -> None:
-        """Initialize global P1 Monitor data updater."""
-        super().__init__(
-            hass,
-            LOGGER,
-            name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
-        )
-
-        self.p1monitor = P1Monitor(
-            self.config_entry.data[CONF_HOST], session=async_get_clientsession(hass)
-        )
-
-    async def _async_update_data(self) -> P1MonitorData:
-        """Fetch data from P1 Monitor."""
-        data: P1MonitorData = {
-            SERVICE_SMARTMETER: await self.p1monitor.smartmeter(),
-            SERVICE_PHASES: await self.p1monitor.phases(),
-            SERVICE_SETTINGS: await self.p1monitor.settings(),
-            SERVICE_WATERMETER: None,
-        }
-
-        if self.has_water_meter or self.has_water_meter is None:
-            try:
-                data[SERVICE_WATERMETER] = await self.p1monitor.watermeter()
-                self.has_water_meter = True
-            except (P1MonitorNoDataError, P1MonitorConnectionError):
-                LOGGER.debug("No water meter data received from P1 Monitor")
-                if self.has_water_meter is None:
-                    self.has_water_meter = False
-
-        return data

--- a/homeassistant/components/p1_monitor/coordinator.py
+++ b/homeassistant/components/p1_monitor/coordinator.py
@@ -1,0 +1,83 @@
+"""Coordinator for the P1 Monitor integration."""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from p1monitor import (
+    P1Monitor,
+    P1MonitorConnectionError,
+    P1MonitorNoDataError,
+    Phases,
+    Settings,
+    SmartMeter,
+    WaterMeter,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import (
+    DOMAIN,
+    LOGGER,
+    SCAN_INTERVAL,
+    SERVICE_PHASES,
+    SERVICE_SETTINGS,
+    SERVICE_SMARTMETER,
+    SERVICE_WATERMETER,
+)
+
+
+class P1MonitorData(TypedDict):
+    """Class for defining data in dict."""
+
+    smartmeter: SmartMeter
+    phases: Phases
+    settings: Settings
+    watermeter: WaterMeter | None
+
+
+class P1MonitorDataUpdateCoordinator(DataUpdateCoordinator[P1MonitorData]):
+    """Class to manage fetching P1 Monitor data from single endpoint."""
+
+    config_entry: ConfigEntry
+    has_water_meter: bool | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Initialize global P1 Monitor data updater."""
+        super().__init__(
+            hass,
+            LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+
+        self.p1monitor = P1Monitor(
+            self.config_entry.data[CONF_HOST], session=async_get_clientsession(hass)
+        )
+
+    async def _async_update_data(self) -> P1MonitorData:
+        """Fetch data from P1 Monitor."""
+        data: P1MonitorData = {
+            SERVICE_SMARTMETER: await self.p1monitor.smartmeter(),
+            SERVICE_PHASES: await self.p1monitor.phases(),
+            SERVICE_SETTINGS: await self.p1monitor.settings(),
+            SERVICE_WATERMETER: None,
+        }
+
+        if self.has_water_meter or self.has_water_meter is None:
+            try:
+                data[SERVICE_WATERMETER] = await self.p1monitor.watermeter()
+                self.has_water_meter = True
+            except (P1MonitorNoDataError, P1MonitorConnectionError):
+                LOGGER.debug("No water meter data received from P1 Monitor")
+                if self.has_water_meter is None:
+                    self.has_water_meter = False
+
+        return data

--- a/homeassistant/components/p1_monitor/diagnostics.py
+++ b/homeassistant/components/p1_monitor/diagnostics.py
@@ -10,7 +10,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
-from . import P1MonitorDataUpdateCoordinator
 from .const import (
     DOMAIN,
     SERVICE_PHASES,
@@ -18,6 +17,7 @@ from .const import (
     SERVICE_SMARTMETER,
     SERVICE_WATERMETER,
 )
+from .coordinator import P1MonitorDataUpdateCoordinator
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance

--- a/homeassistant/components/p1_monitor/sensor.py
+++ b/homeassistant/components/p1_monitor/sensor.py
@@ -26,7 +26,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import P1MonitorDataUpdateCoordinator
 from .const import (
     DOMAIN,
     SERVICE_PHASES,
@@ -34,6 +33,7 @@ from .const import (
     SERVICE_SMARTMETER,
     SERVICE_WATERMETER,
 )
+from .coordinator import P1MonitorDataUpdateCoordinator
 
 SENSORS_SMARTMETER: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(

--- a/tests/components/p1_monitor/conftest.py
+++ b/tests/components/p1_monitor/conftest.py
@@ -27,7 +27,9 @@ def mock_config_entry() -> MockConfigEntry:
 @pytest.fixture
 def mock_p1monitor():
     """Return a mocked P1 Monitor client."""
-    with patch("homeassistant.components.p1_monitor.P1Monitor") as p1monitor_mock:
+    with patch(
+        "homeassistant.components.p1_monitor.coordinator.P1Monitor"
+    ) as p1monitor_mock:
         client = p1monitor_mock.return_value
         client.smartmeter = AsyncMock(
             return_value=SmartMeter.from_dict(

--- a/tests/components/p1_monitor/test_config_flow.py
+++ b/tests/components/p1_monitor/test_config_flow.py
@@ -44,7 +44,7 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
 async def test_api_error(hass: HomeAssistant) -> None:
     """Test we handle cannot connect error."""
     with patch(
-        "homeassistant.components.p1_monitor.P1Monitor.smartmeter",
+        "homeassistant.components.p1_monitor.coordinator.P1Monitor.smartmeter",
         side_effect=P1MonitorError,
     ):
         result = await hass.config_entries.flow.async_init(

--- a/tests/components/p1_monitor/test_init.py
+++ b/tests/components/p1_monitor/test_init.py
@@ -29,7 +29,7 @@ async def test_load_unload_config_entry(
 
 
 @patch(
-    "homeassistant.components.p1_monitor.P1Monitor._request",
+    "homeassistant.components.p1_monitor.coordinator.P1Monitor._request",
     side_effect=P1MonitorConnectionError,
 )
 async def test_config_entry_not_ready(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
