### PR TITLE
Fix dlna_dmr task flood when player changes state

### DIFF
--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -530,8 +530,12 @@ class DlnaDmrEntity(MediaPlayerEntity):
                     TransportState.PAUSED_PLAYBACK,
                 ):
                     force_refresh = True
+                    break
 
-        self.async_schedule_update_ha_state(force_refresh)
+        if force_refresh:
+            self.async_schedule_update_ha_state(force_refresh)
+        else:
+            self.async_write_ha_state()
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes
```
2024-05-16 18:34:44.515 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4a8c2c40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:44.605 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4a8c2c40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:44.700 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4a8c2c40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:44.802 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f51d2af40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:44.911 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb11040> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:45.020 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb11040> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:45.160 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb11b40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:45.234 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f51d2af40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:45.355 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.038 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.116 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.209 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.320 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.434 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f42ed9440> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:46.535 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4413fb40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:51.699 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb10040> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:51.784 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb10040> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:51.892 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f3f6f3740> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:52.027 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb11240> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:52.110 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb11240> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:52.216 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2f4cb10040> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.176 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.259 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.366 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.468 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.576 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.689 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fa29d1540> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.824 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fabccfb40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:54.898 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fabccfb40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
2024-05-16 18:34:55.011 ERROR (MainThread) [homeassistant.core] async_create_task with <coroutine object Entity.async_update_ha_state at 0x7f2fabccfb40> (Entity schedule update ha state media_player.192_168_211_115_sonos_arc_sl)
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
