### PR TITLE
Add value_template option to KNX expose

### DIFF
--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -13,6 +13,7 @@ from xknx.remote_value import RemoteValueSensor
 
 from homeassistant.const import (
     CONF_ENTITY_ID,
+    CONF_VALUE_TEMPLATE,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -26,6 +27,7 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, StateType
 
 from .const import CONF_RESPOND_TO_READ, KNX_ADDRESS
@@ -79,6 +81,9 @@ class KNXExposeSensor:
         )
         self.expose_default = config.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT)
         self.expose_type: int | str = config[ExposeSchema.CONF_KNX_EXPOSE_TYPE]
+        self.value_template: Template | None = config.get(CONF_VALUE_TEMPLATE)
+        if self.value_template is not None:
+            self.value_template.hass = hass
 
         self._remove_listener: Callable[[], None] | None = None
         self.device: ExposeSensor = self.async_register(config)
@@ -87,13 +92,10 @@ class KNXExposeSensor:
     @callback
     def async_register(self, config: ConfigType) -> ExposeSensor:
         """Register listener."""
-        if self.expose_attribute is not None:
-            _name = self.entity_id + "__" + self.expose_attribute
-        else:
-            _name = self.entity_id
+        name = f"{self.entity_id}__{self.expose_attribute or "state"}"
         device = ExposeSensor(
             xknx=self.xknx,
-            name=_name,
+            name=name,
             group_address=config[KNX_ADDRESS],
             respond_to_read=config[CONF_RESPOND_TO_READ],
             value_type=self.expose_type,
@@ -132,24 +134,22 @@ class KNXExposeSensor:
         else:
             value = state.state
 
+        if self.value_template is not None:
+            value = self.value_template.async_render_with_possible_json_value(value)
+
         if self.expose_type == "binary":
             if value in (1, STATE_ON, "True"):
                 return True
             if value in (0, STATE_OFF, "False"):
                 return False
-        if (
-            value is not None
-            and isinstance(self.device.sensor_value, RemoteValueSensor)
-            and issubclass(self.device.sensor_value.dpt_class, DPTNumeric)
+        if value is not None and (
+            isinstance(self.device.sensor_value, RemoteValueSensor)
         ):
-            return float(value)
-        if (
-            value is not None
-            and isinstance(self.device.sensor_value, RemoteValueSensor)
-            and issubclass(self.device.sensor_value.dpt_class, DPTString)
-        ):
-            # DPT 16.000 only allows up to 14 Bytes
-            return str(value)[:14]
+            if issubclass(self.device.sensor_value.dpt_class, DPTNumeric):
+                return float(value)
+            if issubclass(self.device.sensor_value.dpt_class, DPTString):
+                # DPT 16.000 only allows up to 14 Bytes
+                return str(value)[:14]
         return value
 
     async def _async_entity_changed(self, event: Event[EventStateChangedData]) -> None:

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -37,6 +37,7 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_PAYLOAD,
     CONF_TYPE,
+    CONF_VALUE_TEMPLATE,
     Platform,
 )
 import homeassistant.helpers.config_validation as cv
@@ -559,6 +560,7 @@ class ExposeSchema(KNXPlatformSchema):
             vol.Required(CONF_ENTITY_ID): cv.entity_id,
             vol.Optional(CONF_KNX_EXPOSE_ATTRIBUTE): cv.string,
             vol.Optional(CONF_KNX_EXPOSE_DEFAULT): cv.match_all,
+            vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         }
     )
     ENTITY_SCHEMA = vol.Any(EXPOSE_SENSOR_SCHEMA, EXPOSE_TIME_SCHEMA)

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -8,7 +8,12 @@ import pytest
 
 from homeassistant.components.knx import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
-from homeassistant.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_TYPE
+from homeassistant.const import (
+    CONF_ATTRIBUTE,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+    CONF_VALUE_TEMPLATE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
@@ -235,6 +240,45 @@ async def test_expose_cooldown(hass: HomeAssistant, knx: KNXTestKit) -> None:
     )
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", (3,))
+
+
+async def test_expose_value_template(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test an expose with value_template."""
+    entity_id = "fake.entity"
+    attribute = "brightness"
+    binary_address = "1/1/1"
+    percent_address = "2/2/2"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: [
+                {
+                    CONF_TYPE: "binary",
+                    KNX_ADDRESS: binary_address,
+                    CONF_ENTITY_ID: entity_id,
+                    CONF_VALUE_TEMPLATE: "{{ not value == 'on' }}",
+                },
+                {
+                    CONF_TYPE: "percentU8",
+                    KNX_ADDRESS: percent_address,
+                    CONF_ENTITY_ID: entity_id,
+                    CONF_ATTRIBUTE: attribute,
+                    CONF_VALUE_TEMPLATE: "{{ 255 - value }}",
+                },
+            ]
+        },
+    )
+
+    # Change attribute to 0
+    hass.states.async_set(entity_id, "on", {attribute: 0})
+    await hass.async_block_till_done()
+    await knx.assert_write(binary_address, False)
+    await knx.assert_write(percent_address, (255,))
+
+    # Change attribute to 255
+    hass.states.async_set(entity_id, "off", {attribute: 255})
+    await hass.async_block_till_done()
+    await knx.assert_write(binary_address, True)
+    await knx.assert_write(percent_address, (0,))
 
 
 async def test_expose_conversion_exception(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add value_template option to KNX expose.

Some typical KNX value ranges don't match with HAs. Eg. a closed cover in KNX is 100% whereas in HA it is 0% or volume (media player) in KNX is `0..100`% whereas in HA it is `0..1` (float). With `value_template` a user can easily bring HA entity states to KNX.

Example configuration:
```yaml
knx:
  expose:
    - type: percent
      address: "1/1/1"
      entity_id: cover.office
      attribute: current_position
      value_template: "{{ 100 - value }}"
    - type: percent
      address: "2/2/2"
      entity_id: media_player.kitchen
      attribute: volume_level
      value_template: "{{ value * 100 }}"
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32841

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
