### PR TITLE
Whois component maintenance, PR 1 of 3: Light refactoring, adding abstraction

### DIFF
--- a/homeassistant/components/whois/__init__.py
+++ b/homeassistant/components/whois/__init__.py
@@ -2,20 +2,14 @@
 
 from __future__ import annotations
 
-from whois import Domain, query as whois_query
-from whois.exceptions import (
-    FailedParsingWhoisOutput,
-    UnknownDateFormat,
-    UnknownTld,
-    WhoisCommandFailed,
-)
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from . import helper
 from .const import DOMAIN, LOGGER, PLATFORMS, SCAN_INTERVAL
+from .helper import Domain
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -25,11 +19,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Query WHOIS for domain information."""
         try:
             return await hass.async_add_executor_job(
-                whois_query, entry.data[CONF_DOMAIN]
+                helper.query, entry.data[CONF_DOMAIN]
             )
-        except UnknownTld as ex:
+        except helper.WhoisUnknownTLD as ex:
             raise UpdateFailed("Could not set up whois, TLD is unknown") from ex
-        except (FailedParsingWhoisOutput, WhoisCommandFailed, UnknownDateFormat) as ex:
+        except helper.GenericWhoisError as ex:
             raise UpdateFailed("An error occurred during WHOIS lookup") from ex
 
     coordinator: DataUpdateCoordinator[Domain | None] = DataUpdateCoordinator(

--- a/homeassistant/components/whois/config_flow.py
+++ b/homeassistant/components/whois/config_flow.py
@@ -5,17 +5,11 @@ from __future__ import annotations
 from typing import Any
 
 import voluptuous as vol
-import whois
-from whois.exceptions import (
-    FailedParsingWhoisOutput,
-    UnknownDateFormat,
-    UnknownTld,
-    WhoisCommandFailed,
-)
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_DOMAIN
 
+from . import helper
 from .const import DOMAIN
 
 
@@ -39,15 +33,11 @@ class WhoisFlowHandler(ConfigFlow, domain=DOMAIN):
             self._abort_if_unique_id_configured()
 
             try:
-                await self.hass.async_add_executor_job(whois.query, domain)
-            except UnknownTld:
+                await self.hass.async_add_executor_job(helper.query, domain)
+            except helper.WhoisUnknownTLD:
                 errors["base"] = "unknown_tld"
-            except WhoisCommandFailed:
+            except helper.GenericWhoisError:
                 errors["base"] = "whois_command_failed"
-            except FailedParsingWhoisOutput:
-                errors["base"] = "unexpected_response"
-            except UnknownDateFormat:
-                errors["base"] = "unknown_date_format"
             else:
                 return self.async_create_entry(
                     title=self.imported_name or user_input[CONF_DOMAIN],

--- a/homeassistant/components/whois/diagnostics.py
+++ b/homeassistant/components/whois/diagnostics.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from whois import Domain
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
+from .helper import Domain
 
 
 async def async_get_config_entry_diagnostics(

--- a/homeassistant/components/whois/helper.py
+++ b/homeassistant/components/whois/helper.py
@@ -1,0 +1,64 @@
+"""A helper class that abstracts away the usage of external whois libraries."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import whois
+
+
+@dataclass(kw_only=True)
+class Domain:
+    """A class internally representing a domain."""
+
+    admin: Any = None
+    creation_date: Any = None
+    dnssec: Any = None
+    expiration_date: Any = None
+    last_updated: Any = None
+    name_servers: Any = None
+    owner: Any = None
+    registrar: Any = None
+    reseller: Any = None
+    registrant: Any = None
+    status: Any = None
+    statuses: Any = None
+
+
+class WhoisUnknownTLD(Exception):
+    """Exception class when unknown TLD encountered."""
+
+
+class GenericWhoisError(Exception):
+    """Exception class for all other exceptions originating from the external whois library."""
+
+
+def query(domain: str) -> Domain | None:
+    """Wrap around the external whois library call and return internal domain representation."""
+
+    wh = None
+    try:
+        wh = whois.query(domain)
+    except whois.exceptions.UnknownTld as ex:
+        raise WhoisUnknownTLD from ex
+    except Exception as ex:
+        raise GenericWhoisError from ex
+    else:
+        # backward-compatibility
+        if wh is None:
+            return None
+
+        # field mapping here
+        return Domain(
+            admin=wh.admin,
+            creation_date=wh.creation_date,
+            dnssec=wh.dnssec,
+            expiration_date=wh.expiration_date,
+            last_updated=wh.last_updated,
+            name_servers=wh.name_servers,
+            owner=wh.owner,
+            registrar=wh.registrar,
+            reseller=wh.reseller,
+            registrant=wh.registrant,
+            status=wh.status,
+            statuses=wh.statuses,
+        )

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import cast
 
-from whois import Domain
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -26,6 +24,7 @@ from homeassistant.helpers.update_coordinator import (
 from homeassistant.util import dt as dt_util
 
 from .const import ATTR_EXPIRES, ATTR_NAME_SERVERS, ATTR_REGISTRAR, ATTR_UPDATED, DOMAIN
+from .helper import Domain
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/homeassistant/components/whois/strings.json
+++ b/homeassistant/components/whois/strings.json
@@ -8,8 +8,6 @@
       }
     },
     "error": {
-      "unexpected_response": "Unexpected response from whois server",
-      "unknown_date_format": "Unknown date format in whois server response",
       "unknown_tld": "The given TLD is unknown or not available to this integration",
       "whois_command_failed": "Whois command failed: could not retrieve whois information"
     },

--- a/tests/components/whois/snapshots/test_config_flow.ambr
+++ b/tests/components/whois/snapshots/test_config_flow.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_full_flow_with_error[FailedParsingWhoisOutput-unexpected_response]
+# name: test_full_flow_with_error[FailedParsingWhoisOutput-whois_command_failed]
   FlowResultSnapshot({
     'context': dict({
       'source': 'user',
@@ -37,7 +37,7 @@
     'version': 1,
   })
 # ---
-# name: test_full_flow_with_error[UnknownDateFormat-unknown_date_format]
+# name: test_full_flow_with_error[UnknownDateFormat-whois_command_failed]
   FlowResultSnapshot({
     'context': dict({
       'source': 'user',

--- a/tests/components/whois/test_config_flow.py
+++ b/tests/components/whois/test_config_flow.py
@@ -49,8 +49,8 @@ async def test_full_user_flow(
     ("throw", "reason"),
     [
         (UnknownTld, "unknown_tld"),
-        (FailedParsingWhoisOutput, "unexpected_response"),
-        (UnknownDateFormat, "unknown_date_format"),
+        (FailedParsingWhoisOutput, "whois_command_failed"),
+        (UnknownDateFormat, "whois_command_failed"),
         (WhoisCommandFailed, "whois_command_failed"),
     ],
 )

--- a/tests/components/whois/test_diagnostics.py
+++ b/tests/components/whois/test_diagnostics.py
@@ -1,5 +1,6 @@
 """Tests for the diagnostics data provided by the Whois integration."""
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.core import HomeAssistant
@@ -9,6 +10,7 @@ from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
 
+@pytest.mark.usefixtures("mock_whois")
 async def test_diagnostics(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,

--- a/tests/components/whois/test_init.py
+++ b/tests/components/whois/test_init.py
@@ -3,14 +3,9 @@
 from unittest.mock import MagicMock
 
 import pytest
-from whois.exceptions import (
-    FailedParsingWhoisOutput,
-    UnknownDateFormat,
-    UnknownTld,
-    WhoisCommandFailed,
-)
 
 from homeassistant.components.whois.const import DOMAIN
+from homeassistant.components.whois.helper import GenericWhoisError, WhoisUnknownTLD
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -39,7 +34,7 @@ async def test_load_unload_config_entry(
 
 @pytest.mark.parametrize(
     "side_effect",
-    [FailedParsingWhoisOutput, UnknownDateFormat, UnknownTld, WhoisCommandFailed],
+    [WhoisUnknownTLD, GenericWhoisError],
 )
 async def test_error_handling(
     hass: HomeAssistant,


### PR DESCRIPTION
Add a thin abstraction layer to make it easy to replace the external whois-query library

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is Pull Request 1 of 3 that I have lined up as part of my contributions to "whois" component upkeep.
Order of changes:
1. **(we are here)** Light refactoring, adding an abstraction layer separating the use of an external/upstream whois library and home assistant component internals
2. Dependency update: Replacement of unmaintained whois upstream library with a maintained one
3. Breaking change: Removal of "Reseller" entity from the integration

Originally it was one larger PR, but I decided to split it up following the [perfect PR recommendations][perfect-pr].
Ideally, I'd like to get these 3 PRs merged in a relatively quick succession.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
