### PR TITLE
Add support for Glances v4

### DIFF
--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -100,7 +100,7 @@ async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
             )
         _LOGGER.debug("Connected to Glances API v%s", version)
         return api
-    raise ServerVersionMismatch("Could not connect to Glances API version 2 or 3")
+    raise ServerVersionMismatch("Could not connect to Glances API version 2, 3 or 4")
 
 
 class ServerVersionMismatch(HomeAssistantError):

--- a/homeassistant/components/glances/__init__.py
+++ b/homeassistant/components/glances/__init__.py
@@ -73,7 +73,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def get_api(hass: HomeAssistant, entry_data: dict[str, Any]) -> Glances:
     """Return the api from glances_api."""
     httpx_client = get_async_client(hass, verify_ssl=entry_data[CONF_VERIFY_SSL])
-    for version in (3, 2):
+    for version in (4, 3, 2):
         api = Glances(
             host=entry_data[CONF_HOST],
             port=entry_data[CONF_PORT],

--- a/homeassistant/components/glances/manifest.json
+++ b/homeassistant/components/glances/manifest.json
@@ -6,5 +6,5 @@
   "documentation": "https://www.home-assistant.io/integrations/glances",
   "iot_class": "local_polling",
   "loggers": ["glances_api"],
-  "requirements": ["glances-api==0.6.0"]
+  "requirements": ["glances-api==0.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -949,7 +949,7 @@ gios==4.0.0
 gitterpy==0.1.7
 
 # homeassistant.components.glances
-glances-api==0.6.0
+glances-api==0.7.0
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -778,7 +778,7 @@ getmac==0.9.4
 gios==4.0.0
 
 # homeassistant.components.glances
-glances-api==0.6.0
+glances-api==0.7.0
 
 # homeassistant.components.goalzero
 goalzero==0.2.2

--- a/tests/components/glances/test_init.py
+++ b/tests/components/glances/test_init.py
@@ -38,8 +38,9 @@ async def test_entry_deprecated_version(
     entry.add_to_hass(hass)
 
     mock_api.return_value.get_ha_sensor_data.side_effect = [
-        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),
-        HA_SENSOR_DATA,
+        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),  # fail v4
+        GlancesApiNoDataAvailable("endpoint: 'all' is not valid"),  # fail v3
+        HA_SENSOR_DATA,  # success v2
         HA_SENSOR_DATA,
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for Glances v4.
Glances v4 is the new default version in dockerhub since may 2024, so people updating their Glances docker instance to "latest" get an error in Home Assistant (unable to connect).

Glances v4 also introduces a change on network sensor naming, which needs to be handled in the underlying python-glances-api library:
https://github.com/home-assistant-ecosystem/python-glances-api/pull/40

Consequently, this PR upgrades the library glances-api from version 0.6.0 to version 0.7.0.
Changelog:
- Add support for Glances v4 network sensors (Thanks @wittypluck)

https://github.com/home-assistant-ecosystem/python-glances-api/releases/tag/0.7.0

No change in the support of previous versions of Glances.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117360 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
