### PR TITLE
Bump python-kasa to 0.7.0.dev0

### DIFF
--- a/homeassistant/components/tplink/manifest.json
+++ b/homeassistant/components/tplink/manifest.json
@@ -269,5 +269,5 @@
   "iot_class": "local_polling",
   "loggers": ["kasa"],
   "quality_scale": "platinum",
-  "requirements": ["python-kasa[speedups]==0.6.2.1"]
+  "requirements": ["python-kasa[speedups]==0.7.0.dev0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2260,7 +2260,7 @@ python-join-api==0.0.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.6.2.1
+python-kasa[speedups]==0.7.0.dev0
 
 # homeassistant.components.lirc
 # python-lirc==1.2.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1757,7 +1757,7 @@ python-izone==1.2.9
 python-juicenet==1.1.0
 
 # homeassistant.components.tplink
-python-kasa[speedups]==0.6.2.1
+python-kasa[speedups]==0.7.0.dev0
 
 # homeassistant.components.matter
 python-matter-server==5.10.0

--- a/tests/components/tplink/__init__.py
+++ b/tests/components/tplink/__init__.py
@@ -1,5 +1,6 @@
 """Tests for the TP-Link component."""
 
+from collections import namedtuple
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from kasa import (
@@ -9,12 +10,12 @@ from kasa import (
     EncryptType,
     SmartBulb,
     SmartDevice,
+    SmartDeviceException,
     SmartDimmer,
     SmartLightStrip,
     SmartPlug,
     SmartStrip,
 )
-from kasa.exceptions import SmartDeviceException
 from kasa.protocol import BaseProtocol
 
 from homeassistant.components.tplink import (
@@ -28,6 +29,8 @@ from homeassistant.components.tplink.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+
+ColorTempRange = namedtuple("ColorTempRange", ["min", "max"])
 
 MODULE = "homeassistant.components.tplink"
 MODULE_CONFIG_FLOW = "homeassistant.components.tplink.config_flow"
@@ -111,6 +114,9 @@ def _mocked_bulb(
     bulb.brightness = 50
     bulb.color_temp = 4000
     bulb.is_color = True
+    bulb.is_variable_color_temp = True
+    bulb.is_dimmable = True
+    bulb.is_brightness = True
     bulb.is_strip = False
     bulb.is_plug = False
     bulb.is_dimmer = False
@@ -120,8 +126,7 @@ def _mocked_bulb(
     bulb.effect_list = None
     bulb.hsv = (10, 30, 5)
     bulb.device_id = mac
-    bulb.valid_temperature_range.min = 4000
-    bulb.valid_temperature_range.max = 9000
+    bulb.valid_temperature_range = ColorTempRange(min=4000, max=9000)
     bulb.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     bulb.turn_off = AsyncMock()
     bulb.turn_on = AsyncMock()
@@ -152,6 +157,9 @@ def _mocked_smart_light_strip() -> SmartLightStrip:
     strip.brightness = 50
     strip.color_temp = 4000
     strip.is_color = True
+    strip.is_variable_color_temp = True
+    strip.is_dimmable = True
+    strip.is_brightness = True
     strip.is_strip = False
     strip.is_plug = False
     strip.is_dimmer = False
@@ -161,8 +169,7 @@ def _mocked_smart_light_strip() -> SmartLightStrip:
     strip.effect_list = ["Effect1", "Effect2"]
     strip.hsv = (10, 30, 5)
     strip.device_id = MAC_ADDRESS
-    strip.valid_temperature_range.min = 4000
-    strip.valid_temperature_range.max = 9000
+    strip.valid_temperature_range = ColorTempRange(min=4000, max=9000)
     strip.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     strip.turn_off = AsyncMock()
     strip.turn_on = AsyncMock()
@@ -195,8 +202,7 @@ def _mocked_dimmer() -> SmartDimmer:
     dimmer.effect_list = None
     dimmer.hsv = (10, 30, 5)
     dimmer.device_id = MAC_ADDRESS
-    dimmer.valid_temperature_range.min = 4000
-    dimmer.valid_temperature_range.max = 9000
+    dimmer.valid_temperature_range = ColorTempRange(min=4000, max=9000)
     dimmer.hw_info = {"sw_ver": "1.0.0", "hw_ver": "1.0.0"}
     dimmer.turn_off = AsyncMock()
     dimmer.turn_on = AsyncMock()

--- a/tests/components/tplink/test_init.py
+++ b/tests/components/tplink/test_init.py
@@ -7,7 +7,7 @@ from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from kasa.exceptions import AuthenticationException
+from kasa import AuthenticationException
 import pytest
 
 from homeassistant import setup


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Minimal PR to bump the dependency and update some of the tests to work with the newer api that deprecates a number of classes and attributes.  Tested to work with Kasa switches and Tapo bulbs and smart light strips.

### More info

Version 0.7.0 is a major upgrade of the python-kasa library that completes the support of a new protocol called `smart` that TP-Link have rolled out with TAPO devices and newer Kasa devices.  Support for this was partially implemented in 0.6.0 but limited to a subset of devices and features.

The intention is to integrate a series of smaller PRs into the `tplink_rewrite` branch whilst working on the library development releases. Once we have a MVP and the 0.7 library is released as production the intention is to create a single PR from the `tplink_rewrite` branch to `dev` with all the changes. The approach has been discussed with @bdraco.

@rytilahti has created a number of the smaller draft PRs already. It is unlikely these will all make the next HA release but they should allow us to ensure that the library is stable enough for the 0.7.0 production release:

- https://github.com/home-assistant/core/pull/117758
- https://github.com/home-assistant/core/pull/117759
- https://github.com/home-assistant/core/pull/117760
- https://github.com/home-assistant/core/pull/117761
- https://github.com/home-assistant/core/pull/117762
- https://github.com/home-assistant/core/pull/117764
- https://github.com/home-assistant/core/pull/117765

Release notes and full changelog: https://github.com/python-kasa/python-kasa/releases/tag/0.7.0.dev0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
