### PR TITLE
Adjust bootstrap script to use correct version of pre-commit

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,5 +8,5 @@ cd "$(dirname "$0")/.."
 
 echo "Installing development dependencies..."
 python3 -m pip install wheel --constraint homeassistant/package_constraints.txt --upgrade
-python3 -m pip install $(grep colorlog requirements.txt) $(grep pre-commit requirements_test.txt) $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt --upgrade
+python3 -m pip install colorlog $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt --upgrade
 python3 -m pip install -r requirements_test.txt -c homeassistant/package_constraints.txt --upgrade

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -8,5 +8,5 @@ cd "$(dirname "$0")/.."
 
 echo "Installing development dependencies..."
 python3 -m pip install wheel --constraint homeassistant/package_constraints.txt --upgrade
-python3 -m pip install colorlog pre-commit $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt --upgrade
+python3 -m pip install $(grep colorlog requirements.txt) $(grep pre-commit requirements_test.txt) $(grep awesomeversion requirements.txt) --constraint homeassistant/package_constraints.txt --upgrade
 python3 -m pip install -r requirements_test.txt -c homeassistant/package_constraints.txt --upgrade


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Linked to #117619
I spotted this whilst working on #117569

At present, we keep installing the latest in bootstrap, and then right away downgrade to the version in `requirements_test.txt`

```
vscode ➜ /workspaces/home-assistant-core (20240517-1051) $ script/bootstrap
Installing development dependencies...
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: wheel in /usr/local/lib/python3.12/site-packages (0.43.0)
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: colorlog in /home/vscode/.local/lib/python3.12/site-packages (6.8.2)
Requirement already satisfied: pre-commit in /home/vscode/.local/lib/python3.12/site-packages (3.7.0)
Collecting pre-commit
  Using cached pre_commit-3.7.1-py2.py3-none-any.whl.metadata (1.3 kB)
Requirement already satisfied: awesomeversion==24.2.0 in /home/vscode/.local/lib/python3.12/site-packages (24.2.0)
Requirement already satisfied: cfgv>=2.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit) (3.4.0)
Requirement already satisfied: identify>=1.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit) (2.5.36)
Requirement already satisfied: nodeenv>=0.11.1 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit) (1.8.0)
Requirement already satisfied: pyyaml>=5.1 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit) (6.0.1)
Requirement already satisfied: virtualenv>=20.10.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit) (20.26.2)
Requirement already satisfied: setuptools in /usr/local/lib/python3.12/site-packages (from nodeenv>=0.11.1->pre-commit) (69.0.3)
Requirement already satisfied: distlib<1,>=0.3.7 in /home/vscode/.local/lib/python3.12/site-packages (from virtualenv>=20.10.0->pre-commit) (0.3.8)
Requirement already satisfied: filelock<4,>=3.12.2 in /home/vscode/.local/lib/python3.12/site-packages (from virtualenv>=20.10.0->pre-commit) (3.14.0)
Requirement already satisfied: platformdirs<5,>=3.9.1 in /home/vscode/.local/lib/python3.12/site-packages (from virtualenv>=20.10.0->pre-commit) (4.2.2)
Using cached pre_commit-3.7.1-py2.py3-none-any.whl (204 kB)
Installing collected packages: pre-commit
  Attempting uninstall: pre-commit
    Found existing installation: pre-commit 3.7.0
    Uninstalling pre-commit-3.7.0:
      Successfully uninstalled pre-commit-3.7.0
Successfully installed pre-commit-3.7.1
Defaulting to user installation because normal site-packages is not writeable
Requirement already satisfied: codespell==2.2.6 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test_pre_commit.txt (line 3)) (2.2.6)
Requirement already satisfied: ruff==0.4.4 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test_pre_commit.txt (line 4)) (0.4.4)
Requirement already satisfied: yamllint==1.35.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test_pre_commit.txt (line 5)) (1.35.1)
Requirement already satisfied: astroid==3.1.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 10)) (3.1.0)
Requirement already satisfied: coverage==7.5.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 11)) (7.5.0)
Requirement already satisfied: freezegun==1.5.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 12)) (1.5.0)
Requirement already satisfied: mock-open==1.4.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 13)) (1.4.0)
Requirement already satisfied: mypy==1.10.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 14)) (1.10.0)
Collecting pre-commit==3.7.0 (from -r requirements_test.txt (line 15))
  Using cached pre_commit-3.7.0-py2.py3-none-any.whl.metadata (1.3 kB)
Requirement already satisfied: pydantic==1.10.15 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 16)) (1.10.15)
Requirement already satisfied: pylint==3.1.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 17)) (3.1.1)
Requirement already satisfied: pylint-per-file-ignores==1.3.2 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 18)) (1.3.2)
Requirement already satisfied: pipdeptree==2.19.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 19)) (2.19.0)
Requirement already satisfied: pytest-asyncio==0.23.6 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 20)) (0.23.6)
Requirement already satisfied: pytest-aiohttp==1.0.5 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 21)) (1.0.5)
Requirement already satisfied: pytest-cov==5.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 22)) (5.0.0)
Requirement already satisfied: pytest-freezer==0.4.8 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 23)) (0.4.8)
Requirement already satisfied: pytest-github-actions-annotate-failures==0.2.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 24)) (0.2.0)
Requirement already satisfied: pytest-socket==0.7.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 25)) (0.7.0)
Requirement already satisfied: pytest-sugar==1.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 26)) (1.0.0)
Requirement already satisfied: pytest-timeout==2.3.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 27)) (2.3.1)
Requirement already satisfied: pytest-unordered==0.6.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 28)) (0.6.0)
Requirement already satisfied: pytest-picked==0.5.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 29)) (0.5.0)
Requirement already satisfied: pytest-xdist==3.6.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 30)) (3.6.1)
Requirement already satisfied: pytest==8.2.0 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 31)) (8.2.0)
Requirement already satisfied: requests-mock==1.12.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 32)) (1.12.1)
Requirement already satisfied: respx==0.21.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 33)) (0.21.1)
Requirement already satisfied: syrupy==4.6.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 34)) (4.6.1)
Requirement already satisfied: tqdm==4.66.4 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 35)) (4.66.4)
Requirement already satisfied: types-aiofiles==23.2.0.20240403 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 36)) (23.2.0.20240403)
Requirement already satisfied: types-atomicwrites==1.4.5.1 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 37)) (1.4.5.1)
Requirement already satisfied: types-croniter==2.0.0.20240423 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 38)) (2.0.0.20240423)
Requirement already satisfied: types-beautifulsoup4==4.12.0.20240511 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 39)) (4.12.0.20240511)
Requirement already satisfied: types-caldav==1.3.0.20240331 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 40)) (1.3.0.20240331)
Requirement already satisfied: types-chardet==0.1.5 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 41)) (0.1.5)
Requirement already satisfied: types-decorator==5.1.8.20240310 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 42)) (5.1.8.20240310)
Requirement already satisfied: types-paho-mqtt==1.6.0.20240321 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 43)) (1.6.0.20240321)
Requirement already satisfied: types-pillow==10.2.0.20240511 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 44)) (10.2.0.20240511)
Requirement already satisfied: types-protobuf==4.24.0.20240106 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 45)) (4.24.0.20240106)
Requirement already satisfied: types-psutil==5.9.5.20240511 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 46)) (5.9.5.20240511)
Requirement already satisfied: types-python-dateutil==2.9.0.20240316 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 47)) (2.9.0.20240316)
Requirement already satisfied: types-python-slugify==8.0.2.20240310 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 48)) (8.0.2.20240310)
Requirement already satisfied: types-pytz==2024.1.0.20240417 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 49)) (2024.1.0.20240417)
Requirement already satisfied: types-PyYAML==6.0.12.20240311 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 50)) (6.0.12.20240311)
Requirement already satisfied: types-requests==2.31.0.3 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 51)) (2.31.0.3)
Requirement already satisfied: types-xmltodict==0.13.0.3 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 52)) (0.13.0.3)
Requirement already satisfied: uv==0.1.43 in /home/vscode/.local/lib/python3.12/site-packages (from -r requirements_test.txt (line 53)) (0.1.43)
Requirement already satisfied: pathspec>=0.5.3 in /home/vscode/.local/lib/python3.12/site-packages (from yamllint==1.35.1->-r requirements_test_pre_commit.txt (line 5)) (0.12.1)
Requirement already satisfied: pyyaml in /home/vscode/.local/lib/python3.12/site-packages (from yamllint==1.35.1->-r requirements_test_pre_commit.txt (line 5)) (6.0.1)
Requirement already satisfied: python-dateutil>=2.7 in /usr/local/lib/python3.12/site-packages (from freezegun==1.5.0->-r requirements_test.txt (line 12)) (2.9.0.post0)
Requirement already satisfied: typing-extensions>=4.1.0 in /home/vscode/.local/lib/python3.12/site-packages (from mypy==1.10.0->-r requirements_test.txt (line 14)) (4.11.0)
Requirement already satisfied: mypy-extensions>=1.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from mypy==1.10.0->-r requirements_test.txt (line 14)) (1.0.0)
Requirement already satisfied: cfgv>=2.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit==3.7.0->-r requirements_test.txt (line 15)) (3.4.0)
Requirement already satisfied: identify>=1.0.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit==3.7.0->-r requirements_test.txt (line 15)) (2.5.36)
Requirement already satisfied: nodeenv>=0.11.1 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit==3.7.0->-r requirements_test.txt (line 15)) (1.8.0)
Requirement already satisfied: virtualenv>=20.10.0 in /home/vscode/.local/lib/python3.12/site-packages (from pre-commit==3.7.0->-r requirements_test.txt (line 15)) (20.26.2)
Requirement already satisfied: platformdirs>=2.2.0 in /home/vscode/.local/lib/python3.12/site-packages (from pylint==3.1.1->-r requirements_test.txt (line 17)) (4.2.2)
Requirement already satisfied: isort!=5.13.0,<6,>=4.2.5 in /home/vscode/.local/lib/python3.12/site-packages (from pylint==3.1.1->-r requirements_test.txt (line 17)) (5.13.2)
Requirement already satisfied: mccabe<0.8,>=0.6 in /home/vscode/.local/lib/python3.12/site-packages (from pylint==3.1.1->-r requirements_test.txt (line 17)) (0.7.0)
Requirement already satisfied: tomlkit>=0.10.1 in /home/vscode/.local/lib/python3.12/site-packages (from pylint==3.1.1->-r requirements_test.txt (line 17)) (0.12.5)
Requirement already satisfied: dill>=0.3.6 in /home/vscode/.local/lib/python3.12/site-packages (from pylint==3.1.1->-r requirements_test.txt (line 17)) (0.3.8)
Requirement already satisfied: packaging>=23.1 in /home/vscode/.local/lib/python3.12/site-packages (from pipdeptree==2.19.0->-r requirements_test.txt (line 19)) (24.0)
Requirement already satisfied: pip>=23.1.2 in /usr/local/lib/python3.12/site-packages (from pipdeptree==2.19.0->-r requirements_test.txt (line 19)) (24.0)
Requirement already satisfied: aiohttp>=3.8.1 in /home/vscode/.local/lib/python3.12/site-packages (from pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (3.9.5)
Requirement already satisfied: termcolor>=2.1.0 in /home/vscode/.local/lib/python3.12/site-packages (from pytest-sugar==1.0.0->-r requirements_test.txt (line 26)) (2.4.0)
Requirement already satisfied: execnet>=2.1 in /home/vscode/.local/lib/python3.12/site-packages (from pytest-xdist==3.6.1->-r requirements_test.txt (line 30)) (2.1.1)
Requirement already satisfied: iniconfig in /home/vscode/.local/lib/python3.12/site-packages (from pytest==8.2.0->-r requirements_test.txt (line 31)) (2.0.0)
Requirement already satisfied: pluggy<2.0,>=1.5 in /home/vscode/.local/lib/python3.12/site-packages (from pytest==8.2.0->-r requirements_test.txt (line 31)) (1.5.0)
Requirement already satisfied: requests<3,>=2.22 in /usr/local/lib/python3.12/site-packages (from requests-mock==1.12.1->-r requirements_test.txt (line 32)) (2.31.0)
Requirement already satisfied: httpx>=0.21.0 in /home/vscode/.local/lib/python3.12/site-packages (from respx==0.21.1->-r requirements_test.txt (line 33)) (0.27.0)
Requirement already satisfied: types-html5lib in /home/vscode/.local/lib/python3.12/site-packages (from types-beautifulsoup4==4.12.0.20240511->-r requirements_test.txt (line 39)) (1.1.11.20240228)
Requirement already satisfied: types-vobject in /home/vscode/.local/lib/python3.12/site-packages (from types-caldav==1.3.0.20240331->-r requirements_test.txt (line 40)) (0.9.8.20240310)
Requirement already satisfied: types-urllib3 in /home/vscode/.local/lib/python3.12/site-packages (from types-requests==2.31.0.3->-r requirements_test.txt (line 51)) (1.26.25.14)
Requirement already satisfied: aiosignal>=1.1.2 in /home/vscode/.local/lib/python3.12/site-packages (from aiohttp>=3.8.1->pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (1.3.1)
Requirement already satisfied: attrs>=17.3.0 in /home/vscode/.local/lib/python3.12/site-packages (from aiohttp>=3.8.1->pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (23.2.0)
Requirement already satisfied: frozenlist>=1.1.1 in /home/vscode/.local/lib/python3.12/site-packages (from aiohttp>=3.8.1->pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (1.4.1)
Requirement already satisfied: multidict<7.0,>=4.5 in /home/vscode/.local/lib/python3.12/site-packages (from aiohttp>=3.8.1->pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (6.0.5)
Requirement already satisfied: yarl<2.0,>=1.0 in /home/vscode/.local/lib/python3.12/site-packages (from aiohttp>=3.8.1->pytest-aiohttp==1.0.5->-r requirements_test.txt (line 21)) (1.9.4)
Requirement already satisfied: anyio in /home/vscode/.local/lib/python3.12/site-packages (from httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (4.3.0)
Requirement already satisfied: certifi in /usr/local/lib/python3.12/site-packages (from httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (2024.2.2)
Requirement already satisfied: httpcore==1.* in /home/vscode/.local/lib/python3.12/site-packages (from httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (1.0.5)
Requirement already satisfied: idna in /usr/local/lib/python3.12/site-packages (from httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (3.7)
Requirement already satisfied: sniffio in /home/vscode/.local/lib/python3.12/site-packages (from httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (1.3.1)
Requirement already satisfied: h11<0.15,>=0.13 in /home/vscode/.local/lib/python3.12/site-packages (from httpcore==1.*->httpx>=0.21.0->respx==0.21.1->-r requirements_test.txt (line 33)) (0.14.0)
Requirement already satisfied: setuptools in /usr/local/lib/python3.12/site-packages (from nodeenv>=0.11.1->pre-commit==3.7.0->-r requirements_test.txt (line 15)) (69.0.3)
Requirement already satisfied: six>=1.5 in /usr/local/lib/python3.12/site-packages (from python-dateutil>=2.7->freezegun==1.5.0->-r requirements_test.txt (line 12)) (1.16.0)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/vscode/.local/lib/python3.12/site-packages (from requests<3,>=2.22->requests-mock==1.12.1->-r requirements_test.txt (line 32)) (3.2.0)
Requirement already satisfied: urllib3<3,>=1.21.1 in /home/vscode/.local/lib/python3.12/site-packages (from requests<3,>=2.22->requests-mock==1.12.1->-r requirements_test.txt (line 32)) (1.26.18)
Requirement already satisfied: distlib<1,>=0.3.7 in /home/vscode/.local/lib/python3.12/site-packages (from virtualenv>=20.10.0->pre-commit==3.7.0->-r requirements_test.txt (line 15)) (0.3.8)
Requirement already satisfied: filelock<4,>=3.12.2 in /home/vscode/.local/lib/python3.12/site-packages (from virtualenv>=20.10.0->pre-commit==3.7.0->-r requirements_test.txt (line 15)) (3.14.0)
Using cached pre_commit-3.7.0-py2.py3-none-any.whl (204 kB)
Installing collected packages: pre-commit
  Attempting uninstall: pre-commit
    Found existing installation: pre-commit 3.7.1
    Uninstalling pre-commit-3.7.1:
      Successfully uninstalled pre-commit-3.7.1
Successfully installed pre-commit-3.7.0
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
