### PR TITLE
Check if we are running in Kubernetes

### DIFF
--- a/homeassistant/helpers/system_info.py
+++ b/homeassistant/helpers/system_info.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 from homeassistant.const import __version__ as current_version
 from homeassistant.core import HomeAssistant
 from homeassistant.loader import bind_hass
-from homeassistant.util.package import is_docker_env, is_virtual_env
+from homeassistant.util.package import is_virtual_env, is_container
 
 from .importlib import async_import_module
 from .singleton import singleton
@@ -76,7 +76,7 @@ async def async_get_system_info(hass: HomeAssistant) -> dict[str, Any]:
     if platform.system() == "Darwin":
         info_object["os_version"] = await async_get_mac_ver(hass)
     elif platform.system() == "Linux":
-        info_object["docker"] = is_docker_env()
+        info_object["docker"] = is_container()
 
     # Determine installation type on current data
     if info_object["docker"]:

--- a/homeassistant/util/package.py
+++ b/homeassistant/util/package.py
@@ -31,6 +31,33 @@ def is_docker_env() -> bool:
     return Path("/.dockerenv").exists()
 
 
+@cache
+def is_container() -> bool:
+    """Returns True if we run in a container (Kubernetes or Docker env)."""
+    if is_running_in_kubernetes:
+        return True
+    elif is_docker_env:
+        return True
+    else:
+        return False
+
+
+@cache
+def is_running_in_kubernetes() -> bool:
+    """Return true if we run in a kubernetes env."""
+    # Check for the presence of Kubernetes service account token file
+    if os.path.exists("/var/run/secrets/kubernetes.io/serviceaccount/token"):
+        return True
+
+    # Check for the presence of Kubernetes Downward API environment variables
+    if os.environ.get("KUBERNETES_SERVICE_HOST") and os.environ.get(
+        "KUBERNETES_SERVICE_PORT"
+    ):
+        return True
+
+    return False
+
+
 def get_installed_versions(specifiers: set[str]) -> set[str]:
     """Return a set of installed packages and versions."""
     return {specifier for specifier in specifiers if is_installed(specifier)}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes the way we are checking if we are running inside a container. Instead of relying on .dockerenv alone, we now also check for Kubernetes related env variables if they exist.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
