### PR TITLE
Support Rest sensor XML responses that don't have an XML content type set

### DIFF
--- a/homeassistant/components/rest/const.py
+++ b/homeassistant/components/rest/const.py
@@ -27,6 +27,8 @@ REST_DATA = "rest_data"
 
 METHODS = ["POST", "GET"]
 
+XML_CONTENT_INDICATORS = ('<?xml version="1.0"?>',)
+XML_FILENAME_EXTENSIONS = (".xml",)
 XML_MIME_TYPES = (
     "application/rss+xml",
     "application/xhtml+xml",

--- a/homeassistant/components/rest/const.py
+++ b/homeassistant/components/rest/const.py
@@ -27,7 +27,7 @@ REST_DATA = "rest_data"
 
 METHODS = ["POST", "GET"]
 
-XML_CONTENT_INDICATORS = ('<?xml version="1.0"?>',)
+XML_CONTENT_INDICATORS = ('<?xml version="1.0"',)
 XML_FILENAME_EXTENSIONS = (".xml",)
 XML_MIME_TYPES = (
     "application/rss+xml",

--- a/tests/components/rest/test_sensor.py
+++ b/tests/components/rest/test_sensor.py
@@ -479,12 +479,76 @@ async def test_setup_post(hass: HomeAssistant) -> None:
 
 
 @respx.mock
-async def test_setup_get_xml(hass: HomeAssistant) -> None:
-    """Test setup with valid xml configuration."""
+async def test_setup_get_xml_content_type(hass: HomeAssistant) -> None:
+    """Test setup with valid xml configuration and an xml http content type."""
     respx.get("http://localhost").respond(
         status_code=HTTPStatus.OK,
         headers={"content-type": "text/xml"},
         content="<dog>123</dog>",
+    )
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://localhost",
+                "method": "GET",
+                "value_template": "{{ value_json.dog }}",
+                "name": "foo",
+                "unit_of_measurement": UnitOfInformation.MEGABYTES,
+                "verify_ssl": "true",
+                "timeout": 30,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
+
+    state = hass.states.get("sensor.foo")
+    assert state.state == "123"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfInformation.MEGABYTES
+
+
+@respx.mock
+async def test_setup_get_xml_file_extension(hass: HomeAssistant) -> None:
+    """Test setup with valid xml configuration."""
+    respx.get("http://localhost/file.xml").respond(
+        status_code=HTTPStatus.OK,
+        headers={"content-type": "application/octet-stream"},
+        content="<dog>123</dog>",
+    )
+    assert await async_setup_component(
+        hass,
+        SENSOR_DOMAIN,
+        {
+            SENSOR_DOMAIN: {
+                "platform": DOMAIN,
+                "resource": "http://localhost/file.xml",
+                "method": "GET",
+                "value_template": "{{ value_json.dog }}",
+                "name": "foo",
+                "unit_of_measurement": UnitOfInformation.MEGABYTES,
+                "verify_ssl": "true",
+                "timeout": 30,
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all(SENSOR_DOMAIN)) == 1
+
+    state = hass.states.get("sensor.foo")
+    assert state.state == "123"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfInformation.MEGABYTES
+
+
+@respx.mock
+async def test_setup_get_xml_content(hass: HomeAssistant) -> None:
+    """Test setup with valid xml configuration."""
+    respx.get("http://localhost").respond(
+        status_code=HTTPStatus.OK,
+        headers={"content-type": "application/octet-stream"},
+        content='<?xml version="1.0"?><dog>123</dog>',
     )
     assert await async_setup_component(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently the rest sensor parses the returned result content as xml rather than json when the content-type is 'correctly' set by a server to include one of a set of specified xml mime types (such as text/xml).

This change extends this matching logic to also also look so see if the file extension ends in xml, or if the content starts with \<?xml version="1.0" in order to support less compliant servers that are returning xml results without setting a 'correct' mime type (which I have come across). 

It's unlikely this would be a breaking change for anyone as the current code falls back to parsing as json if an xml conversion fails.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32840

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
