### PR TITLE
Exclude gold and platinum integrations from .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1044,6 +1044,10 @@ omit =
     homeassistant/components/plex/view.py
     homeassistant/components/plum_lightpad/light.py
     homeassistant/components/pocketcasts/sensor.py
+    homeassistant/components/point/__init__.py
+    homeassistant/components/point/alarm_control_panel.py
+    homeassistant/components/point/binary_sensor.py
+    homeassistant/components/point/sensor.py
     homeassistant/components/powerwall/__init__.py
     homeassistant/components/progettihwsw/__init__.py
     homeassistant/components/progettihwsw/binary_sensor.py
@@ -1407,6 +1411,13 @@ omit =
     homeassistant/components/telegram_bot/__init__.py
     homeassistant/components/telegram_bot/polling.py
     homeassistant/components/telegram_bot/webhooks.py
+    homeassistant/components/tellduslive/__init__.py
+    homeassistant/components/tellduslive/binary_sensor.py
+    homeassistant/components/tellduslive/cover.py
+    homeassistant/components/tellduslive/entry.py
+    homeassistant/components/tellduslive/light.py
+    homeassistant/components/tellduslive/sensor.py
+    homeassistant/components/tellduslive/switch.py
     homeassistant/components/tellstick/*
     homeassistant/components/telnet/switch.py
     homeassistant/components/temper/sensor.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -730,7 +730,6 @@ omit =
     homeassistant/components/lookin/sensor.py
     homeassistant/components/loqed/sensor.py
     homeassistant/components/luci/device_tracker.py
-    homeassistant/components/luftdaten/sensor.py
     homeassistant/components/lupusec/__init__.py
     homeassistant/components/lupusec/alarm_control_panel.py
     homeassistant/components/lupusec/binary_sensor.py
@@ -1045,10 +1044,6 @@ omit =
     homeassistant/components/plex/view.py
     homeassistant/components/plum_lightpad/light.py
     homeassistant/components/pocketcasts/sensor.py
-    homeassistant/components/point/__init__.py
-    homeassistant/components/point/alarm_control_panel.py
-    homeassistant/components/point/binary_sensor.py
-    homeassistant/components/point/sensor.py
     homeassistant/components/powerwall/__init__.py
     homeassistant/components/progettihwsw/__init__.py
     homeassistant/components/progettihwsw/binary_sensor.py
@@ -1412,13 +1407,6 @@ omit =
     homeassistant/components/telegram_bot/__init__.py
     homeassistant/components/telegram_bot/polling.py
     homeassistant/components/telegram_bot/webhooks.py
-    homeassistant/components/tellduslive/__init__.py
-    homeassistant/components/tellduslive/binary_sensor.py
-    homeassistant/components/tellduslive/cover.py
-    homeassistant/components/tellduslive/entry.py
-    homeassistant/components/tellduslive/light.py
-    homeassistant/components/tellduslive/sensor.py
-    homeassistant/components/tellduslive/switch.py
     homeassistant/components/tellstick/*
     homeassistant/components/telnet/switch.py
     homeassistant/components/temper/sensor.py

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -112,6 +112,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
                     f"has quality scale {integration.quality_scale} and "
                     "should not be present in .coveragerc file",
                 )
+                continue
 
             if (
                 path.parts[-1] in {"*", "const.py"}
@@ -121,6 +122,7 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
                     "coverage",
                     f"has tests and should not use {last_part} in .coveragerc file",
                 )
+                continue
 
             for check in DONT_IGNORE:
                 if path.parts[-1] not in {"*", check}:

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -114,10 +114,9 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
                 )
                 continue
 
-            if (
-                path.parts[-1] in {"*", "const.py"}
-                and Path(f"tests/components/{integration.domain}/__init__.py").exists()
-            ):
+            if (last_part := path.parts[-1]) in {"*", "const.py"} and Path(
+                f"tests/components/{integration.domain}/__init__.py"
+            ).exists():
                 integration.add_error(
                     "coverage",
                     f"has tests and should not use {last_part} in .coveragerc file",

--- a/script/hassfest/coverage.py
+++ b/script/hassfest/coverage.py
@@ -19,6 +19,7 @@ DONT_IGNORE = (
     "recorder.py",
     "scene.py",
 )
+FORCE_COVERAGE = ("gold", "platinum")
 
 CORE_PREFIX = """# Sorted by hassfest.
 #
@@ -105,9 +106,17 @@ def validate(integrations: dict[str, Integration], config: Config) -> None:
 
             integration = integrations[integration_path.name]
 
-            if (last_part := path.parts[-1]) in {"*", "const.py"} and Path(
-                f"tests/components/{integration.domain}/__init__.py"
-            ).exists():
+            if integration.quality_scale in FORCE_COVERAGE:
+                integration.add_error(
+                    "coverage",
+                    f"has quality scale {integration.quality_scale} and "
+                    "should not be present in .coveragerc file",
+                )
+
+            if (
+                path.parts[-1] in {"*", "const.py"}
+                and Path(f"tests/components/{integration.domain}/__init__.py").exists()
+            ):
                 integration.add_error(
                     "coverage",
                     f"has tests and should not use {last_part} in .coveragerc file",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, based on https://developers.home-assistant.io/docs/integration_quality_scale_index/#gold- and https://github.com/home-assistant/developers.home-assistant/pull/1194
`Tests: Above average test coverage for all integration modules`

Sample output
```
Integrations: 1264
Invalid integrations: 3

Found errors. Generating files canceled.

Integration luftdaten:
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file

Integration point:
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file

Integration tellduslive:
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
* [ERROR] [COVERAGE] has quality scale gold and should not be present in .coveragerc file
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
