### PR TITLE
Fix ruff version conflict in vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,8 +50,7 @@
         ],
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
-        },
-        "ruff.path": ["/home/vscode/.local/bin/ruff"]
+        }
       }
     }
   }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -50,7 +50,8 @@
         ],
         "[python]": {
           "editor.defaultFormatter": "charliermarsh.ruff"
-        }
+        },
+        "ruff.path": ["/home/vscode/.local/bin/ruff"]
       }
     }
   }

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -43,13 +43,5 @@ RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
 
 WORKDIR /workspaces
 
-# Install Python dependencies from requirements
-COPY requirements.txt ./
-COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
-RUN pip3 install -r requirements.txt
-COPY requirements_test.txt requirements_test_pre_commit.txt ./
-RUN pip3 install -r requirements_test.txt
-RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
-
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -53,6 +53,7 @@ COPY requirements_test.txt requirements_test_pre_commit.txt ./
 RUN pip3 install -r requirements_test.txt
 USER root
 RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
+USER vscode
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -43,5 +43,15 @@ RUN git clone --depth 1 https://github.com/home-assistant/hass-release \
 
 WORKDIR /workspaces
 
+# Install Python dependencies from requirements, using regular user to avoid
+# broken permissions and conflicting behaviour
+USER vscode
+COPY requirements.txt ./
+COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
+RUN pip3 install -r requirements.txt
+COPY requirements_test.txt requirements_test_pre_commit.txt ./
+RUN pip3 install -r requirements_test.txt
+RUN rm -f requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/package_constraints.txt
+
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -51,9 +51,7 @@ COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
 RUN pip3 install -r requirements.txt
 COPY requirements_test.txt requirements_test_pre_commit.txt ./
 RUN pip3 install -r requirements_test.txt
-USER root
-RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
-USER vscode
+RUN sudo rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -51,7 +51,8 @@ COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
 RUN pip3 install -r requirements.txt
 COPY requirements_test.txt requirements_test_pre_commit.txt ./
 RUN pip3 install -r requirements_test.txt
-RUN rm -f requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/package_constraints.txt
+USER root
+RUN rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
 
 # Set the default shell to bash instead of sh
 ENV SHELL /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -51,6 +51,7 @@ COPY homeassistant/package_constraints.txt homeassistant/package_constraints.txt
 RUN pip3 install -r requirements.txt
 COPY requirements_test.txt requirements_test_pre_commit.txt ./
 RUN pip3 install -r requirements_test.txt
+# hadolint ignore=DL3004
 RUN sudo rm -rf requirements.txt requirements_test.txt requirements_test_pre_commit.txt homeassistant/
 
 # Set the default shell to bash instead of sh


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Based on discussion with @balloob and @autinerd on Discord

The vscode extension ships with an older version of ruff, which causes conflict with the required version in `pyproject.toml`.
```
Ruff: Lint failed (ruff failed
  Cause: Required version `>=0.4.4` does not match the running version `0.4.1`
)
```

⚠️ Note: it works for me (Windows + WSL + Docker + VSCode), but I am unable to test for other setups.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
