### PR TITLE
Add alarm clock helper

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -82,6 +82,8 @@ build.json @home-assistant/supervisor
 /tests/components/airzone_cloud/ @Noltari
 /homeassistant/components/aladdin_connect/ @mkmer
 /tests/components/aladdin_connect/ @mkmer
+/homeassistant/components/alarm_clock/ @Nezz
+/tests/components/alarm_clock/ @Nezz
 /homeassistant/components/alarm_control_panel/ @home-assistant/core
 /tests/components/alarm_control_panel/ @home-assistant/core
 /homeassistant/components/alert/ @home-assistant/core @frenck

--- a/homeassistant/components/alarm_clock/__init__.py
+++ b/homeassistant/components/alarm_clock/__init__.py
@@ -1,0 +1,351 @@
+"""The Alarm Clock integration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, time, timedelta
+import logging
+from typing import Any, Self
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    ATTR_ENTITY_ID,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    SERVICE_RELOAD,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    WEEKDAYS,
+    Platform,
+)
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import collection, service
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_track_point_in_time
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import ConfigType
+import homeassistant.util.dt as dt_util
+
+from .const import (
+    ATTR_ALARM_TIME,
+    ATTR_NEXT_ALARM,
+    ATTR_REPEAT_DAYS,
+    CONF_ALARM_TIME,
+    CONF_REPEAT_DAYS,
+    DOMAIN,
+    ENTITY_ID_FORMAT,
+    EVENT_ALARM_CLOCK_CANCELLED,
+    EVENT_ALARM_CLOCK_CHANGED,
+    EVENT_ALARM_CLOCK_FINISHED,
+    EVENT_ALARM_CLOCK_STARTED,
+    STORAGE_FIELDS,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _format_time(time_obj):
+    return time_obj.strftime("%H:%M:%S")
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: cv.schema_with_slug_keys(
+            vol.All(
+                {
+                    vol.Optional(CONF_NAME): cv.string,
+                    vol.Optional(CONF_ICON): cv.icon,
+                    vol.Required(CONF_ALARM_TIME): vol.All(cv.time, _format_time),
+                    vol.Optional(CONF_REPEAT_DAYS, default=[]): cv.weekdays,
+                },
+            )
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+RELOAD_SERVICE_SCHEMA = vol.Schema({})
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up an alarm clock."""
+    component = EntityComponent[AlarmClock](_LOGGER, DOMAIN, hass)
+    id_manager = collection.IDManager()
+
+    yaml_collection = collection.YamlCollection(
+        logging.getLogger(f"{__name__}.yaml_collection"), id_manager
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, yaml_collection, AlarmClock
+    )
+
+    storage_collection = AlarmClockStorageCollection(
+        Store(hass, STORAGE_VERSION, STORAGE_KEY),
+        id_manager,
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, storage_collection, AlarmClock
+    )
+
+    await yaml_collection.async_load(
+        [{CONF_ID: id_, **cfg} for id_, cfg in config.get(DOMAIN, {}).items()]
+    )
+    await storage_collection.async_load()
+
+    collection.DictStorageCollectionWebsocket(
+        storage_collection, DOMAIN, DOMAIN, STORAGE_FIELDS, STORAGE_FIELDS
+    ).async_setup(hass)
+
+    async def reload_service_handler(service_call: ServiceCall) -> None:
+        """Reload yaml entities."""
+        conf = await component.async_prepare_reload(skip_reset=True)
+        if conf is None:
+            conf = {DOMAIN: {}}
+        await yaml_collection.async_load(
+            [{CONF_ID: id_, **cfg} for id_, cfg in conf.get(DOMAIN, {}).items()]
+        )
+
+    service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_service_handler,
+        schema=RELOAD_SERVICE_SCHEMA,
+    )
+    component.async_register_entity_service(
+        SERVICE_TURN_ON,
+        {vol.Optional(ATTR_ALARM_TIME): cv.time},
+        "async_turn_on",
+    )
+    component.async_register_entity_service(SERVICE_TURN_OFF, {}, "async_turn_off")
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    if unload_ok := await hass.config_entries.async_unload_platforms(
+        entry, (Platform.SENSOR,)
+    ):
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok
+
+
+class AlarmClock(collection.CollectionEntity, RestoreEntity):
+    """Representation of an alarm clock."""
+
+    editable: bool
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize a timer."""
+        self._config: dict = config
+        self._state = STATE_OFF
+        self._alarm_time = cv.time(self._config[CONF_ALARM_TIME])
+        self._repeat_days = self._config.get(CONF_REPEAT_DAYS, [])
+        self._next_alarm = None
+        self._listener: Callable[[], None] | None = None
+
+        self._attr_should_poll = False
+        self._attr_force_update = True
+
+    @classmethod
+    def from_storage(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from storage."""
+        timer = cls(config)
+        timer.editable = True
+        return timer
+
+    @classmethod
+    def from_yaml(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from yaml."""
+        timer = cls(config)
+        timer.entity_id = ENTITY_ID_FORMAT.format(config[CONF_ID])
+        timer.editable = False
+        return timer
+
+    @property
+    def name(self) -> str | None:
+        """Return name of the timer."""
+        return self._config.get(CONF_NAME)
+
+    @property
+    def icon(self) -> str | None:
+        """Return the icon to be used for this entity."""
+        return self._config.get(CONF_ICON)
+
+    @property
+    def state(self) -> str:
+        """Return the current state of the alarm clock."""
+        return self._state
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        attrs: dict[str, Any] = {
+            ATTR_ALARM_TIME: self._alarm_time,
+            ATTR_EDITABLE: self.editable,
+        }
+
+        if self._repeat_days is not None:
+            attrs[ATTR_REPEAT_DAYS] = self._repeat_days
+
+        if self._next_alarm is not None:
+            attrs[ATTR_NEXT_ALARM] = self._next_alarm.isoformat()
+
+        return attrs
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return unique id for the entity."""
+        return self._config[CONF_ID]  # type: ignore[no-any-return]
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity is about to be added to Home Assistant."""
+        # If no previous state exists, start with off
+        if (state := await self.async_get_last_state()) is None:
+            self._state = STATE_OFF
+            return
+
+        # Begin restoring state
+        self._state = state.state
+
+        # Nothing more to do if the alarm is off
+        if self._state == STATE_OFF:
+            return
+
+        self._next_alarm = cv.datetime(state.attributes[ATTR_NEXT_ALARM])
+
+        # If the alarm ended before now, finish it.
+        # The event will indicate when the alarm was expected to fire.
+        if (
+            self._next_alarm - dt_util.utcnow().replace(microsecond=0) <= timedelta(0)
+            and not self._repeat_days
+        ):
+            self._async_finish()
+        else:
+            self.async_turn_on()
+
+    @callback
+    def async_turn_on(self, alarm_time: time | None = None) -> None:
+        """Turn on an alarm clock."""
+        if self._listener:
+            self._listener()
+            self._listener = None
+
+        if alarm_time:
+            self._alarm_time = alarm_time
+
+        event = (
+            EVENT_ALARM_CLOCK_STARTED
+            if self._state == STATE_OFF
+            else EVENT_ALARM_CLOCK_CHANGED
+        )
+
+        self._state = STATE_ON
+
+        now = dt_util.utcnow().replace(microsecond=0)
+
+        # Set the alarm to the next valid date in the future
+        alarm_time_delta = timedelta(
+            hours=self._alarm_time.hour,
+            minutes=self._alarm_time.minute,
+            seconds=self._alarm_time.second,
+        )
+        self._next_alarm = dt_util.start_of_local_day(now) + alarm_time_delta
+        if self._next_alarm <= now:
+            self._next_alarm += timedelta(days=1)
+
+        if self._repeat_days:
+            # Map days of the week from strings to integers that match datetime
+            day_indexes = {day: i for i, day in enumerate(WEEKDAYS)}
+            repeat_day_indexes = [day_indexes[day] for day in self._repeat_days]
+
+            # Increment the date until we find one that matches the repeat days
+            while self._next_alarm.weekday() not in repeat_day_indexes:
+                self._next_alarm += timedelta(days=1)
+
+        self.async_write_ha_state()
+        self.hass.bus.async_fire(event, {ATTR_ENTITY_ID: self.entity_id})
+
+        self._listener = async_track_point_in_time(
+            self.hass, self._async_finish, self._next_alarm
+        )
+
+    @callback
+    def async_turn_off(self) -> None:
+        """Turn off an alarm clock."""
+        if self._listener:
+            self._listener()
+            self._listener = None
+
+        self._state = STATE_OFF
+        self._next_alarm = None
+        self.async_write_ha_state()
+        self.hass.bus.async_fire(
+            EVENT_ALARM_CLOCK_CANCELLED, {ATTR_ENTITY_ID: self.entity_id}
+        )
+
+    @callback
+    def _async_finish(self, _: datetime | None = None) -> None:
+        """Reset and updates the states, fire finished event."""
+        if not self._repeat_days:
+            if self._listener:
+                self._listener()
+                self._listener = None
+
+            self._state = STATE_OFF
+            self._next_alarm = None
+            self.async_write_ha_state()
+            self.hass.bus.async_fire(
+                EVENT_ALARM_CLOCK_FINISHED, {ATTR_ENTITY_ID: self.entity_id}
+            )
+        else:
+            self.async_turn_on()
+
+    async def async_update_config(self, config: ConfigType) -> None:
+        """Handle config updates."""
+        self._config = config
+        self._alarm_time = cv.time(self._config[CONF_ALARM_TIME])
+        self._repeat_days = self._config.get(CONF_REPEAT_DAYS, [])
+
+        if self._state == STATE_ON:
+            self.async_turn_on()
+        else:
+            self.async_write_ha_state()
+
+
+class AlarmClockStorageCollection(collection.DictStorageCollection):
+    """Alarm Clock storage collection."""
+
+    CREATE_UPDATE_SCHEMA = vol.Schema(STORAGE_FIELDS)
+
+    async def _process_create_data(self, data: dict) -> dict:
+        """Validate the config is valid."""
+        data = self.CREATE_UPDATE_SCHEMA(data)
+        # make alarm_time JSON serializeable
+        data[CONF_ALARM_TIME] = _format_time(data[CONF_ALARM_TIME])
+        return data
+
+    @callback
+    def _get_suggested_id(self, info: dict) -> str:
+        """Suggest an ID based on the config."""
+        return info[CONF_NAME]  # type: ignore[no-any-return]
+
+    async def _update_data(self, item: dict, update_data: dict) -> dict:
+        """Return a new updated data object."""
+        data = {CONF_ID: item[CONF_ID]} | self.CREATE_UPDATE_SCHEMA(update_data)
+        # make alarm_time JSON serializeable
+        if CONF_ALARM_TIME in update_data:
+            data[CONF_ALARM_TIME] = _format_time(data[CONF_ALARM_TIME])
+        return data  # type: ignore[no-any-return]

--- a/homeassistant/components/alarm_clock/const.py
+++ b/homeassistant/components/alarm_clock/const.py
@@ -1,0 +1,31 @@
+"""Constants for the Alarm Clock integration."""
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_ICON, CONF_NAME
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = "alarm_clock"
+ENTITY_ID_FORMAT = DOMAIN + ".{}"
+
+ATTR_ALARM_TIME = "alarm_time"
+ATTR_REPEAT_DAYS = "repeat_days"
+ATTR_NEXT_ALARM = "next_alarm"
+
+CONF_ALARM_TIME = "alarm_time"
+CONF_REPEAT_DAYS = "repeat_days"
+
+EVENT_ALARM_CLOCK_STARTED = "alarm_clock.started"
+EVENT_ALARM_CLOCK_FINISHED = "alarm_clock.finished"
+EVENT_ALARM_CLOCK_CANCELLED = "alarm_clock.cancelled"
+EVENT_ALARM_CLOCK_CHANGED = "alarm_clock.changed"
+
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+
+STORAGE_FIELDS = {
+    vol.Required(CONF_NAME): cv.string,
+    vol.Optional(CONF_ICON): cv.icon,
+    vol.Required(CONF_ALARM_TIME): cv.time,
+    vol.Required(CONF_REPEAT_DAYS): cv.weekdays,
+}

--- a/homeassistant/components/alarm_clock/icons.json
+++ b/homeassistant/components/alarm_clock/icons.json
@@ -1,0 +1,6 @@
+{
+  "services": {
+    "turn_on": "mdi:alarm",
+    "turn_off": "mdi:alarm-off"
+  }
+}

--- a/homeassistant/components/alarm_clock/manifest.json
+++ b/homeassistant/components/alarm_clock/manifest.json
@@ -4,5 +4,6 @@
   "codeowners": ["@Nezz"],
   "documentation": "https://www.home-assistant.io/integrations/alarm_clock",
   "integration_type": "helper",
+  "iot_class": "local_push",
   "quality_scale": "internal"
 }

--- a/homeassistant/components/alarm_clock/manifest.json
+++ b/homeassistant/components/alarm_clock/manifest.json
@@ -1,0 +1,8 @@
+{
+  "domain": "alarm_clock",
+  "name": "Alarm Clock",
+  "codeowners": ["@Nezz"],
+  "documentation": "https://www.home-assistant.io/integrations/alarm_clock",
+  "integration_type": "helper",
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/alarm_clock/reproduce_state.py
+++ b/homeassistant/components/alarm_clock/reproduce_state.py
@@ -1,0 +1,76 @@
+"""Reproduce an Alarm Clock state."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterable
+import logging
+from typing import Any
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import Context, HomeAssistant, State
+
+from . import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+VALID_STATES = {STATE_OFF, STATE_ON}
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistant,
+    state: State,
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce a single state."""
+    if (cur_state := hass.states.get(state.entity_id)) is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if state.state not in VALID_STATES:
+        _LOGGER.warning(
+            "Invalid state specified for %s: %s", state.entity_id, state.state
+        )
+        return
+
+    # Return if we are already at the right state.
+    if cur_state.state == state.state:
+        return
+
+    service_data = {ATTR_ENTITY_ID: state.entity_id}
+
+    if state.state == STATE_ON:
+        service = SERVICE_TURN_ON
+
+    elif state.state == STATE_OFF:
+        service = SERVICE_TURN_OFF
+
+    await hass.services.async_call(
+        DOMAIN, service, service_data, context=context, blocking=True
+    )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistant,
+    states: Iterable[State],
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce Alarm Clock states."""
+    await asyncio.gather(
+        *(
+            _async_reproduce_state(
+                hass, state, context=context, reproduce_options=reproduce_options
+            )
+            for state in states
+        )
+    )

--- a/homeassistant/components/alarm_clock/services.yaml
+++ b/homeassistant/components/alarm_clock/services.yaml
@@ -1,0 +1,14 @@
+# Describes the format for available alarm clock services
+
+turn_on:
+  target:
+    entity:
+      domain: alarm_clock
+  fields:
+    alarm_time:
+      example: "09:00:00"
+
+turn_off:
+  target:
+    entity:
+      domain: alarm_clock

--- a/homeassistant/components/alarm_clock/strings.json
+++ b/homeassistant/components/alarm_clock/strings.json
@@ -1,0 +1,45 @@
+{
+  "entity_component": {
+    "_": {
+      "name": "Alarm Clock",
+      "state": {
+        "on": "[%key:common::state::on%]",
+        "off": "[%key:common::state::off%]"
+      },
+      "state_attributes": {
+        "alarm_time": {
+          "name": "Time"
+        },
+        "editable": {
+          "name": "[%key:common::generic::ui_managed%]",
+          "state": {
+            "true": "[%key:common::state::yes%]",
+            "false": "[%key:common::state::no%]"
+          }
+        },
+        "repeat_days": {
+          "name": "Repeat"
+        },
+        "next_alarm": {
+          "name": "next_alarm"
+        }
+      }
+    }
+  },
+  "services": {
+    "turn_on": {
+      "name": "[%key:common::action::turn_on%]",
+      "description": "Turns on the alarm.",
+      "fields": {
+        "alarm_time": {
+          "name": "Time",
+          "description": "Time for the alarm to go off. [optional]"
+        }
+      }
+    },
+    "turn_off": {
+      "name": "[%key:common::action::turn_off%]",
+      "description": "Turns off the alarm."
+    }
+  }
+}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7115,6 +7115,12 @@
     }
   },
   "helper": {
+    "alarm_clock": {
+      "name": "Alarm Clock",
+      "integration_type": "helper",
+      "config_flow": false,
+      "iot_class": "local_push"
+    },
     "counter": {
       "integration_type": "helper",
       "config_flow": false

--- a/tests/components/alarm_clock/__init__.py
+++ b/tests/components/alarm_clock/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Alarm Clock component."""

--- a/tests/components/alarm_clock/test_init.py
+++ b/tests/components/alarm_clock/test_init.py
@@ -1,0 +1,377 @@
+"""Tests for the alarm clock component."""
+
+from datetime import datetime, time
+
+import pytest
+
+from homeassistant.components.alarm_clock.const import (
+    ATTR_ALARM_TIME,
+    ATTR_NEXT_ALARM,
+    ATTR_REPEAT_DAYS,
+    CONF_ALARM_TIME,
+    CONF_REPEAT_DAYS,
+    DOMAIN,
+    EVENT_ALARM_CLOCK_CANCELLED,
+    EVENT_ALARM_CLOCK_CHANGED,
+    EVENT_ALARM_CLOCK_FINISHED,
+    EVENT_ALARM_CLOCK_STARTED,
+)
+from homeassistant.const import (
+    ATTR_FRIENDLY_NAME,
+    ATTR_ID,
+    ATTR_NAME,
+    CONF_ENTITY_ID,
+    CONF_NAME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+)
+from homeassistant.core import CoreState, HomeAssistant, callback
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_fire_time_changed
+from tests.typing import WebSocketGenerator
+
+
+@pytest.fixture
+def storage_setup(hass: HomeAssistant, hass_storage):
+    """Storage setup."""
+
+    async def _storage(items=None, config=None):
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {
+                    "items": [
+                        {
+                            ATTR_ID: "alarm_from_storage",
+                            ATTR_NAME: "alarm from storage",
+                            ATTR_ALARM_TIME: "12:00:00",
+                        }
+                    ]
+                },
+            }
+        else:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {"items": items},
+            }
+        if config is None:
+            config = {DOMAIN: {}}
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _storage
+
+
+async def test_config(hass: HomeAssistant) -> None:
+    """Test config."""
+    invalid_configs = [None, 1, {}, {"name with space": None}]
+
+    for cfg in invalid_configs:
+        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: cfg})
+
+
+async def test_config_single(hass: HomeAssistant) -> None:
+    """Test configuration for non-repeating alarm."""
+    count_start = len(hass.states.async_entity_ids())
+
+    config = {
+        DOMAIN: {
+            "single": {
+                CONF_ALARM_TIME: "09:00:00",
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    assert count_start + 1 == len(hass.states.async_entity_ids())
+    await hass.async_block_till_done()
+
+    single_state = hass.states.get("alarm_clock.single")
+    assert single_state is not None
+    assert single_state.state == STATE_OFF
+    assert single_state.attributes.get(ATTR_ALARM_TIME) == time(9, 0)
+    assert single_state.attributes.get(ATTR_REPEAT_DAYS) == []
+
+
+async def test_config_repeat(hass: HomeAssistant) -> None:
+    """Test configuration for repeating alarm."""
+    count_start = len(hass.states.async_entity_ids())
+
+    config = {
+        DOMAIN: {
+            "repeat": {
+                CONF_ALARM_TIME: "09:00:00",
+                CONF_REPEAT_DAYS: ["mon", "tue"],
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    assert count_start + 1 == len(hass.states.async_entity_ids())
+    await hass.async_block_till_done()
+
+    repeat_state = hass.states.get("alarm_clock.repeat")
+    assert repeat_state is not None
+    assert repeat_state.state == STATE_OFF
+    assert repeat_state.attributes.get(ATTR_ALARM_TIME) == time(9, 0)
+    assert repeat_state.attributes.get(ATTR_REPEAT_DAYS) == ["mon", "tue"]
+
+
+@pytest.mark.freeze_time("2024-05-20T09:00:00-07:00")
+async def test_turn_single(hass: HomeAssistant) -> None:
+    """Test turning on/off a non-repeating alarm."""
+    config = {
+        DOMAIN: {
+            "test": {
+                CONF_ALARM_TIME: "09:00:00",
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    # Turn on the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, {CONF_ENTITY_ID: "alarm_clock.test"}, blocking=True
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-21T09:00:00-07:00"
+
+    # Change on the alarm
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "alarm_clock.test", ATTR_ALARM_TIME: "12:00:00"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-20T12:00:00-07:00"
+
+    # Turn off the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {CONF_ENTITY_ID: "alarm_clock.test"}, blocking=True
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_OFF
+    assert ATTR_NEXT_ALARM not in state.attributes
+
+
+@pytest.mark.freeze_time("2024-05-20T09:00:00-07:00")
+async def test_turn_repeating(hass: HomeAssistant) -> None:
+    """Test turning on/off a repeating alarm."""
+    config = {
+        DOMAIN: {
+            "test": {
+                CONF_ALARM_TIME: "09:00:00",
+                CONF_REPEAT_DAYS: ["sun", "mon"],
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    # Turn on the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, {CONF_ENTITY_ID: "alarm_clock.test"}, blocking=True
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-26T09:00:00-07:00"
+
+    # Change on the alarm
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "alarm_clock.test", ATTR_ALARM_TIME: "12:00:00"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-20T12:00:00-07:00"
+
+    # Turn off the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_OFF, {CONF_ENTITY_ID: "alarm_clock.test"}, blocking=True
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("alarm_clock.test")
+    assert state
+    assert state.state == STATE_OFF
+    assert ATTR_NEXT_ALARM not in state.attributes
+
+
+@pytest.mark.freeze_time("2024-05-20T22:00:00-07:00")
+async def test_events(hass: HomeAssistant) -> None:
+    """Test for alarm clock events."""
+    hass.set_state(CoreState.starting)
+
+    config = {
+        DOMAIN: {
+            "test": {
+                CONF_ALARM_TIME: "09:00:00",
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    results = []
+
+    @callback
+    def fake_event_listener(event):
+        """Fake event listener for trigger."""
+        results.append(event)
+
+    hass.bus.async_listen(EVENT_ALARM_CLOCK_STARTED, fake_event_listener)
+    hass.bus.async_listen(EVENT_ALARM_CLOCK_CHANGED, fake_event_listener)
+    hass.bus.async_listen(EVENT_ALARM_CLOCK_FINISHED, fake_event_listener)
+    hass.bus.async_listen(EVENT_ALARM_CLOCK_CANCELLED, fake_event_listener)
+
+    # Turn on the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, {CONF_ENTITY_ID: "alarm_clock.test"}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert len(results) == 1
+    assert results[-1].event_type == EVENT_ALARM_CLOCK_STARTED
+
+    # Change on the alarm
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_TURN_ON,
+        {CONF_ENTITY_ID: "alarm_clock.test", ATTR_ALARM_TIME: "12:00:00"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert len(results) == 2
+    assert results[-1].event_type == EVENT_ALARM_CLOCK_CHANGED
+
+    # Let time pass
+    async_fire_time_changed(
+        hass, datetime.strptime("2024-05-21T12:00:00-07:00", "%Y-%m-%dT%H:%M:%S%z")
+    )
+    await hass.async_block_till_done()
+
+    assert len(results) == 3
+    assert results[-1].event_type == EVENT_ALARM_CLOCK_FINISHED
+
+
+async def test_load_from_storage(hass: HomeAssistant, storage_setup) -> None:
+    """Test set up from storage."""
+    assert await storage_setup()
+    state = hass.states.get(f"{DOMAIN}.alarm_from_storage")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_FRIENDLY_NAME) == "alarm from storage"
+    assert state.attributes.get(ATTR_ALARM_TIME) == time(12, 0)
+
+
+async def test_update_while_off(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
+    """Test updating alarm clock while off."""
+    assert await storage_setup()
+
+    alarm_clock_id = "alarm_from_storage"
+    alarm_entity_id = f"{DOMAIN}.{alarm_clock_id}"
+
+    state = hass.states.get(alarm_entity_id)
+    assert state
+
+    client = await hass_ws_client(hass)
+
+    updated_settings = {
+        CONF_NAME: "alarm updated",
+        CONF_ALARM_TIME: "18:00:00",
+        CONF_REPEAT_DAYS: ["wed"],
+    }
+    await client.send_json(
+        {
+            "id": 6,
+            "type": f"{DOMAIN}/update",
+            f"{DOMAIN}_id": alarm_clock_id,
+            **updated_settings,
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(alarm_entity_id)
+    assert state.state == STATE_OFF
+    assert ATTR_NEXT_ALARM not in state.attributes
+
+
+@pytest.mark.freeze_time("2024-05-20T09:00:00-07:00")
+async def test_update_while_on(
+    hass: HomeAssistant, hass_ws_client: WebSocketGenerator, storage_setup
+) -> None:
+    """Test updating alarm clock while on."""
+    assert await storage_setup(
+        items=[
+            {
+                ATTR_ID: "alarm_from_storage",
+                ATTR_NAME: "alarm from storage",
+                ATTR_ALARM_TIME: "12:00:00",
+            }
+        ]
+    )
+
+    alarm_clock_id = "alarm_from_storage"
+    alarm_entity_id = f"{DOMAIN}.{alarm_clock_id}"
+
+    # Turn on the alarm
+    await hass.services.async_call(
+        DOMAIN, SERVICE_TURN_ON, {CONF_ENTITY_ID: alarm_entity_id}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    # Assert initial state
+    state = hass.states.get(alarm_entity_id)
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-20T12:00:00-07:00"
+
+    # Update settings
+    client = await hass_ws_client(hass)
+
+    updated_settings = {
+        CONF_NAME: "alarm updated",
+        CONF_ALARM_TIME: "18:00:00",
+        CONF_REPEAT_DAYS: ["wed"],
+    }
+    await client.send_json(
+        {
+            "id": 6,
+            "type": f"{DOMAIN}/update",
+            f"{DOMAIN}_id": alarm_clock_id,
+            **updated_settings,
+        }
+    )
+    resp = await client.receive_json()
+    assert resp["success"]
+
+    state = hass.states.get(alarm_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_ALARM] == "2024-05-22T18:00:00-07:00"

--- a/tests/components/alarm_clock/test_reproduce_state.py
+++ b/tests/components/alarm_clock/test_reproduce_state.py
@@ -1,0 +1,57 @@
+"""Test reproduce state for Alert."""
+
+import pytest
+
+from homeassistant.components.alarm_clock import DOMAIN
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.state import async_reproduce_state
+
+from tests.common import async_mock_service
+
+
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test reproducing Alarm Clock states."""
+    hass.states.async_set(f"{DOMAIN}.entity_off", "off", {})
+    hass.states.async_set(f"{DOMAIN}.entity_on", "on", {})
+
+    turn_on_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_ON)
+    turn_off_calls = async_mock_service(hass, DOMAIN, SERVICE_TURN_OFF)
+
+    # These calls should do nothing as entities already in desired state
+    await async_reproduce_state(
+        hass, [State(f"{DOMAIN}.entity_off", "off"), State(f"{DOMAIN}.entity_on", "on")]
+    )
+
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Test invalid state is handled
+    await async_reproduce_state(hass, [State(f"{DOMAIN}.entity_off", "not_supported")])
+
+    assert "not_supported" in caplog.text
+    assert len(turn_on_calls) == 0
+    assert len(turn_off_calls) == 0
+
+    # Make sure correct services are called
+    await async_reproduce_state(
+        hass,
+        [
+            State(f"{DOMAIN}.entity_on", "off"),
+            State(f"{DOMAIN}.entity_off", "on"),
+            # Should not raise
+            State(f"{DOMAIN}.non_existing", "on"),
+        ],
+    )
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == DOMAIN
+    assert turn_on_calls[0].data == {
+        "entity_id": f"{DOMAIN}.entity_off",
+    }
+
+    assert len(turn_off_calls) == 1
+    assert turn_off_calls[0].domain == DOMAIN
+    assert turn_off_calls[0].data == {"entity_id": f"{DOMAIN}.entity_on"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an alarm clock helper that can be used to set alarms. This can be used also by various integrations that provide alarms such as:
https://github.com/theneweinstein/somneo
https://github.com/lukas-clarke/eight_sleep

Without this integration, other integrations need to set up one alarm clock using several individual entities:
- Switch entity for turning on/off the alarm
- Time entity for the alarm's time
- Select entity for choosing between days. However, this only supports one selection. Therefore a text entity might be used but is really clumsy.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32858

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [x] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
