### PR TITLE
Use PEP 695 type alias for ConfigEntry types

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -33,7 +33,7 @@ class AccuWeatherData:
     coordinator_daily_forecast: AccuWeatherDailyForecastDataUpdateCoordinator
 
 
-AccuWeatherConfigEntry = ConfigEntry[AccuWeatherData]
+type AccuWeatherConfigEntry = ConfigEntry[AccuWeatherData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AccuWeatherConfigEntry) -> bool:

--- a/homeassistant/components/acmeda/__init__.py
+++ b/homeassistant/components/acmeda/__init__.py
@@ -10,7 +10,7 @@ CONF_HUBS = "hubs"
 
 PLATFORMS = [Platform.COVER, Platform.SENSOR]
 
-AcmedaConfigEntry = ConfigEntry[PulseHub]
+type AcmedaConfigEntry = ConfigEntry[PulseHub]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -43,7 +43,7 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = [Platform.SENSOR, Platform.SWITCH]
-AdGuardConfigEntry = ConfigEntry["AdGuardData"]
+type AdGuardConfigEntry = ConfigEntry[AdGuardData]
 
 
 @dataclass

--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import ADVANTAGE_AIR_RETRY
 from .models import AdvantageAirData
 
-AdvantageAirDataConfigEntry = ConfigEntry[AdvantageAirData]
+type AdvantageAirDataConfigEntry = ConfigEntry[AdvantageAirData]
 
 ADVANTAGE_AIR_SYNC_INTERVAL = 15
 PLATFORMS = [

--- a/homeassistant/components/aemet/__init__.py
+++ b/homeassistant/components/aemet/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import WeatherUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-AemetConfigEntry = ConfigEntry["AemetData"]
+type AemetConfigEntry = ConfigEntry[AemetData]
 
 
 @dataclass

--- a/homeassistant/components/aftership/__init__.py
+++ b/homeassistant/components/aftership/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
-AfterShipConfigEntry = ConfigEntry[AfterShip]
+type AfterShipConfigEntry = ConfigEntry[AfterShip]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AfterShipConfigEntry) -> bool:

--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -19,7 +19,7 @@ PLATFORMS = [Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
-AirlyConfigEntry = ConfigEntry[AirlyDataUpdateCoordinator]
+type AirlyConfigEntry = ConfigEntry[AirlyDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AirlyConfigEntry) -> bool:

--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -21,7 +21,7 @@ from .coordinator import AirNowDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR]
 
-AirNowConfigEntry = ConfigEntry[AirNowDataUpdateCoordinator]
+type AirNowConfigEntry = ConfigEntry[AirNowDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AirNowConfigEntry) -> bool:

--- a/homeassistant/components/airthings/__init__.py
+++ b/homeassistant/components/airthings/__init__.py
@@ -20,9 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 SCAN_INTERVAL = timedelta(minutes=6)
 
-AirthingsDataCoordinatorType = DataUpdateCoordinator[dict[str, AirthingsDevice]]
-
-AirthingsConfigEntry = ConfigEntry[AirthingsDataCoordinatorType]
+type AirthingsDataCoordinatorType = DataUpdateCoordinator[dict[str, AirthingsDevice]]
+type AirthingsConfigEntry = ConfigEntry[AirthingsDataCoordinatorType]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AirthingsConfigEntry) -> bool:

--- a/homeassistant/components/airtouch5/__init__.py
+++ b/homeassistant/components/airtouch5/__init__.py
@@ -13,7 +13,7 @@ from .const import DOMAIN
 
 PLATFORMS: list[Platform] = [Platform.CLIMATE]
 
-Airtouch5ConfigEntry = ConfigEntry[Airtouch5SimpleClient]
+type Airtouch5ConfigEntry = ConfigEntry[Airtouch5SimpleClient]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: Airtouch5ConfigEntry) -> bool:

--- a/homeassistant/components/airvisual_pro/__init__.py
+++ b/homeassistant/components/airvisual_pro/__init__.py
@@ -38,7 +38,7 @@ PLATFORMS = [Platform.SENSOR]
 
 UPDATE_INTERVAL = timedelta(minutes=1)
 
-AirVisualProConfigEntry = ConfigEntry["AirVisualProData"]
+type AirVisualProConfigEntry = ConfigEntry[AirVisualProData]
 
 
 @dataclass

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -39,7 +39,7 @@ DEFAULT_SOCKET_MIN_RETRY = 15
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
-AmbientStationConfigEntry = ConfigEntry["AmbientStation"]
+type AmbientStationConfigEntry = ConfigEntry[AmbientStation]
 
 
 @callback

--- a/homeassistant/components/analytics_insights/__init__.py
+++ b/homeassistant/components/analytics_insights/__init__.py
@@ -19,7 +19,7 @@ from .const import CONF_TRACKED_INTEGRATIONS
 from .coordinator import HomeassistantAnalyticsDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
-AnalyticsInsightsConfigEntry = ConfigEntry["AnalyticsInsightsData"]
+type AnalyticsInsightsConfigEntry = ConfigEntry[AnalyticsInsightsData]
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -73,7 +73,7 @@ DEVICE_EXCEPTIONS = (
     exceptions.DeviceIdMissingError,
 )
 
-AppleTvConfigEntry = ConfigEntry["AppleTVManager"]
+type AppleTvConfigEntry = ConfigEntry[AppleTVManager]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AppleTvConfigEntry) -> bool:

--- a/homeassistant/components/apsystems/__init__.py
+++ b/homeassistant/components/apsystems/__init__.py
@@ -12,7 +12,7 @@ from .coordinator import ApSystemsDataCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
-ApsystemsConfigEntry = ConfigEntry[ApSystemsDataCoordinator]
+type ApsystemsConfigEntry = ConfigEntry[ApSystemsDataCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ApsystemsConfigEntry) -> bool:

--- a/homeassistant/components/asuswrt/__init__.py
+++ b/homeassistant/components/asuswrt/__init__.py
@@ -8,7 +8,7 @@ from .router import AsusWrtRouter
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR]
 
-AsusWrtConfigEntry = ConfigEntry[AsusWrtRouter]
+type AsusWrtConfigEntry = ConfigEntry[AsusWrtRouter]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AsusWrtConfigEntry) -> bool:

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -49,7 +49,7 @@ API_CACHED_ATTRS = {
 }
 YALEXS_BLE_DOMAIN = "yalexs_ble"
 
-AugustConfigEntry = ConfigEntry["AugustData"]
+type AugustConfigEntry = ConfigEntry[AugustData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/aurora/__init__.py
+++ b/homeassistant/components/aurora/__init__.py
@@ -8,7 +8,7 @@ from .coordinator import AuroraDataUpdateCoordinator
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
-AuroraConfigEntry = ConfigEntry[AuroraDataUpdateCoordinator]
+type AuroraConfigEntry = ConfigEntry[AuroraDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: AuroraConfigEntry) -> bool:

--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -13,7 +13,7 @@ from .hub import AxisHub, get_axis_api
 
 _LOGGER = logging.getLogger(__name__)
 
-AxisConfigEntry = ConfigEntry[AxisHub]
+type AxisConfigEntry = ConfigEntry[AxisHub]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: AxisConfigEntry) -> bool:

--- a/homeassistant/components/baf/__init__.py
+++ b/homeassistant/components/baf/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import QUERY_INTERVAL, RUN_TIMEOUT
 
-BAFConfigEntry = ConfigEntry[Device]
+type BAFConfigEntry = ConfigEntry[Device]
 
 
 PLATFORMS: list[Platform] = [

--- a/homeassistant/components/bond/__init__.py
+++ b/homeassistant/components/bond/__init__.py
@@ -35,7 +35,7 @@ _API_TIMEOUT = SLOW_UPDATE_WARNING - 1
 
 _LOGGER = logging.getLogger(__name__)
 
-BondConfigEntry = ConfigEntry[BondData]
+type BondConfigEntry = ConfigEntry[BondData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BondConfigEntry) -> bool:

--- a/homeassistant/components/bring/__init__.py
+++ b/homeassistant/components/bring/__init__.py
@@ -24,7 +24,7 @@ PLATFORMS: list[Platform] = [Platform.TODO]
 
 _LOGGER = logging.getLogger(__name__)
 
-BringConfigEntry = ConfigEntry[BringDataUpdateCoordinator]
+type BringConfigEntry = ConfigEntry[BringDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BringConfigEntry) -> bool:

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -15,7 +15,7 @@ from .utils import get_snmp_engine
 
 PLATFORMS = [Platform.SENSOR]
 
-BrotherConfigEntry = ConfigEntry[BrotherDataUpdateCoordinator]
+type BrotherConfigEntry = ConfigEntry[BrotherDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BrotherConfigEntry) -> bool:

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -11,7 +11,7 @@ from .coordinator import CertExpiryDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-CertExpiryConfigEntry = ConfigEntry[CertExpiryDataUpdateCoordinator]
+type CertExpiryConfigEntry = ConfigEntry[CertExpiryDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CertExpiryConfigEntry) -> bool:

--- a/homeassistant/components/co2signal/__init__.py
+++ b/homeassistant/components/co2signal/__init__.py
@@ -14,7 +14,7 @@ from .coordinator import CO2SignalCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-CO2SignalConfigEntry = ConfigEntry[CO2SignalCoordinator]
+type CO2SignalConfigEntry = ConfigEntry[CO2SignalCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: CO2SignalConfigEntry) -> bool:

--- a/homeassistant/components/devolo_home_control/__init__.py
+++ b/homeassistant/components/devolo_home_control/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import CONF_MYDEVOLO, DEFAULT_MYDEVOLO, GATEWAY_SERIAL_PATTERN, PLATFORMS
 
-DevoloHomeControlConfigEntry = ConfigEntry[list[HomeControl]]
+type DevoloHomeControlConfigEntry = ConfigEntry[list[HomeControl]]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/devolo_home_network/__init__.py
+++ b/homeassistant/components/devolo_home_network/__init__.py
@@ -49,7 +49,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-DevoloHomeNetworkConfigEntry = ConfigEntry["DevoloHomeNetworkData"]
+type DevoloHomeNetworkConfigEntry = ConfigEntry[DevoloHomeNetworkData]
 
 
 @dataclass

--- a/homeassistant/components/discovergy/__init__.py
+++ b/homeassistant/components/discovergy/__init__.py
@@ -16,7 +16,7 @@ from .coordinator import DiscovergyUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-DiscovergyConfigEntry = ConfigEntry[list[DiscovergyUpdateCoordinator]]
+type DiscovergyConfigEntry = ConfigEntry[list[DiscovergyUpdateCoordinator]]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: DiscovergyConfigEntry) -> bool:

--- a/homeassistant/components/dwd_weather_warnings/coordinator.py
+++ b/homeassistant/components/dwd_weather_warnings/coordinator.py
@@ -19,7 +19,7 @@ from .const import (
 from .exceptions import EntityNotFoundError
 from .util import get_position_data
 
-DwdWeatherWarningsConfigEntry = ConfigEntry["DwdWeatherWarningsCoordinator"]
+type DwdWeatherWarningsConfigEntry = ConfigEntry[DwdWeatherWarningsCoordinator]
 
 
 class DwdWeatherWarningsCoordinator(DataUpdateCoordinator[None]):

--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -37,7 +37,7 @@ PLATFORMS = [
     Platform.SWITCH,
     Platform.VACUUM,
 ]
-EcovacsConfigEntry = ConfigEntry[EcovacsController]
+type EcovacsConfigEntry = ConfigEntry[EcovacsController]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -8,7 +8,7 @@ from .coordinator import ElgatoDataUpdateCoordinator
 
 PLATFORMS = [Platform.BUTTON, Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
 
-ElgatorConfigEntry = ConfigEntry[ElgatoDataUpdateCoordinator]
+type ElgatorConfigEntry = ConfigEntry[ElgatoDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ElgatorConfigEntry) -> bool:

--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -69,7 +69,7 @@ from .discovery import (
 )
 from .models import ELKM1Data
 
-ElkM1ConfigEntry = ConfigEntry[ELKM1Data]
+type ElkM1ConfigEntry = ConfigEntry[ELKM1Data]
 
 SYNC_TIMEOUT = 120
 

--- a/homeassistant/components/filesize/__init__.py
+++ b/homeassistant/components/filesize/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from .const import PLATFORMS
 from .coordinator import FileSizeCoordinator
 
-FileSizeConfigEntry = ConfigEntry[FileSizeCoordinator]
+type FileSizeConfigEntry = ConfigEntry[FileSizeCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FileSizeConfigEntry) -> bool:

--- a/homeassistant/components/fritzbox/coordinator.py
+++ b/homeassistant/components/fritzbox/coordinator.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, LOGGER
 
-FritzboxConfigEntry = ConfigEntry["FritzboxDataUpdateCoordinator"]
+type FritzboxConfigEntry = ConfigEntry[FritzboxDataUpdateCoordinator]
 
 
 @dataclass

--- a/homeassistant/components/fritzbox_callmonitor/__init__.py
+++ b/homeassistant/components/fritzbox_callmonitor/__init__.py
@@ -15,7 +15,7 @@ from .const import CONF_PHONEBOOK, CONF_PREFIXES, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
-FritzBoxCallMonitorConfigEntry = ConfigEntry[FritzBoxPhonebook]
+type FritzBoxCallMonitorConfigEntry = ConfigEntry[FritzBoxPhonebook]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -41,7 +41,7 @@ PLATFORMS: Final = [Platform.SENSOR]
 
 _FroniusCoordinatorT = TypeVar("_FroniusCoordinatorT", bound=FroniusCoordinatorBase)
 
-FroniusConfigEntry = ConfigEntry["FroniusSolarNet"]
+type FroniusConfigEntry = ConfigEntry[FroniusSolarNet]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: FroniusConfigEntry) -> bool:

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
-GiosConfigEntry = ConfigEntry["GiosData"]
+type GiosConfigEntry = ConfigEntry[GiosData]
 
 
 @dataclass

--- a/homeassistant/components/habitica/__init__.py
+++ b/homeassistant/components/habitica/__init__.py
@@ -37,7 +37,7 @@ from .coordinator import HabiticaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-HabiticaConfigEntry = ConfigEntry[HabiticaDataUpdateCoordinator]
+type HabiticaConfigEntry = ConfigEntry[HabiticaDataUpdateCoordinator]
 
 SENSORS_TYPES = ["name", "hp", "maxHealth", "mp", "maxMP", "exp", "toNextLevel", "lvl"]
 

--- a/homeassistant/components/imgw_pib/__init__.py
+++ b/homeassistant/components/imgw_pib/__init__.py
@@ -22,7 +22,7 @@ PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 _LOGGER = logging.getLogger(__name__)
 
-ImgwPibConfigEntry = ConfigEntry["ImgwPibData"]
+type ImgwPibConfigEntry = ConfigEntry[ImgwPibData]
 
 
 @dataclass

--- a/homeassistant/components/ipp/__init__.py
+++ b/homeassistant/components/ipp/__init__.py
@@ -17,7 +17,7 @@ from .coordinator import IPPDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-IPPConfigEntry = ConfigEntry[IPPDataUpdateCoordinator]
+type IPPConfigEntry = ConfigEntry[IPPDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: IPPConfigEntry) -> bool:

--- a/homeassistant/components/local_todo/__init__.py
+++ b/homeassistant/components/local_todo/__init__.py
@@ -17,7 +17,7 @@ PLATFORMS: list[Platform] = [Platform.TODO]
 
 STORAGE_PATH = ".storage/local_todo.{key}.ics"
 
-LocalTodoConfigEntry = ConfigEntry[LocalTodoListStore]
+type LocalTodoConfigEntry = ConfigEntry[LocalTodoListStore]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: LocalTodoConfigEntry) -> bool:

--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -21,7 +21,7 @@ PLATFORMS = [Platform.WEATHER]
 
 _LOGGER = logging.getLogger(__name__)
 
-MetWeatherConfigEntry = ConfigEntry[MetDataUpdateCoordinator]
+type MetWeatherConfigEntry = ConfigEntry[MetDataUpdateCoordinator]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -28,7 +28,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BUTTON, Platform.SENSOR]
 
-NAMConfigEntry = ConfigEntry[NAMDataUpdateCoordinator]
+type NAMConfigEntry = ConfigEntry[NAMDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NAMConfigEntry) -> bool:

--- a/homeassistant/components/nextcloud/__init__.py
+++ b/homeassistant/components/nextcloud/__init__.py
@@ -30,7 +30,7 @@ CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
 _LOGGER = logging.getLogger(__name__)
 
-NextcloudConfigEntry = ConfigEntry[NextcloudDataUpdateCoordinator]
+type NextcloudConfigEntry = ConfigEntry[NextcloudDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NextcloudConfigEntry) -> bool:

--- a/homeassistant/components/nextdns/__init__.py
+++ b/homeassistant/components/nextdns/__init__.py
@@ -49,7 +49,7 @@ from .coordinator import (
     NextDnsUpdateCoordinator,
 )
 
-NextDnsConfigEntry = ConfigEntry["NextDnsData"]
+type NextDnsConfigEntry = ConfigEntry[NextDnsData]
 
 
 @dataclass

--- a/homeassistant/components/nut/__init__.py
+++ b/homeassistant/components/nut/__init__.py
@@ -36,7 +36,7 @@ NUT_FAKE_SERIAL = ["unknown", "blank"]
 
 _LOGGER = logging.getLogger(__name__)
 
-NutConfigEntry = ConfigEntry["NutRuntimeData"]
+type NutConfigEntry = ConfigEntry[NutRuntimeData]
 
 
 @dataclass

--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -31,7 +31,7 @@ RETRY_STOP = datetime.timedelta(minutes=10)
 
 DEBOUNCE_TIME = 10 * 60  # in seconds
 
-NWSConfigEntry = ConfigEntry["NWSData"]
+type NWSConfigEntry = ConfigEntry[NWSData]
 
 
 def base_unique_id(latitude: float, longitude: float) -> str:

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -13,7 +13,7 @@ from .const import DOMAIN, PLATFORMS
 from .onewirehub import CannotConnect, OneWireHub
 
 _LOGGER = logging.getLogger(__name__)
-OneWireConfigEntry = ConfigEntry[OneWireHub]
+type OneWireConfigEntry = ConfigEntry[OneWireHub]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: OneWireConfigEntry) -> bool:

--- a/homeassistant/components/openweathermap/__init__.py
+++ b/homeassistant/components/openweathermap/__init__.py
@@ -30,7 +30,7 @@ from .coordinator import WeatherUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-OpenweathermapConfigEntry = ConfigEntry["OpenweathermapData"]
+type OpenweathermapConfigEntry = ConfigEntry[OpenweathermapData]
 
 
 @dataclass

--- a/homeassistant/components/pegel_online/__init__.py
+++ b/homeassistant/components/pegel_online/__init__.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.SENSOR]
 
-PegelOnlineConfigEntry = ConfigEntry[PegelOnlineDataUpdateCoordinator]
+type PegelOnlineConfigEntry = ConfigEntry[PegelOnlineDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PegelOnlineConfigEntry) -> bool:

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -42,7 +42,7 @@ PLATFORMS = [
     Platform.UPDATE,
 ]
 
-PiHoleConfigEntry = ConfigEntry["PiHoleData"]
+type PiHoleConfigEntry = ConfigEntry[PiHoleData]
 
 
 @dataclass

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import PlugwiseDataUpdateCoordinator
 
-PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
+type PlugwiseConfigEntry = ConfigEntry[PlugwiseDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PlugwiseConfigEntry) -> bool:

--- a/homeassistant/components/poolsense/__init__.py
+++ b/homeassistant/components/poolsense/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import aiohttp_client
 
 from .coordinator import PoolSenseDataUpdateCoordinator
 
-PoolSenseConfigEntry = ConfigEntry[PoolSenseDataUpdateCoordinator]
+type PoolSenseConfigEntry = ConfigEntry[PoolSenseDataUpdateCoordinator]
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 

--- a/homeassistant/components/proximity/coordinator.py
+++ b/homeassistant/components/proximity/coordinator.py
@@ -45,7 +45,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-ProximityConfigEntry = ConfigEntry["ProximityDataUpdateCoordinator"]
+type ProximityConfigEntry = ConfigEntry[ProximityDataUpdateCoordinator]
 
 
 @dataclass

--- a/homeassistant/components/radio_browser/__init__.py
+++ b/homeassistant/components/radio_browser/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-RadioBrowserConfigEntry = ConfigEntry[RadioBrowser]
+type RadioBrowserConfigEntry = ConfigEntry[RadioBrowser]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/renault/__init__.py
+++ b/homeassistant/components/renault/__init__.py
@@ -15,7 +15,7 @@ from .renault_hub import RenaultHub
 from .services import setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
-RenaultConfigEntry = ConfigEntry[RenaultHub]
+type RenaultConfigEntry = ConfigEntry[RenaultHub]
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -15,7 +15,7 @@ from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import SensiboDataUpdateCoordinator
 from .util import NoDevicesError, NoUsernameError, async_validate_api
 
-SensiboConfigEntry = ConfigEntry["SensiboDataUpdateCoordinator"]
+type SensiboConfigEntry = ConfigEntry[SensiboDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: SensiboConfigEntry) -> bool:

--- a/homeassistant/components/shelly/coordinator.py
+++ b/homeassistant/components/shelly/coordinator.py
@@ -84,7 +84,7 @@ class ShellyEntryData:
     rpc_poll: ShellyRpcPollingCoordinator | None = None
 
 
-ShellyConfigEntry = ConfigEntry[ShellyEntryData]
+type ShellyConfigEntry = ConfigEntry[ShellyEntryData]
 
 
 class ShellyCoordinatorBase(DataUpdateCoordinator[None], Generic[_DeviceT]):

--- a/homeassistant/components/speedtestdotnet/__init__.py
+++ b/homeassistant/components/speedtestdotnet/__init__.py
@@ -16,7 +16,7 @@ from .coordinator import SpeedTestDataCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-SpeedTestConfigEntry = ConfigEntry[SpeedTestDataCoordinator]
+type SpeedTestConfigEntry = ConfigEntry[SpeedTestDataCoordinator]
 
 
 async def async_setup_entry(

--- a/homeassistant/components/sun/entity.py
+++ b/homeassistant/components/sun/entity.py
@@ -31,7 +31,7 @@ from .const import (
     STATE_BELOW_HORIZON,
 )
 
-SunConfigEntry = ConfigEntry["Sun"]
+type SunConfigEntry = ConfigEntry[Sun]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/systemmonitor/__init__.py
+++ b/homeassistant/components/systemmonitor/__init__.py
@@ -18,7 +18,7 @@ _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
-SystemMonitorConfigEntry = ConfigEntry["SystemMonitorData"]
+type SystemMonitorConfigEntry = ConfigEntry[SystemMonitorData]
 
 
 @dataclass

--- a/homeassistant/components/tailwind/typing.py
+++ b/homeassistant/components/tailwind/typing.py
@@ -4,4 +4,4 @@ from homeassistant.config_entries import ConfigEntry
 
 from .coordinator import TailwindDataUpdateCoordinator
 
-TailwindConfigEntry = ConfigEntry[TailwindDataUpdateCoordinator]
+type TailwindConfigEntry = ConfigEntry[TailwindDataUpdateCoordinator]

--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -28,7 +28,7 @@ from .const import CONF_FUEL_TYPES, CONF_STATIONS
 
 _LOGGER = logging.getLogger(__name__)
 
-TankerkoenigConfigEntry = ConfigEntry["TankerkoenigDataUpdateCoordinator"]
+type TankerkoenigConfigEntry = ConfigEntry[TankerkoenigDataUpdateCoordinator]
 
 
 class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator[dict[str, PriceInfo]]):

--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -73,7 +73,7 @@ class TractiveData:
     trackables: list[Trackables]
 
 
-TractiveConfigEntry = ConfigEntry[TractiveData]
+type TractiveConfigEntry = ConfigEntry[TractiveData]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> bool:

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -35,7 +35,7 @@ from .const import (
 # Suppress logs from the library, it logs unneeded on error
 logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
 
-TuyaConfigEntry = ConfigEntry["HomeAssistantTuyaData"]
+type TuyaConfigEntry = ConfigEntry[HomeAssistantTuyaData]
 
 
 class HomeAssistantTuyaData(NamedTuple):

--- a/homeassistant/components/twentemilieu/__init__.py
+++ b/homeassistant/components/twentemilieu/__init__.py
@@ -23,8 +23,10 @@ SERVICE_SCHEMA = vol.Schema({vol.Optional(CONF_ID): cv.string})
 
 PLATFORMS = [Platform.CALENDAR, Platform.SENSOR]
 
-TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator[dict[WasteType, list[date]]]
-TwenteMilieuConfigEntry = ConfigEntry[TwenteMilieuDataUpdateCoordinator]
+type TwenteMilieuDataUpdateCoordinator = DataUpdateCoordinator[
+    dict[WasteType, list[date]]
+]
+type TwenteMilieuConfigEntry = ConfigEntry[TwenteMilieuDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/unifi/__init__.py
+++ b/homeassistant/components/unifi/__init__.py
@@ -16,7 +16,7 @@ from .errors import AuthenticationRequired, CannotConnect
 from .hub import UnifiHub, get_unifi_api
 from .services import async_setup_services
 
-UnifiConfigEntry = ConfigEntry[UnifiHub]
+type UnifiConfigEntry = ConfigEntry[UnifiHub]
 
 SAVE_DELAY = 10
 STORAGE_KEY = "unifi_data"

--- a/homeassistant/components/upnp/__init__.py
+++ b/homeassistant/components/upnp/__init__.py
@@ -36,7 +36,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 CONFIG_SCHEMA = cv.removed(DOMAIN, raise_if_present=False)
 
-UpnpConfigEntry = ConfigEntry[UpnpDataUpdateCoordinator]
+type UpnpConfigEntry = ConfigEntry[UpnpDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: UpnpConfigEntry) -> bool:

--- a/homeassistant/components/vlc_telnet/__init__.py
+++ b/homeassistant/components/vlc_telnet/__init__.py
@@ -14,7 +14,7 @@ from .const import LOGGER
 
 PLATFORMS = [Platform.MEDIA_PLAYER]
 
-VlcConfigEntry = ConfigEntry["VlcData"]
+type VlcConfigEntry = ConfigEntry[VlcData]
 
 
 @dataclass

--- a/homeassistant/components/webmin/__init__.py
+++ b/homeassistant/components/webmin/__init__.py
@@ -8,7 +8,7 @@ from .coordinator import WebminUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
-WebminConfigEntry = ConfigEntry[WebminUpdateCoordinator]
+type WebminConfigEntry = ConfigEntry[WebminUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WebminConfigEntry) -> bool:

--- a/homeassistant/components/withings/__init__.py
+++ b/homeassistant/components/withings/__init__.py
@@ -59,7 +59,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.CALENDAR, Platform.SENSOR]
 SUBSCRIBE_DELAY = timedelta(seconds=5)
 UNSUBSCRIBE_DELAY = timedelta(seconds=1)
 CONF_CLOUDHOOK_URL = "cloudhook_url"
-WithingsConfigEntry = ConfigEntry["WithingsData"]
+type WithingsConfigEntry = ConfigEntry[WithingsData]
 
 
 @dataclass(slots=True)

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -20,7 +20,7 @@ PLATFORMS = (
     Platform.UPDATE,
 )
 
-WLEDConfigEntry = ConfigEntry[WLEDDataUpdateCoordinator]
+type WLEDConfigEntry = ConfigEntry[WLEDDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: WLEDConfigEntry) -> bool:

--- a/homeassistant/components/yale_smart_alarm/__init__.py
+++ b/homeassistant/components/yale_smart_alarm/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.helpers import entity_registry as er
 from .const import LOGGER, PLATFORMS
 from .coordinator import YaleDataUpdateCoordinator
 
-YaleConfigEntry = ConfigEntry["YaleDataUpdateCoordinator"]
+type YaleConfigEntry = ConfigEntry[YaleDataUpdateCoordinator]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool:

--- a/homeassistant/components/yalexs_ble/__init__.py
+++ b/homeassistant/components/yalexs_ble/__init__.py
@@ -29,7 +29,7 @@ from .const import (
 from .models import YaleXSBLEData
 from .util import async_find_existing_service_info, bluetooth_callback_matcher
 
-YALEXSBLEConfigEntry = ConfigEntry[YaleXSBLEData]
+type YALEXSBLEConfigEntry = ConfigEntry[YaleXSBLEData]
 
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.LOCK, Platform.SENSOR]


### PR DESCRIPTION
## Proposed change
Use [PEP 695](https://peps.python.org/pep-0695/) type aliases for `ConfigEntry` types.

> [!IMPORTANT]
> The type alias isn't evaluated at runtime. Thus any quotes can be omitted. However, that also means they can't be used in a runtime context like for `isinstance` checks or instantiation. Those cases will result in a `TypeError`.
>
> _That isn't a relevant for the `ConfigEntry` type aliases though. These are only used in annotations._


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
