### PR TITLE
Add binary_sensor platform for tplink

### DIFF
--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -1,0 +1,66 @@
+"""Support for TPLink binary sensors."""
+
+from __future__ import annotations
+
+from kasa import Device, Feature
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import TPLinkDataUpdateCoordinator
+from .entity import (
+    CoordinatedTPLinkEntity,
+    _description_for_feature,
+    _entities_for_device_and_its_children,
+)
+from .models import TPLinkData
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up sensors."""
+    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    parent_coordinator = data.parent_coordinator
+    device = parent_coordinator.device
+
+    entities = _entities_for_device_and_its_children(
+        device,
+        feature_type=Feature.BinarySensor,
+        entity_class=BinarySensor,
+        coordinator=parent_coordinator,
+    )
+
+    async_add_entities(entities)
+
+
+class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
+    """Representation of a TPLink binary sensor."""
+
+    def __init__(
+        self,
+        device: Device,
+        coordinator: TPLinkDataUpdateCoordinator,
+        feature: Feature,
+        parent: Device | None = None,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(device, coordinator, feature=feature, parent=parent)
+        self._feature: Feature
+        self.entity_description = _description_for_feature(
+            BinarySensorEntityDescription, feature
+        )
+        self._async_update_attrs()
+
+    @callback
+    def _async_update_attrs(self) -> None:
+        """Update the entity's attributes."""
+        self._attr_is_on = self._feature.value

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -20,8 +20,7 @@ from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkFeatureEntity,
     TPLinkFeatureEntityDescription,
-    _description_for_feature,
-    _entities_for_device_and_its_children,
+    entities_for_device_and_its_children,
 )
 
 
@@ -32,7 +31,7 @@ class TPLinkBinarySensorEntityDescription(
     """Base class for a TPLink feature based sensor entity description."""
 
 
-BINARYSENSOR_DESCRIPTIONS: Final = [
+BINARYSENSOR_DESCRIPTIONS: Final = (
     TPLinkBinarySensorEntityDescription(
         key="overheated",
         device_class=BinarySensorDeviceClass.HEAT,
@@ -52,12 +51,11 @@ BINARYSENSOR_DESCRIPTIONS: Final = [
     ),
     TPLinkBinarySensorEntityDescription(
         key="temperature_warning",
-        device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     TPLinkBinarySensorEntityDescription(
-        key="humidity_warning", device_class=BinarySensorDeviceClass.PROBLEM
+        key="humidity_warning",
     ),
-]
+)
 
 BINARYSENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in BINARYSENSOR_DESCRIPTIONS}
 
@@ -73,7 +71,7 @@ async def async_setup_entry(
     children_coordinators = data.children_coordinators
     device = parent_coordinator.device
 
-    entities = _entities_for_device_and_its_children(
+    entities = entities_for_device_and_its_children(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.BinarySensor,
@@ -97,7 +95,7 @@ class BinarySensor(CoordinatedTPLinkFeatureEntity, BinarySensorEntity):
         parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
-        description = _description_for_feature(
+        description = self._description_for_feature(
             TPLinkBinarySensorEntityDescription, feature, BINARYSENSOR_DESCRIPTIONS_MAP
         )
         super().__init__(

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -2,63 +2,108 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Final
+
 from kasa import Device, Feature
 
 from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TPLinkConfigEntry
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
-    CoordinatedTPLinkEntity,
+    CoordinatedTPLinkFeatureEntity,
+    TPLinkFeatureEntityDescription,
     _description_for_feature,
     _entities_for_device_and_its_children,
 )
-from .models import TPLinkData
+
+
+@dataclass(frozen=True, kw_only=True)
+class TPLinkBinarySensorEntityDescription(
+    BinarySensorEntityDescription, TPLinkFeatureEntityDescription
+):
+    """Base class for a TPLink feature based sensor entity description."""
+
+
+BINARYSENSOR_DESCRIPTIONS: Final = [
+    TPLinkBinarySensorEntityDescription(
+        key="overheated",
+        device_class=BinarySensorDeviceClass.HEAT,
+    ),
+    TPLinkBinarySensorEntityDescription(
+        key="battery_low",
+        device_class=BinarySensorDeviceClass.BATTERY,
+    ),
+    TPLinkBinarySensorEntityDescription(
+        key="cloud_connection",
+        device_class=BinarySensorDeviceClass.CONNECTIVITY,
+    ),
+    # To be replaced & disabled per default by the upcoming update platform.
+    TPLinkBinarySensorEntityDescription(
+        key="update_available",
+        device_class=BinarySensorDeviceClass.UPDATE,
+    ),
+    TPLinkBinarySensorEntityDescription(
+        key="temperature_warning",
+        device_class=BinarySensorDeviceClass.PROBLEM,
+    ),
+    TPLinkBinarySensorEntityDescription(
+        key="humidity_warning", device_class=BinarySensorDeviceClass.PROBLEM
+    ),
+]
+
+BINARYSENSOR_DESCRIPTIONS_MAP = {desc.key: desc for desc in BINARYSENSOR_DESCRIPTIONS}
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TPLinkConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors."""
-    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
     parent_coordinator = data.parent_coordinator
+    children_coordinators = data.children_coordinators
     device = parent_coordinator.device
 
     entities = _entities_for_device_and_its_children(
-        device,
-        feature_type=Feature.BinarySensor,
-        entity_class=BinarySensor,
+        device=device,
         coordinator=parent_coordinator,
+        feature_type=Feature.Type.BinarySensor,
+        entity_class=BinarySensor,
+        child_coordinators=children_coordinators,
     )
-
     async_add_entities(entities)
 
 
-class BinarySensor(CoordinatedTPLinkEntity, BinarySensorEntity):
+class BinarySensor(CoordinatedTPLinkFeatureEntity, BinarySensorEntity):
     """Representation of a TPLink binary sensor."""
+
+    entity_description: TPLinkBinarySensorEntityDescription
 
     def __init__(
         self,
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
+        *,
         feature: Feature,
         parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(device, coordinator, feature=feature, parent=parent)
-        self._feature: Feature
-        self.entity_description = _description_for_feature(
-            BinarySensorEntityDescription, feature
+        description = _description_for_feature(
+            TPLinkBinarySensorEntityDescription, feature, BINARYSENSOR_DESCRIPTIONS_MAP
         )
-        self._async_update_attrs()
+        super().__init__(
+            device, coordinator, description=description, feature=feature, parent=parent
+        )
+        self._async_call_update_attrs()
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Final
 
-from kasa import Device, Feature
+from kasa import Feature
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -16,12 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import TPLinkConfigEntry
-from .coordinator import TPLinkDataUpdateCoordinator
-from .entity import (
-    CoordinatedTPLinkFeatureEntity,
-    TPLinkFeatureEntityDescription,
-    entities_for_device_and_its_children,
-)
+from .entity import CoordinatedTPLinkFeatureEntity, TPLinkFeatureEntityDescription
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -71,11 +66,12 @@ async def async_setup_entry(
     children_coordinators = data.children_coordinators
     device = parent_coordinator.device
 
-    entities = entities_for_device_and_its_children(
+    entities = CoordinatedTPLinkFeatureEntity.entities_for_device_and_its_children(
         device=device,
         coordinator=parent_coordinator,
         feature_type=Feature.Type.BinarySensor,
         entity_class=BinarySensor,
+        descriptions=BINARYSENSOR_DESCRIPTIONS_MAP,
         child_coordinators=children_coordinators,
     )
     async_add_entities(entities)
@@ -85,23 +81,6 @@ class BinarySensor(CoordinatedTPLinkFeatureEntity, BinarySensorEntity):
     """Representation of a TPLink binary sensor."""
 
     entity_description: TPLinkBinarySensorEntityDescription
-
-    def __init__(
-        self,
-        device: Device,
-        coordinator: TPLinkDataUpdateCoordinator,
-        *,
-        feature: Feature,
-        parent: Device | None = None,
-    ) -> None:
-        """Initialize the sensor."""
-        description = self._description_for_feature(
-            TPLinkBinarySensorEntityDescription, feature, BINARYSENSOR_DESCRIPTIONS_MAP
-        )
-        super().__init__(
-            device, coordinator, description=description, feature=feature, parent=parent
-        )
-        self._async_call_update_attrs()
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/binary_sensor.py
+++ b/homeassistant/components/tplink/binary_sensor.py
@@ -29,7 +29,7 @@ class TPLinkBinarySensorEntityDescription(
 BINARYSENSOR_DESCRIPTIONS: Final = (
     TPLinkBinarySensorEntityDescription(
         key="overheated",
-        device_class=BinarySensorDeviceClass.HEAT,
+        device_class=BinarySensorDeviceClass.PROBLEM,
     ),
     TPLinkBinarySensorEntityDescription(
         key="battery_low",

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -21,4 +21,9 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 
 CONF_DEVICE_CONFIG: Final = "device_config"
 
-PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS: Final = [
+    Platform.BINARY_SENSOR,
+    Platform.LIGHT,
+    Platform.SENSOR,
+    Platform.SWITCH,
+]

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -226,6 +226,7 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         """Initialize the entity."""
         self.entity_description = description
         super().__init__(device, coordinator, parent=parent, feature=feature)
+        self._async_call_update_attrs()
 
     def _get_unique_id(self) -> str:
         """Return unique ID for the entity."""

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -169,6 +169,11 @@ class CoordinatedTPLinkEntity(CoordinatorEntity[TPLinkDataUpdateCoordinator], AB
         # it needs to implement this.
         raise NotImplementedError
 
+    async def async_added_to_hass(self) -> None:
+        """Handle being added to hass."""
+        self._async_call_update_attrs()
+        return await super().async_added_to_hass()
+
     @abstractmethod
     @callback
     def _async_update_attrs(self) -> None:
@@ -226,7 +231,6 @@ class CoordinatedTPLinkFeatureEntity(CoordinatedTPLinkEntity, ABC):
         """Initialize the entity."""
         self.entity_description = description
         super().__init__(device, coordinator, parent=parent, feature=feature)
-        self._async_call_update_attrs()
 
     def _get_unique_id(self) -> str:
         """Return unique ID for the entity."""

--- a/homeassistant/components/tplink/icons.json
+++ b/homeassistant/components/tplink/icons.json
@@ -1,5 +1,19 @@
 {
   "entity": {
+    "binary_sensor": {
+      "humidity_warning": {
+        "default": "mdi:water-percent",
+        "state": {
+          "on": "mdi:water-percent-alert"
+        }
+      },
+      "temperature_warning": {
+        "default": "mdi:thermometer-check",
+        "state": {
+          "on": "mdi:thermometer-alert"
+        }
+      }
+    },
     "switch": {
       "led": {
         "default": "mdi:led-off",

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -59,6 +59,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "humidity_warning": {
+        "name": "Humidity warning"
+      },
+      "temperature_warning": {
+        "name": "Temperature warning"
+      }
+    },
     "sensor": {
       "current_consumption": {
         "name": "Current consumption"

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -65,6 +65,9 @@
       },
       "temperature_warning": {
         "name": "Temperature warning"
+      },
+      "overheated": {
+        "name": "Overheated"
       }
     },
     "button": {

--- a/tests/components/tplink/test_binary_sensor.py
+++ b/tests/components/tplink/test_binary_sensor.py
@@ -1,0 +1,122 @@
+"""Tests for tplink binary_sensor platform."""
+
+from kasa import Feature
+
+from homeassistant.components import tplink
+from homeassistant.components.tplink.const import DOMAIN
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from . import (
+    DEVICE_ID,
+    MAC_ADDRESS,
+    _mocked_device,
+    _mocked_energy_features,
+    _mocked_feature,
+    _mocked_strip_children,
+    _patch_connect,
+    _patch_discovery,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_binary_sensor_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a sensor unique ids."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    emeter_features = _mocked_energy_features(
+        power=100,
+        total=30,
+        voltage=121,
+        current=5,
+        today=None,
+    )
+    plug = _mocked_device(alias="my_plug", features=emeter_features)
+    with _patch_discovery(device=plug), _patch_connect(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    expected = {
+        "sensor.my_plug_current_consumption": f"{DEVICE_ID}_current_power_w",
+        "sensor.my_plug_total_consumption": f"{DEVICE_ID}_total_energy_kwh",
+        "sensor.my_plug_today_s_consumption": f"{DEVICE_ID}_today_energy_kwh",
+        "sensor.my_plug_voltage": f"{DEVICE_ID}_voltage",
+        "sensor.my_plug_current": f"{DEVICE_ID}_current_a",
+    }
+    for sensor_entity_id, value in expected.items():
+        assert entity_registry.async_get(sensor_entity_id).unique_id == value
+
+
+async def test_binary_sensor(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a sensor unique ids."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    new_feature = _mocked_feature(
+        False,
+        "some_binary_sensor",
+        name="Some binary sensor",
+        type_=Feature.Type.BinarySensor,
+        category=Feature.Category.Primary,
+    )
+    plug = _mocked_device(alias="my_plug", features=[new_feature])
+    with _patch_discovery(device=plug), _patch_connect(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "binary_sensor.my_plug_some_binary_sensor"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    assert entity.unique_id == f"{DEVICE_ID}_some_binary_sensor"
+
+
+async def test_binary_sensor_children(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a sensor unique ids."""
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+    new_feature = _mocked_feature(
+        False,
+        "some_binary_sensor",
+        name="Some binary sensor",
+        type_=Feature.Type.BinarySensor,
+        category=Feature.Category.Primary,
+    )
+    plug = _mocked_device(
+        alias="my_plug",
+        features=[new_feature],
+        children=_mocked_strip_children(features=[new_feature]),
+    )
+    with _patch_discovery(device=plug), _patch_connect(device=plug):
+        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    entity_id = "binary_sensor.my_plug_some_binary_sensor"
+    entity = entity_registry.async_get(entity_id)
+    assert entity
+    device = device_registry.async_get(entity.device_id)
+
+    for plug_id in range(2):
+        child_entity_id = f"binary_sensor.my_plug_plug{plug_id}_some_binary_sensor"
+        child_entity = entity_registry.async_get(child_entity_id)
+        assert child_entity
+        assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_some_binary_sensor"
+        assert child_entity.device_id != entity.device_id
+        child_device = device_registry.async_get(child_entity.device_id)
+        assert child_device
+        assert child_device.via_device_id == device.id

--- a/tests/components/tplink/test_binary_sensor.py
+++ b/tests/components/tplink/test_binary_sensor.py
@@ -1,6 +1,7 @@
 """Tests for tplink binary_sensor platform."""
 
 from kasa import Feature
+import pytest
 
 from homeassistant.components import tplink
 from homeassistant.components.tplink.const import DOMAIN
@@ -13,7 +14,6 @@ from . import (
     DEVICE_ID,
     MAC_ADDRESS,
     _mocked_device,
-    _mocked_energy_features,
     _mocked_feature,
     _mocked_strip_children,
     _patch_connect,
@@ -23,99 +23,73 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_binary_sensor_unique_id(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test a sensor unique ids."""
-    already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
-    )
-    already_migrated_config_entry.add_to_hass(hass)
-    emeter_features = _mocked_energy_features(
-        power=100,
-        total=30,
-        voltage=121,
-        current=5,
-        today=None,
-    )
-    plug = _mocked_device(alias="my_plug", features=emeter_features)
-    with _patch_discovery(device=plug), _patch_connect(device=plug):
-        await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
-        await hass.async_block_till_done()
-
-    expected = {
-        "sensor.my_plug_current_consumption": f"{DEVICE_ID}_current_power_w",
-        "sensor.my_plug_total_consumption": f"{DEVICE_ID}_total_energy_kwh",
-        "sensor.my_plug_today_s_consumption": f"{DEVICE_ID}_today_energy_kwh",
-        "sensor.my_plug_voltage": f"{DEVICE_ID}_voltage",
-        "sensor.my_plug_current": f"{DEVICE_ID}_current_a",
-    }
-    for sensor_entity_id, value in expected.items():
-        assert entity_registry.async_get(sensor_entity_id).unique_id == value
-
-
-async def test_binary_sensor(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry
-) -> None:
-    """Test a sensor unique ids."""
-    already_migrated_config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
-    )
-    already_migrated_config_entry.add_to_hass(hass)
-    new_feature = _mocked_feature(
+@pytest.fixture
+def mocked_feature_binary_sensor() -> Feature:
+    """Return mocked tplink binary sensor feature."""
+    return _mocked_feature(
         False,
-        "some_binary_sensor",
-        name="Some binary sensor",
+        "overheated",
+        name="Overheated",
         type_=Feature.Type.BinarySensor,
         category=Feature.Category.Primary,
     )
-    plug = _mocked_device(alias="my_plug", features=[new_feature])
+
+
+async def test_binary_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mocked_feature_binary_sensor: Feature,
+) -> None:
+    """Test a sensor unique ids."""
+    mocked_feature = mocked_feature_binary_sensor
+    already_migrated_config_entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
+    )
+    already_migrated_config_entry.add_to_hass(hass)
+
+    plug = _mocked_device(alias="my_plug", features=[mocked_feature])
     with _patch_discovery(device=plug), _patch_connect(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "binary_sensor.my_plug_some_binary_sensor"
+    # The entity_id is based on standard name from core.
+    entity_id = "binary_sensor.my_plug_heat"
     entity = entity_registry.async_get(entity_id)
     assert entity
-    assert entity.unique_id == f"{DEVICE_ID}_some_binary_sensor"
+    assert entity.unique_id == f"{DEVICE_ID}_{mocked_feature.id}"
 
 
 async def test_binary_sensor_children(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
+    mocked_feature_binary_sensor: Feature,
 ) -> None:
     """Test a sensor unique ids."""
+    mocked_feature = mocked_feature_binary_sensor
     already_migrated_config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "127.0.0.1"}, unique_id=MAC_ADDRESS
     )
     already_migrated_config_entry.add_to_hass(hass)
-    new_feature = _mocked_feature(
-        False,
-        "some_binary_sensor",
-        name="Some binary sensor",
-        type_=Feature.Type.BinarySensor,
-        category=Feature.Category.Primary,
-    )
     plug = _mocked_device(
         alias="my_plug",
-        features=[new_feature],
-        children=_mocked_strip_children(features=[new_feature]),
+        features=[mocked_feature],
+        children=_mocked_strip_children(features=[mocked_feature]),
     )
     with _patch_discovery(device=plug), _patch_connect(device=plug):
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "binary_sensor.my_plug_some_binary_sensor"
+    entity_id = "binary_sensor.my_plug_heat"
     entity = entity_registry.async_get(entity_id)
     assert entity
     device = device_registry.async_get(entity.device_id)
 
     for plug_id in range(2):
-        child_entity_id = f"binary_sensor.my_plug_plug{plug_id}_some_binary_sensor"
+        child_entity_id = f"binary_sensor.my_plug_plug{plug_id}_heat"
         child_entity = entity_registry.async_get(child_entity_id)
         assert child_entity
-        assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_some_binary_sensor"
+        assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_{mocked_feature.id}"
         assert child_entity.device_id != entity.device_id
         child_device = device_registry.async_get(child_entity.device_id)
         assert child_device

--- a/tests/components/tplink/test_binary_sensor.py
+++ b/tests/components/tplink/test_binary_sensor.py
@@ -53,7 +53,7 @@ async def test_binary_sensor(
         await hass.async_block_till_done()
 
     # The entity_id is based on standard name from core.
-    entity_id = "binary_sensor.my_plug_heat"
+    entity_id = "binary_sensor.my_plug_overheated"
     entity = entity_registry.async_get(entity_id)
     assert entity
     assert entity.unique_id == f"{DEVICE_ID}_{mocked_feature.id}"
@@ -80,13 +80,13 @@ async def test_binary_sensor_children(
         await async_setup_component(hass, tplink.DOMAIN, {tplink.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    entity_id = "binary_sensor.my_plug_heat"
+    entity_id = "binary_sensor.my_plug_overheated"
     entity = entity_registry.async_get(entity_id)
     assert entity
     device = device_registry.async_get(entity.device_id)
 
     for plug_id in range(2):
-        child_entity_id = f"binary_sensor.my_plug_plug{plug_id}_heat"
+        child_entity_id = f"binary_sensor.my_plug_plug{plug_id}_overheated"
         child_entity = entity_registry.async_get(child_entity_id)
         assert child_entity
         assert child_entity.unique_id == f"PLUG{plug_id}DEVICEID_{mocked_feature.id}"


### PR DESCRIPTION
## This PR is part of the tplink rewrite series, to be merged into `tplink_rewrite` branch (see #120060).
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `binary_sensor` platform for tplink.

TBD:
- [x] Tests
- [x] humidity & temperature warnings needs to be custom (instead of `BinarySensorDeviceClass.PROBLEM`), see the screenshot

![image](https://github.com/home-assistant/core/assets/3705853/ef72aa8c-6e1c-462a-b5b2-c6c07c9bf0c9)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/33354

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
