### PR TITLE
Use PEP 695 for decorator typing (2)

### DIFF
--- a/homeassistant/components/iaqualink/__init__.py
+++ b/homeassistant/components/iaqualink/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime
 from functools import wraps
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 import httpx
 from iaqualink.client import AqualinkClient
@@ -38,9 +38,6 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN, UPDATE_INTERVAL
-
-_AqualinkEntityT = TypeVar("_AqualinkEntityT", bound="AqualinkEntity")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,7 +179,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return await hass.config_entries.async_unload_platforms(entry, platforms_to_unload)
 
 
-def refresh_system(
+def refresh_system[_AqualinkEntityT: AqualinkEntity, **_P](
     func: Callable[Concatenate[_AqualinkEntityT, _P], Awaitable[Any]],
 ) -> Callable[Concatenate[_AqualinkEntityT, _P], Coroutine[Any, Any, None]]:
     """Force update all entities after state change."""

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from functools import wraps
 import logging
 import re
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from jsonrpc_base.jsonrpc import ProtocolError, TransportError
 from pykodi import CannotConnectError
@@ -70,9 +70,6 @@ from .const import (
     EVENT_TURN_OFF,
     EVENT_TURN_ON,
 )
-
-_KodiEntityT = TypeVar("_KodiEntityT", bound="KodiEntity")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -231,7 +228,7 @@ async def async_setup_entry(
     async_add_entities([entity])
 
 
-def cmd(
+def cmd[_KodiEntityT: KodiEntity, **_P](
     func: Callable[Concatenate[_KodiEntityT, _P], Awaitable[Any]],
 ) -> Callable[Concatenate[_KodiEntityT, _P], Coroutine[Any, Any, None]]:
     """Catch command exceptions."""

--- a/homeassistant/components/lametric/helpers.py
+++ b/homeassistant/components/lametric/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from demetriek import LaMetricConnectionError, LaMetricError
 
@@ -15,11 +15,8 @@ from .const import DOMAIN
 from .coordinator import LaMetricDataUpdateCoordinator
 from .entity import LaMetricEntity
 
-_LaMetricEntityT = TypeVar("_LaMetricEntityT", bound=LaMetricEntity)
-_P = ParamSpec("_P")
 
-
-def lametric_exception_handler(
+def lametric_exception_handler[_LaMetricEntityT: LaMetricEntity, **_P](
     func: Callable[Concatenate[_LaMetricEntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_LaMetricEntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate LaMetric calls to handle LaMetric exceptions.

--- a/homeassistant/components/limitlessled/light.py
+++ b/homeassistant/components/limitlessled/light.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, cast
 
 from limitlessled import Color
 from limitlessled.bridge import Bridge
@@ -39,9 +39,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util.color import color_hs_to_RGB, color_temperature_mired_to_kelvin
-
-_LimitlessLEDGroupT = TypeVar("_LimitlessLEDGroupT", bound="LimitlessLEDGroup")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -176,7 +173,7 @@ def setup_platform(
     add_entities(lights)
 
 
-def state(
+def state[_LimitlessLEDGroupT: LimitlessLEDGroup, **_P](
     new_state: bool,
 ) -> Callable[
     [Callable[Concatenate[_LimitlessLEDGroupT, int, Pipeline, _P], Any]],

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate, ParamSpec
+from typing import Any, Concatenate
 
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
@@ -17,8 +17,6 @@ from homeassistant.core import HomeAssistant, callback
 
 from .adapter import MatterAdapter
 from .helpers import MissingNode, get_matter, node_from_ha_device_id
-
-_P = ParamSpec("_P")
 
 ID = "id"
 TYPE = "type"
@@ -93,7 +91,7 @@ def async_get_matter_adapter(
     return _get_matter
 
 
-def async_handle_failed_command(
+def async_handle_failed_command[**_P](
     func: Callable[
         Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
         Coroutine[Any, Any, None],

--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from aiomodernforms import ModernFormsConnectionError, ModernFormsError
 
@@ -16,11 +16,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import ModernFormsDataUpdateCoordinator
-
-_ModernFormsDeviceEntityT = TypeVar(
-    "_ModernFormsDeviceEntityT", bound="ModernFormsDeviceEntity"
-)
-_P = ParamSpec("_P")
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -61,7 +56,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-def modernforms_exception_handler(
+def modernforms_exception_handler[
+    _ModernFormsDeviceEntityT: ModernFormsDeviceEntity,
+    **_P,
+](
     func: Callable[Concatenate[_ModernFormsDeviceEntityT, _P], Any],
 ) -> Callable[Concatenate[_ModernFormsDeviceEntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate Modern Forms calls to handle Modern Forms exceptions.

--- a/homeassistant/components/otbr/util.py
+++ b/homeassistant/components/otbr/util.py
@@ -7,7 +7,7 @@ import dataclasses
 from functools import wraps
 import logging
 import random
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, cast
 
 import python_otbr_api
 from python_otbr_api import PENDING_DATASET_DELAY_TIMER, tlv_parser
@@ -26,9 +26,6 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 
 from .const import DOMAIN
-
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +58,7 @@ def generate_random_pan_id() -> int:
     return random.randint(0, 0xFFFE)
 
 
-def _handle_otbr_error(
+def _handle_otbr_error[**_P, _R](
     func: Callable[Concatenate[OTBRData, _P], Coroutine[Any, Any, _R]],
 ) -> Callable[Concatenate[OTBRData, _P], Coroutine[Any, Any, _R]]:
     """Handle OTBR errors."""

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, cast
 
 import plexapi.exceptions
 import requests.exceptions
@@ -46,14 +46,10 @@ from .helpers import get_plex_data, get_plex_server
 from .media_browser import browse_media
 from .services import process_plex_payload
 
-_PlexMediaPlayerT = TypeVar("_PlexMediaPlayerT", bound="PlexMediaPlayer")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
 _LOGGER = logging.getLogger(__name__)
 
 
-def needs_session(
+def needs_session[_PlexMediaPlayerT: PlexMediaPlayer, **_P, _R](
     func: Callable[Concatenate[_PlexMediaPlayerT, _P], _R],
 ) -> Callable[Concatenate[_PlexMediaPlayerT, _P], _R | None]:
     """Ensure session is available for certain attributes."""

--- a/homeassistant/components/plugwise/util.py
+++ b/homeassistant/components/plugwise/util.py
@@ -1,7 +1,7 @@
 """Utilities for Plugwise."""
 
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from plugwise.exceptions import PlugwiseException
 
@@ -9,12 +9,8 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .entity import PlugwiseEntity
 
-_PlugwiseEntityT = TypeVar("_PlugwiseEntityT", bound=PlugwiseEntity)
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
-
-def plugwise_command(
+def plugwise_command[_PlugwiseEntityT: PlugwiseEntity, **_P, _R](
     func: Callable[Concatenate[_PlugwiseEntityT, _P], Awaitable[_R]],
 ) -> Callable[Concatenate[_PlugwiseEntityT, _P], Coroutine[Any, Any, _R]]:
     """Decorate Plugwise calls that send commands/make changes to the device.

--- a/homeassistant/components/rainmachine/switch.py
+++ b/homeassistant/components/rainmachine/switch.py
@@ -6,7 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from regenmaschine.errors import RainMachineError
 import voluptuous as vol
@@ -110,11 +110,7 @@ VEGETATION_MAP = {
 }
 
 
-_T = TypeVar("_T", bound="RainMachineBaseSwitch")
-_P = ParamSpec("_P")
-
-
-def raise_on_request_error(
+def raise_on_request_error[_T: RainMachineBaseSwitch, **_P](
     func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Define a decorator to raise on a request error."""

--- a/homeassistant/components/renault/renault_vehicle.py
+++ b/homeassistant/components/renault/renault_vehicle.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from functools import wraps
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, cast
 
 from renault_api.exceptions import RenaultException
 from renault_api.kamereon import models
@@ -22,13 +22,11 @@ from .const import DOMAIN
 from .coordinator import RenaultDataUpdateCoordinator
 
 LOGGER = logging.getLogger(__name__)
-_T = TypeVar("_T")
-_P = ParamSpec("_P")
 
 
-def with_error_wrapping(
-    func: Callable[Concatenate[RenaultVehicleProxy, _P], Awaitable[_T]],
-) -> Callable[Concatenate[RenaultVehicleProxy, _P], Coroutine[Any, Any, _T]]:
+def with_error_wrapping[**_P, _R](
+    func: Callable[Concatenate[RenaultVehicleProxy, _P], Awaitable[_R]],
+) -> Callable[Concatenate[RenaultVehicleProxy, _P], Coroutine[Any, Any, _R]]:
     """Catch Renault errors."""
 
     @wraps(func)
@@ -36,7 +34,7 @@ def with_error_wrapping(
         self: RenaultVehicleProxy,
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> _T:
+    ) -> _R:
         """Catch RenaultException errors and raise HomeAssistantError."""
         try:
             return await func(self, *args, **kwargs)

--- a/homeassistant/components/ring/entity.py
+++ b/homeassistant/components/ring/entity.py
@@ -1,7 +1,7 @@
 """Base class for Ring entity."""
 
 from collections.abc import Callable
-from typing import Any, Concatenate, Generic, ParamSpec, cast
+from typing import Any, Concatenate, Generic, cast
 
 from ring_doorbell import (
     AuthenticationError,
@@ -26,12 +26,9 @@ _RingCoordinatorT = TypeVar(
     "_RingCoordinatorT",
     bound=(RingDataCoordinator | RingNotificationsCoordinator),
 )
-_RingBaseEntityT = TypeVar("_RingBaseEntityT", bound="RingBaseEntity[Any, Any]")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 
-def exception_wrap(
+def exception_wrap[_RingBaseEntityT: RingBaseEntity[Any, Any], **_P, _R](
     func: Callable[Concatenate[_RingBaseEntityT, _P], _R],
 ) -> Callable[Concatenate[_RingBaseEntityT, _P], _R]:
     """Define a wrapper to catch exceptions and raise HomeAssistant errors."""

--- a/homeassistant/components/sensibo/entity.py
+++ b/homeassistant/components/sensibo/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate
 
 from pysensibo.model import MotionSensor, SensiboDevice
 
@@ -15,11 +15,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, LOGGER, SENSIBO_ERRORS, TIMEOUT
 from .coordinator import SensiboDataUpdateCoordinator
 
-_T = TypeVar("_T", bound="SensiboDeviceBaseEntity")
-_P = ParamSpec("_P")
 
-
-def async_handle_api_call(
+def async_handle_api_call[_T: SensiboDeviceBaseEntity, **_P](
     function: Callable[Concatenate[_T, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, Any]]:
     """Decorate api calls."""

--- a/homeassistant/components/sfr_box/button.py
+++ b/homeassistant/components/sfr_box/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from sfrbox_api.bridge import SFRBox
 from sfrbox_api.exceptions import SFRBoxError
@@ -26,13 +26,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .models import DomainData
 
-_T = TypeVar("_T")
-_P = ParamSpec("_P")
 
-
-def with_error_wrapping(
-    func: Callable[Concatenate[SFRBoxButton, _P], Awaitable[_T]],
-) -> Callable[Concatenate[SFRBoxButton, _P], Coroutine[Any, Any, _T]]:
+def with_error_wrapping[**_P, _R](
+    func: Callable[Concatenate[SFRBoxButton, _P], Awaitable[_R]],
+) -> Callable[Concatenate[SFRBoxButton, _P], Coroutine[Any, Any, _R]]:
     """Catch SFR errors."""
 
     @wraps(func)
@@ -40,7 +37,7 @@ def with_error_wrapping(
         self: SFRBoxButton,
         *args: _P.args,
         **kwargs: _P.kwargs,
-    ) -> _T:
+    ) -> _R:
         """Catch SFRBoxError errors and raise HomeAssistantError."""
         try:
             return await func(self, *args, **kwargs)

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -6,7 +6,7 @@ from asyncio import run_coroutine_threadsafe
 from collections.abc import Callable
 from datetime import timedelta
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 import requests
 from spotipy import SpotifyException
@@ -34,10 +34,6 @@ from . import HomeAssistantSpotifyData
 from .browse_media import async_browse_media_internal
 from .const import DOMAIN, MEDIA_PLAYER_PREFIX, PLAYABLE_MEDIA_TYPES, SPOTIFY_SCOPES
 from .util import fetch_image_url
-
-_SpotifyMediaPlayerT = TypeVar("_SpotifyMediaPlayerT", bound="SpotifyMediaPlayer")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -86,7 +82,7 @@ async def async_setup_entry(
     async_add_entities([spotify], True)
 
 
-def spotify_exception_handler(
+def spotify_exception_handler[_SpotifyMediaPlayerT: SpotifyMediaPlayer, **_P, _R](
     func: Callable[Concatenate[_SpotifyMediaPlayerT, _P], _R],
 ) -> Callable[Concatenate[_SpotifyMediaPlayerT, _P], _R | None]:
     """Decorate Spotify calls to handle Spotify exception.


### PR DESCRIPTION
## Proposed change
Use [PEP 695](https://peps.python.org/pep-0695/) for decorator typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
