### PR TITLE
Bump aioautomower to 2024.5.1

### DIFF
--- a/homeassistant/components/husqvarna_automower/manifest.json
+++ b/homeassistant/components/husqvarna_automower/manifest.json
@@ -7,5 +7,5 @@
   "documentation": "https://www.home-assistant.io/integrations/husqvarna_automower",
   "iot_class": "cloud_push",
   "loggers": ["aioautomower"],
-  "requirements": ["aioautomower==2024.5.0"]
+  "requirements": ["aioautomower==2024.5.1"]
 }

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -30,8 +30,8 @@ def _async_get_cutting_height(data: MowerAttributes) -> int:
     """Return the cutting height."""
     if TYPE_CHECKING:
         # Sensor does not get created if it is None
-        assert data.cutting_height is not None
-    return data.cutting_height
+        assert data.settings.cutting_height is not None
+    return data.settings.cutting_height
 
 
 @callback
@@ -84,7 +84,7 @@ NUMBER_TYPES: tuple[AutomowerNumberEntityDescription, ...] = (
         entity_category=EntityCategory.CONFIG,
         native_min_value=1,
         native_max_value=9,
-        exists_fn=lambda data: data.cutting_height is not None,
+        exists_fn=lambda data: data.settings.cutting_height is not None,
         value_fn=_async_get_cutting_height,
         set_value_fn=async_set_cutting_height,
     ),

--- a/homeassistant/components/husqvarna_automower/select.py
+++ b/homeassistant/components/husqvarna_automower/select.py
@@ -59,7 +59,9 @@ class AutomowerSelectEntity(AutomowerControlEntity, SelectEntity):
     @property
     def current_option(self) -> str:
         """Return the current option for the entity."""
-        return cast(HeadlightModes, self.mower_attributes.headlight.mode).lower()
+        return cast(
+            HeadlightModes, self.mower_attributes.settings.headlight.mode
+        ).lower()
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -201,7 +201,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.5.0
+aioautomower==2024.5.1
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -180,7 +180,7 @@ aioaseko==0.1.1
 aioasuswrt==1.4.0
 
 # homeassistant.components.husqvarna_automower
-aioautomower==2024.5.0
+aioautomower==2024.5.1
 
 # homeassistant.components.azure_devops
 aioazuredevops==2.0.0

--- a/tests/components/husqvarna_automower/fixtures/mower.json
+++ b/tests/components/husqvarna_automower/fixtures/mower.json
@@ -157,9 +157,11 @@
             }
           ]
         },
-        "cuttingHeight": 4,
-        "headlight": {
-          "mode": "EVENING_ONLY"
+        "settings": {
+          "cuttingHeight": 4,
+          "headlight": {
+            "mode": "EVENING_ONLY"
+          }
         }
       }
     }

--- a/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
+++ b/tests/components/husqvarna_automower/snapshots/test_diagnostics.ambr
@@ -54,10 +54,6 @@
       'stay_out_zones': True,
       'work_areas': True,
     }),
-    'cutting_height': 4,
-    'headlight': dict({
-      'mode': 'EVENING_ONLY',
-    }),
     'metadata': dict({
       'connected': True,
       'status_dateteime': '2023-10-18T22:58:52.683000+00:00',
@@ -80,6 +76,12 @@
       'restricted_reason': 'WEEK_SCHEDULE',
     }),
     'positions': '**REDACTED**',
+    'settings': dict({
+      'cutting_height': 4,
+      'headlight': dict({
+        'mode': 'EVENING_ONLY',
+      }),
+    }),
     'statistics': dict({
       'cutting_blade_usage_time': 123,
       'number_of_charging_cycles': 1380,

--- a/tests/components/husqvarna_automower/test_select.py
+++ b/tests/components/husqvarna_automower/test_select.py
@@ -46,7 +46,7 @@ async def test_select_states(
         (HeadlightModes.ALWAYS_ON, "always_on"),
         (HeadlightModes.EVENING_AND_NIGHT, "evening_and_night"),
     ]:
-        values[TEST_MOWER_ID].headlight.mode = state
+        values[TEST_MOWER_ID].settings.headlight.mode = state
         mock_automower_client.get_status.return_value = values
         freezer.tick(SCAN_INTERVAL)
         async_fire_time_changed(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump aioautomower to 2024.5.1
Release notes: https://github.com/Thomas55555/aioautomower/releases/tag/2024.5.1
Changelog: https://github.com/Thomas55555/aioautomower/compare/2024.5.0...2024.5.1

This avoids false positive reauth, which were produced by "unauthorized" response. Exception changed here: https://github.com/Thomas55555/aioautomower/pull/313
```
2024-05-20 17:54:16.779 ERROR (MainThread) [custom_components.husqvarna_automower.coordinator] Authentication failed while fetching husqvarna_automower data: Unable to authenticate with API: 401, message='Unauthorized', url=URL('https://api.amc.husqvarna.dev/v1/mowers/')
2024-05-20 17:54:16.780 DEBUG (MainThread) [custom_components.husqvarna_automower.coordinator] Finished fetching husqvarna_automower data in 10.160 seconds (success: False)
2024-05-20 18:00:06.857 DEBUG (MainThread) [aioautomower.session] Got status-event, data: {'id': ...
2024-05-20 18:00:06.873 DEBUG (MainThread) [aioautomower.session] Got positions-event, data: {'id': '...
2024-05-20 18:00:06.874 DEBUG (MainThread) [custom_components.husqvarna_automower.coordinator] Manually updated husqvarna_automower data
2024-05-20 18:08:06.620 DEBUG (MainThread) [aioautomower.auth] request[get]=https://api.amc.husqvarna.dev/v1/mowers/ None
2024-05-20 18:08:06.985 DEBUG (MainThread) [aioautomower.auth] response={'data': [{'type': 'mower', 'id': .....
``` 
Candidate for next patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
