### PR TITLE
Implement dynamic sensors for tplink

### DIFF
--- a/homeassistant/components/tplink/README.md
+++ b/homeassistant/components/tplink/README.md
@@ -4,9 +4,9 @@ This document covers details that new contributors may find helpful when getting
 
 ## Modules vs Features
 
-The kasa library which this integration depends on exposes functionality via modules and features.
-The `Module` apis encapsulate groups of functionality provided by a device,
-e.g. Light which has multiple attributes and methods such as `set_has`, `brightness` etc.
+The python-kasa library which this integration depends on exposes functionality via modules and features.
+The `Module` APIs encapsulate groups of functionality provided by a device,
+e.g. Light which has multiple attributes and methods such as `set_hsv`, `brightness` etc.
 The `features` encapsulate unitary functions and allow for introspection.
 e.g. `on_since`, `voltage` etc.
 
@@ -17,15 +17,18 @@ use modules.
 
 ## Dynamic feature creation
 
-Entities can be dynamically created by inspecting various properties of a feature such
-as `type`, `unit` or `precision`. If more data is needed than the feature provides,
-i.e. to set HA `device_class` or `state_class` on a sensor entity, then a static `EntityExtras` entry
-should be created in `const.py`.
+Entity attributes are dynamically set by inspecting various properties of a feature such
+as `type`, `unit` or `precision`.
+If more data is needed than the feature provides,
+i.e. to set HA `device_class` or `state_class` on a sensor entity, then add it to the static
+`PLATFORM_DESCRIPTIONS` entry in the appropriate platform.
+All feature ids should be described in the static entity descriptions but if a new feature
+is not yet added it will be created manually and a warning will be logged.
 
 ### Translation keys and icons
 
-For `Feature` based platforms translation keys should match `feature.id`.
-If a translation key and icon has been added to `strings.json` and `icons.json` it should be added to
-`ENTITY_EXTRAS` as an indication not to set the `name` or `icon` from the feature,
-as it will override the translation otherwise.
+For features to use translation keys they should be added to `strings.json` and `icons.json`
+with the feature.id as key.
+
+**All described features must have corresponding entries in `strings.json` and `icons.json`**
 

--- a/homeassistant/components/tplink/README.md
+++ b/homeassistant/components/tplink/README.md
@@ -1,0 +1,31 @@
+# TPLink Integration
+
+This document covers details that new contributors may find helpful when getting started.
+
+## Modules vs Features
+
+The kasa library which this integration depends on exposes functionality via modules and features.
+The `Module` apis encapsulate groups of functionality provided by a device,
+e.g. Light which has multiple attributes and methods such as `set_has`, `brightness` etc.
+The `features` encapsulate unitary functions and allow for introspection.
+e.g. `on_since`, `voltage` etc.
+
+If the integration implements a platform that presents single functions or data points, such as `sensor`,
+`button`, `switch` it uses features.
+If it's implementing a platform with more complex functionality like `light`, `fan` or `climate` it will
+use modules.
+
+## Dynamic feature creation
+
+Entities can be dynamically created by inspecting various properties of a feature such
+as `type`, `unit` or `precision`. If more data is needed than the feature provides,
+i.e. to set HA `device_class` or `state_class` on a sensor entity, then a static `EntityExtras` entry
+should be created in `const.py`.
+
+### Translation keys and icons
+
+For `Feature` based platforms translation keys should match `feature.id`.
+If a translation key and icon has been added to `strings.json` and `icons.json` it should be added to
+`ENTITY_EXTRAS` as an indication not to set the `name` or `icon` from the feature,
+as it will override the translation otherwise.
+

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -210,11 +210,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bo
 
 async def async_unload_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bool:
     """Unload a config entry."""
-    hass_data: dict[str, Any] = hass.data[DOMAIN]
     data = entry.runtime_data
     device = data.parent_coordinator.device
-    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass_data.pop(entry.entry_id)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     await device.protocol.close()
 
     return unload_ok

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -52,6 +52,8 @@ from .const import (
 from .coordinator import TPLinkDataUpdateCoordinator
 from .models import TPLinkData
 
+type TPLinkConfigEntry = ConfigEntry[TPLinkData]
+
 DISCOVERY_INTERVAL = timedelta(minutes=15)
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -127,7 +129,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
     host: str = entry.data[CONF_HOST]
     credentials = await get_credentials(hass)
@@ -200,18 +202,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             for child in device.children
         ]
 
-    hass.data[DOMAIN][entry.entry_id] = TPLinkData(
-        parent_coordinator, child_coordinators
-    )
+    entry.runtime_data = TPLinkData(parent_coordinator, child_coordinators)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: TPLinkConfigEntry) -> bool:
     """Unload a config entry."""
     hass_data: dict[str, Any] = hass.data[DOMAIN]
-    data: TPLinkData = hass_data[entry.entry_id]
+    data = entry.runtime_data
     device = data.parent_coordinator.device
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass_data.pop(entry.entry_id)

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, TypedDict
 
-from homeassistant.const import Platform
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import ATTR_VOLTAGE, Platform
 
 DOMAIN = "tplink"
 
@@ -22,3 +23,40 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 CONF_DEVICE_CONFIG: Final = "device_config"
 
 PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
+
+
+class EntityExtras(TypedDict):
+    """Class to define additional properties to be set on feature based entities."""
+
+    key: str | None
+    device_class: str | None
+    state_class: str | None
+
+
+ENTITY_EXTRAS: Final = {
+    "current_consumption": EntityExtras(
+        key=ATTR_CURRENT_POWER_W,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "consumption_total": EntityExtras(
+        key=ATTR_TOTAL_ENERGY_KWH,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "consumption_today": EntityExtras(
+        key=ATTR_TODAY_ENERGY_KWH,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+    ),
+    "voltage": EntityExtras(
+        key=ATTR_VOLTAGE,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    "current": EntityExtras(
+        key=ATTR_CURRENT_A,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+}

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -59,4 +59,9 @@ ENTITY_EXTRAS: Final = {
         device_class=SensorDeviceClass.CURRENT,
         state_class=SensorStateClass.MEASUREMENT,
     ),
+    "temperature": EntityExtras(
+        key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
 }

--- a/homeassistant/components/tplink/const.py
+++ b/homeassistant/components/tplink/const.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Final, TypedDict
+from typing import Final
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
-from homeassistant.const import ATTR_VOLTAGE, Platform
+from homeassistant.const import Platform
 
 DOMAIN = "tplink"
 
@@ -23,45 +22,3 @@ ATTR_TOTAL_ENERGY_KWH: Final = "total_energy_kwh"
 CONF_DEVICE_CONFIG: Final = "device_config"
 
 PLATFORMS: Final = [Platform.LIGHT, Platform.SENSOR, Platform.SWITCH]
-
-
-class EntityExtras(TypedDict):
-    """Class to define additional properties to be set on feature based entities."""
-
-    key: str | None
-    device_class: str | None
-    state_class: str | None
-
-
-ENTITY_EXTRAS: Final = {
-    "current_consumption": EntityExtras(
-        key=ATTR_CURRENT_POWER_W,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    "consumption_total": EntityExtras(
-        key=ATTR_TOTAL_ENERGY_KWH,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    "consumption_today": EntityExtras(
-        key=ATTR_TODAY_ENERGY_KWH,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-    ),
-    "voltage": EntityExtras(
-        key=ATTR_VOLTAGE,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    "current": EntityExtras(
-        key=ATTR_CURRENT_A,
-        device_class=SensorDeviceClass.CURRENT,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-    "temperature": EntityExtras(
-        key="temperature",
-        device_class=SensorDeviceClass.TEMPERATURE,
-        state_class=SensorStateClass.MEASUREMENT,
-    ),
-}

--- a/homeassistant/components/tplink/diagnostics.py
+++ b/homeassistant/components/tplink/diagnostics.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import format_mac
 
-from .const import DOMAIN
-from .models import TPLinkData
+from . import TPLinkConfigEntry
 
 TO_REDACT = {
     # Entry fields
@@ -42,10 +40,10 @@ TO_REDACT = {
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: TPLinkConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    data: TPLinkData = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
     coordinator = data.parent_coordinator
     oui = format_mac(coordinator.device.mac)[:8].upper()
     return async_redact_data(

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -54,6 +54,7 @@ class EntityDescriptionExtras(TypedDict, total=False):
     """Extra kwargs that can be provided to entity descriptions."""
 
     entity_registry_enabled_default: bool
+    native_unit_of_measurement: str | None
 
 
 def async_refresh_after[_T: CoordinatedTPLinkEntity, **_P](

--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -340,7 +340,4 @@ def _description_for_feature[_D: EntityDescription](
     )
     kwargs["entity_category"] = _category_for_feature(feature)
 
-    if feature.type == Feature.Type.Sensor:
-        kwargs["native_unit_of_measurement"] = feature.unit
-        kwargs["precision"] = feature.precision_hint
     return desc_cls(**kwargs)

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -145,8 +145,8 @@ async def async_setup_entry(
                 TPLinkSmartLightStrip(
                     device,
                     parent_coordinator,
-                    device.modules[Module.Light],
-                    effect_module,
+                    light_module=device.modules[Module.Light],
+                    effect_module=effect_module,
                 )
             ]
         )
@@ -163,7 +163,13 @@ async def async_setup_entry(
         )
     elif Module.Light in device.modules:
         async_add_entities(
-            [TPLinkSmartBulb(device, parent_coordinator, device.modules[Module.Light])]
+            [
+                TPLinkSmartBulb(
+                    device,
+                    parent_coordinator,
+                    light_module=device.modules[Module.Light],
+                )
+            ]
         )
 
 
@@ -178,6 +184,7 @@ class TPLinkSmartBulb(CoordinatedTPLinkEntity, LightEntity):
         self,
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
+        *,
         light_module: Light,
     ) -> None:
         """Initialize the switch."""
@@ -313,12 +320,13 @@ class TPLinkSmartLightStrip(TPLinkSmartBulb):
         self,
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
+        *,
         light_module: Light,
         effect_module: LightEffect,
     ) -> None:
-        """Initialize the switch."""
+        """Initialize the light strip."""
         self._effect_module = effect_module
-        super().__init__(device, coordinator, light_module)
+        super().__init__(device, coordinator, light_module=light_module)
 
     _attr_supported_features = LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
 

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -22,16 +22,14 @@ from homeassistant.components.light import (
     LightEntityFeature,
     filter_supported_color_modes,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TPLinkConfigEntry
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import CoordinatedTPLinkEntity, async_refresh_after
-from .models import TPLinkData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -132,11 +130,11 @@ def _async_build_base_effect(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TPLinkConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches."""
-    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
     parent_coordinator = data.parent_coordinator
     device = parent_coordinator.device
     if (

--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -269,5 +269,5 @@
   "iot_class": "local_polling",
   "loggers": ["kasa"],
   "quality_scale": "platinum",
-  "requirements": ["python-kasa[speedups]==0.7.0.dev4"]
+  "requirements": ["python-kasa[speedups]==0.7.0.dev5"]
 }

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import TPLinkConfigEntry
 from .const import (
     ATTR_CURRENT_A,
     ATTR_CURRENT_POWER_W,
@@ -134,11 +135,11 @@ def _async_sensors_for_device(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TPLinkConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensors."""
-    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
     parent_coordinator = data.parent_coordinator
     children_coordinators = data.children_coordinators
     entities: list[CoordinatedTPLinkEntity] = []

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -5,129 +5,26 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from kasa import Device, Feature, SmartStrip
+from kasa import Device, Feature
 
-from homeassistant.components.sensor import (
-    SensorDeviceClass,
-    SensorEntity,
-    SensorEntityDescription,
-    SensorStateClass,
-)
-from homeassistant.const import (
-    ATTR_VOLTAGE,
-    UnitOfElectricCurrent,
-    UnitOfElectricPotential,
-    UnitOfEnergy,
-    UnitOfPower,
-)
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import TPLinkConfigEntry
-from .const import (
-    ATTR_CURRENT_A,
-    ATTR_CURRENT_POWER_W,
-    ATTR_TODAY_ENERGY_KWH,
-    ATTR_TOTAL_ENERGY_KWH,
-)
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkEntity,
     _description_for_feature,
-    _entities_for_device,
+    _entities_for_device_and_its_children,
 )
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TPLinkSensorEntityDescription(SensorEntityDescription):
     """Describes TPLink sensor entity."""
 
-    emeter_attr: str | None = None
     precision: int | None = None
-
-
-ENERGY_SENSORS: tuple[TPLinkSensorEntityDescription, ...] = (
-    TPLinkSensorEntityDescription(
-        key=ATTR_CURRENT_POWER_W,
-        translation_key="current_consumption",
-        native_unit_of_measurement=UnitOfPower.WATT,
-        device_class=SensorDeviceClass.POWER,
-        state_class=SensorStateClass.MEASUREMENT,
-        emeter_attr="power",
-        precision=1,
-    ),
-    TPLinkSensorEntityDescription(
-        key=ATTR_TOTAL_ENERGY_KWH,
-        translation_key="total_consumption",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        emeter_attr="total",
-        precision=3,
-    ),
-    TPLinkSensorEntityDescription(
-        key=ATTR_TODAY_ENERGY_KWH,
-        translation_key="today_consumption",
-        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-        device_class=SensorDeviceClass.ENERGY,
-        state_class=SensorStateClass.TOTAL_INCREASING,
-        precision=3,
-    ),
-    TPLinkSensorEntityDescription(
-        key=ATTR_VOLTAGE,
-        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
-        device_class=SensorDeviceClass.VOLTAGE,
-        state_class=SensorStateClass.MEASUREMENT,
-        emeter_attr="voltage",
-        precision=1,
-    ),
-    TPLinkSensorEntityDescription(
-        key=ATTR_CURRENT_A,
-        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
-        device_class=SensorDeviceClass.CURRENT,
-        state_class=SensorStateClass.MEASUREMENT,
-        emeter_attr="current",
-        precision=2,
-    ),
-)
-
-
-def async_emeter_from_device(
-    device: Device, description: TPLinkSensorEntityDescription
-) -> float | None:
-    """Map a sensor key to the device attribute."""
-    if attr := description.emeter_attr:
-        if (val := getattr(device.emeter_realtime, attr)) is None:
-            return None
-        return round(cast(float, val), description.precision)
-
-    # ATTR_TODAY_ENERGY_KWH
-    if (emeter_today := device.emeter_today) is not None:
-        return round(cast(float, emeter_today), description.precision)
-    # today's consumption not available, when device was off all the day
-    # bulb's do not report this information, so filter it out
-    return None if device.device_type == Device.Type.Bulb else 0.0
-
-
-def _async_sensors_for_device(
-    device: Device,
-    coordinator: TPLinkDataUpdateCoordinator,
-    parent: Device | None = None,
-) -> list[CoordinatedTPLinkEntity]:
-    """Generate the sensors for the device."""
-    sensors: list[CoordinatedTPLinkEntity] = []
-    if device.has_emeter:
-        sensors = [
-            SmartPlugSensor(device, coordinator, description, parent=parent)
-            for description in ENERGY_SENSORS
-            if async_emeter_from_device(device, description) is not None
-        ]
-    new_sensors: list[CoordinatedTPLinkEntity] = [
-        Sensor(device, coordinator, feat, parent=parent)
-        for feat in device.features.values()
-        if feat.type == Feature.Sensor
-    ]
-    return sensors + new_sensors
 
 
 async def async_setup_entry(
@@ -142,54 +39,36 @@ async def async_setup_entry(
     entities: list[CoordinatedTPLinkEntity] = []
     device = parent_coordinator.device
 
-    for idx, child in enumerate(device.children):
-        # HS300 does not like too many concurrent requests and its emeter data requires
-        # a request for each socket, so we create separate coordinators.
-        if isinstance(device, SmartStrip):
-            entities.extend(
-                _async_sensors_for_device(
-                    child, children_coordinators[idx], parent=device
-                )
-            )
-        else:
-            entities.extend(
-                _entities_for_device(
-                    child,
-                    feature_type=Feature.Sensor,
-                    entity_class=Sensor,
-                    coordinator=parent_coordinator,
-                    parent=device,
-                )
-            )
-
-    entities.extend(
-        _entities_for_device(
-            device,
-            feature_type=Feature.Sensor,
-            entity_class=Sensor,
-            coordinator=parent_coordinator,
-        )
+    entities = _entities_for_device_and_its_children(
+        device=device,
+        coordinator=parent_coordinator,
+        feature_type=Feature.Type.Sensor,
+        entity_class=TPLinkSensor,
+        child_coordinators=children_coordinators,
     )
-
     async_add_entities(entities)
 
 
-class Sensor(CoordinatedTPLinkEntity, SensorEntity):
+class TPLinkSensor(CoordinatedTPLinkEntity, SensorEntity):
     """Representation of a feature-based TPLink sensor."""
+
+    entity_description: TPLinkSensorEntityDescription
 
     def __init__(
         self,
         device: Device,
         coordinator: TPLinkDataUpdateCoordinator,
+        *,
         feature: Feature,
         parent: Device | None = None,
     ) -> None:
         """Initialize the sensor."""
+        self.entity_description = _description_for_feature(
+            TPLinkSensorEntityDescription, feature
+        )
         super().__init__(device, coordinator, feature=feature, parent=parent)
         self._feature: Feature
-        self.entity_description = _description_for_feature(
-            SensorEntityDescription, feature, native_unit_of_measurement=feature.unit
-        )
+        self._async_call_update_attrs()
 
     @callback
     def _async_update_attrs(self) -> None:
@@ -198,37 +77,3 @@ class Sensor(CoordinatedTPLinkEntity, SensorEntity):
         if value is not None and self._feature.precision_hint is not None:
             value = round(cast(float, value), self._feature.precision_hint)
         self._attr_native_value = value
-
-
-class SmartPlugSensor(CoordinatedTPLinkEntity, SensorEntity):
-    """Representation of a TPLink sensor."""
-
-    entity_description: TPLinkSensorEntityDescription
-
-    def __init__(
-        self,
-        device: Device,
-        coordinator: TPLinkDataUpdateCoordinator,
-        description: TPLinkSensorEntityDescription,
-        parent: Device | None = None,
-    ) -> None:
-        """Initialize the switch."""
-        self.entity_description = description
-        super().__init__(device, coordinator, parent=parent)
-
-        if parent is not None:
-            assert device.alias
-            self._attr_translation_placeholders = {"device_name": device.alias}
-            if description.translation_key:
-                self._attr_translation_key = f"{description.translation_key}_child"
-            else:
-                assert description.device_class
-                self._attr_translation_key = f"{description.device_class.value}_child"
-        self._async_call_update_attrs()
-
-    @callback
-    def _async_update_attrs(self) -> None:
-        """Update the entity's attributes."""
-        self._attr_native_value = async_emeter_from_device(
-            self._device, self.entity_description
-        )

--- a/homeassistant/components/tplink/sensor.py
+++ b/homeassistant/components/tplink/sensor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import cast
 
-from kasa import Device, Feature
+from kasa import Device, Feature, SmartStrip
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -108,7 +108,7 @@ def async_emeter_from_device(
         return round(cast(float, emeter_today), description.precision)
     # today's consumption not available, when device was off all the day
     # bulb's do not report this information, so filter it out
-    return None if device.device_type == DeviceType.Bulb else 0.0
+    return None if device.device_type == Device.Type.Bulb else 0.0
 
 
 def _async_sensors_for_device(
@@ -146,8 +146,6 @@ async def async_setup_entry(
 
     for idx, child in enumerate(device.children):
         # TODO: nicer way for multi-coordinator updates.
-        from kasa import SmartStrip  # noqa: C0415
-
         if isinstance(device, SmartStrip):
             entities.extend(
                 _async_sensors_for_device(

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -63,26 +63,11 @@
       "current_consumption": {
         "name": "Current consumption"
       },
-      "total_consumption": {
+      "consumption_total": {
         "name": "Total consumption"
       },
-      "today_consumption": {
+      "consumption_today": {
         "name": "Today's consumption"
-      },
-      "current_consumption_child": {
-        "name": "{device_name} current consumption"
-      },
-      "total_consumption_child": {
-        "name": "{device_name} total consumption"
-      },
-      "today_consumption_child": {
-        "name": "{device_name} today's consumption"
-      },
-      "current_child": {
-        "name": "{device_name} current"
-      },
-      "voltage_child": {
-        "name": "{device_name} voltage"
       }
     },
     "switch": {

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -77,12 +77,12 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
     @async_refresh_after
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        await self._feature.set_value(True)  # type: ignore[no-untyped-call]
+        await self._feature.set_value(True)
 
     @async_refresh_after
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        await self._feature.set_value(False)  # type: ignore[no-untyped-call]
+        await self._feature.set_value(False)
 
     @callback
     def _async_update_attrs(self) -> None:

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -8,11 +8,10 @@ from typing import Any
 from kasa import Device, Feature
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TPLinkConfigEntry
 from .coordinator import TPLinkDataUpdateCoordinator
 from .entity import (
     CoordinatedTPLinkEntity,
@@ -20,18 +19,17 @@ from .entity import (
     _entities_for_device_and_its_children,
     async_refresh_after,
 )
-from .models import TPLinkData
 
 _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: TPLinkConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switches."""
-    data: TPLinkData = hass.data[DOMAIN][config_entry.entry_id]
+    data = config_entry.runtime_data
     parent_coordinator = data.parent_coordinator
     device = parent_coordinator.device
 

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -44,7 +44,7 @@ async def async_setup_entry(
 
 
 class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
-    """Representation of a feature-based TPLink sensor."""
+    """Representation of a feature-based TPLink switch."""
 
     def __init__(
         self,
@@ -66,7 +66,6 @@ class TPLinkSwitch(CoordinatedTPLinkEntity, SwitchEntity):
         # Use the device name for the primary switch control
         if feature.category is Feature.Category.Primary and not parent:
             self._attr_name = None
-
         self.entity_description = _description_for_feature(
             SwitchEntityDescription, feature
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2272,7 +2272,7 @@ python-join-api==0.0.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.7.0.dev4
+python-kasa[speedups]==0.7.0.dev5
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1772,7 +1772,7 @@ python-izone==1.2.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.7.0.dev4
+python-kasa[speedups]==0.7.0.dev5
 
 # homeassistant.components.matter
 python-matter-server==6.1.0


### PR DESCRIPTION
## This PR is part of the tplink rewrite series, to be merged into `tplink_rewrite` branch (see #111151).
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a base entity class shared by all platforms & converts `sensor` platform to use upstream-provided definitions in addition to the existing ones.
This is a backwards compatible with the existing sensors (emeter) and switches (led).

![image](https://github.com/home-assistant/core/assets/3705853/f99a2a25-fa9b-4d71-9b58-4495c402e1e7)



TODO:
- [x] Child device specific data update coordinators
- [x] Removing legacy handling altogether
- [ ] Tests for backwards compat of legacy identifiers
- [x] ~~Add translations~~ (can be done in a subsequent PR, to unblock other platforms for now)
- [x] Mapping for `(feature_id, device_class)` & co

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
