### PR TITLE
Fix for Synology DSM shared images

### DIFF
--- a/homeassistant/components/synology_dsm/const.py
+++ b/homeassistant/components/synology_dsm/const.py
@@ -45,6 +45,8 @@ DEFAULT_SNAPSHOT_QUALITY = SNAPSHOT_PROFILE_BALANCED
 
 ENTITY_UNIT_LOAD = "load"
 
+SHARED_SUFFIX = "_shared"
+
 # Signals
 SIGNAL_CAMERA_SOURCE_CHANGED = "synology_dsm.camera_stream_source_changed"
 

--- a/homeassistant/components/synology_dsm/media_source.py
+++ b/homeassistant/components/synology_dsm/media_source.py
@@ -232,6 +232,11 @@ class SynologyDsmMediaView(http.HomeAssistantView):
         item = SynoPhotosItem(image_id, "", "", "", cache_key, "", False)
         try:
             image = await diskstation.api.photos.download_item(item)
-        except SynologyDSMException as exc:
-            raise web.HTTPNotFound from exc
+        except SynologyDSMException:
+            # If the download fails, it could also mean that it is an shared image
+            item = SynoPhotosItem(image_id, "", "", "", cache_key, "", True)
+            try:
+                image = await diskstation.api.photos.download_item(item)
+            except SynologyDSMException as exc:
+                raise web.HTTPNotFound from exc
         return web.Response(body=image, content_type=mime_type)

--- a/homeassistant/components/synology_dsm/media_source.py
+++ b/homeassistant/components/synology_dsm/media_source.py
@@ -45,6 +45,7 @@ class SynologyPhotosMediaSourceIdentifier:
         self.album_id = None
         self.cache_key = None
         self.file_name = None
+        self.is_shared = None
 
         if parts:
             self.unique_id = parts[0]
@@ -54,6 +55,9 @@ class SynologyPhotosMediaSourceIdentifier:
                 self.cache_key = parts[2]
             if len(parts) > 3:
                 self.file_name = parts[3]
+                if self.file_name.endswith("_shared"):
+                    self.is_shared = True
+                    self.file_name = self.file_name.removesuffix("_shared")
 
 
 class SynologyPhotosMediaSource(MediaSource):
@@ -160,10 +164,13 @@ class SynologyPhotosMediaSource(MediaSource):
             if isinstance(mime_type, str) and mime_type.startswith("image/"):
                 # Force small small thumbnails
                 album_item.thumbnail_size = "sm"
+                suffix = ""
+                if album_item.is_shared:
+                    suffix = "_shared"
                 ret.append(
                     BrowseMediaSource(
                         domain=DOMAIN,
-                        identifier=f"{identifier.unique_id}/{identifier.album_id}/{album_item.thumbnail_cache_key}/{album_item.file_name}",
+                        identifier=f"{identifier.unique_id}/{identifier.album_id}/{album_item.thumbnail_cache_key}/{album_item.file_name}{suffix}",
                         media_class=MediaClass.IMAGE,
                         media_content_type=mime_type,
                         title=album_item.file_name,
@@ -186,8 +193,11 @@ class SynologyPhotosMediaSource(MediaSource):
         mime_type, _ = mimetypes.guess_type(identifier.file_name)
         if not isinstance(mime_type, str):
             raise Unresolvable("No file extension")
+        suffix = ""
+        if identifier.is_shared:
+            suffix = "_shared"
         return PlayMedia(
-            f"/synology_dsm/{identifier.unique_id}/{identifier.cache_key}/{identifier.file_name}",
+            f"/synology_dsm/{identifier.unique_id}/{identifier.cache_key}/{identifier.file_name}{suffix}",
             mime_type,
         )
 
@@ -223,20 +233,18 @@ class SynologyDsmMediaView(http.HomeAssistantView):
         # location: {cache_key}/{filename}
         cache_key, file_name = location.split("/")
         image_id = int(cache_key.split("_")[0])
+        shared = False
+        if file_name.endswith("_shared"):
+            shared = True
+            file_name = file_name.removesuffix("_shared")
         mime_type, _ = mimetypes.guess_type(file_name)
         if not isinstance(mime_type, str):
             raise web.HTTPNotFound
         diskstation: SynologyDSMData = self.hass.data[DOMAIN][source_dir_id]
-
         assert diskstation.api.photos is not None
-        item = SynoPhotosItem(image_id, "", "", "", cache_key, "", False)
+        item = SynoPhotosItem(image_id, "", "", "", cache_key, "", shared)
         try:
             image = await diskstation.api.photos.download_item(item)
-        except SynologyDSMException:
-            # If the download fails, it could also mean that it is an shared image
-            item = SynoPhotosItem(image_id, "", "", "", cache_key, "", True)
-            try:
-                image = await diskstation.api.photos.download_item(item)
-            except SynologyDSMException as exc:
-                raise web.HTTPNotFound from exc
+        except SynologyDSMException as exc:
+            raise web.HTTPNotFound from exc
         return web.Response(body=image, content_type=mime_type)

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -50,7 +50,8 @@ def dsm_with_photos() -> MagicMock:
     dsm.photos.get_albums = AsyncMock(return_value=[SynoPhotosAlbum(1, "Album 1", 10)])
     dsm.photos.get_items_from_album = AsyncMock(
         return_value=[
-            SynoPhotosItem(10, "", "filename.jpg", 12345, "10_1298753", "sm", False)
+            SynoPhotosItem(10, "", "filename.jpg", 12345, "10_1298753", "sm", False),
+            SynoPhotosItem(10, "", "filename.jpg", 12345, "10_1298753", "sm", True),
         ]
     )
     dsm.photos.get_item_thumbnail_url = AsyncMock(
@@ -377,10 +378,19 @@ async def test_browse_media_get_items(
     result = await source.async_browse_media(item)
 
     assert result
-    assert len(result.children) == 1
+    assert len(result.children) == 2
     item = result.children[0]
     assert isinstance(item, BrowseMedia)
     assert item.identifier == "mocked_syno_dsm_entry/1/10_1298753/filename.jpg"
+    assert item.title == "filename.jpg"
+    assert item.media_class == MediaClass.IMAGE
+    assert item.media_content_type == "image/jpeg"
+    assert item.can_play
+    assert not item.can_expand
+    assert item.thumbnail == "http://my.thumbnail.url"
+    item = result.children[1]
+    assert isinstance(item, BrowseMedia)
+    assert item.identifier == "mocked_syno_dsm_entry/1/10_1298753/filename.jpg_shared"
     assert item.title == "filename.jpg"
     assert item.media_class == MediaClass.IMAGE
     assert item.media_content_type == "image/jpeg"

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -339,7 +339,7 @@ async def test_browse_media_get_items_thumbnail_error(
     result = await source.async_browse_media(item)
 
     assert result
-    assert len(result.children) == 1
+    assert len(result.children) == 2
     item = result.children[0]
     assert isinstance(item, BrowseMedia)
     assert item.thumbnail is None
@@ -448,5 +448,10 @@ async def test_media_view(
     with patch.object(tempfile, "tempdir", tmp_path):
         result = await view.get(
             request, "mocked_syno_dsm_entry", "10_1298753/filename.jpg"
+        )
+        assert isinstance(result, web.Response)
+    with patch.object(tempfile, "tempdir", tmp_path):
+        result = await view.get(
+            request, "mocked_syno_dsm_entry", "10_1298753/filename.jpg_shared"
         )
         assert isinstance(result, web.Response)

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -102,6 +102,11 @@ async def test_resolve_media_bad_identifier(
             "/synology_dsm/ABC012345/12631_47189/filename.png",
             "image/png",
         ),
+        (
+            "ABC012345/12/12631_47189/filename.png_shared",
+            "/synology_dsm/ABC012345/12631_47189/filename.png_shared",
+            "image/png",
+        ),
     ],
 )
 async def test_resolve_media_success(


### PR DESCRIPTION

## Breaking change

## Proposed change
Synology photos uses a different api if an image is your own, or someone else's. This would fix the issue


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #103653
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
