### PR TITLE
Add number entities for screenlogic values used in SI calc

### DIFF
--- a/homeassistant/components/screenlogic/number.py
+++ b/homeassistant/components/screenlogic/number.py
@@ -43,7 +43,7 @@ class ScreenLogicNumberDescription(
     """Describes a ScreenLogic number entity."""
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ScreenLogicPushNumberDescription(
     ScreenLogicNumberDescription,
     ScreenLogicPushEntityDescription,

--- a/homeassistant/components/screenlogic/number.py
+++ b/homeassistant/components/screenlogic/number.py
@@ -5,12 +5,14 @@ import logging
 
 from screenlogicpy.const.common import ScreenLogicCommunicationError, ScreenLogicError
 from screenlogicpy.const.data import ATTR, DEVICE, GROUP, VALUE
+from screenlogicpy.const.msg import CODE
 from screenlogicpy.device_const.system import EQUIPMENT_FLAG
 
 from homeassistant.components.number import (
     DOMAIN,
     NumberEntity,
     NumberEntityDescription,
+    NumberMode,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -20,7 +22,12 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN as SL_DOMAIN
 from .coordinator import ScreenlogicDataUpdateCoordinator
-from .entity import ScreenLogicEntity, ScreenLogicEntityDescription
+from .entity import (
+    ScreenLogicEntity,
+    ScreenLogicEntityDescription,
+    ScreenLogicPushEntity,
+    ScreenLogicPushEntityDescription,
+)
 from .util import cleanup_excluded_entity, get_ha_unit
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,6 +42,45 @@ class ScreenLogicNumberDescription(
 ):
     """Describes a ScreenLogic number entity."""
 
+
+@dataclass(frozen=True)
+class ScreenLogicPushNumberDescription(
+    ScreenLogicNumberDescription,
+    ScreenLogicPushEntityDescription,
+):
+    """Describes a ScreenLogic push number entity."""
+
+
+SUPPORTED_INTELLICHEM_NUMBERS = [
+    ScreenLogicPushNumberDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.CALCIUM_HARDNESS,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+    ),
+    ScreenLogicPushNumberDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.CYA,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+    ),
+    ScreenLogicPushNumberDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.TOTAL_ALKALINITY,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+    ),
+    ScreenLogicPushNumberDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.SALT_TDS_PPM,
+        entity_category=EntityCategory.CONFIG,
+        mode=NumberMode.BOX,
+    ),
+]
 
 SUPPORTED_SCG_NUMBERS = [
     ScreenLogicNumberDescription(
@@ -61,6 +107,19 @@ async def async_setup_entry(
         config_entry.entry_id
     ]
     gateway = coordinator.gateway
+
+    for chem_number_description in SUPPORTED_INTELLICHEM_NUMBERS:
+        chem_number_data_path = (
+            *chem_number_description.data_root,
+            chem_number_description.key,
+        )
+        if EQUIPMENT_FLAG.INTELLICHEM not in gateway.equipment_flags:
+            cleanup_excluded_entity(coordinator, DOMAIN, chem_number_data_path)
+            continue
+        if gateway.get_data(*chem_number_data_path):
+            entities.append(
+                ScreenLogicChemistryNumber(coordinator, chem_number_description)
+            )
 
     for scg_number_description in SUPPORTED_SCG_NUMBERS:
         scg_number_data_path = (
@@ -113,6 +172,31 @@ class ScreenLogicNumber(ScreenLogicEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         raise NotImplementedError
+
+
+class ScreenLogicPushNumber(ScreenLogicPushEntity, ScreenLogicNumber):
+    """Base class to preresent a ScreenLogic Push Number entity."""
+
+    entity_description: ScreenLogicPushNumberDescription
+
+
+class ScreenLogicChemistryNumber(ScreenLogicPushNumber):
+    """Class to represent a ScreenLogic Chemistry Number entity."""
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value."""
+
+        # Current API requires int values for the currently supported numbers.
+        value = int(value)
+
+        try:
+            await self.gateway.async_set_chem_data(**{self._data_key: value})
+        except (ScreenLogicCommunicationError, ScreenLogicError) as sle:
+            raise HomeAssistantError(
+                f"Failed to set '{self._data_key}' to {value}: {sle.msg}"
+            ) from sle
+        _LOGGER.debug("Set '%s' to %s", self._data_key, value)
+        await self._async_refresh()
 
 
 class ScreenLogicSCGNumber(ScreenLogicNumber):

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -135,32 +135,12 @@ SUPPORTED_INTELLICHEM_SENSORS = [
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
         data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
-        key=VALUE.CALCIUM_HARDNESS,
-    ),
-    ScreenLogicPushSensorDescription(
-        subscription_code=CODE.CHEMISTRY_CHANGED,
-        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
-        key=VALUE.CYA,
-    ),
-    ScreenLogicPushSensorDescription(
-        subscription_code=CODE.CHEMISTRY_CHANGED,
-        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
         key=VALUE.ORP_SETPOINT,
     ),
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
         data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
         key=VALUE.PH_SETPOINT,
-    ),
-    ScreenLogicPushSensorDescription(
-        subscription_code=CODE.CHEMISTRY_CHANGED,
-        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
-        key=VALUE.TOTAL_ALKALINITY,
-    ),
-    ScreenLogicPushSensorDescription(
-        subscription_code=CODE.CHEMISTRY_CHANGED,
-        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
-        key=VALUE.SALT_TDS_PPM,
     ),
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
@@ -218,6 +198,13 @@ SUPPORTED_SCG_SENSORS = [
         data_root=(DEVICE.SCG, GROUP.CONFIGURATION),
         key=VALUE.SUPER_CHLOR_TIMER,
     ),
+]
+
+REMOVED_SENSORS = [
+    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.CALCIUM_HARDNESS),
+    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.CYA),
+    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.TOTAL_ALKALINITY),
+    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.SALT_TDS_PPM),
 ]
 
 
@@ -288,6 +275,9 @@ async def async_setup_entry(
                 scg_sensor_description, entity_category=EntityCategory.DIAGNOSTIC
             )
             entities.append(ScreenLogicSensor(coordinator, scg_sensor_description))
+
+    for sensor_data_path in REMOVED_SENSORS:
+        cleanup_excluded_entity(coordinator, DOMAIN, sensor_data_path)
 
     async_add_entities(entities)
 

--- a/homeassistant/components/screenlogic/sensor.py
+++ b/homeassistant/components/screenlogic/sensor.py
@@ -135,12 +135,36 @@ SUPPORTED_INTELLICHEM_SENSORS = [
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
         data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.CALCIUM_HARDNESS,
+        entity_registry_enabled_default=False,  # Superseded by number entity
+    ),
+    ScreenLogicPushSensorDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.CYA,
+        entity_registry_enabled_default=False,  # Superseded by number entity
+    ),
+    ScreenLogicPushSensorDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
         key=VALUE.ORP_SETPOINT,
     ),
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
         data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
         key=VALUE.PH_SETPOINT,
+    ),
+    ScreenLogicPushSensorDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.TOTAL_ALKALINITY,
+        entity_registry_enabled_default=False,  # Superseded by number entity
+    ),
+    ScreenLogicPushSensorDescription(
+        subscription_code=CODE.CHEMISTRY_CHANGED,
+        data_root=(DEVICE.INTELLICHEM, GROUP.CONFIGURATION),
+        key=VALUE.SALT_TDS_PPM,
+        entity_registry_enabled_default=False,  # Superseded by number entity
     ),
     ScreenLogicPushSensorDescription(
         subscription_code=CODE.CHEMISTRY_CHANGED,
@@ -198,13 +222,6 @@ SUPPORTED_SCG_SENSORS = [
         data_root=(DEVICE.SCG, GROUP.CONFIGURATION),
         key=VALUE.SUPER_CHLOR_TIMER,
     ),
-]
-
-REMOVED_SENSORS = [
-    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.CALCIUM_HARDNESS),
-    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.CYA),
-    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.TOTAL_ALKALINITY),
-    (DEVICE.INTELLICHEM, GROUP.CONFIGURATION, VALUE.SALT_TDS_PPM),
 ]
 
 
@@ -275,9 +292,6 @@ async def async_setup_entry(
                 scg_sensor_description, entity_category=EntityCategory.DIAGNOSTIC
             )
             entities.append(ScreenLogicSensor(coordinator, scg_sensor_description))
-
-    for sensor_data_path in REMOVED_SENSORS:
-        cleanup_excluded_entity(coordinator, DOMAIN, sensor_data_path)
 
     async_add_entities(entities)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add number entities for:
- Calcium Hardness
- Cyanuric Acid
- Total Alkalinity
- Salt/Total Dissolved Solids (TDS)

These values are currently exposed as sensors, but are user inputs on a Pentair IntelliChem controller and enable proper calculation of the Saturation Index. This PR makes them settable in the `screenlogic` integration as well.

Previous sensor entities for these values remain, but are set to be disabled by default.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
