### PR TITLE
Remove @ from codeowners when downloading diagnostics

### DIFF
--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -173,7 +173,7 @@ def async_format_manifest(manifest: Manifest) -> Manifest:
     manifest_copy = manifest.copy()
     if "codeowners" in manifest_copy:
         manifest_copy["codeowners"] = [
-            codeowner.replace("@", "") for codeowner in manifest_copy["codeowners"]
+            codeowner.lstrip("@") for codeowner in manifest_copy["codeowners"]
         ]
     return manifest_copy
 

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -23,7 +23,11 @@ from homeassistant.helpers.json import (
 )
 from homeassistant.helpers.system_info import async_get_system_info
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.loader import async_get_custom_components, async_get_integration
+from homeassistant.loader import (
+    Manifest,
+    async_get_custom_components,
+    async_get_integration,
+)
 from homeassistant.setup import async_get_domain_setup_times
 from homeassistant.util.json import format_unserializable_data
 
@@ -157,6 +161,23 @@ def handle_get(
     )
 
 
+@callback
+def async_format_manifest(manifest: Manifest) -> Manifest:
+    """Format manifest for diagnostics.
+
+    Remove the @ from codeowners so that
+    when users download the diagnostics and paste
+    the codeowners into the repository, it will
+    not notify the users in the codeowners file.
+    """
+    manifest_copy = manifest.copy()
+    if "codeowners" in manifest_copy:
+        manifest_copy["codeowners"] = [
+            codeowner.replace("@", "") for codeowner in manifest_copy["codeowners"]
+        ]
+    return manifest_copy
+
+
 async def _async_get_json_file_response(
     hass: HomeAssistant,
     data: Mapping[str, Any],
@@ -182,7 +203,7 @@ async def _async_get_json_file_response(
     payload = {
         "home_assistant": hass_sys_info,
         "custom_components": custom_components,
-        "integration_manifest": integration.manifest,
+        "integration_manifest": async_format_manifest(integration.manifest),
         "setup_times": async_get_domain_setup_times(hass, domain),
         "data": data,
     }

--- a/tests/components/diagnostics/test_init.py
+++ b/tests/components/diagnostics/test_init.py
@@ -1,7 +1,7 @@
 """Test the Diagnostics integration."""
 
 from http import HTTPStatus
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -9,6 +9,7 @@ from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import async_get
 from homeassistant.helpers.system_info import async_get_system_info
+from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
 from . import _get_diagnostics_for_config_entry, _get_diagnostics_for_device
@@ -90,8 +91,14 @@ async def test_download_diagnostics(
     hass_sys_info = await async_get_system_info(hass)
     hass_sys_info["run_as_root"] = hass_sys_info["user"] == "root"
     del hass_sys_info["user"]
-
-    assert await _get_diagnostics_for_config_entry(hass, hass_client, config_entry) == {
+    integration = await async_get_integration(hass, "fake_integration")
+    original_manifest = integration.manifest.copy()
+    original_manifest["codeowners"] = ["@test"]
+    with patch.object(integration, "manifest", original_manifest):
+        response = await _get_diagnostics_for_config_entry(
+            hass, hass_client, config_entry
+        )
+    assert response == {
         "home_assistant": hass_sys_info,
         "setup_times": {},
         "custom_components": {
@@ -162,7 +169,7 @@ async def test_download_diagnostics(
             },
         },
         "integration_manifest": {
-            "codeowners": [],
+            "codeowners": ["test"],
             "dependencies": [],
             "domain": "fake_integration",
             "is_built_in": True,


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Its common for diagnostics to get pasted into a github issue which notifies all the codeowners because the codeowners field has an @ in front of each github user. Since the bot already does this we do not want to keep pinging codeowners as new diagnostics are added to an issue.

I'm not sure how much this affects others, but I get 4-5 unintentional GitHub or forums pings a day (sometimes a lot more) because of users pasting in the whole diagnostics payload without realizing it will notify all the codeowners because they are embedded in the JSON output.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
