### PR TITLE
Use PEP 695 for decorator typing (3)

### DIFF
--- a/homeassistant/components/synology_dsm/coordinator.py
+++ b/homeassistant/components/synology_dsm/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine
 from datetime import timedelta
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate, TypeVar
 
 from synology_dsm.api.surveillance_station.camera import SynoCamera
 from synology_dsm.exceptions import (
@@ -31,16 +31,12 @@ _LOGGER = logging.getLogger(__name__)
 _DataT = TypeVar("_DataT")
 
 
-_T = TypeVar("_T", bound="SynologyDSMUpdateCoordinator")
-_P = ParamSpec("_P")
-
-
-def async_re_login_on_expired(
-    func: Callable[Concatenate[_T, _P], Awaitable[_DataT]],
-) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _DataT]]:
+def async_re_login_on_expired[_T: SynologyDSMUpdateCoordinator[Any], **_P, _R](
+    func: Callable[Concatenate[_T, _P], Awaitable[_R]],
+) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, _R]]:
     """Define a wrapper to re-login when expired."""
 
-    async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _DataT:
+    async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         for attempts in range(2):
             try:
                 return await func(self, *args, **kwargs)

--- a/homeassistant/components/technove/helpers.py
+++ b/homeassistant/components/technove/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from technove import TechnoVEConnectionError, TechnoVEError
 
@@ -11,11 +11,8 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .entity import TechnoVEEntity
 
-_TechnoVEEntityT = TypeVar("_TechnoVEEntityT", bound=TechnoVEEntity)
-_P = ParamSpec("_P")
 
-
-def technove_exception_handler(
+def technove_exception_handler[_TechnoVEEntityT: TechnoVEEntity, **_P](
     func: Callable[Concatenate[_TechnoVEEntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_TechnoVEEntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate TechnoVE calls to handle TechnoVE exceptions.

--- a/homeassistant/components/toon/helpers.py
+++ b/homeassistant/components/toon/helpers.py
@@ -4,19 +4,16 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from toonapi import ToonConnectionError, ToonError
 
 from .models import ToonEntity
 
-_ToonEntityT = TypeVar("_ToonEntityT", bound=ToonEntity)
-_P = ParamSpec("_P")
-
 _LOGGER = logging.getLogger(__name__)
 
 
-def toon_exception_handler(
+def toon_exception_handler[_ToonEntityT: ToonEntity, **_P](
     func: Callable[Concatenate[_ToonEntityT, _P], Coroutine[Any, Any, None]],
 ) -> Callable[Concatenate[_ToonEntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate Toon calls to handle Toon exceptions.

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from kasa import (
     AuthenticationException,
@@ -20,11 +20,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import TPLinkDataUpdateCoordinator
 
-_T = TypeVar("_T", bound="CoordinatedTPLinkEntity")
-_P = ParamSpec("_P")
 
-
-def async_refresh_after(
+def async_refresh_after[_T: CoordinatedTPLinkEntity, **_P](
     func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Define a wrapper to raise HA errors and refresh after."""

--- a/homeassistant/components/velbus/entity.py
+++ b/homeassistant/components/velbus/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from velbusaio.channels import Channel as VelbusChannel
 
@@ -44,11 +44,7 @@ class VelbusEntity(Entity):
         self.async_write_ha_state()
 
 
-_T = TypeVar("_T", bound="VelbusEntity")
-_P = ParamSpec("_P")
-
-
-def api_call(
+def api_call[_T: VelbusEntity, **_P](
     func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Catch command exceptions."""

--- a/homeassistant/components/vlc_telnet/media_player.py
+++ b/homeassistant/components/vlc_telnet/media_player.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from aiovlc.client import Client
 from aiovlc.exceptions import AuthError, CommandError, ConnectError
@@ -30,9 +30,6 @@ from .const import DEFAULT_NAME, DOMAIN, LOGGER
 
 MAX_VOLUME = 500
 
-_VlcDeviceT = TypeVar("_VlcDeviceT", bound="VlcDevice")
-_P = ParamSpec("_P")
-
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: VlcConfigEntry, async_add_entities: AddEntitiesCallback
@@ -46,7 +43,7 @@ async def async_setup_entry(
     async_add_entities([VlcDevice(entry, vlc, name, available)], True)
 
 
-def catch_vlc_errors(
+def catch_vlc_errors[_VlcDeviceT: VlcDevice, **_P](
     func: Callable[Concatenate[_VlcDeviceT, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_VlcDeviceT, _P], Coroutine[Any, Any, None]]:
     """Catch VLC errors."""

--- a/homeassistant/components/wallbox/coordinator.py
+++ b/homeassistant/components/wallbox/coordinator.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from datetime import timedelta
 from http import HTTPStatus
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 import requests
 from wallbox import Wallbox
@@ -64,11 +64,8 @@ CHARGER_STATUS: dict[int, ChargerStatus] = {
     210: ChargerStatus.LOCKED_CAR_CONNECTED,
 }
 
-_WallboxCoordinatorT = TypeVar("_WallboxCoordinatorT", bound="WallboxCoordinator")
-_P = ParamSpec("_P")
 
-
-def _require_authentication(
+def _require_authentication[_WallboxCoordinatorT: WallboxCoordinator, **_P](
     func: Callable[Concatenate[_WallboxCoordinatorT, _P], Any],
 ) -> Callable[Concatenate[_WallboxCoordinatorT, _P], Any]:
     """Authenticate with decorator using Wallbox API."""

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar, cast
+from typing import Any, Concatenate, cast
 
 from aiowebostv import WebOsClient, WebOsTvPairError
 
@@ -79,11 +79,7 @@ async def async_setup_entry(
     async_add_entities([LgWebOSMediaPlayerEntity(entry, client)])
 
 
-_T = TypeVar("_T", bound="LgWebOSMediaPlayerEntity")
-_P = ParamSpec("_P")
-
-
-def cmd(
+def cmd[_T: LgWebOSMediaPlayerEntity, **_P](
     func: Callable[Concatenate[_T, _P], Awaitable[None]],
 ) -> Callable[Concatenate[_T, _P], Coroutine[Any, Any, None]]:
     """Catch command exceptions."""

--- a/homeassistant/components/wled/helpers.py
+++ b/homeassistant/components/wled/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from wled import WLEDConnectionError, WLEDError
 
@@ -11,11 +11,8 @@ from homeassistant.exceptions import HomeAssistantError
 
 from .entity import WLEDEntity
 
-_WLEDEntityT = TypeVar("_WLEDEntityT", bound=WLEDEntity)
-_P = ParamSpec("_P")
 
-
-def wled_exception_handler(
+def wled_exception_handler[_WLEDEntityT: WLEDEntity, **_P](
     func: Callable[Concatenate[_WLEDEntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_WLEDEntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate WLED calls to handle WLED exceptions.

--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 import logging
 import math
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 import voluptuous as vol
 import yeelight
@@ -66,10 +66,6 @@ from .const import (
 )
 from .device import YeelightDevice
 from .entity import YeelightEntity
-
-_YeelightBaseLightT = TypeVar("_YeelightBaseLightT", bound="YeelightBaseLight")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -243,7 +239,7 @@ def _parse_custom_effects(effects_config) -> dict[str, dict[str, Any]]:
     return effects
 
 
-def _async_cmd(
+def _async_cmd[_YeelightBaseLightT: YeelightBaseLight, **_P, _R](
     func: Callable[Concatenate[_YeelightBaseLightT, _P], Coroutine[Any, Any, _R]],
 ) -> Callable[Concatenate[_YeelightBaseLightT, _P], Coroutine[Any, Any, _R | None]]:
     """Define a wrapper to catch exceptions from the bulb."""

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Coroutine
 import dataclasses
 from functools import partial, wraps
-from typing import Any, Concatenate, Literal, ParamSpec, cast
+from typing import Any, Concatenate, Literal, cast
 
 from aiohttp import web, web_exceptions, web_request
 import voluptuous as vol
@@ -83,8 +83,6 @@ from .helpers import (
     async_get_node_from_device_id,
     get_device_id,
 )
-
-_P = ParamSpec("_P")
 
 DATA_UNSUBSCRIBE = "unsubs"
 
@@ -362,7 +360,7 @@ def async_get_node(
     return async_get_node_func
 
 
-def async_handle_failed_command(
+def async_handle_failed_command[**_P](
     orig_func: Callable[
         Concatenate[HomeAssistant, ActiveConnection, dict[str, Any], _P],
         Coroutine[Any, Any, None],

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -12,7 +12,7 @@ from functools import partial, wraps
 import logging
 from random import randint
 import time
-from typing import TYPE_CHECKING, Any, Concatenate, Generic, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate, Generic, TypeVar
 
 from homeassistant.const import (
     EVENT_CORE_CONFIG_UPDATE,
@@ -93,7 +93,6 @@ RANDOM_MICROSECOND_MIN = 50000
 RANDOM_MICROSECOND_MAX = 500000
 
 _TypedDictT = TypeVar("_TypedDictT", bound=Mapping[str, Any])
-_P = ParamSpec("_P")
 
 
 @dataclass(slots=True, frozen=True)
@@ -168,7 +167,7 @@ class TrackTemplateResult:
     result: Any
 
 
-def threaded_listener_factory(
+def threaded_listener_factory[**_P](
     async_factory: Callable[Concatenate[HomeAssistant, _P], Any],
 ) -> Callable[Concatenate[HomeAssistant, _P], CALLBACK_TYPE]:
     """Convert an async event helper to a threaded one."""

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -8,7 +8,7 @@ import functools
 import linecache
 import logging
 import threading
-from typing import Any, ParamSpec, TypeVar
+from typing import Any
 
 from homeassistant.core import HomeAssistant, async_get_hass
 from homeassistant.exceptions import HomeAssistantError
@@ -20,10 +20,6 @@ from homeassistant.helpers.frame import (
 from homeassistant.loader import async_suggest_report_issue
 
 _LOGGER = logging.getLogger(__name__)
-
-
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
 
 
 def _get_line_from_cache(filename: str, lineno: int) -> str:
@@ -114,7 +110,7 @@ def raise_for_blocking_call(
         )
 
 
-def protect_loop(
+def protect_loop[**_P, _R](
     func: Callable[_P, _R],
     loop_thread_id: int,
     strict: bool = True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import reprlib
 import sqlite3
 import ssl
 import threading
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aiohttp import client
@@ -204,11 +204,7 @@ class HAFakeDatetime(freezegun.api.FakeDatetime):  # type: ignore[name-defined]
         return ha_datetime_to_fakedatetime(result)
 
 
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
-
-def check_real(func: Callable[_P, Coroutine[Any, Any, _R]]):
+def check_real[**_P, _R](func: Callable[_P, Coroutine[Any, Any, _R]]):
     """Force a function to require a keyword _test_real to be passed in."""
 
     @functools.wraps(func)


### PR DESCRIPTION
## Proposed change
Use [PEP 695](https://peps.python.org/pep-0695/) for decorator typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
