### PR TITLE
Rework and simplify the cleanup of orphan AVM Fritz!Tools entities

### DIFF
--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -28,11 +28,11 @@ from homeassistant.components.device_tracker import (
     DEFAULT_CONSIDER_HOME,
     DOMAIN as DEVICE_TRACKER_DOMAIN,
 )
-from homeassistant.components.switch import DOMAIN as DEVICE_SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -75,13 +75,6 @@ def device_filter_out_from_trackers(
             "Skip adding device %s [%s], reason: %s", device.hostname, mac, reason
         )
     return bool(reason)
-
-
-def _cleanup_entity_filter(device: er.RegistryEntry) -> bool:
-    """Filter only relevant entities."""
-    return device.domain == DEVICE_TRACKER_DOMAIN or (
-        device.domain == DEVICE_SWITCH_DOMAIN and "_internet_access" in device.entity_id
-    )
 
 
 def _ha_is_stopping(activity: str) -> None:
@@ -168,6 +161,8 @@ class UpdateCoordinatorDataType(TypedDict):
 
 class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
     """FritzBoxTools class."""
+
+    config_entry: ConfigEntry
 
     def __init__(
         self,
@@ -649,71 +644,37 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             self.fritz_guest_wifi.set_password, password, length
         )
 
-    async def async_trigger_cleanup(
-        self, config_entry: ConfigEntry | None = None
-    ) -> None:
+    async def async_trigger_cleanup(self) -> None:
         """Trigger device trackers cleanup."""
         device_hosts = await self._async_update_hosts_info()
         entity_reg: er.EntityRegistry = er.async_get(self.hass)
+        config_entry = self.config_entry
 
-        if config_entry is None:
-            if self.config_entry is None:
-                return
-            config_entry = self.config_entry
-
-        ha_entity_reg_list: list[er.RegistryEntry] = er.async_entries_for_config_entry(
+        entities: list[er.RegistryEntry] = er.async_entries_for_config_entry(
             entity_reg, config_entry.entry_id
         )
-        entities_removed: bool = False
 
-        device_hosts_macs = set()
-        device_hosts_names = set()
-        for mac, device in device_hosts.items():
-            device_hosts_macs.add(mac)
-            device_hosts_names.add(device.name)
-
-        for entry in ha_entity_reg_list:
-            if entry.original_name is None:
-                continue
-            entry_name = entry.name or entry.original_name
-            entry_host = entry_name.split(" ")[0]
-            entry_mac = entry.unique_id.split("_")[0]
-
-            if not _cleanup_entity_filter(entry) or (
-                entry_mac in device_hosts_macs and entry_host in device_hosts_names
-            ):
-                _LOGGER.debug(
-                    "Skipping entity %s [mac=%s, host=%s]",
-                    entry_name,
-                    entry_mac,
-                    entry_host,
-                )
-                continue
-            _LOGGER.info("Removing entity: %s", entry_name)
-            entity_reg.async_remove(entry.entity_id)
-            entities_removed = True
-
-        if entities_removed:
-            self._async_remove_empty_devices(entity_reg, config_entry)
-
-    @callback
-    def _async_remove_empty_devices(
-        self, entity_reg: er.EntityRegistry, config_entry: ConfigEntry
-    ) -> None:
-        """Remove devices with no entities."""
+        orphan_macs: set[str] = set()
+        for entity in entities:
+            entry_mac = entity.unique_id.split("_")[0]
+            if (
+                entity.domain == DEVICE_TRACKER_DOMAIN
+                or "_internet_access" in entity.unique_id
+            ) and entry_mac not in device_hosts:
+                _LOGGER.info("Removing orphan entity entry %s", entity.entity_id)
+                orphan_macs.add(entry_mac)
+                entity_reg.async_remove(entity.entity_id)
 
         device_reg = dr.async_get(self.hass)
-        device_list = dr.async_entries_for_config_entry(
+        orphan_connections = {(CONNECTION_NETWORK_MAC, mac) for mac in orphan_macs}
+        for device in dr.async_entries_for_config_entry(
             device_reg, config_entry.entry_id
-        )
-        for device_entry in device_list:
-            if not er.async_entries_for_device(
-                entity_reg,
-                device_entry.id,
-                include_disabled_entities=True,
-            ):
-                _LOGGER.info("Removing device: %s", device_entry.name)
-                device_reg.async_remove_device(device_entry.id)
+        ):
+            if any(con in device.connections for con in orphan_connections):
+                _LOGGER.debug("Removing obsolete device entry %s", device.name)
+                device_reg.async_update_device(
+                    device.id, remove_config_entry_id=config_entry.entry_id
+                )
 
     async def service_fritzbox(
         self, service_call: ServiceCall, config_entry: ConfigEntry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a rework of the cleanup service in the `fritz` integration.

1. we fetch all current available physical devices (_based on their mac addresses_)
2. we fetch all entities linked to the current config entry
  2.1. check if their mac is in list of available physical devices
  2.2. if not, store its mac as orphan and remove the entity
3. we fetch all device entries linked to the current config entry
  3.1. check if it contains any connection related to an orphan mac (_from above_)
  3.2. if yes, remove the config entry from this device


In a follow-up PR (_based on https://github.com/home-assistant/core/pull/116024#discussion_r1605775931_) this cleanup-service will not be exposed anymore to the user, but will run automatically during coordinator updates, when changes in available physical devices are detected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
