### PR TITLE
Use PEP 695 for decorator typing with type aliases (1)

### DIFF
--- a/homeassistant/components/androidtv/entity.py
+++ b/homeassistant/components/androidtv/entity.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Coroutine
 import functools
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from androidtv.exceptions import LockNotAcquiredException
 
@@ -34,15 +34,13 @@ PREFIX_FIRETV = "Fire TV"
 
 _LOGGER = logging.getLogger(__name__)
 
-_ADBDeviceT = TypeVar("_ADBDeviceT", bound="AndroidTVEntity")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
-_FuncType = Callable[Concatenate[_ADBDeviceT, _P], Awaitable[_R]]
-_ReturnFuncType = Callable[Concatenate[_ADBDeviceT, _P], Coroutine[Any, Any, _R | None]]
+type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], Awaitable[_R]]
+type _ReturnFuncType[_T, **_P, _R] = Callable[
+    Concatenate[_T, _P], Coroutine[Any, Any, _R | None]
+]
 
 
-def adb_decorator(
+def adb_decorator[_ADBDeviceT: AndroidTVEntity, **_P, _R](
     override_available: bool = False,
 ) -> Callable[[_FuncType[_ADBDeviceT, _P, _R]], _ReturnFuncType[_ADBDeviceT, _P, _R]]:
     """Wrap ADB methods and catch exceptions.

--- a/homeassistant/components/asuswrt/bridge.py
+++ b/homeassistant/components/asuswrt/bridge.py
@@ -7,7 +7,7 @@ from collections import namedtuple
 from collections.abc import Awaitable, Callable, Coroutine
 import functools
 import logging
-from typing import Any, TypeVar, cast
+from typing import Any, cast
 
 from aioasuswrt.asuswrt import AsusWrt as AsusWrtLegacy
 from aiohttp import ClientSession
@@ -56,15 +56,11 @@ WrtDevice = namedtuple("WrtDevice", ["ip", "name", "connected_to"])
 
 _LOGGER = logging.getLogger(__name__)
 
-
-_AsusWrtBridgeT = TypeVar("_AsusWrtBridgeT", bound="AsusWrtBridge")
-_FuncType = Callable[
-    [_AsusWrtBridgeT], Awaitable[list[Any] | tuple[Any] | dict[str, Any]]
-]
-_ReturnFuncType = Callable[[_AsusWrtBridgeT], Coroutine[Any, Any, dict[str, Any]]]
+type _FuncType[_T] = Callable[[_T], Awaitable[list[Any] | tuple[Any] | dict[str, Any]]]
+type _ReturnFuncType[_T] = Callable[[_T], Coroutine[Any, Any, dict[str, Any]]]
 
 
-def handle_errors_and_zip(
+def handle_errors_and_zip[_AsusWrtBridgeT: AsusWrtBridge](
     exceptions: type[Exception] | tuple[type[Exception], ...], keys: list[str] | None
 ) -> Callable[[_FuncType[_AsusWrtBridgeT]], _ReturnFuncType[_AsusWrtBridgeT]]:
     """Run library methods and zip results or manage exceptions."""

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from functools import wraps
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Concatenate, ParamSpec, TypeVar
+from typing import TYPE_CHECKING, Any, Concatenate
 
 import pychromecast
 from pychromecast.controllers.homeassistant import HomeAssistantController
@@ -85,18 +85,12 @@ APP_IDS_UNRELIABLE_MEDIA_INFO = ("Netflix",)
 
 CAST_SPLASH = "https://www.home-assistant.io/images/cast/splash.png"
 
-
-_CastDeviceT = TypeVar("_CastDeviceT", bound="CastDevice")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
-_FuncType = Callable[Concatenate[_CastDeviceT, _P], _R]
-_ReturnFuncType = Callable[Concatenate[_CastDeviceT, _P], _R]
+type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], _R]
 
 
-def api_error(
+def api_error[_CastDeviceT: CastDevice, **_P, _R](
     func: _FuncType[_CastDeviceT, _P, _R],
-) -> _ReturnFuncType[_CastDeviceT, _P, _R]:
+) -> _FuncType[_CastDeviceT, _P, _R]:
     """Handle PyChromecastError and reraise a HomeAssistantError."""
 
     @wraps(func)

--- a/homeassistant/components/hassio/addon_manager.py
+++ b/homeassistant/components/hassio/addon_manager.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from enum import Enum
 from functools import partial, wraps
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -28,15 +28,13 @@ from .handler import (
     async_update_addon,
 )
 
-_AddonManagerT = TypeVar("_AddonManagerT", bound="AddonManager")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-
-_FuncType = Callable[Concatenate[_AddonManagerT, _P], Awaitable[_R]]
-_ReturnFuncType = Callable[Concatenate[_AddonManagerT, _P], Coroutine[Any, Any, _R]]
+type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], Awaitable[_R]]
+type _ReturnFuncType[_T, **_P, _R] = Callable[
+    Concatenate[_T, _P], Coroutine[Any, Any, _R]
+]
 
 
-def api_error(
+def api_error[_AddonManagerT: AddonManager, **_P, _R](
     error_message: str,
 ) -> Callable[
     [_FuncType[_AddonManagerT, _P, _R]], _ReturnFuncType[_AddonManagerT, _P, _R]

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -6,7 +6,7 @@ from collections.abc import Awaitable, Callable, Coroutine
 from functools import reduce, wraps
 import logging
 from operator import ior
-from typing import Any, ParamSpec
+from typing import Any
 
 from pyheos import HeosError, const as heos_const
 
@@ -40,8 +40,6 @@ from .const import (
     SIGNAL_HEOS_PLAYER_ADDED,
     SIGNAL_HEOS_UPDATED,
 )
-
-_P = ParamSpec("_P")
 
 BASE_SUPPORTED_FEATURES = (
     MediaPlayerEntityFeature.VOLUME_MUTE
@@ -90,11 +88,13 @@ async def async_setup_entry(
     async_add_entities(devices, True)
 
 
-_FuncType = Callable[_P, Awaitable[Any]]
-_ReturnFuncType = Callable[_P, Coroutine[Any, Any, None]]
+type _FuncType[**_P] = Callable[_P, Awaitable[Any]]
+type _ReturnFuncType[**_P] = Callable[_P, Coroutine[Any, Any, None]]
 
 
-def log_command_error(command: str) -> Callable[[_FuncType[_P]], _ReturnFuncType[_P]]:
+def log_command_error[**_P](
+    command: str,
+) -> Callable[[_FuncType[_P]], _ReturnFuncType[_P]]:
     """Return decorator that logs command failure."""
 
     def decorator(func: _FuncType[_P]) -> _ReturnFuncType[_P]:

--- a/homeassistant/components/http/decorators.py
+++ b/homeassistant/components/http/decorators.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate, ParamSpec, TypeVar, overload
+from typing import Any, Concatenate, overload
 
 from aiohttp.web import Request, Response, StreamResponse
 
@@ -13,16 +13,18 @@ from homeassistant.exceptions import Unauthorized
 
 from .view import HomeAssistantView
 
-_HomeAssistantViewT = TypeVar("_HomeAssistantViewT", bound=HomeAssistantView)
-_ResponseT = TypeVar("_ResponseT", bound=Response | StreamResponse)
-_P = ParamSpec("_P")
-_FuncType = Callable[
-    Concatenate[_HomeAssistantViewT, Request, _P], Coroutine[Any, Any, _ResponseT]
+type _ResponseType = Response | StreamResponse
+type _FuncType[_T, **_P, _R] = Callable[
+    Concatenate[_T, Request, _P], Coroutine[Any, Any, _R]
 ]
 
 
 @overload
-def require_admin(
+def require_admin[
+    _HomeAssistantViewT: HomeAssistantView,
+    **_P,
+    _ResponseT: _ResponseType,
+](
     _func: None = None,
     *,
     error: Unauthorized | None = None,
@@ -33,12 +35,20 @@ def require_admin(
 
 
 @overload
-def require_admin(
+def require_admin[
+    _HomeAssistantViewT: HomeAssistantView,
+    **_P,
+    _ResponseT: _ResponseType,
+](
     _func: _FuncType[_HomeAssistantViewT, _P, _ResponseT],
 ) -> _FuncType[_HomeAssistantViewT, _P, _ResponseT]: ...
 
 
-def require_admin(
+def require_admin[
+    _HomeAssistantViewT: HomeAssistantView,
+    **_P,
+    _ResponseT: _ResponseType,
+](
     _func: _FuncType[_HomeAssistantViewT, _P, _ResponseT] | None = None,
     *,
     error: Unauthorized | None = None,

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 import logging
-from typing import Any, Concatenate, ParamSpec, TypeVar
+from typing import Any, Concatenate
 
 from pizone import Controller, Zone
 import voluptuous as vol
@@ -48,11 +48,7 @@ from .const import (
     IZONE,
 )
 
-_DeviceT = TypeVar("_DeviceT", bound="ControllerDevice | ZoneDevice")
-_T = TypeVar("_T")
-_R = TypeVar("_R")
-_P = ParamSpec("_P")
-_FuncType = Callable[Concatenate[_T, _P], _R]
+type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], _R]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,7 +115,7 @@ async def async_setup_entry(
     )
 
 
-def _return_on_connection_error(
+def _return_on_connection_error[_DeviceT: ControllerDevice | ZoneDevice, **_P, _R, _T](
     ret: _T = None,  # type: ignore[assignment]
 ) -> Callable[[_FuncType[_DeviceT, _P, _R]], _FuncType[_DeviceT, _P, _R | _T]]:
     def wrap(func: _FuncType[_DeviceT, _P, _R]) -> _FuncType[_DeviceT, _P, _R | _T]:


### PR DESCRIPTION
## Proposed change
Use [PEP 695](https://peps.python.org/pep-0695/) for advanced decorator typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
