### PR TITLE
Use PEP 695 for class annotations (4)

### DIFF
--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 import logging
-from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from homeassistant import config_entries
 from homeassistant.components import onboarding
@@ -22,13 +22,12 @@ if TYPE_CHECKING:
 
     from .service_info.mqtt import MqttServiceInfo
 
-_R = TypeVar("_R", bound="Awaitable[bool] | bool")
-DiscoveryFunctionType = Callable[[HomeAssistant], _R]
+type DiscoveryFunctionType[_R] = Callable[[HomeAssistant], _R]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class DiscoveryFlowHandler(config_entries.ConfigFlow, Generic[_R]):
+class DiscoveryFlowHandler[_R: Awaitable[bool] | bool](config_entries.ConfigFlow):
     """Handle a discovery config flow."""
 
     VERSION = 1

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -7,7 +7,7 @@ from enum import StrEnum
 from functools import cached_property, lru_cache, partial
 import logging
 import time
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 import attr
 from yarl import URL
@@ -449,10 +449,9 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
         return old_data
 
 
-_EntryTypeT = TypeVar("_EntryTypeT", DeviceEntry, DeletedDeviceEntry)
-
-
-class DeviceRegistryItems(BaseRegistryItems[_EntryTypeT]):
+class DeviceRegistryItems[_EntryTypeT: (DeviceEntry, DeletedDeviceEntry)](
+    BaseRegistryItems[_EntryTypeT]
+):
     """Container for device registry items, maps device id -> entry.
 
     Maintains two additional indexes:

--- a/homeassistant/helpers/normalized_name_base_registry.py
+++ b/homeassistant/helpers/normalized_name_base_registry.py
@@ -2,7 +2,6 @@
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import TypeVar
 
 from .registry import BaseRegistryItems
 
@@ -15,16 +14,15 @@ class NormalizedNameBaseRegistryEntry:
     normalized_name: str
 
 
-_VT = TypeVar("_VT", bound=NormalizedNameBaseRegistryEntry)
-
-
 @lru_cache(maxsize=1024)
 def normalize_name(name: str) -> str:
     """Normalize a name by removing whitespace and case folding."""
     return name.casefold().replace(" ", "")
 
 
-class NormalizedNameBaseRegistryItems(BaseRegistryItems[_VT]):
+class NormalizedNameBaseRegistryItems[_VT: NormalizedNameBaseRegistryEntry](
+    BaseRegistryItems[_VT]
+):
     """Base container for normalized name registry items, maps key -> entry.
 
     Maintains an additional index:

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections import UserDict
 from collections.abc import Mapping, Sequence, ValuesView
-from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Any, Literal
 
 from homeassistant.core import CoreState, HomeAssistant, callback
 
@@ -16,11 +16,7 @@ SAVE_DELAY = 10
 SAVE_DELAY_LONG = 180
 
 
-_DataT = TypeVar("_DataT")
-_StoreDataT = TypeVar("_StoreDataT", bound=Mapping[str, Any] | Sequence[Any])
-
-
-class BaseRegistryItems(UserDict[str, _DataT], ABC):
+class BaseRegistryItems[_DataT](UserDict[str, _DataT], ABC):
     """Base class for registry items."""
 
     data: dict[str, _DataT]
@@ -65,7 +61,7 @@ class BaseRegistryItems(UserDict[str, _DataT], ABC):
         super().__delitem__(key)
 
 
-class BaseRegistry(ABC, Generic[_StoreDataT]):
+class BaseRegistry[_StoreDataT: Mapping[str, Any] | Sequence[Any]](ABC):
     """Class to implement a registry."""
 
     hass: HomeAssistant

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Mapping, Sequence
 from enum import StrEnum
 from functools import cache
 import importlib
-from typing import Any, Generic, Literal, Required, TypedDict, TypeVar, cast
+from typing import Any, Literal, Required, TypedDict, cast
 from uuid import UUID
 
 import voluptuous as vol
@@ -20,8 +20,6 @@ from homeassistant.util.yaml import dumper
 from . import config_validation as cv
 
 SELECTORS: decorator.Registry[str, type[Selector]] = decorator.Registry()
-
-_T = TypeVar("_T", bound=Mapping[str, Any])
 
 
 def _get_selector_class(config: Any) -> type[Selector]:
@@ -62,7 +60,7 @@ def validate_selector(config: Any) -> dict:
     }
 
 
-class Selector(Generic[_T]):
+class Selector[_T: Mapping[str, Any]]:
     """Base class for selectors."""
 
     CONFIG_SCHEMA: Callable

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -9,7 +9,7 @@ from enum import Enum
 from functools import cache, partial
 import logging
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Generic, TypedDict, TypeGuard, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypedDict, TypeGuard, cast
 
 import voluptuous as vol
 
@@ -78,8 +78,6 @@ SERVICE_DESCRIPTION_CACHE: HassKey[dict[tuple[str, str], dict[str, Any] | None]]
 ALL_SERVICE_DESCRIPTIONS_CACHE: HassKey[
     tuple[set[tuple[str, str]], dict[str, dict[str, Any]]]
 ] = HassKey("all_service_descriptions_cache")
-
-_T = TypeVar("_T")
 
 
 @cache
@@ -1153,7 +1151,7 @@ def verify_domain_control(
     return decorator
 
 
-class ReloadServiceHelper(Generic[_T]):
+class ReloadServiceHelper[_T]:
     """Helper for reload services.
 
     The helper has the following purposes:

--- a/homeassistant/util/decorator.py
+++ b/homeassistant/util/decorator.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Hashable
-from typing import Any, TypeVar
-
-_KT = TypeVar("_KT", bound=Hashable)
-_VT = TypeVar("_VT", bound=Callable[..., Any])
+from typing import Any
 
 
-class Registry(dict[_KT, _VT]):
+class Registry[_KT: Hashable, _VT: Callable[..., Any]](dict[_KT, _VT]):
     """Registry of items."""
 
     def register(self, name: _KT) -> Callable[[_VT], _VT]:

--- a/homeassistant/util/limited_size_dict.py
+++ b/homeassistant/util/limited_size_dict.py
@@ -3,13 +3,10 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from typing import Any, TypeVar
-
-_KT = TypeVar("_KT")
-_VT = TypeVar("_VT")
+from typing import Any
 
 
-class LimitedSizeDict(OrderedDict[_KT, _VT]):
+class LimitedSizeDict[_KT, _VT](OrderedDict[_KT, _VT]):
     """OrderedDict limited in size."""
 
     def __init__(self, *args: Any, **kwds: Any) -> None:

--- a/homeassistant/util/read_only_dict.py
+++ b/homeassistant/util/read_only_dict.py
@@ -1,6 +1,6 @@
 """Read only dictionary."""
 
-from typing import Any, TypeVar
+from typing import Any
 
 
 def _readonly(*args: Any, **kwargs: Any) -> Any:
@@ -8,11 +8,7 @@ def _readonly(*args: Any, **kwargs: Any) -> Any:
     raise RuntimeError("Cannot modify ReadOnlyDict")
 
 
-_KT = TypeVar("_KT")
-_VT = TypeVar("_VT")
-
-
-class ReadOnlyDict(dict[_KT, _VT]):
+class ReadOnlyDict[_KT, _VT](dict[_KT, _VT]):
     """Read only version of dict that is compatible with dict types."""
 
     __setitem__ = _readonly

--- a/homeassistant/util/signal_type.py
+++ b/homeassistant/util/signal_type.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Generic, TypeVarTuple
-
-_Ts = TypeVarTuple("_Ts")
+from typing import Any
 
 
 @dataclass(frozen=True)
-class _SignalTypeBase(Generic[*_Ts]):
+class _SignalTypeBase[*_Ts]:
     """Generic base class for SignalType."""
 
     name: str
@@ -30,12 +28,12 @@ class _SignalTypeBase(Generic[*_Ts]):
 
 
 @dataclass(frozen=True, eq=False)
-class SignalType(_SignalTypeBase[*_Ts]):
+class SignalType[*_Ts](_SignalTypeBase[*_Ts]):
     """Generic string class for signal to improve typing."""
 
 
 @dataclass(frozen=True, eq=False)
-class SignalTypeFormat(_SignalTypeBase[*_Ts]):
+class SignalTypeFormat[*_Ts](_SignalTypeBase[*_Ts]):
     """Generic string class for signal. Requires call to 'format' before use."""
 
     def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]:

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,7 +17,7 @@ import pathlib
 import threading
 import time
 from types import FrameType, ModuleType
-from typing import Any, NoReturn, TypeVar
+from typing import Any, NoReturn
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa: F401
@@ -199,10 +199,7 @@ def get_test_home_assistant() -> Generator[HomeAssistant, None, None]:
     loop.close()
 
 
-_T = TypeVar("_T", bound=Mapping[str, Any] | Sequence[Any])
-
-
-class StoreWithoutWriteLoad(storage.Store[_T]):
+class StoreWithoutWriteLoad[_T: (Mapping[str, Any] | Sequence[Any])](storage.Store[_T]):
     """Fake store that does not write or load. Used for testing."""
 
     async def async_save(self, *args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
## Proposed change
Use [PEP 695](https://peps.python.org/pep-0695/) for class annotations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
