### PR TITLE
Consequently ignore empty MQTT state payloads and set state to `unknown` on "None" payload

### DIFF
--- a/homeassistant/components/mqtt/alarm_control_panel.py
+++ b/homeassistant/components/mqtt/alarm_control_panel.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_RETAIN,
     CONF_STATE_TOPIC,
     CONF_SUPPORTED_FEATURES,
+    PAYLOAD_NONE,
 )
 from .mixins import MqttEntity, async_setup_entity_entry_helper
 from .models import MqttCommandTemplate, MqttValueTemplate, ReceiveMessage
@@ -176,6 +177,16 @@ class MqttAlarm(MqttEntity, alarm.AlarmControlPanelEntity):
     def _state_message_received(self, msg: ReceiveMessage) -> None:
         """Run when new MQTT message has been received."""
         payload = self._value_template(msg.payload)
+        if not payload.strip():  # No output from template, ignore
+            _LOGGER.debug(
+                "Ignoring empty payload '%s' after rendering for topic %s",
+                payload,
+                msg.topic,
+            )
+            return
+        if payload == PAYLOAD_NONE:
+            self._attr_state = None
+            return
         if payload not in (
             STATE_ALARM_DISARMED,
             STATE_ALARM_ARMED_HOME,

--- a/homeassistant/components/mqtt/select.py
+++ b/homeassistant/components/mqtt/select.py
@@ -122,6 +122,13 @@ class MqttSelect(MqttEntity, SelectEntity, RestoreEntity):
         def message_received(msg: ReceiveMessage) -> None:
             """Handle new MQTT messages."""
             payload = str(self._value_template(msg.payload))
+            if not payload.strip():  # No output from template, ignore
+                _LOGGER.debug(
+                    "Ignoring empty payload '%s' after rendering for topic %s",
+                    payload,
+                    msg.topic,
+                )
+                return
             if payload.lower() == "none":
                 self._attr_current_option = None
                 return

--- a/homeassistant/components/mqtt/water_heater.py
+++ b/homeassistant/components/mqtt/water_heater.py
@@ -260,22 +260,22 @@ class MqttWaterHeater(MqttTemperatureControlEntity, WaterHeaterEntity):
     @callback
     def _handle_current_mode_received(self, msg: ReceiveMessage) -> None:
         """Handle receiving operation mode via MQTT."""
+
         payload = self.render_template(msg, CONF_MODE_STATE_TEMPLATE)
 
         if not payload.strip():  # No output from template, ignore
             _LOGGER.debug(
-                "Ignoring empty payload '%s' for attr '%s' "
+                "Ignoring empty payload '%s' for current operation "
                 "after rendering for topic %s",
                 payload,
-                attr,
                 msg.topic,
             )
             return
 
         if payload == PAYLOAD_NONE:
-            setattr(self, attr, None)
-        elif payload not in self._config[mode_list]:
-            _LOGGER.warning("Invalid %s mode: %s", mode_list, payload)
+            self._attr_current_operation = None
+        elif payload not in self._config[CONF_MODE_LIST]:
+            _LOGGER.warning("Invalid %s mode: %s", CONF_MODE_LIST, payload)
         else:
             if TYPE_CHECKING:
                 assert isinstance(payload, str)

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -209,6 +209,14 @@ async def test_update_state_via_state_topic(
         async_fire_mqtt_message(hass, "alarm/state", state)
         assert hass.states.get(entity_id).state == state
 
+    # Ignore empty payload (last state is STATE_ALARM_TRIGGERED)
+    async_fire_mqtt_message(hass, "alarm/state", "")
+    assert hass.states.get(entity_id).state == STATE_ALARM_TRIGGERED
+
+    # Reset state on `None` payload
+    async_fire_mqtt_message(hass, "alarm/state", "None")
+    assert hass.states.get(entity_id).state == STATE_UNKNOWN
+
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
 async def test_ignore_update_state_if_unknown_via_state_topic(

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -1194,7 +1194,7 @@ async def test_set_preset_mode_pessimistic(
 
     async_fire_mqtt_message(hass, "preset-mode-state", "None")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") is None
+    assert state.attributes.get("preset_mode") == "none"
 
     async_fire_mqtt_message(hass, "preset-mode-state", "home")
     state = hass.states.get(ENTITY_CLIMATE)

--- a/tests/components/mqtt/test_climate.py
+++ b/tests/components/mqtt/test_climate.py
@@ -32,7 +32,7 @@ from homeassistant.components.mqtt.climate import (
     MQTT_CLIMATE_ATTRIBUTES_BLOCKED,
     VALUE_TEMPLATE_KEYS,
 )
-from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.const import ATTR_TEMPERATURE, STATE_UNKNOWN, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
@@ -245,11 +245,11 @@ async def test_set_operation_pessimistic(
     await mqtt_mock_entry()
 
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     await common.async_set_hvac_mode(hass, "cool", ENTITY_CLIMATE)
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     async_fire_mqtt_message(hass, "mode-state", "cool")
     state = hass.states.get(ENTITY_CLIMATE)
@@ -258,6 +258,16 @@ async def test_set_operation_pessimistic(
     async_fire_mqtt_message(hass, "mode-state", "bogus mode")
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.state == "cool"
+
+    # Ignored
+    async_fire_mqtt_message(hass, "mode-state", "")
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == "cool"
+
+    # Reset with `None`
+    async_fire_mqtt_message(hass, "mode-state", "None")
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(
@@ -1011,11 +1021,7 @@ async def test_handle_action_received(
     """Test getting the action received via MQTT."""
     await mqtt_mock_entry()
 
-    # Cycle through valid modes and also check for wrong input such as "None" (str(None))
-    async_fire_mqtt_message(hass, "action", "None")
-    state = hass.states.get(ENTITY_CLIMATE)
-    hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
-    assert hvac_action is None
+    # Cycle through valid modes
     # Redefine actions according to https://developers.home-assistant.io/docs/core/entity/climate/#hvac-action
     actions = ["off", "preheating", "heating", "cooling", "drying", "idle", "fan"]
     assert all(elem in actions for elem in HVACAction)
@@ -1024,6 +1030,18 @@ async def test_handle_action_received(
         state = hass.states.get(ENTITY_CLIMATE)
         hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
         assert hvac_action == action
+
+    # Check empty payload is ignored (last action == "fan")
+    async_fire_mqtt_message(hass, "action", "")
+    state = hass.states.get(ENTITY_CLIMATE)
+    hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
+    assert hvac_action == "fan"
+
+    # Check "None" payload is resetting the action
+    async_fire_mqtt_message(hass, "action", "None")
+    state = hass.states.get(ENTITY_CLIMATE)
+    hvac_action = state.attributes.get(ATTR_HVAC_ACTION)
+    assert hvac_action is None
 
 
 @pytest.mark.parametrize("hass_config", [DEFAULT_CONFIG])
@@ -1170,9 +1188,13 @@ async def test_set_preset_mode_pessimistic(
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("preset_mode") == "comfort"
 
+    async_fire_mqtt_message(hass, "preset-mode-state", "")
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get("preset_mode") == "comfort"
+
     async_fire_mqtt_message(hass, "preset-mode-state", "None")
     state = hass.states.get(ENTITY_CLIMATE)
-    assert state.attributes.get("preset_mode") == "none"
+    assert state.attributes.get("preset_mode") is None
 
     async_fire_mqtt_message(hass, "preset-mode-state", "home")
     state = hass.states.get(ENTITY_CLIMATE)
@@ -1449,10 +1471,15 @@ async def test_get_with_templates(
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("hvac_action") == "cooling"
 
-    # Test ignoring null values
-    async_fire_mqtt_message(hass, "action", "null")
+    # Test ignoring empty values
+    async_fire_mqtt_message(hass, "action", "")
     state = hass.states.get(ENTITY_CLIMATE)
     assert state.attributes.get("hvac_action") == "cooling"
+
+    # Test resetting with null values
+    async_fire_mqtt_message(hass, "action", "null")
+    state = hass.states.get(ENTITY_CLIMATE)
+    assert state.attributes.get("hvac_action") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -123,6 +123,11 @@ async def test_state_via_state_topic(
     state = hass.states.get("cover.test")
     assert state.state == STATE_OPEN
 
+    async_fire_mqtt_message(hass, "state-topic", "None")
+
+    state = hass.states.get("cover.test")
+    assert state.state == STATE_UNKNOWN
+
 
 @pytest.mark.parametrize(
     "hass_config",

--- a/tests/components/mqtt/test_device_tracker.py
+++ b/tests/components/mqtt/test_device_tracker.py
@@ -325,6 +325,11 @@ async def test_setting_device_tracker_value_via_mqtt_message(
     state = hass.states.get("device_tracker.test")
     assert state.state == STATE_NOT_HOME
 
+    # Test an empty value is ignored and the state is retained
+    async_fire_mqtt_message(hass, "test-topic", "")
+    state = hass.states.get("device_tracker.test")
+    assert state.state == STATE_NOT_HOME
+
 
 async def test_setting_device_tracker_value_via_mqtt_message_and_template(
     hass: HomeAssistant,

--- a/tests/components/mqtt/test_lock.py
+++ b/tests/components/mqtt/test_lock.py
@@ -148,6 +148,12 @@ async def test_controlling_non_default_state_via_topic(
     state = hass.states.get("lock.test")
     assert state.state is lock_state
 
+    # Empty state is ignored
+    async_fire_mqtt_message(hass, "state-topic", "")
+
+    state = hass.states.get("lock.test")
+    assert state.state is lock_state
+
 
 @pytest.mark.parametrize(
     ("hass_config", "payload", "lock_state"),

--- a/tests/components/mqtt/test_valve.py
+++ b/tests/components/mqtt/test_valve.py
@@ -131,6 +131,11 @@ async def test_state_via_state_topic_no_position(
     state = hass.states.get("valve.test")
     assert state.state == asserted_state
 
+    async_fire_mqtt_message(hass, "state-topic", "None")
+
+    state = hass.states.get("valve.test")
+    assert state.state == STATE_UNKNOWN
+
 
 @pytest.mark.parametrize(
     "hass_config",
@@ -197,6 +202,7 @@ async def test_state_via_state_topic_with_template(
         ('{"position":100}', STATE_OPEN),
         ('{"position":50.0}', STATE_OPEN),
         ('{"position":0}', STATE_CLOSED),
+        ('{"position":null}', STATE_UNKNOWN),
         ('{"position":"non_numeric"}', STATE_UNKNOWN),
         ('{"ignored":12}', STATE_UNKNOWN),
     ],

--- a/tests/components/mqtt/test_water_heater.py
+++ b/tests/components/mqtt/test_water_heater.py
@@ -25,7 +25,12 @@ from homeassistant.components.water_heater import (
     STATE_PERFORMANCE,
     WaterHeaterEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE, STATE_OFF, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    STATE_OFF,
+    STATE_UNKNOWN,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.util.unit_conversion import TemperatureConverter
 
@@ -200,7 +205,7 @@ async def test_set_operation_pessimistic(
     await mqtt_mock_entry()
 
     state = hass.states.get(ENTITY_WATER_HEATER)
-    assert state.state == "unknown"
+    assert state.state == STATE_UNKNOWN
 
     await common.async_set_operation_mode(hass, "eco", ENTITY_WATER_HEATER)
     state = hass.states.get(ENTITY_WATER_HEATER)
@@ -213,6 +218,16 @@ async def test_set_operation_pessimistic(
     async_fire_mqtt_message(hass, "mode-state", "bogus mode")
     state = hass.states.get(ENTITY_WATER_HEATER)
     assert state.state == "eco"
+
+    # Empty state ignored
+    async_fire_mqtt_message(hass, "mode-state", "")
+    state = hass.states.get(ENTITY_WATER_HEATER)
+    assert state.state == "eco"
+
+    # Test None payload
+    async_fire_mqtt_message(hass, "mode-state", "None")
+    state = hass.states.get(ENTITY_WATER_HEATER)
+    assert state.state == STATE_UNKNOWN
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The behavior on processing  empty and `"None"` state payloads for MQTT entities has been made more predictable for `alarm_control_panel`, `climate`, `cover`, `device_tracker`, `lock`, `select`, `valve` and `water_heater` items,
- A "None" (str) for a state payload generally means that the state becomes `unknown`.
- An empty payload is ignored.

Previously a "None" state could be considered invalid or was just ignored.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See also breaking change section. The handling of empty payloads and payloads rendering to "None" are handled more consequently now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #117597
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32864

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
