### PR TITLE
Unpause media players that were paused outside voice

### DIFF
--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -1,17 +1,20 @@
 """Intents for the media_player integration."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import time
+from typing import Final
 
 import voluptuous as vol
 
 from homeassistant.const import (
+    EVENT_STATE_CHANGED,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_VOLUME_SET,
+    STATE_PAUSED,
 )
-from homeassistant.core import HomeAssistant, State
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant, State
 from homeassistant.helpers import intent
 
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
@@ -22,21 +25,44 @@ INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
 INTENT_SET_VOLUME = "HassSetVolume"
 
-DATA_LAST_PAUSED = f"{DOMAIN}.last_paused"
+_PAUSE_DELAY: Final = 5
 
 
-@dataclass(frozen=True)
+@dataclass
 class LastPaused:
     """Information about last media players that were paused by voice."""
 
-    timestamp: float
-    entity_ids: set[str]
+    timestamp: float | None = None
+    entity_ids: set[str] = field(default_factory=set)
+    waiting_entity_ids: set[str] = field(default_factory=set)
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the media_player intents."""
-    intent.async_register(hass, MediaUnpauseHandler())
-    intent.async_register(hass, MediaPauseHandler())
+    last_paused = LastPaused()
+
+    def state_changed_listener(event: Event[EventStateChangedData]) -> None:
+        """Update last paused timestamp as expected media players enter their paused states."""
+        if (
+            ((state := event.data.get("new_state")) is None)
+            or (state.domain != DOMAIN)
+            or (state.state != STATE_PAUSED)
+        ):
+            return
+
+        entity_id = state.entity_id
+        if entity_id not in last_paused.waiting_entity_ids:
+            return
+
+        # Move out of waiting and bump timestamp
+        last_paused.waiting_entity_ids.remove(entity_id)
+        last_paused.entity_ids.add(entity_id)
+        last_paused.timestamp = time.time()
+
+    hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed_listener)
+
+    intent.async_register(hass, MediaUnpauseHandler(last_paused))
+    intent.async_register(hass, MediaPauseHandler(last_paused))
     intent.async_register(
         hass,
         intent.ServiceIntentHandler(
@@ -69,7 +95,7 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
 class MediaPauseHandler(intent.ServiceIntentHandler):
     """Handler for pause intent. Records last paused media players."""
 
-    def __init__(self) -> None:
+    def __init__(self, last_paused: LastPaused) -> None:
         """Initialize handler."""
         super().__init__(
             INTENT_MEDIA_PAUSE,
@@ -79,6 +105,7 @@ class MediaPauseHandler(intent.ServiceIntentHandler):
             required_features=MediaPlayerEntityFeature.PAUSE,
             required_states={MediaPlayerState.PLAYING},
         )
+        self.last_paused = last_paused
 
     async def async_handle_states(
         self,
@@ -88,13 +115,13 @@ class MediaPauseHandler(intent.ServiceIntentHandler):
         match_preferences: intent.MatchTargetsPreferences | None = None,
     ) -> intent.IntentResponse:
         """Record last paused media players."""
-        hass = intent_obj.hass
-
         if match_result.is_match:
             # Save entity ids of paused media players
-            hass.data[DATA_LAST_PAUSED] = LastPaused(
-                timestamp=time.time(),
-                entity_ids={s.entity_id for s in match_result.states},
+            self.last_paused.timestamp = time.time()
+            self.last_paused.entity_ids.clear()
+            self.last_paused.waiting_entity_ids.clear()
+            self.last_paused.waiting_entity_ids.update(
+                s.entity_id for s in match_result.states
             )
 
         return await super().async_handle_states(
@@ -105,7 +132,7 @@ class MediaPauseHandler(intent.ServiceIntentHandler):
 class MediaUnpauseHandler(intent.ServiceIntentHandler):
     """Handler for unpause/resume intent. Uses last paused media players."""
 
-    def __init__(self) -> None:
+    def __init__(self, last_paused: LastPaused) -> None:
         """Initialize handler."""
         super().__init__(
             INTENT_MEDIA_UNPAUSE,
@@ -114,6 +141,7 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
             required_domains={DOMAIN},
             required_states={MediaPlayerState.PAUSED},
         )
+        self.last_paused = last_paused
 
     async def async_handle_states(
         self,
@@ -123,18 +151,17 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
         match_preferences: intent.MatchTargetsPreferences | None = None,
     ) -> intent.IntentResponse:
         """Unpause last paused media players."""
-        hass = intent_obj.hass
-
         if (
             match_result.is_match
             and (not match_constraints.name)
-            and (last_paused := hass.data.get(DATA_LAST_PAUSED))
+            and (self.last_paused.timestamp is not None)
+            and self.last_paused.entity_ids
         ):
             # Check for a media player that was paused more recently than the
             # ones by voice.
             recent_state: State | None = None
             for state in match_result.states:
-                if state.last_changed_timestamp <= last_paused.timestamp:
+                if state.last_changed_timestamp <= self.last_paused.timestamp:
                     continue
 
                 if (recent_state is None) or (
@@ -145,12 +172,14 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
             if recent_state is not None:
                 # Resume the more recently paused media player (outside of voice).
                 match_result.states = [recent_state]
-                hass.data.pop(DATA_LAST_PAUSED)
+                self.last_paused.timestamp = None
+                self.last_paused.entity_ids.clear()
+                self.last_paused.waiting_entity_ids.clear()
             else:
                 # Resume only the previously paused media players if they are in the
                 # targeted set.
                 targeted_ids = {s.entity_id for s in match_result.states}
-                overlapping_ids = targeted_ids.intersection(last_paused.entity_ids)
+                overlapping_ids = targeted_ids.intersection(self.last_paused.entity_ids)
                 if overlapping_ids:
                     match_result.states = [
                         s for s in match_result.states if s.entity_id in overlapping_ids

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -1,20 +1,18 @@
 """Intents for the media_player integration."""
 
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 import time
-from typing import Final
 
 import voluptuous as vol
 
 from homeassistant.const import (
-    EVENT_STATE_CHANGED,
     SERVICE_MEDIA_NEXT_TRACK,
     SERVICE_MEDIA_PAUSE,
     SERVICE_MEDIA_PLAY,
     SERVICE_VOLUME_SET,
-    STATE_PAUSED,
 )
-from homeassistant.core import Event, EventStateChangedData, HomeAssistant, State
+from homeassistant.core import Context, HomeAssistant, State
 from homeassistant.helpers import intent
 
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
@@ -25,41 +23,37 @@ INTENT_MEDIA_UNPAUSE = "HassMediaUnpause"
 INTENT_MEDIA_NEXT = "HassMediaNext"
 INTENT_SET_VOLUME = "HassSetVolume"
 
-_PAUSE_DELAY: Final = 5
-
 
 @dataclass
 class LastPaused:
     """Information about last media players that were paused by voice."""
 
     timestamp: float | None = None
+    context: Context | None = None
     entity_ids: set[str] = field(default_factory=set)
-    waiting_entity_ids: set[str] = field(default_factory=set)
+
+    def clear(self) -> None:
+        """Clear timestamp and entities."""
+        self.timestamp = None
+        self.context = None
+        self.entity_ids.clear()
+
+    def update(self, context: Context | None, entity_ids: Iterable[str]) -> None:
+        """Update last paused group."""
+        self.timestamp = time.time()
+        self.context = context
+        self.entity_ids.clear()
+        self.entity_ids.update(entity_ids)
+
+    @property
+    def is_set(self) -> bool:
+        """Return True if group is set."""
+        return (self.timestamp is not None) and bool(self.entity_ids)
 
 
 async def async_setup_intents(hass: HomeAssistant) -> None:
     """Set up the media_player intents."""
     last_paused = LastPaused()
-
-    def state_changed_listener(event: Event[EventStateChangedData]) -> None:
-        """Update last paused timestamp as expected media players enter their paused states."""
-        if (
-            ((state := event.data.get("new_state")) is None)
-            or (state.domain != DOMAIN)
-            or (state.state != STATE_PAUSED)
-        ):
-            return
-
-        entity_id = state.entity_id
-        if entity_id not in last_paused.waiting_entity_ids:
-            return
-
-        # Move out of waiting and bump timestamp
-        last_paused.waiting_entity_ids.remove(entity_id)
-        last_paused.entity_ids.add(entity_id)
-        last_paused.timestamp = time.time()
-
-    hass.bus.async_listen(EVENT_STATE_CHANGED, state_changed_listener)
 
     intent.async_register(hass, MediaUnpauseHandler(last_paused))
     intent.async_register(hass, MediaPauseHandler(last_paused))
@@ -117,11 +111,8 @@ class MediaPauseHandler(intent.ServiceIntentHandler):
         """Record last paused media players."""
         if match_result.is_match:
             # Save entity ids of paused media players
-            self.last_paused.timestamp = time.time()
-            self.last_paused.entity_ids.clear()
-            self.last_paused.waiting_entity_ids.clear()
-            self.last_paused.waiting_entity_ids.update(
-                s.entity_id for s in match_result.states
+            self.last_paused.update(
+                intent_obj.context, (s.entity_id for s in match_result.states)
             )
 
         return await super().async_handle_states(
@@ -154,14 +145,17 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
         if (
             match_result.is_match
             and (not match_constraints.name)
-            and (self.last_paused.timestamp is not None)
-            and self.last_paused.entity_ids
+            and self.last_paused.is_set
         ):
+            assert self.last_paused.timestamp is not None
+
             # Check for a media player that was paused more recently than the
             # ones by voice.
             recent_state: State | None = None
             for state in match_result.states:
-                if state.last_changed_timestamp <= self.last_paused.timestamp:
+                if (state.last_changed_timestamp <= self.last_paused.timestamp) or (
+                    state.context == self.last_paused.context
+                ):
                     continue
 
                 if (recent_state is None) or (
@@ -172,9 +166,6 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
             if recent_state is not None:
                 # Resume the more recently paused media player (outside of voice).
                 match_result.states = [recent_state]
-                self.last_paused.timestamp = None
-                self.last_paused.entity_ids.clear()
-                self.last_paused.waiting_entity_ids.clear()
             else:
                 # Resume only the previously paused media players if they are in the
                 # targeted set.
@@ -184,6 +175,8 @@ class MediaUnpauseHandler(intent.ServiceIntentHandler):
                     match_result.states = [
                         s for s in match_result.states if s.entity_id in overlapping_ids
                     ]
+
+            self.last_paused.clear()
 
         return await super().async_handle_states(
             intent_obj, match_result, match_constraints

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -1,6 +1,7 @@
 """Intents for the media_player integration."""
 
 from dataclasses import dataclass
+import time
 
 import voluptuous as vol
 
@@ -12,7 +13,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import intent
-from homeassistant.util import dt as dt_util
 
 from . import ATTR_MEDIA_VOLUME_LEVEL, DOMAIN
 from .const import MediaPlayerEntityFeature, MediaPlayerState
@@ -93,7 +93,7 @@ class MediaPauseHandler(intent.ServiceIntentHandler):
         if match_result.is_match:
             # Save entity ids of paused media players
             hass.data[DATA_LAST_PAUSED] = LastPaused(
-                timestamp=dt_util.now().timestamp(),
+                timestamp=time.time(),
                 entity_ids={s.entity_id for s in match_result.states},
             )
 

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -536,6 +536,34 @@ async def test_manual_pause_unpause(
     device_2 = entity_registry.async_update_entity(device_2.entity_id, name="device 2")
     hass.states.async_set(device_2.entity_id, STATE_PLAYING, attributes=attributes)
 
+    # Pause both devices by voice
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PAUSE)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_PAUSE,
+    )
+    await hass.async_block_till_done()
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 2
+
+    hass.states.async_set(device_1.entity_id, STATE_PAUSED, attributes=attributes)
+    hass.states.async_set(device_2.entity_id, STATE_PAUSED, attributes=attributes)
+
+    # Unpause both devices by voice
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PLAY)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_UNPAUSE,
+    )
+    await hass.async_block_till_done()
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 2
+
+    hass.states.async_set(device_1.entity_id, STATE_PLAYING, attributes=attributes)
+    hass.states.async_set(device_2.entity_id, STATE_PLAYING, attributes=attributes)
+
     # Pause the first device by voice
     calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PAUSE)
     response = await intent.async_handle(

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -515,3 +515,54 @@ async def test_multiple_media_players(
     hass.states.async_set(
         kitchen_smart_speaker.entity_id, STATE_PLAYING, attributes=attributes
     )
+
+
+async def test_manual_pause_unpause(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test unpausing a media player that was manually paused outside of voice."""
+    await media_player_intent.async_setup_intents(hass)
+
+    attributes = {ATTR_SUPPORTED_FEATURES: MediaPlayerEntityFeature.PAUSE}
+
+    # Create two playing devices
+    device_1 = entity_registry.async_get_or_create("media_player", "test", "device-1")
+    device_1 = entity_registry.async_update_entity(device_1.entity_id, name="device 1")
+    hass.states.async_set(device_1.entity_id, STATE_PLAYING, attributes=attributes)
+
+    device_2 = entity_registry.async_get_or_create("media_player", "test", "device-2")
+    device_2 = entity_registry.async_update_entity(device_2.entity_id, name="device 2")
+    hass.states.async_set(device_2.entity_id, STATE_PLAYING, attributes=attributes)
+
+    # Pause the first device by voice
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PAUSE)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_PAUSE,
+        {"name": {"value": "device 1"}},
+    )
+    await hass.async_block_till_done()
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": device_1.entity_id}
+
+    hass.states.async_set(device_1.entity_id, STATE_PAUSED, attributes=attributes)
+
+    # "Manually" pause the second device (outside of voice)
+    hass.states.async_set(device_2.entity_id, STATE_PAUSED, attributes=attributes)
+
+    # Unpause with no constraints.
+    # Should resume the more recently (manually) paused device.
+    calls = async_mock_service(hass, DOMAIN, SERVICE_MEDIA_PLAY)
+    response = await intent.async_handle(
+        hass,
+        "test",
+        media_player_intent.INTENT_MEDIA_UNPAUSE,
+    )
+    await hass.async_block_till_done()
+    assert response.response_type == intent.IntentResponseType.ACTION_DONE
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": device_2.entity_id}

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -1,5 +1,7 @@
 """The tests for the media_player platform."""
 
+import asyncio
+
 import pytest
 
 from homeassistant.components.media_player import (
@@ -580,6 +582,7 @@ async def test_manual_pause_unpause(
     hass.states.async_set(device_1.entity_id, STATE_PAUSED, attributes=attributes)
 
     # "Manually" pause the second device (outside of voice)
+    await asyncio.sleep(0.2)
     hass.states.async_set(device_2.entity_id, STATE_PAUSED, attributes=attributes)
 
     # Unpause with no constraints.


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pausing media players by voice puts them into a list so they can later be resumed. If you manually pause a media player outside of voice, however, the old list was still being resumed.

This PR ensures that the most recently paused media player is resumed if it was paused outside of voice.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
