### PR TITLE
Move modern_forms coordinator to separate module

### DIFF
--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -3,36 +3,25 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from datetime import timedelta
 import logging
 from typing import Any, Concatenate, ParamSpec, TypeVar
 
-from aiomodernforms import (
-    ModernFormsConnectionError,
-    ModernFormsDevice,
-    ModernFormsError,
-)
-from aiomodernforms.models import Device as ModernFormsDeviceState
+from aiomodernforms import ModernFormsConnectionError, ModernFormsError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 _ModernFormsDeviceEntityT = TypeVar(
     "_ModernFormsDeviceEntityT", bound="ModernFormsDeviceEntity"
 )
 _P = ParamSpec("_P")
 
-SCAN_INTERVAL = timedelta(seconds=5)
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.FAN,
@@ -97,37 +86,6 @@ def modernforms_exception_handler(
             _LOGGER.error("Invalid response from API: %s", error)
 
     return handler
-
-
-class ModernFormsDataUpdateCoordinator(DataUpdateCoordinator[ModernFormsDeviceState]):  # pylint: disable=hass-enforce-coordinator-module
-    """Class to manage fetching Modern Forms data from single endpoint."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        *,
-        host: str,
-    ) -> None:
-        """Initialize global Modern Forms data updater."""
-        self.modern_forms = ModernFormsDevice(
-            host, session=async_get_clientsession(hass)
-        )
-
-        super().__init__(
-            hass,
-            _LOGGER,
-            name=DOMAIN,
-            update_interval=SCAN_INTERVAL,
-        )
-
-    async def _async_update_data(self) -> ModernFormsDevice:
-        """Fetch data from Modern Forms."""
-        try:
-            return await self.modern_forms.update(
-                full_update=not self.last_update_success
-            )
-        except ModernFormsError as error:
-            raise UpdateFailed(f"Invalid response from API: {error}") from error
 
 
 class ModernFormsDeviceEntity(CoordinatorEntity[ModernFormsDataUpdateCoordinator]):

--- a/homeassistant/components/modern_forms/binary_sensor.py
+++ b/homeassistant/components/modern_forms/binary_sensor.py
@@ -8,8 +8,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util import dt as dt_util
 
-from . import ModernFormsDataUpdateCoordinator, ModernFormsDeviceEntity
+from . import ModernFormsDeviceEntity
 from .const import CLEAR_TIMER, DOMAIN
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/coordinator.py
+++ b/homeassistant/components/modern_forms/coordinator.py
@@ -1,0 +1,49 @@
+"""Coordiantor for the Modern Forms integration."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+
+from aiomodernforms import ModernFormsDevice, ModernFormsError
+from aiomodernforms.models import Device as ModernFormsDeviceState
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+SCAN_INTERVAL = timedelta(seconds=5)
+_LOGGER = logging.getLogger(__name__)
+
+
+class ModernFormsDataUpdateCoordinator(DataUpdateCoordinator[ModernFormsDeviceState]):
+    """Class to manage fetching Modern Forms data from single endpoint."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        host: str,
+    ) -> None:
+        """Initialize global Modern Forms data updater."""
+        self.modern_forms = ModernFormsDevice(
+            host, session=async_get_clientsession(hass)
+        )
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> ModernFormsDevice:
+        """Fetch data from Modern Forms."""
+        try:
+            return await self.modern_forms.update(
+                full_update=not self.last_update_success
+            )
+        except ModernFormsError as error:
+            raise UpdateFailed(f"Invalid response from API: {error}") from error

--- a/homeassistant/components/modern_forms/coordinator.py
+++ b/homeassistant/components/modern_forms/coordinator.py
@@ -1,4 +1,4 @@
-"""Coordiantor for the Modern Forms integration."""
+"""Coordinator for the Modern Forms integration."""
 
 from __future__ import annotations
 

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -18,11 +18,7 @@ from homeassistant.util.percentage import (
 )
 from homeassistant.util.scaling import int_states_in_range
 
-from . import (
-    ModernFormsDataUpdateCoordinator,
-    ModernFormsDeviceEntity,
-    modernforms_exception_handler,
-)
+from . import ModernFormsDeviceEntity, modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
@@ -32,6 +28,7 @@ from .const import (
     SERVICE_CLEAR_FAN_SLEEP_TIMER,
     SERVICE_SET_FAN_SLEEP_TIMER,
 )
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/light.py
+++ b/homeassistant/components/modern_forms/light.py
@@ -17,11 +17,7 @@ from homeassistant.util.percentage import (
     ranged_value_to_percentage,
 )
 
-from . import (
-    ModernFormsDataUpdateCoordinator,
-    ModernFormsDeviceEntity,
-    modernforms_exception_handler,
-)
+from . import ModernFormsDeviceEntity, modernforms_exception_handler
 from .const import (
     ATTR_SLEEP_TIME,
     CLEAR_TIMER,
@@ -31,6 +27,7 @@ from .const import (
     SERVICE_CLEAR_LIGHT_SLEEP_TIMER,
     SERVICE_SET_LIGHT_SLEEP_TIMER,
 )
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 BRIGHTNESS_RANGE = (1, 255)
 

--- a/homeassistant/components/modern_forms/sensor.py
+++ b/homeassistant/components/modern_forms/sensor.py
@@ -11,8 +11,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 
-from . import ModernFormsDataUpdateCoordinator, ModernFormsDeviceEntity
+from . import ModernFormsDeviceEntity
 from .const import CLEAR_TIMER, DOMAIN
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -9,12 +9,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from . import (
-    ModernFormsDataUpdateCoordinator,
-    ModernFormsDeviceEntity,
-    modernforms_exception_handler,
-)
+from . import ModernFormsDeviceEntity, modernforms_exception_handler
 from .const import DOMAIN
+from .coordinator import ModernFormsDataUpdateCoordinator
 
 
 async def async_setup_entry(

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -102,7 +102,7 @@ async def test_full_zeroconf_flow_implementation(
 
 
 @patch(
-    "homeassistant.components.modern_forms.ModernFormsDevice.update",
+    "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update",
     side_effect=ModernFormsConnectionError,
 )
 async def test_connection_error(
@@ -123,7 +123,7 @@ async def test_connection_error(
 
 
 @patch(
-    "homeassistant.components.modern_forms.ModernFormsDevice.update",
+    "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update",
     side_effect=ModernFormsConnectionError,
 )
 async def test_zeroconf_connection_error(
@@ -151,7 +151,7 @@ async def test_zeroconf_connection_error(
 
 
 @patch(
-    "homeassistant.components.modern_forms.ModernFormsDevice.update",
+    "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update",
     side_effect=ModernFormsConnectionError,
 )
 async def test_zeroconf_confirm_connection_error(

--- a/tests/components/modern_forms/test_fan.py
+++ b/tests/components/modern_forms/test_fan.py
@@ -191,7 +191,9 @@ async def test_fan_error(
 
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch("homeassistant.components.modern_forms.ModernFormsDevice.update"):
+    with patch(
+        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    ):
         await hass.services.async_call(
             FAN_DOMAIN,
             SERVICE_TURN_OFF,
@@ -211,9 +213,11 @@ async def test_fan_connection_error(
     await init_integration(hass, aioclient_mock)
 
     with (
-        patch("homeassistant.components.modern_forms.ModernFormsDevice.update"),
         patch(
-            "homeassistant.components.modern_forms.ModernFormsDevice.fan",
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.fan",
             side_effect=ModernFormsConnectionError,
         ),
     ):

--- a/tests/components/modern_forms/test_init.py
+++ b/tests/components/modern_forms/test_init.py
@@ -15,7 +15,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 @patch(
-    "homeassistant.components.modern_forms.ModernFormsDevice.update",
+    "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update",
     side_effect=ModernFormsConnectionError,
 )
 async def test_config_entry_not_ready(

--- a/tests/components/modern_forms/test_light.py
+++ b/tests/components/modern_forms/test_light.py
@@ -119,7 +119,9 @@ async def test_light_error(
 
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch("homeassistant.components.modern_forms.ModernFormsDevice.update"):
+    with patch(
+        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    ):
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
@@ -139,9 +141,11 @@ async def test_light_connection_error(
     await init_integration(hass, aioclient_mock)
 
     with (
-        patch("homeassistant.components.modern_forms.ModernFormsDevice.update"),
         patch(
-            "homeassistant.components.modern_forms.ModernFormsDevice.light",
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.light",
             side_effect=ModernFormsConnectionError,
         ),
     ):

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -110,7 +110,9 @@ async def test_switch_error(
     aioclient_mock.clear_requests()
     aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
 
-    with patch("homeassistant.components.modern_forms.ModernFormsDevice.update"):
+    with patch(
+        "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+    ):
         await hass.services.async_call(
             SWITCH_DOMAIN,
             SERVICE_TURN_ON,
@@ -131,9 +133,11 @@ async def test_switch_connection_error(
     await init_integration(hass, aioclient_mock)
 
     with (
-        patch("homeassistant.components.modern_forms.ModernFormsDevice.update"),
         patch(
-            "homeassistant.components.modern_forms.ModernFormsDevice.away",
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.update"
+        ),
+        patch(
+            "homeassistant.components.modern_forms.coordinator.ModernFormsDevice.away",
             side_effect=ModernFormsConnectionError,
         ),
     ):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #108174

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
