### PR TITLE
2024.5.4

### DIFF
--- a/homeassistant/components/analytics_insights/config_flow.py
+++ b/homeassistant/components/analytics_insights/config_flow.py
@@ -82,6 +82,9 @@ class HomeassistantAnalyticsConfigFlow(ConfigFlow, domain=DOMAIN):
         except HomeassistantAnalyticsConnectionError:
             LOGGER.exception("Error connecting to Home Assistant analytics")
             return self.async_abort(reason="cannot_connect")
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Unexpected error")
+            return self.async_abort(reason="unknown")
 
         options = [
             SelectOptionDict(

--- a/homeassistant/components/analytics_insights/config_flow.py
+++ b/homeassistant/components/analytics_insights/config_flow.py
@@ -82,7 +82,7 @@ class HomeassistantAnalyticsConfigFlow(ConfigFlow, domain=DOMAIN):
         except HomeassistantAnalyticsConnectionError:
             LOGGER.exception("Error connecting to Home Assistant analytics")
             return self.async_abort(reason="cannot_connect")
-        except Exception:  # noqa: BLE001
+        except Exception:  # pylint: disable=broad-except
             LOGGER.exception("Unexpected error")
             return self.async_abort(reason="unknown")
 

--- a/homeassistant/components/analytics_insights/strings.json
+++ b/homeassistant/components/analytics_insights/strings.json
@@ -13,7 +13,8 @@
       }
     },
     "abort": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "error": {
       "no_integration_selected": "You must select at least one integration to track"

--- a/homeassistant/components/aurora/entity.py
+++ b/homeassistant/components/aurora/entity.py
@@ -15,6 +15,7 @@ class AuroraEntity(CoordinatorEntity[AuroraDataUpdateCoordinator]):
     """Implementation of the base Aurora Entity."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(
         self,

--- a/homeassistant/components/duotecno/entity.py
+++ b/homeassistant/components/duotecno/entity.py
@@ -41,6 +41,11 @@ class DuotecnoEntity(Entity):
         """When a unit has an update."""
         self.async_write_ha_state()
 
+    @property
+    def available(self) -> bool:
+        """Available state for the unit."""
+        return self._unit.is_available()
+
 
 _T = TypeVar("_T", bound="DuotecnoEntity")
 _P = ParamSpec("_P")

--- a/homeassistant/components/duotecno/manifest.json
+++ b/homeassistant/components/duotecno/manifest.json
@@ -7,5 +7,5 @@
   "iot_class": "local_push",
   "loggers": ["pyduotecno", "pyduotecno-node", "pyduotecno-unit"],
   "quality_scale": "silver",
-  "requirements": ["pyDuotecno==2024.3.2"]
+  "requirements": ["pyDuotecno==2024.5.0"]
 }

--- a/homeassistant/components/fully_kiosk/services.py
+++ b/homeassistant/components/fully_kiosk/services.py
@@ -69,18 +69,21 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     async def async_set_config(call: ServiceCall) -> None:
         """Set a Fully Kiosk Browser config value on the device."""
         for coordinator in await collect_coordinators(call.data[ATTR_DEVICE_ID]):
+            key = call.data[ATTR_KEY]
+            value = call.data[ATTR_VALUE]
+
             # Fully API has different methods for setting string and bool values.
             # check if call.data[ATTR_VALUE] is a bool
-            if isinstance(call.data[ATTR_VALUE], bool) or call.data[
-                ATTR_VALUE
-            ].lower() in ("true", "false"):
-                await coordinator.fully.setConfigurationBool(
-                    call.data[ATTR_KEY], call.data[ATTR_VALUE]
-                )
+            if isinstance(value, bool) or (
+                isinstance(value, str) and value.lower() in ("true", "false")
+            ):
+                await coordinator.fully.setConfigurationBool(key, value)
             else:
-                await coordinator.fully.setConfigurationString(
-                    call.data[ATTR_KEY], call.data[ATTR_VALUE]
-                )
+                # Convert any int values to string
+                if isinstance(value, int):
+                    value = str(value)
+
+                await coordinator.fully.setConfigurationString(key, value)
 
     # Register all the above services
     service_mapping = [
@@ -111,7 +114,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 {
                     vol.Required(ATTR_DEVICE_ID): cv.ensure_list,
                     vol.Required(ATTR_KEY): cv.string,
-                    vol.Required(ATTR_VALUE): vol.Any(str, bool),
+                    vol.Required(ATTR_VALUE): vol.Any(str, bool, int),
                 }
             )
         ),

--- a/homeassistant/components/google_assistant_sdk/__init__.py
+++ b/homeassistant/components/google_assistant_sdk/__init__.py
@@ -169,7 +169,9 @@ class GoogleAssistantConversationAgent(conversation.AbstractConversationAgent):
             self.language = user_input.language
             self.assistant = TextAssistant(credentials, self.language)
 
-        resp = self.assistant.assist(user_input.text)
+        resp = await self.hass.async_add_executor_job(
+            self.assistant.assist, user_input.text
+        )
         text_response = resp[0] or "<empty response>"
 
         intent_response = intent.IntentResponse(language=user_input.language)

--- a/homeassistant/components/google_assistant_sdk/helpers.py
+++ b/homeassistant/components/google_assistant_sdk/helpers.py
@@ -79,7 +79,7 @@ async def async_send_text_commands(
     ) as assistant:
         command_response_list = []
         for command in commands:
-            resp = assistant.assist(command)
+            resp = await hass.async_add_executor_job(assistant.assist, command)
             text_response = resp[0]
             _LOGGER.debug("command: %s\nresponse: %s", command, text_response)
             audio_response = resp[2]

--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -182,11 +182,11 @@ class GoogleGenerativeAIAgent(conversation.AbstractConversationAgent):
             conversation_id = ulid.ulid_now()
             messages = [{}, {}]
 
+        intent_response = intent.IntentResponse(language=user_input.language)
         try:
             prompt = self._async_generate_prompt(raw_prompt)
         except TemplateError as err:
             _LOGGER.error("Error rendering prompt: %s", err)
-            intent_response = intent.IntentResponse(language=user_input.language)
             intent_response.async_set_error(
                 intent.IntentResponseErrorCode.UNKNOWN,
                 f"Sorry, I had a problem with my template: {err}",
@@ -210,7 +210,6 @@ class GoogleGenerativeAIAgent(conversation.AbstractConversationAgent):
             genai_types.StopCandidateException,
         ) as err:
             _LOGGER.error("Error sending message: %s", err)
-            intent_response = intent.IntentResponse(language=user_input.language)
             intent_response.async_set_error(
                 intent.IntentResponseErrorCode.UNKNOWN,
                 f"Sorry, I had a problem talking to Google Generative AI: {err}",
@@ -220,9 +219,15 @@ class GoogleGenerativeAIAgent(conversation.AbstractConversationAgent):
             )
 
         _LOGGER.debug("Response: %s", chat_response.parts)
+        if not chat_response.parts:
+            intent_response.async_set_error(
+                intent.IntentResponseErrorCode.UNKNOWN,
+                "Sorry, I had a problem talking to Google Generative AI. Likely blocked",
+            )
+            return conversation.ConversationResult(
+                response=intent_response, conversation_id=conversation_id
+            )
         self.history[conversation_id] = chat.history
-
-        intent_response = intent.IntentResponse(language=user_input.language)
         intent_response.async_set_speech(chat_response.text)
         return conversation.ConversationResult(
             response=intent_response, conversation_id=conversation_id

--- a/homeassistant/components/husqvarna_automower/__init__.py
+++ b/homeassistant/components/husqvarna_automower/__init__.py
@@ -57,6 +57,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
+    if "amc:api" not in entry.data["token"]["scope"]:
+        # We raise ConfigEntryAuthFailed here because the websocket can't be used
+        # without the scope. So only polling would be possible.
+        raise ConfigEntryAuthFailed
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -4,12 +4,17 @@ import asyncio
 from datetime import timedelta
 import logging
 
-from aioautomower.exceptions import ApiException, HusqvarnaWSServerHandshakeError
+from aioautomower.exceptions import (
+    ApiException,
+    AuthException,
+    HusqvarnaWSServerHandshakeError,
+)
 from aioautomower.model import MowerAttributes
 from aioautomower.session import AutomowerSession
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -46,6 +51,8 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[dict[str, MowerAttrib
             return await self.api.get_status()
         except ApiException as err:
             raise UpdateFailed(err) from err
+        except AuthException as err:
+            raise ConfigEntryAuthFailed(err) from err
 
     @callback
     def callback(self, ws_data: dict[str, MowerAttributes]) -> None:

--- a/homeassistant/components/husqvarna_automower/strings.json
+++ b/homeassistant/components/husqvarna_automower/strings.json
@@ -5,6 +5,10 @@
         "title": "[%key:common::config_flow::title::reauth%]",
         "description": "The Husqvarna Automower integration needs to re-authenticate your account"
       },
+      "missing_scope": {
+        "title": "Your account is missing some API connections",
+        "description": "For the best experience with this integration both the `Authentication API` and the `Automower Connect API` should be connected. Please make sure that both of them are connected to your account in the [Husqvarna Developer Portal]({application_url})."
+      },
       "pick_implementation": {
         "title": "[%key:common::config_flow::title::oauth2_pick_implementation%]"
       }
@@ -22,7 +26,8 @@
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "oauth_failed": "[%key:common::config_flow::abort::oauth2_failed%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-      "wrong_account": "You can only reauthenticate this entry with the same Husqvarna account."
+      "wrong_account": "You can only reauthenticate this entry with the same Husqvarna account.",
+      "missing_amc_scope": "The `Authentication API` and the `Automower Connect API` are not connected to your application in the Husqvarna Developer Portal."
     },
     "create_entry": {
       "default": "[%key:common::config_flow::create_entry::authenticated%]"

--- a/homeassistant/components/insteon/schemas.py
+++ b/homeassistant/components/insteon/schemas.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_CAT,
     CONF_DIM_STEPS,
     CONF_HOUSECODE,
+    CONF_HUB_VERSION,
     CONF_SUBCAT,
     CONF_UNITCODE,
     HOUSECODES,
@@ -143,6 +144,7 @@ def build_hub_schema(
     schema = {
         vol.Required(CONF_HOST, default=host): str,
         vol.Required(CONF_PORT, default=port): int,
+        vol.Required(CONF_HUB_VERSION, default=hub_version): int,
     }
     if hub_version == 2:
         schema[vol.Required(CONF_USERNAME, default=username)] = str

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -480,7 +480,13 @@ class KodiEntity(MediaPlayerEntity):
             self._reset_state()
             return
 
-        self._players = await self._kodi.get_players()
+        try:
+            self._players = await self._kodi.get_players()
+        except (TransportError, ProtocolError):
+            if not self._connection.can_subscribe:
+                self._reset_state()
+                return
+            raise
 
         if self._kodi_is_off:
             self._reset_state()

--- a/homeassistant/components/lutron_caseta/cover.py
+++ b/homeassistant/components/lutron_caseta/cover.py
@@ -96,7 +96,7 @@ class LutronCasetaTiltOnlyBlind(LutronCasetaDeviceUpdatableEntity, CoverEntity):
 
     async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the blind to a specific tilt."""
-        self._smartbridge.set_tilt(self.device_id, kwargs[ATTR_TILT_POSITION])
+        await self._smartbridge.set_tilt(self.device_id, kwargs[ATTR_TILT_POSITION])
 
 
 PYLUTRON_TYPE_TO_CLASSES = {

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -83,8 +83,18 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+MIN_BUFFER_SIZE = 131072  # Minimum buffer size to use if preferred size fails
+PREFERRED_BUFFER_SIZE = 2097152  # Set receive buffer size to 2MB
+
 DISCOVERY_COOLDOWN = 5
-INITIAL_SUBSCRIBE_COOLDOWN = 3.0
+# The initial subscribe cooldown controls how long to wait to group
+# subscriptions together. This is to avoid making too many subscribe
+# requests in a short period of time. If the number is too low, the
+# system will be flooded with subscribe requests. If the number is too
+# high, we risk being flooded with responses to the subscribe requests
+# which can exceed the receive buffer size of the socket. To mitigate
+# this, we increase the receive buffer size of the socket as well.
+INITIAL_SUBSCRIBE_COOLDOWN = 0.5
 SUBSCRIBE_COOLDOWN = 0.1
 UNSUBSCRIBE_COOLDOWN = 0.1
 TIMEOUT_ACK = 10
@@ -429,6 +439,7 @@ class MQTT:
                 hass.bus.async_listen(EVENT_HOMEASSISTANT_STOP, self._async_ha_stop),
             )
         )
+        self._socket_buffersize: int | None = None
 
     @callback
     def _async_ha_started(self, _hass: HomeAssistant) -> None:
@@ -529,6 +540,29 @@ class MQTT:
                 self.hass, self._misc_loop(), name="mqtt misc loop"
             )
 
+    def _increase_socket_buffer_size(self, sock: SocketType) -> None:
+        """Increase the socket buffer size."""
+        new_buffer_size = PREFERRED_BUFFER_SIZE
+        while True:
+            try:
+                # Some operating systems do not allow us to set the preferred
+                # buffer size. In that case we try some other size options.
+                sock.setsockopt(socket.SOL_SOCKET, socket.SO_RCVBUF, new_buffer_size)
+            except OSError as err:
+                if new_buffer_size <= MIN_BUFFER_SIZE:
+                    _LOGGER.warning(
+                        "Unable to increase the socket buffer size to %s; "
+                        "The connection may be unstable if the MQTT broker "
+                        "sends data at volume or a large amount of subscriptions "
+                        "need to be processed: %s",
+                        new_buffer_size,
+                        err,
+                    )
+                    return
+                new_buffer_size //= 2
+            else:
+                return
+
     def _on_socket_open(
         self, client: mqtt.Client, userdata: Any, sock: SocketType
     ) -> None:
@@ -545,6 +579,7 @@ class MQTT:
         fileno = sock.fileno()
         _LOGGER.debug("%s: connection opened %s", self.config_entry.title, fileno)
         if fileno > -1:
+            self._increase_socket_buffer_size(sock)
             self.loop.add_reader(sock, partial(self._async_reader_callback, client))
         self._async_start_misc_loop()
 

--- a/homeassistant/components/ondilo_ico/coordinator.py
+++ b/homeassistant/components/ondilo_ico/coordinator.py
@@ -24,7 +24,7 @@ class OndiloIcoCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             hass,
             logger=_LOGGER,
             name=DOMAIN,
-            update_interval=timedelta(minutes=5),
+            update_interval=timedelta(minutes=20),
         )
         self.api = api
 

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -55,7 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     use_tls = entry.data[CONF_SSL]
     verify_tls = entry.data[CONF_VERIFY_SSL]
     location = entry.data[CONF_LOCATION]
-    api_key = entry.data.get(CONF_API_KEY)
+    api_key = entry.data.get(CONF_API_KEY, "")
 
     # remove obsolet CONF_STATISTICS_ONLY from entry.data
     if CONF_STATISTICS_ONLY in entry.data:

--- a/homeassistant/components/poolsense/entity.py
+++ b/homeassistant/components/poolsense/entity.py
@@ -1,9 +1,10 @@
 """Base entity for poolsense integration."""
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION
+from .const import ATTRIBUTION, DOMAIN
 from .coordinator import PoolSenseDataUpdateCoordinator
 
 
@@ -11,6 +12,7 @@ class PoolSenseEntity(CoordinatorEntity[PoolSenseDataUpdateCoordinator]):
     """Implements a common class elements representing the PoolSense component."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -21,5 +23,8 @@ class PoolSenseEntity(CoordinatorEntity[PoolSenseDataUpdateCoordinator]):
         """Initialize poolsense sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_name = f"PoolSense {description.name}"
         self._attr_unique_id = f"{email}-{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, email)},
+            model="PoolSense",
+        )

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -85,6 +85,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             try:
                 await host.update_states()
             except CredentialsInvalidError as err:
+                await host.stop()
                 raise ConfigEntryAuthFailed(err) from err
             except ReolinkError as err:
                 raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -18,5 +18,5 @@
   "documentation": "https://www.home-assistant.io/integrations/reolink",
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
-  "requirements": ["reolink-aio==0.8.9"]
+  "requirements": ["reolink-aio==0.8.10"]
 }

--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/sonos",
   "iot_class": "local_push",
   "loggers": ["soco"],
-  "requirements": ["soco==0.30.3", "sonos-websocket==0.1.3"],
+  "requirements": ["soco==0.30.4", "sonos-websocket==0.1.3"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:ZonePlayer:1"

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -92,7 +92,7 @@ SQUEEZEBOX_MODE = {
 }
 
 
-async def start_server_discovery(hass):
+async def start_server_discovery(hass: HomeAssistant) -> None:
     """Start a server discovery task."""
 
     def _discovered_server(server):
@@ -110,8 +110,9 @@ async def start_server_discovery(hass):
     hass.data.setdefault(DOMAIN, {})
     if DISCOVERY_TASK not in hass.data[DOMAIN]:
         _LOGGER.debug("Adding server discovery task for squeezebox")
-        hass.data[DOMAIN][DISCOVERY_TASK] = hass.async_create_task(
-            async_discover(_discovered_server)
+        hass.data[DOMAIN][DISCOVERY_TASK] = hass.async_create_background_task(
+            async_discover(_discovered_server),
+            name="squeezebox server discovery",
         )
 
 

--- a/homeassistant/components/tellduslive/const.py
+++ b/homeassistant/components/tellduslive/const.py
@@ -24,7 +24,6 @@ SCAN_INTERVAL = timedelta(minutes=1)
 
 ATTR_LAST_UPDATED = "time_last_updated"
 
-SIGNAL_UPDATE_ENTITY = "tellduslive_update"
 TELLDUS_DISCOVERY_NEW = "telldus_new_{}_{}"
 
 CLOUD_NAME = "Cloud API"

--- a/homeassistant/components/tellduslive/cover.py
+++ b/homeassistant/components/tellduslive/cover.py
@@ -46,14 +46,14 @@ class TelldusLiveCover(TelldusLiveEntity, CoverEntity):
     def close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         self.device.down()
-        self._update_callback()
+        self.schedule_update_ha_state()
 
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         self.device.up()
-        self._update_callback()
+        self.schedule_update_ha_state()
 
     def stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         self.device.stop()
-        self._update_callback()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/tellduslive/entry.py
+++ b/homeassistant/components/tellduslive/entry.py
@@ -11,7 +11,6 @@ from homeassistant.const import (
     ATTR_MODEL,
     ATTR_VIA_DEVICE,
 )
-from homeassistant.core import callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
@@ -33,24 +32,15 @@ class TelldusLiveEntity(Entity):
         """Initialize the entity."""
         self._id = device_id
         self._client = client
-        self._async_unsub_dispatcher_connect = None
 
     async def async_added_to_hass(self):
         """Call when entity is added to hass."""
         _LOGGER.debug("Created device %s", self)
-        self._async_unsub_dispatcher_connect = async_dispatcher_connect(
-            self.hass, SIGNAL_UPDATE_ENTITY, self._update_callback
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_UPDATE_ENTITY, self.async_write_ha_state
+            )
         )
-
-    async def async_will_remove_from_hass(self):
-        """Disconnect dispatcher listener when removed."""
-        if self._async_unsub_dispatcher_connect:
-            self._async_unsub_dispatcher_connect()
-
-    @callback
-    def _update_callback(self):
-        """Return the property of the device might have changed."""
-        self.async_write_ha_state()
 
     @property
     def device_id(self):

--- a/homeassistant/components/tellduslive/light.py
+++ b/homeassistant/components/tellduslive/light.py
@@ -50,7 +50,7 @@ class TelldusLiveLight(TelldusLiveEntity, LightEntity):
     def changed(self):
         """Define a property of the device that might have changed."""
         self._last_brightness = self.brightness
-        self._update_callback()
+        self.schedule_update_ha_state()
 
     @property
     def brightness(self):

--- a/homeassistant/components/tellduslive/switch.py
+++ b/homeassistant/components/tellduslive/switch.py
@@ -45,9 +45,9 @@ class TelldusLiveSwitch(TelldusLiveEntity, SwitchEntity):
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         self.device.turn_on()
-        self._update_callback()
+        self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         self.device.turn_off()
-        self._update_callback()
+        self.schedule_update_ha_state()

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "quality_scale": "platinum",
-  "requirements": ["wled==0.17.0"],
+  "requirements": ["wled==0.17.1"],
   "zeroconf": ["_wled._tcp.local."]
 }

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -41,7 +41,6 @@ from zwave_js_server.const.command_class.thermostat import (
     THERMOSTAT_SETPOINT_PROPERTY,
 )
 from zwave_js_server.exceptions import UnknownValueData
-from zwave_js_server.model.device_class import DeviceClassItem
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import (
     ConfigurationValue,
@@ -1180,14 +1179,22 @@ def async_discover_single_value(
             continue
 
         # check device_class_generic
-        if value.node.device_class and not check_device_class(
-            value.node.device_class.generic, schema.device_class_generic
+        if schema.device_class_generic and (
+            not value.node.device_class
+            or not any(
+                value.node.device_class.generic.label == val
+                for val in schema.device_class_generic
+            )
         ):
             continue
 
         # check device_class_specific
-        if value.node.device_class and not check_device_class(
-            value.node.device_class.specific, schema.device_class_specific
+        if schema.device_class_specific and (
+            not value.node.device_class
+            or not any(
+                value.node.device_class.specific.label == val
+                for val in schema.device_class_specific
+            )
         ):
             continue
 
@@ -1379,15 +1386,3 @@ def check_value(value: ZwaveValue, schema: ZWaveValueDiscoverySchema) -> bool:
     if schema.stateful is not None and value.metadata.stateful != schema.stateful:
         return False
     return True
-
-
-@callback
-def check_device_class(
-    device_class: DeviceClassItem, required_value: set[str] | None
-) -> bool:
-    """Check if device class id or label matches."""
-    if required_value is None:
-        return True
-    if any(device_class.label == val for val in required_value):
-        return True
-    return False

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 APPLICATION_NAME: Final = "HomeAssistant"
 MAJOR_VERSION: Final = 2024
 MINOR_VERSION: Final = 5
-PATCH_VERSION: Final = "3"
+PATCH_VERSION: Final = "4"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 12, 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name        = "homeassistant"
-version     = "2024.5.3"
+version     = "2024.5.4"
 license     = {text = "Apache-2.0"}
 description = "Open-source home automation platform running on Python 3."
 readme      = "README.rst"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2572,7 +2572,7 @@ smhi-pkg==1.0.16
 snapcast==2.3.6
 
 # homeassistant.components.sonos
-soco==0.30.3
+soco==0.30.4
 
 # homeassistant.components.solaredge_local
 solaredge-local==0.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1649,7 +1649,7 @@ pyCEC==0.5.2
 pyControl4==1.1.0
 
 # homeassistant.components.duotecno
-pyDuotecno==2024.3.2
+pyDuotecno==2024.5.0
 
 # homeassistant.components.electrasmart
 pyElectra==1.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2439,7 +2439,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.9
+reolink-aio==0.8.10
 
 # homeassistant.components.idteck_prox
 rfk101py==0.0.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2866,7 +2866,7 @@ wiffi==1.1.2
 wirelesstagpy==0.8.1
 
 # homeassistant.components.wled
-wled==0.17.0
+wled==0.17.1
 
 # homeassistant.components.wolflink
 wolf-comm==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1305,7 +1305,7 @@ pyCEC==0.5.2
 pyControl4==1.1.0
 
 # homeassistant.components.duotecno
-pyDuotecno==2024.3.2
+pyDuotecno==2024.5.0
 
 # homeassistant.components.electrasmart
 pyElectra==1.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -2222,7 +2222,7 @@ whois==0.9.27
 wiffi==1.1.2
 
 # homeassistant.components.wled
-wled==0.17.0
+wled==0.17.1
 
 # homeassistant.components.wolflink
 wolf-comm==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1991,7 +1991,7 @@ smhi-pkg==1.0.16
 snapcast==2.3.6
 
 # homeassistant.components.sonos
-soco==0.30.3
+soco==0.30.4
 
 # homeassistant.components.solax
 solax==3.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1897,7 +1897,7 @@ renault-api==0.2.2
 renson-endura-delta==1.7.1
 
 # homeassistant.components.reolink
-reolink-aio==0.8.9
+reolink-aio==0.8.10
 
 # homeassistant.components.rflink
 rflink==0.0.66

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -1522,4 +1522,4 @@ async def test_verify_group_color_mode_fallback(
     )
     group_state = hass.states.get("light.opbergruimte")
     assert group_state.state == STATE_ON
-    assert group_state.attributes[ATTR_COLOR_MODE] is ColorMode.UNKNOWN
+    assert group_state.attributes[ATTR_COLOR_MODE] is ColorMode.BRIGHTNESS

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -72,6 +72,22 @@ async def test_services(
     mock_fully_kiosk.setConfigurationString.assert_called_once_with(key, value)
 
     key = "test_key"
+    value = 1234
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONFIG,
+        {
+            ATTR_DEVICE_ID: [device_entry.id],
+            ATTR_KEY: key,
+            ATTR_VALUE: value,
+        },
+        blocking=True,
+    )
+
+    mock_fully_kiosk.setConfigurationString.assert_called_with(key, str(value))
+
+    key = "test_key"
     value = "true"
     await hass.services.async_call(
         DOMAIN,

--- a/tests/components/husqvarna_automower/conftest.py
+++ b/tests/components/husqvarna_automower/conftest.py
@@ -22,7 +22,7 @@ from tests.common import MockConfigEntry, load_fixture, load_json_value_fixture
 
 
 @pytest.fixture(name="jwt")
-def load_jwt_fixture():
+def load_jwt_fixture() -> str:
     """Load Fixture data."""
     return load_fixture("jwt", DOMAIN)
 
@@ -33,8 +33,14 @@ def mock_expires_at() -> float:
     return time.time() + 3600
 
 
+@pytest.fixture(name="scope")
+def mock_scope() -> str:
+    """Fixture to set correct scope for the token."""
+    return "iam:read amc:api"
+
+
 @pytest.fixture
-def mock_config_entry(jwt, expires_at: int) -> MockConfigEntry:
+def mock_config_entry(jwt: str, expires_at: int, scope: str) -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
         version=1,
@@ -44,7 +50,7 @@ def mock_config_entry(jwt, expires_at: int) -> MockConfigEntry:
             "auth_implementation": DOMAIN,
             "token": {
                 "access_token": jwt,
-                "scope": "iam:read amc:api",
+                "scope": scope,
                 "expires_in": 86399,
                 "refresh_token": "3012bc9f-7a65-4240-b817-9154ffdcc30f",
                 "provider": "husqvarna",

--- a/tests/components/husqvarna_automower/test_init.py
+++ b/tests/components/husqvarna_automower/test_init.py
@@ -44,6 +44,26 @@ async def test_load_unload_entry(
 
 
 @pytest.mark.parametrize(
+    ("scope"),
+    [
+        ("iam:read"),
+    ],
+)
+async def test_load_missing_scope(
+    hass: HomeAssistant,
+    mock_automower_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test if the entry starts a reauth with the missing token scope."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    result = flows[0]
+    assert result["step_id"] == "missing_scope"
+
+
+@pytest.mark.parametrize(
     ("expires_at", "status", "expected_state"),
     [
         (

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -4385,6 +4385,34 @@ async def test_server_sock_connect_and_disconnect(
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
 @patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
+async def test_server_sock_buffer_size(
+    hass: HomeAssistant,
+    mqtt_client_mock: MqttMockPahoClient,
+    mqtt_mock_entry: MqttMockHAClientGenerator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test handling the socket buffer size fails."""
+    mqtt_mock = await mqtt_mock_entry()
+    await hass.async_block_till_done()
+    assert mqtt_mock.connected is True
+
+    mqtt_client_mock.loop_misc.return_value = paho_mqtt.MQTT_ERR_SUCCESS
+
+    client, server = socket.socketpair(
+        family=socket.AF_UNIX, type=socket.SOCK_STREAM, proto=0
+    )
+    client.setblocking(False)
+    server.setblocking(False)
+    with patch.object(client, "setsockopt", side_effect=OSError("foo")):
+        mqtt_client_mock.on_socket_open(mqtt_client_mock, None, client)
+        mqtt_client_mock.on_socket_register_write(mqtt_client_mock, None, client)
+        await hass.async_block_till_done()
+    assert "Unable to increase the socket buffer size" in caplog.text
+
+
+@patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
+@patch("homeassistant.components.mqtt.client.DISCOVERY_COOLDOWN", 0.0)
+@patch("homeassistant.components.mqtt.client.SUBSCRIBE_COOLDOWN", 0.0)
 async def test_client_sock_failure_after_connect(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -1,7 +1,7 @@
 """Test pi_hole component."""
 
 import logging
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 from hole.exceptions import HoleError
 import pytest
@@ -12,18 +12,49 @@ from homeassistant.components.pi_hole.const import (
     SERVICE_DISABLE,
     SERVICE_DISABLE_ATTR_DURATION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_HOST,
+    CONF_LOCATION,
+    CONF_NAME,
+    CONF_SSL,
+)
 from homeassistant.core import HomeAssistant
 
 from . import (
+    API_KEY,
     CONFIG_DATA,
     CONFIG_DATA_DEFAULTS,
+    CONFIG_ENTRY_WITHOUT_API_KEY,
     SWITCH_ENTITY_ID,
     _create_mocked_hole,
     _patch_init_hole,
 )
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("config_entry_data", "expected_api_token"),
+    [(CONFIG_DATA_DEFAULTS, API_KEY), (CONFIG_ENTRY_WITHOUT_API_KEY, "")],
+)
+async def test_setup_api(
+    hass: HomeAssistant, config_entry_data: dict, expected_api_token: str
+) -> None:
+    """Tests the API object is created with the expected parameters."""
+    mocked_hole = _create_mocked_hole()
+    config_entry_data = {**config_entry_data, CONF_STATISTICS_ONLY: True}
+    entry = MockConfigEntry(domain=pi_hole.DOMAIN, data=config_entry_data)
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole) as patched_init_hole:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        patched_init_hole.assert_called_once_with(
+            config_entry_data[CONF_HOST],
+            ANY,
+            api_token=expected_api_token,
+            location=config_entry_data[CONF_LOCATION],
+            tls=config_entry_data[CONF_SSL],
+        )
 
 
 async def test_setup_with_defaults(hass: HomeAssistant) -> None:

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -5,7 +5,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from reolink_aio.exceptions import ReolinkError
+from reolink_aio.exceptions import CredentialsInvalidError, ReolinkError
 
 from homeassistant.components.reolink import FIRMWARE_UPDATE_INTERVAL, const
 from homeassistant.config import async_process_ha_core_config
@@ -49,6 +49,11 @@ pytestmark = pytest.mark.usefixtures("reolink_connect", "reolink_platforms")
             "get_states",
             AsyncMock(side_effect=ReolinkError("Test error")),
             ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            "get_states",
+            AsyncMock(side_effect=CredentialsInvalidError("Test error")),
+            ConfigEntryState.SETUP_ERROR,
         ),
         (
             "supported",

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -675,6 +675,12 @@ def central_scene_node_state_fixture():
     return json.loads(load_fixture("zwave_js/central_scene_node_state.json"))
 
 
+@pytest.fixture(name="light_device_class_is_null_state", scope="package")
+def light_device_class_is_null_state_fixture():
+    """Load node with device class is None state fixture data."""
+    return json.loads(load_fixture("zwave_js/light_device_class_is_null_state.json"))
+
+
 # model fixtures
 
 
@@ -1323,5 +1329,13 @@ def logic_group_zdb5100_fixture(client, logic_group_zdb5100_state):
 def central_scene_node_fixture(client, central_scene_node_state):
     """Mock a node with the Central Scene CC."""
     node = Node(client, copy.deepcopy(central_scene_node_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="light_device_class_is_null")
+def light_device_class_is_null_fixture(client, light_device_class_is_null_state):
+    """Mock a node when device class is null."""
+    node = Node(client, copy.deepcopy(light_device_class_is_null_state))
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/fixtures/light_device_class_is_null_state.json
+++ b/tests/components/zwave_js/fixtures/light_device_class_is_null_state.json
@@ -1,0 +1,10611 @@
+{
+  "nodeId": 45,
+  "index": 0,
+  "installerIcon": 1536,
+  "userIcon": 1536,
+  "status": 4,
+  "ready": true,
+  "isListening": true,
+  "isRouting": true,
+  "isSecure": false,
+  "manufacturerId": 29,
+  "productId": 1,
+  "productType": 12801,
+  "firmwareVersion": "1.20",
+  "zwavePlusVersion": 1,
+  "name": "Bar Display Cases",
+  "location": "**REDACTED**",
+  "deviceConfig": {
+    "filename": "/Users/spike/zwavestore/.config-db/devices/0x001d/dz6hd.json",
+    "isEmbedded": true,
+    "manufacturer": "Leviton",
+    "manufacturerId": 29,
+    "label": "DZ6HD",
+    "description": "In-Wall 600W Dimmer",
+    "devices": [
+      {
+        "productType": 12801,
+        "productId": 1
+      }
+    ],
+    "firmwareVersion": {
+      "min": "0.0",
+      "max": "255.255"
+    },
+    "preferred": false,
+    "paramInformation": {
+      "_map": {}
+    },
+    "metadata": {
+      "inclusion": "Enter programming mode by holding down the top of the paddle for 7 seconds, the LED will blink Amber. Tap the top of the paddle one time. The LED will flash green. Upon successful addition to network, the LED will blink 3 times.",
+      "exclusion": "Enter programming mode by holding down the top of the paddle for 7 seconds, the LED will blink Amber. Tap the top of the paddle one time. The LED will flash green. Upon successful removal from network, the LED will blink 3 times.",
+      "reset": "Hold the top of the paddle down for 14 seconds. Upon successful reset, the LED with blink red/amber.",
+      "manual": "https://www.leviton.com/fr/docs/DI-000-DZ6HD-02A-W.pdf"
+    }
+  },
+  "label": "DZ6HD",
+  "interviewAttempts": 0,
+  "isFrequentListening": false,
+  "maxDataRate": 100000,
+  "supportedDataRates": [40000, 100000],
+  "protocolVersion": 3,
+  "supportsBeaming": true,
+  "supportsSecurity": false,
+  "nodeType": 1,
+  "zwavePlusNodeType": 0,
+  "zwavePlusRoleType": 5,
+  "deviceClass": null,
+  "interviewStage": "Complete",
+  "deviceDatabaseUrl": "https://devices.zwave-js.io/?jumpTo=0x001d:0x3201:0x0001:1.20",
+  "statistics": {
+    "commandsTX": 1,
+    "commandsRX": 0,
+    "commandsDroppedRX": 0,
+    "commandsDroppedTX": 0,
+    "timeoutResponse": 0,
+    "rtt": 31.5,
+    "lastSeen": "2024-05-10T21:42:42.472Z",
+    "lwr": {
+      "repeaters": [],
+      "protocolDataRate": 3
+    }
+  },
+  "highestSecurityClass": -1,
+  "isControllerNode": false,
+  "keepAwake": false,
+  "lastSeen": "2024-05-10T21:42:42.472Z",
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "duration",
+      "propertyName": "duration",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": false,
+        "label": "Remaining duration",
+        "stateful": true,
+        "secret": false
+      },
+      "value": {
+        "value": 1,
+        "unit": "seconds"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value",
+        "min": 0,
+        "max": 99,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Up",
+      "propertyName": "Up",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Perform a level change (Up)",
+        "ccSpecific": {
+          "switchType": 2
+        },
+        "valueChangeOptions": ["transitionDuration"],
+        "states": {
+          "true": "Start",
+          "false": "Stop"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Down",
+      "propertyName": "Down",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Perform a level change (Down)",
+        "ccSpecific": {
+          "switchType": 2
+        },
+        "valueChangeOptions": ["transitionDuration"],
+        "states": {
+          "true": "Start",
+          "false": "Stop"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "restorePrevious",
+      "propertyName": "restorePrevious",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Restore previous value",
+        "states": {
+          "true": "Restore"
+        },
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 43,
+      "commandClassName": "Scene Activation",
+      "property": "sceneId",
+      "propertyName": "sceneId",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Scene ID",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 1,
+        "max": 255,
+        "stateful": false,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 43,
+      "commandClassName": "Scene Activation",
+      "property": "dimmingDuration",
+      "propertyName": "dimmingDuration",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 1,
+      "propertyName": "level",
+      "propertyKeyName": "1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (1)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 1,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "1",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (1)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 2,
+      "propertyName": "level",
+      "propertyKeyName": "2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (2)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 2,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (2)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 3,
+      "propertyName": "level",
+      "propertyKeyName": "3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (3)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 3,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "3",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (3)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 4,
+      "propertyName": "level",
+      "propertyKeyName": "4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (4)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 4,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "4",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (4)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 5,
+      "propertyName": "level",
+      "propertyKeyName": "5",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (5)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 5,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "5",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (5)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 6,
+      "propertyName": "level",
+      "propertyKeyName": "6",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (6)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 6,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "6",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (6)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 7,
+      "propertyName": "level",
+      "propertyKeyName": "7",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (7)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 7,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "7",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (7)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 8,
+      "propertyName": "level",
+      "propertyKeyName": "8",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (8)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 8,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "8",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (8)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 9,
+      "propertyName": "level",
+      "propertyKeyName": "9",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (9)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 9,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "9",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (9)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 10,
+      "propertyName": "level",
+      "propertyKeyName": "10",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (10)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 10,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "10",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (10)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 11,
+      "propertyName": "level",
+      "propertyKeyName": "11",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (11)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 11,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "11",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (11)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 12,
+      "propertyName": "level",
+      "propertyKeyName": "12",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (12)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 12,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "12",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (12)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 13,
+      "propertyName": "level",
+      "propertyKeyName": "13",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (13)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 13,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "13",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (13)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 14,
+      "propertyName": "level",
+      "propertyKeyName": "14",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (14)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 14,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "14",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (14)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 15,
+      "propertyName": "level",
+      "propertyKeyName": "15",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (15)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 15,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "15",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (15)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 16,
+      "propertyName": "level",
+      "propertyKeyName": "16",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (16)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 16,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "16",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (16)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 17,
+      "propertyName": "level",
+      "propertyKeyName": "17",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (17)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 17,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "17",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (17)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 18,
+      "propertyName": "level",
+      "propertyKeyName": "18",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (18)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 18,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "18",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (18)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 19,
+      "propertyName": "level",
+      "propertyKeyName": "19",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (19)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 19,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "19",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (19)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 20,
+      "propertyName": "level",
+      "propertyKeyName": "20",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (20)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 20,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "20",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (20)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 21,
+      "propertyName": "level",
+      "propertyKeyName": "21",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (21)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 21,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "21",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (21)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 22,
+      "propertyName": "level",
+      "propertyKeyName": "22",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (22)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 22,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "22",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (22)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 23,
+      "propertyName": "level",
+      "propertyKeyName": "23",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (23)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 23,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "23",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (23)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 24,
+      "propertyName": "level",
+      "propertyKeyName": "24",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (24)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 24,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "24",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (24)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 25,
+      "propertyName": "level",
+      "propertyKeyName": "25",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (25)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 25,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "25",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (25)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 26,
+      "propertyName": "level",
+      "propertyKeyName": "26",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (26)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 26,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "26",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (26)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 27,
+      "propertyName": "level",
+      "propertyKeyName": "27",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (27)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 27,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "27",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (27)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 28,
+      "propertyName": "level",
+      "propertyKeyName": "28",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (28)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 28,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "28",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (28)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 29,
+      "propertyName": "level",
+      "propertyKeyName": "29",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (29)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 29,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "29",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (29)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 30,
+      "propertyName": "level",
+      "propertyKeyName": "30",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (30)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 30,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "30",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (30)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 31,
+      "propertyName": "level",
+      "propertyKeyName": "31",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (31)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 31,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "31",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (31)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 32,
+      "propertyName": "level",
+      "propertyKeyName": "32",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (32)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 32,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "32",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (32)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 33,
+      "propertyName": "level",
+      "propertyKeyName": "33",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (33)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 33,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "33",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (33)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 34,
+      "propertyName": "level",
+      "propertyKeyName": "34",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (34)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 34,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "34",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (34)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 35,
+      "propertyName": "level",
+      "propertyKeyName": "35",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (35)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 35,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "35",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (35)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 36,
+      "propertyName": "level",
+      "propertyKeyName": "36",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (36)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 36,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "36",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (36)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 37,
+      "propertyName": "level",
+      "propertyKeyName": "37",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (37)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 37,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "37",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (37)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 38,
+      "propertyName": "level",
+      "propertyKeyName": "38",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (38)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 38,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "38",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (38)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 39,
+      "propertyName": "level",
+      "propertyKeyName": "39",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (39)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 39,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "39",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (39)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 40,
+      "propertyName": "level",
+      "propertyKeyName": "40",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (40)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 40,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "40",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (40)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 41,
+      "propertyName": "level",
+      "propertyKeyName": "41",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (41)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 41,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "41",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (41)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 42,
+      "propertyName": "level",
+      "propertyKeyName": "42",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (42)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 42,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "42",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (42)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 43,
+      "propertyName": "level",
+      "propertyKeyName": "43",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (43)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 43,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "43",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (43)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 44,
+      "propertyName": "level",
+      "propertyKeyName": "44",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (44)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 44,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "44",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (44)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 45,
+      "propertyName": "level",
+      "propertyKeyName": "45",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (45)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 45,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "45",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (45)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 46,
+      "propertyName": "level",
+      "propertyKeyName": "46",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (46)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 46,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "46",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (46)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 47,
+      "propertyName": "level",
+      "propertyKeyName": "47",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (47)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 47,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "47",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (47)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 48,
+      "propertyName": "level",
+      "propertyKeyName": "48",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (48)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 48,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "48",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (48)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 49,
+      "propertyName": "level",
+      "propertyKeyName": "49",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (49)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 49,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "49",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (49)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 50,
+      "propertyName": "level",
+      "propertyKeyName": "50",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (50)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 50,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "50",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (50)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 51,
+      "propertyName": "level",
+      "propertyKeyName": "51",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (51)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 51,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "51",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (51)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 52,
+      "propertyName": "level",
+      "propertyKeyName": "52",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (52)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 52,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "52",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (52)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 53,
+      "propertyName": "level",
+      "propertyKeyName": "53",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (53)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 53,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "53",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (53)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 54,
+      "propertyName": "level",
+      "propertyKeyName": "54",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (54)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 54,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "54",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (54)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 55,
+      "propertyName": "level",
+      "propertyKeyName": "55",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (55)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 55,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "55",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (55)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 56,
+      "propertyName": "level",
+      "propertyKeyName": "56",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (56)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 56,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "56",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (56)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 57,
+      "propertyName": "level",
+      "propertyKeyName": "57",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (57)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 57,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "57",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (57)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 58,
+      "propertyName": "level",
+      "propertyKeyName": "58",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (58)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 58,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "58",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (58)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 59,
+      "propertyName": "level",
+      "propertyKeyName": "59",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (59)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 59,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "59",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (59)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 60,
+      "propertyName": "level",
+      "propertyKeyName": "60",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (60)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 60,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "60",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (60)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 61,
+      "propertyName": "level",
+      "propertyKeyName": "61",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (61)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 61,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "61",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (61)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 62,
+      "propertyName": "level",
+      "propertyKeyName": "62",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (62)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 62,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "62",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (62)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 63,
+      "propertyName": "level",
+      "propertyKeyName": "63",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (63)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 63,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "63",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (63)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 64,
+      "propertyName": "level",
+      "propertyKeyName": "64",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (64)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 64,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "64",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (64)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 65,
+      "propertyName": "level",
+      "propertyKeyName": "65",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (65)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 65,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "65",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (65)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 66,
+      "propertyName": "level",
+      "propertyKeyName": "66",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (66)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 66,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "66",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (66)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 67,
+      "propertyName": "level",
+      "propertyKeyName": "67",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (67)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 67,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "67",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (67)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 68,
+      "propertyName": "level",
+      "propertyKeyName": "68",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (68)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 68,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "68",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (68)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 69,
+      "propertyName": "level",
+      "propertyKeyName": "69",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (69)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 69,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "69",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (69)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 70,
+      "propertyName": "level",
+      "propertyKeyName": "70",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (70)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 70,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "70",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (70)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 71,
+      "propertyName": "level",
+      "propertyKeyName": "71",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (71)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 71,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "71",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (71)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 72,
+      "propertyName": "level",
+      "propertyKeyName": "72",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (72)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 72,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "72",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (72)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 73,
+      "propertyName": "level",
+      "propertyKeyName": "73",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (73)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 73,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "73",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (73)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 74,
+      "propertyName": "level",
+      "propertyKeyName": "74",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (74)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 74,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "74",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (74)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 75,
+      "propertyName": "level",
+      "propertyKeyName": "75",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (75)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 75,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "75",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (75)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 76,
+      "propertyName": "level",
+      "propertyKeyName": "76",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (76)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 76,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "76",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (76)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 77,
+      "propertyName": "level",
+      "propertyKeyName": "77",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (77)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 77,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "77",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (77)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 78,
+      "propertyName": "level",
+      "propertyKeyName": "78",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (78)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 78,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "78",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (78)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 79,
+      "propertyName": "level",
+      "propertyKeyName": "79",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (79)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 79,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "79",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (79)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 80,
+      "propertyName": "level",
+      "propertyKeyName": "80",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (80)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 80,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "80",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (80)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 81,
+      "propertyName": "level",
+      "propertyKeyName": "81",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (81)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 81,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "81",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (81)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 82,
+      "propertyName": "level",
+      "propertyKeyName": "82",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (82)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 82,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "82",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (82)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 83,
+      "propertyName": "level",
+      "propertyKeyName": "83",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (83)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 83,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "83",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (83)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 84,
+      "propertyName": "level",
+      "propertyKeyName": "84",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (84)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 84,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "84",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (84)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 85,
+      "propertyName": "level",
+      "propertyKeyName": "85",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (85)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 85,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "85",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (85)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 86,
+      "propertyName": "level",
+      "propertyKeyName": "86",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (86)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 86,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "86",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (86)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 87,
+      "propertyName": "level",
+      "propertyKeyName": "87",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (87)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 87,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "87",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (87)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 88,
+      "propertyName": "level",
+      "propertyKeyName": "88",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (88)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 88,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "88",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (88)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 89,
+      "propertyName": "level",
+      "propertyKeyName": "89",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (89)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 89,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "89",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (89)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 90,
+      "propertyName": "level",
+      "propertyKeyName": "90",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (90)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 90,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "90",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (90)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 91,
+      "propertyName": "level",
+      "propertyKeyName": "91",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (91)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 91,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "91",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (91)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 92,
+      "propertyName": "level",
+      "propertyKeyName": "92",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (92)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 92,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "92",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (92)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 93,
+      "propertyName": "level",
+      "propertyKeyName": "93",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (93)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 93,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "93",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (93)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 94,
+      "propertyName": "level",
+      "propertyKeyName": "94",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (94)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 94,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "94",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (94)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 95,
+      "propertyName": "level",
+      "propertyKeyName": "95",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (95)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 95,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "95",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (95)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 96,
+      "propertyName": "level",
+      "propertyKeyName": "96",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (96)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 96,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "96",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (96)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 97,
+      "propertyName": "level",
+      "propertyKeyName": "97",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (97)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 97,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "97",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (97)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 98,
+      "propertyName": "level",
+      "propertyKeyName": "98",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (98)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 98,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "98",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (98)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 99,
+      "propertyName": "level",
+      "propertyKeyName": "99",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (99)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 99,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "99",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (99)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 100,
+      "propertyName": "level",
+      "propertyKeyName": "100",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (100)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 100,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "100",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (100)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 101,
+      "propertyName": "level",
+      "propertyKeyName": "101",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (101)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 101,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "101",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (101)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 102,
+      "propertyName": "level",
+      "propertyKeyName": "102",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (102)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 102,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "102",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (102)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 103,
+      "propertyName": "level",
+      "propertyKeyName": "103",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (103)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 103,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "103",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (103)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 104,
+      "propertyName": "level",
+      "propertyKeyName": "104",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (104)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 104,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "104",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (104)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 105,
+      "propertyName": "level",
+      "propertyKeyName": "105",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (105)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 105,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "105",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (105)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 106,
+      "propertyName": "level",
+      "propertyKeyName": "106",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (106)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 106,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "106",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (106)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 107,
+      "propertyName": "level",
+      "propertyKeyName": "107",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (107)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 107,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "107",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (107)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 108,
+      "propertyName": "level",
+      "propertyKeyName": "108",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (108)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 108,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "108",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (108)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 109,
+      "propertyName": "level",
+      "propertyKeyName": "109",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (109)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 109,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "109",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (109)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 110,
+      "propertyName": "level",
+      "propertyKeyName": "110",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (110)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 110,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "110",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (110)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 111,
+      "propertyName": "level",
+      "propertyKeyName": "111",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (111)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 111,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "111",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (111)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 112,
+      "propertyName": "level",
+      "propertyKeyName": "112",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (112)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 112,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "112",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (112)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 113,
+      "propertyName": "level",
+      "propertyKeyName": "113",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (113)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 113,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "113",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (113)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 114,
+      "propertyName": "level",
+      "propertyKeyName": "114",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (114)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 114,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "114",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (114)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 115,
+      "propertyName": "level",
+      "propertyKeyName": "115",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (115)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 115,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "115",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (115)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 116,
+      "propertyName": "level",
+      "propertyKeyName": "116",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (116)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 116,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "116",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (116)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 117,
+      "propertyName": "level",
+      "propertyKeyName": "117",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (117)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 117,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "117",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (117)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 118,
+      "propertyName": "level",
+      "propertyKeyName": "118",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (118)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 118,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "118",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (118)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 119,
+      "propertyName": "level",
+      "propertyKeyName": "119",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (119)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 119,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "119",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (119)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 120,
+      "propertyName": "level",
+      "propertyKeyName": "120",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (120)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 120,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "120",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (120)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 121,
+      "propertyName": "level",
+      "propertyKeyName": "121",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (121)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 121,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "121",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (121)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 122,
+      "propertyName": "level",
+      "propertyKeyName": "122",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (122)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 122,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "122",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (122)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 123,
+      "propertyName": "level",
+      "propertyKeyName": "123",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (123)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 123,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "123",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (123)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 124,
+      "propertyName": "level",
+      "propertyKeyName": "124",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (124)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 124,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "124",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (124)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 125,
+      "propertyName": "level",
+      "propertyKeyName": "125",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (125)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 125,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "125",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (125)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 126,
+      "propertyName": "level",
+      "propertyKeyName": "126",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (126)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 126,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "126",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (126)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 127,
+      "propertyName": "level",
+      "propertyKeyName": "127",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (127)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 127,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "127",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (127)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 128,
+      "propertyName": "level",
+      "propertyKeyName": "128",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (128)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 128,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "128",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (128)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 129,
+      "propertyName": "level",
+      "propertyKeyName": "129",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (129)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 129,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "129",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (129)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 130,
+      "propertyName": "level",
+      "propertyKeyName": "130",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (130)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 130,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "130",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (130)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 131,
+      "propertyName": "level",
+      "propertyKeyName": "131",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (131)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 131,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "131",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (131)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 132,
+      "propertyName": "level",
+      "propertyKeyName": "132",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (132)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 132,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "132",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (132)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 133,
+      "propertyName": "level",
+      "propertyKeyName": "133",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (133)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 133,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "133",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (133)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 134,
+      "propertyName": "level",
+      "propertyKeyName": "134",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (134)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 134,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "134",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (134)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 135,
+      "propertyName": "level",
+      "propertyKeyName": "135",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (135)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 135,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "135",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (135)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 136,
+      "propertyName": "level",
+      "propertyKeyName": "136",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (136)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 136,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "136",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (136)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 137,
+      "propertyName": "level",
+      "propertyKeyName": "137",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (137)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 137,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "137",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (137)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 138,
+      "propertyName": "level",
+      "propertyKeyName": "138",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (138)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 138,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "138",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (138)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 139,
+      "propertyName": "level",
+      "propertyKeyName": "139",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (139)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 139,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "139",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (139)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 140,
+      "propertyName": "level",
+      "propertyKeyName": "140",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (140)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 140,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "140",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (140)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 141,
+      "propertyName": "level",
+      "propertyKeyName": "141",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (141)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 141,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "141",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (141)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 142,
+      "propertyName": "level",
+      "propertyKeyName": "142",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (142)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 142,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "142",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (142)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 143,
+      "propertyName": "level",
+      "propertyKeyName": "143",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (143)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 143,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "143",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (143)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 144,
+      "propertyName": "level",
+      "propertyKeyName": "144",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (144)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 144,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "144",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (144)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 145,
+      "propertyName": "level",
+      "propertyKeyName": "145",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (145)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 145,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "145",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (145)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 146,
+      "propertyName": "level",
+      "propertyKeyName": "146",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (146)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 146,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "146",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (146)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 147,
+      "propertyName": "level",
+      "propertyKeyName": "147",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (147)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 147,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "147",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (147)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 148,
+      "propertyName": "level",
+      "propertyKeyName": "148",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (148)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 148,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "148",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (148)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 149,
+      "propertyName": "level",
+      "propertyKeyName": "149",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (149)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 149,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "149",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (149)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 150,
+      "propertyName": "level",
+      "propertyKeyName": "150",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (150)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 150,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "150",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (150)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 151,
+      "propertyName": "level",
+      "propertyKeyName": "151",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (151)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 151,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "151",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (151)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 152,
+      "propertyName": "level",
+      "propertyKeyName": "152",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (152)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 152,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "152",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (152)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 153,
+      "propertyName": "level",
+      "propertyKeyName": "153",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (153)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 153,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "153",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (153)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 154,
+      "propertyName": "level",
+      "propertyKeyName": "154",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (154)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 154,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "154",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (154)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 155,
+      "propertyName": "level",
+      "propertyKeyName": "155",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (155)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 155,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "155",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (155)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 156,
+      "propertyName": "level",
+      "propertyKeyName": "156",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (156)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 156,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "156",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (156)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 157,
+      "propertyName": "level",
+      "propertyKeyName": "157",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (157)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 157,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "157",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (157)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 158,
+      "propertyName": "level",
+      "propertyKeyName": "158",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (158)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 158,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "158",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (158)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 159,
+      "propertyName": "level",
+      "propertyKeyName": "159",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (159)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 159,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "159",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (159)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 160,
+      "propertyName": "level",
+      "propertyKeyName": "160",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (160)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 160,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "160",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (160)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 161,
+      "propertyName": "level",
+      "propertyKeyName": "161",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (161)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 161,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "161",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (161)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 162,
+      "propertyName": "level",
+      "propertyKeyName": "162",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (162)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 162,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "162",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (162)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 163,
+      "propertyName": "level",
+      "propertyKeyName": "163",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (163)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 163,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "163",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (163)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 164,
+      "propertyName": "level",
+      "propertyKeyName": "164",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (164)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 164,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "164",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (164)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 165,
+      "propertyName": "level",
+      "propertyKeyName": "165",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (165)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 165,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "165",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (165)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 166,
+      "propertyName": "level",
+      "propertyKeyName": "166",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (166)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 166,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "166",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (166)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 167,
+      "propertyName": "level",
+      "propertyKeyName": "167",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (167)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 167,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "167",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (167)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 168,
+      "propertyName": "level",
+      "propertyKeyName": "168",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (168)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 168,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "168",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (168)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 169,
+      "propertyName": "level",
+      "propertyKeyName": "169",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (169)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 169,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "169",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (169)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 170,
+      "propertyName": "level",
+      "propertyKeyName": "170",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (170)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 170,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "170",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (170)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 171,
+      "propertyName": "level",
+      "propertyKeyName": "171",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (171)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 171,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "171",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (171)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 172,
+      "propertyName": "level",
+      "propertyKeyName": "172",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (172)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 172,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "172",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (172)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 173,
+      "propertyName": "level",
+      "propertyKeyName": "173",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (173)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 173,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "173",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (173)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 174,
+      "propertyName": "level",
+      "propertyKeyName": "174",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (174)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 174,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "174",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (174)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 175,
+      "propertyName": "level",
+      "propertyKeyName": "175",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (175)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 175,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "175",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (175)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 176,
+      "propertyName": "level",
+      "propertyKeyName": "176",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (176)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 176,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "176",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (176)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 177,
+      "propertyName": "level",
+      "propertyKeyName": "177",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (177)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 177,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "177",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (177)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 178,
+      "propertyName": "level",
+      "propertyKeyName": "178",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (178)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 178,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "178",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (178)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 179,
+      "propertyName": "level",
+      "propertyKeyName": "179",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (179)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 179,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "179",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (179)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 180,
+      "propertyName": "level",
+      "propertyKeyName": "180",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (180)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 180,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "180",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (180)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 181,
+      "propertyName": "level",
+      "propertyKeyName": "181",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (181)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 181,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "181",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (181)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 182,
+      "propertyName": "level",
+      "propertyKeyName": "182",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (182)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 182,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "182",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (182)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 183,
+      "propertyName": "level",
+      "propertyKeyName": "183",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (183)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 183,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "183",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (183)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 184,
+      "propertyName": "level",
+      "propertyKeyName": "184",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (184)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 184,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "184",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (184)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 185,
+      "propertyName": "level",
+      "propertyKeyName": "185",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (185)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 185,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "185",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (185)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 186,
+      "propertyName": "level",
+      "propertyKeyName": "186",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (186)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 186,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "186",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (186)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 187,
+      "propertyName": "level",
+      "propertyKeyName": "187",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (187)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 187,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "187",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (187)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 188,
+      "propertyName": "level",
+      "propertyKeyName": "188",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (188)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 188,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "188",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (188)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 189,
+      "propertyName": "level",
+      "propertyKeyName": "189",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (189)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 189,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "189",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (189)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 190,
+      "propertyName": "level",
+      "propertyKeyName": "190",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (190)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 190,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "190",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (190)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 191,
+      "propertyName": "level",
+      "propertyKeyName": "191",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (191)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 191,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "191",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (191)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 192,
+      "propertyName": "level",
+      "propertyKeyName": "192",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (192)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 192,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "192",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (192)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 193,
+      "propertyName": "level",
+      "propertyKeyName": "193",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (193)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 193,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "193",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (193)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 194,
+      "propertyName": "level",
+      "propertyKeyName": "194",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (194)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 194,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "194",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (194)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 195,
+      "propertyName": "level",
+      "propertyKeyName": "195",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (195)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 195,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "195",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (195)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 196,
+      "propertyName": "level",
+      "propertyKeyName": "196",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (196)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 196,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "196",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (196)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 197,
+      "propertyName": "level",
+      "propertyKeyName": "197",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (197)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 197,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "197",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (197)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 198,
+      "propertyName": "level",
+      "propertyKeyName": "198",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (198)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 198,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "198",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (198)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 199,
+      "propertyName": "level",
+      "propertyKeyName": "199",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (199)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 199,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "199",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (199)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 200,
+      "propertyName": "level",
+      "propertyKeyName": "200",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (200)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 200,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "200",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (200)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 201,
+      "propertyName": "level",
+      "propertyKeyName": "201",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (201)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 201,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "201",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (201)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 202,
+      "propertyName": "level",
+      "propertyKeyName": "202",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (202)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 202,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "202",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (202)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 203,
+      "propertyName": "level",
+      "propertyKeyName": "203",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (203)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 203,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "203",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (203)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 204,
+      "propertyName": "level",
+      "propertyKeyName": "204",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (204)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 204,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "204",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (204)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 205,
+      "propertyName": "level",
+      "propertyKeyName": "205",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (205)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 205,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "205",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (205)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 206,
+      "propertyName": "level",
+      "propertyKeyName": "206",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (206)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 206,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "206",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (206)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 207,
+      "propertyName": "level",
+      "propertyKeyName": "207",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (207)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 207,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "207",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (207)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 208,
+      "propertyName": "level",
+      "propertyKeyName": "208",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (208)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 208,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "208",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (208)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 209,
+      "propertyName": "level",
+      "propertyKeyName": "209",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (209)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 209,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "209",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (209)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 210,
+      "propertyName": "level",
+      "propertyKeyName": "210",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (210)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 210,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "210",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (210)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 211,
+      "propertyName": "level",
+      "propertyKeyName": "211",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (211)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 211,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "211",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (211)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 212,
+      "propertyName": "level",
+      "propertyKeyName": "212",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (212)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 212,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "212",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (212)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 213,
+      "propertyName": "level",
+      "propertyKeyName": "213",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (213)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 213,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "213",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (213)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 214,
+      "propertyName": "level",
+      "propertyKeyName": "214",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (214)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 214,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "214",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (214)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 215,
+      "propertyName": "level",
+      "propertyKeyName": "215",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (215)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 215,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "215",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (215)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 216,
+      "propertyName": "level",
+      "propertyKeyName": "216",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (216)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 216,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "216",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (216)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 217,
+      "propertyName": "level",
+      "propertyKeyName": "217",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (217)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 217,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "217",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (217)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 218,
+      "propertyName": "level",
+      "propertyKeyName": "218",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (218)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 218,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "218",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (218)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 219,
+      "propertyName": "level",
+      "propertyKeyName": "219",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (219)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 219,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "219",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (219)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 220,
+      "propertyName": "level",
+      "propertyKeyName": "220",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (220)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 220,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "220",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (220)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 221,
+      "propertyName": "level",
+      "propertyKeyName": "221",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (221)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 221,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "221",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (221)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 222,
+      "propertyName": "level",
+      "propertyKeyName": "222",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (222)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 222,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "222",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (222)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 223,
+      "propertyName": "level",
+      "propertyKeyName": "223",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (223)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 223,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "223",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (223)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 224,
+      "propertyName": "level",
+      "propertyKeyName": "224",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (224)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 224,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "224",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (224)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 225,
+      "propertyName": "level",
+      "propertyKeyName": "225",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (225)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 225,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "225",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (225)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 226,
+      "propertyName": "level",
+      "propertyKeyName": "226",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (226)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 226,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "226",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (226)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 227,
+      "propertyName": "level",
+      "propertyKeyName": "227",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (227)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 227,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "227",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (227)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 228,
+      "propertyName": "level",
+      "propertyKeyName": "228",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (228)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 228,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "228",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (228)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 229,
+      "propertyName": "level",
+      "propertyKeyName": "229",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (229)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 229,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "229",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (229)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 230,
+      "propertyName": "level",
+      "propertyKeyName": "230",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (230)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 230,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "230",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (230)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 231,
+      "propertyName": "level",
+      "propertyKeyName": "231",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (231)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 231,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "231",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (231)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 232,
+      "propertyName": "level",
+      "propertyKeyName": "232",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (232)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 232,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "232",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (232)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 233,
+      "propertyName": "level",
+      "propertyKeyName": "233",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (233)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 233,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "233",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (233)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 234,
+      "propertyName": "level",
+      "propertyKeyName": "234",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (234)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 234,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "234",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (234)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 235,
+      "propertyName": "level",
+      "propertyKeyName": "235",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (235)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 235,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "235",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (235)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 236,
+      "propertyName": "level",
+      "propertyKeyName": "236",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (236)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 236,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "236",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (236)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 237,
+      "propertyName": "level",
+      "propertyKeyName": "237",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (237)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 237,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "237",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (237)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 238,
+      "propertyName": "level",
+      "propertyKeyName": "238",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (238)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 238,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "238",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (238)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 239,
+      "propertyName": "level",
+      "propertyKeyName": "239",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (239)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 239,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "239",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (239)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 240,
+      "propertyName": "level",
+      "propertyKeyName": "240",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (240)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 240,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "240",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (240)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 241,
+      "propertyName": "level",
+      "propertyKeyName": "241",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (241)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 241,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "241",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (241)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 242,
+      "propertyName": "level",
+      "propertyKeyName": "242",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (242)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 242,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "242",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (242)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 243,
+      "propertyName": "level",
+      "propertyKeyName": "243",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (243)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 243,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "243",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (243)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 244,
+      "propertyName": "level",
+      "propertyKeyName": "244",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (244)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 244,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "244",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (244)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 245,
+      "propertyName": "level",
+      "propertyKeyName": "245",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (245)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 245,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "245",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (245)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 246,
+      "propertyName": "level",
+      "propertyKeyName": "246",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (246)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 246,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "246",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (246)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 247,
+      "propertyName": "level",
+      "propertyKeyName": "247",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (247)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 247,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "247",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (247)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 248,
+      "propertyName": "level",
+      "propertyKeyName": "248",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (248)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 248,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "248",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (248)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 249,
+      "propertyName": "level",
+      "propertyKeyName": "249",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (249)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 249,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "249",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (249)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 250,
+      "propertyName": "level",
+      "propertyKeyName": "250",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (250)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 250,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "250",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (250)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 251,
+      "propertyName": "level",
+      "propertyKeyName": "251",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (251)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 251,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "251",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (251)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 252,
+      "propertyName": "level",
+      "propertyKeyName": "252",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (252)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 252,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "252",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (252)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 253,
+      "propertyName": "level",
+      "propertyKeyName": "253",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (253)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 253,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "253",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (253)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 254,
+      "propertyName": "level",
+      "propertyKeyName": "254",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (254)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 254,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "254",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (254)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "level",
+      "propertyKey": 255,
+      "propertyName": "level",
+      "propertyKeyName": "255",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Level (255)",
+        "valueChangeOptions": ["transitionDuration"],
+        "min": 0,
+        "max": 255,
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 44,
+      "commandClassName": "Scene Actuator Configuration",
+      "property": "dimmingDuration",
+      "propertyKey": 255,
+      "propertyName": "dimmingDuration",
+      "propertyKeyName": "255",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Dimming duration (255)",
+        "stateful": true,
+        "secret": false
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 1,
+      "propertyName": "Fade On Time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Values 1-127 = seconds; 128-253 = minutes (minus 127)",
+        "label": "Fade On Time",
+        "default": 2,
+        "min": 0,
+        "max": 253,
+        "states": {
+          "0": "Instant on"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 2,
+      "propertyName": "Fade Off Time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "Values 1-127 = seconds; 128-253 = minutes (minus 127)",
+        "label": "Fade Off Time",
+        "default": 2,
+        "min": 0,
+        "max": 253,
+        "states": {
+          "0": "Instant off"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 2
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 3,
+      "propertyName": "Minimum Dim Level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Minimum Dim Level",
+        "default": 10,
+        "min": 1,
+        "max": 99,
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 10
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 4,
+      "propertyName": "Maximum Dim Level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Maximum Dim Level",
+        "default": 100,
+        "min": 0,
+        "max": 100,
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 100
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 5,
+      "propertyName": "Initial Dim Level",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Initial Dim Level",
+        "default": 0,
+        "min": 0,
+        "max": 100,
+        "states": {
+          "0": "Last dim level"
+        },
+        "unit": "%",
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 6,
+      "propertyName": "LED Dim Level Indicator Timeout",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "description": "How long the level indicators should stay illuminated after the dimming level is changed",
+        "label": "LED Dim Level Indicator Timeout",
+        "default": 3,
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "Always Off",
+          "255": "Always On"
+        },
+        "unit": "seconds",
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": true,
+        "isFromConfig": true
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 7,
+      "propertyName": "Locator LED Status",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Locator LED Status",
+        "default": 255,
+        "min": 0,
+        "max": 255,
+        "states": {
+          "0": "LED always off",
+          "254": "LED on when switch is on",
+          "255": "LED on when switch is off"
+        },
+        "valueSize": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      },
+      "value": 255
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 8,
+      "propertyName": "Load Type",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "label": "Load Type",
+        "default": 0,
+        "min": 0,
+        "max": 2,
+        "states": {
+          "0": "Incandescent",
+          "1": "LED",
+          "2": "CFL"
+        },
+        "valueSize": 1,
+        "format": 0,
+        "allowManualEntry": false,
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Manufacturer ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 29
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product type",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 12801
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Product ID",
+        "min": 0,
+        "max": 65535,
+        "stateful": true,
+        "secret": false
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type",
+        "states": {
+          "0": "Unknown",
+          "1": "Static Controller",
+          "2": "Controller",
+          "3": "Enhanced Slave",
+          "4": "Slave",
+          "5": "Installer",
+          "6": "Routing Slave",
+          "7": "Bridge Controller",
+          "8": "Device under Test",
+          "9": "N/A",
+          "10": "AV Remote",
+          "11": "AV Device"
+        },
+        "stateful": true,
+        "secret": false
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": "4.33"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "string[]",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions",
+        "stateful": true,
+        "secret": false
+      },
+      "value": ["1.20"]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version",
+        "stateful": true,
+        "secret": false
+      },
+      "value": 255
+    }
+  ],
+  "endpoints": [
+    {
+      "nodeId": 45,
+      "index": 0,
+      "installerIcon": 1536,
+      "userIcon": 1536,
+      "deviceClass": null,
+      "commandClasses": [
+        {
+          "id": 94,
+          "name": "Z-Wave Plus Info",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 133,
+          "name": "Association",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 89,
+          "name": "Association Group Information",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 134,
+          "name": "Version",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 114,
+          "name": "Manufacturer Specific",
+          "version": 2,
+          "isSecure": false
+        },
+        {
+          "id": 112,
+          "name": "Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 90,
+          "name": "Device Reset Locally",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 115,
+          "name": "Powerlevel",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 38,
+          "name": "Multilevel Switch",
+          "version": 4,
+          "isSecure": false
+        },
+        {
+          "id": 44,
+          "name": "Scene Actuator Configuration",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 43,
+          "name": "Scene Activation",
+          "version": 1,
+          "isSecure": false
+        },
+        {
+          "id": 122,
+          "name": "Firmware Update Meta Data",
+          "version": 4,
+          "isSecure": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -305,3 +305,15 @@ async def test_indicator_test(
         "propertyKey": "Switch",
     }
     assert args["value"] is False
+
+
+async def test_light_device_class_is_null(
+    hass: HomeAssistant, client, light_device_class_is_null, integration
+) -> None:
+    """Test that a Multilevel Switch CC value with a null device class is discovered as a light.
+
+    Tied to #117121.
+    """
+    node = light_device_class_is_null
+    assert node.device_class is None
+    assert hass.states.get("light.bar_display_cases")


### PR DESCRIPTION
- Fix Fully Kiosk set config service ([@amura11] - [#112840]) ([fully_kiosk docs])
- Mark Duotecno entities unavailable when tcp goes down ([@Cereal2nd] - [#114325]) ([duotecno docs])
- Catch auth exception in husqvarna automower ([@Thomas55555] - [#115365]) ([husqvarna_automower docs])
- Avoid exceptions when Gemini responses are blocked ([@tronikos] - [#116847]) ([google_generative_ai_conversation docs])
- Reduce update interval in Ondilo Ico ([@nijel] - [#116989]) ([ondilo_ico docs])
- Add reauth for missing token scope in Husqvarna Automower ([@Thomas55555] - [#117098]) ([husqvarna_automower docs])
- Fix issue changing Insteon Hub configuration ([@teharris1] - [#117204]) ([insteon docs])
- Bump SoCo to 0.30.4 ([@jjlawren] - [#117212]) ([sonos docs]) (dependency)
- Fix zwave_js discovery logic for node device class ([@raman325] - [#117232]) ([zwave_js docs])
- Increase MQTT broker socket buffer size ([@jbouwh] - [#117267]) ([mqtt docs])
- Fix Aurora naming ([@joostlek] - [#117314]) ([aurora docs])
- Call Google Assistant SDK service using async_add_executor_job ([@tronikos] - [#117325]) ([google_assistant_sdk docs])
- Fix squeezebox blocking startup ([@bdraco] - [#117331]) ([squeezebox docs])
- Fix Lutron Serena Tilt Only Wood Blinds set tilt function ([@wujiaqi] - [#117374]) ([lutron_caseta docs])
- Fix Kodi on/off status ([@mk-81] - [#117436]) ([kodi docs])
- Update wled to 0.17.1 ([@frenck] - [#117444]) ([wled docs]) (dependency)
- Bump pyduotecno to 2024.5.0 ([@Cereal2nd] - [#117446]) ([duotecno docs]) (dependency)
- Fix non-thread-safe state write in tellduslive ([@bdraco] - [#117487]) ([tellduslive docs])
- Reolink fix not unregistering webhook during ReAuth ([@starkillerOG] - [#117490]) ([reolink docs])
- Fix API creation for passwordless pi_hole ([@emontnemery] - [#117494]) ([pi_hole docs])
- Bump reolink-aio to 0.8.10 ([@starkillerOG] - [#117501]) ([reolink docs]) (dependency)
- Handle uncaught exceptions in Analytics insights ([@joostlek] - [#117558]) ([analytics_insights docs])
- Fix poolsense naming ([@joostlek] - [#117567]) ([poolsense docs])
- Improve syncing light states to deCONZ groups ([@Kane610] - [#117588]) ([deconz docs])

[#112840]: https://github.com/home-assistant/core/pull/112840
[#114325]: https://github.com/home-assistant/core/pull/114325
[#115365]: https://github.com/home-assistant/core/pull/115365
[#116538]: https://github.com/home-assistant/core/pull/116538
[#116696]: https://github.com/home-assistant/core/pull/116696
[#116847]: https://github.com/home-assistant/core/pull/116847
[#116937]: https://github.com/home-assistant/core/pull/116937
[#116989]: https://github.com/home-assistant/core/pull/116989
[#117098]: https://github.com/home-assistant/core/pull/117098
[#117203]: https://github.com/home-assistant/core/pull/117203
[#117204]: https://github.com/home-assistant/core/pull/117204
[#117212]: https://github.com/home-assistant/core/pull/117212
[#117232]: https://github.com/home-assistant/core/pull/117232
[#117267]: https://github.com/home-assistant/core/pull/117267
[#117314]: https://github.com/home-assistant/core/pull/117314
[#117325]: https://github.com/home-assistant/core/pull/117325
[#117331]: https://github.com/home-assistant/core/pull/117331
[#117374]: https://github.com/home-assistant/core/pull/117374
[#117436]: https://github.com/home-assistant/core/pull/117436
[#117444]: https://github.com/home-assistant/core/pull/117444
[#117446]: https://github.com/home-assistant/core/pull/117446
[#117487]: https://github.com/home-assistant/core/pull/117487
[#117490]: https://github.com/home-assistant/core/pull/117490
[#117494]: https://github.com/home-assistant/core/pull/117494
[#117501]: https://github.com/home-assistant/core/pull/117501
[#117558]: https://github.com/home-assistant/core/pull/117558
[#117567]: https://github.com/home-assistant/core/pull/117567
[#117588]: https://github.com/home-assistant/core/pull/117588
[@Cereal2nd]: https://github.com/Cereal2nd
[@Kane610]: https://github.com/Kane610
[@Thomas55555]: https://github.com/Thomas55555
[@amura11]: https://github.com/amura11
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[@jbouwh]: https://github.com/jbouwh
[@jjlawren]: https://github.com/jjlawren
[@joostlek]: https://github.com/joostlek
[@mk-81]: https://github.com/mk-81
[@nijel]: https://github.com/nijel
[@raman325]: https://github.com/raman325
[@starkillerOG]: https://github.com/starkillerOG
[@teharris1]: https://github.com/teharris1
[@tronikos]: https://github.com/tronikos
[@wujiaqi]: https://github.com/wujiaqi
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[analytics_insights docs]: https://www.home-assistant.io/integrations/analytics_insights/
[aurora docs]: https://www.home-assistant.io/integrations/aurora/
[deconz docs]: https://www.home-assistant.io/integrations/deconz/
[duotecno docs]: https://www.home-assistant.io/integrations/duotecno/
[fully_kiosk docs]: https://www.home-assistant.io/integrations/fully_kiosk/
[google_assistant_sdk docs]: https://www.home-assistant.io/integrations/google_assistant_sdk/
[google_generative_ai_conversation docs]: https://www.home-assistant.io/integrations/google_generative_ai_conversation/
[husqvarna_automower docs]: https://www.home-assistant.io/integrations/husqvarna_automower/
[insteon docs]: https://www.home-assistant.io/integrations/insteon/
[kodi docs]: https://www.home-assistant.io/integrations/kodi/
[lutron_caseta docs]: https://www.home-assistant.io/integrations/lutron_caseta/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[ondilo_ico docs]: https://www.home-assistant.io/integrations/ondilo_ico/
[pi_hole docs]: https://www.home-assistant.io/integrations/pi_hole/
[poolsense docs]: https://www.home-assistant.io/integrations/poolsense/
[reolink docs]: https://www.home-assistant.io/integrations/reolink/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/
[squeezebox docs]: https://www.home-assistant.io/integrations/squeezebox/
[tellduslive docs]: https://www.home-assistant.io/integrations/tellduslive/
[wled docs]: https://www.home-assistant.io/integrations/wled/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/

Docs PR: https://github.com/home-assistant/home-assistant.io/pull/32817