### PR TITLE
Adopt new runtime entry data model for AlarmDecoder

### DIFF
--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -1,5 +1,7 @@
 """Support for AlarmDecoder devices."""
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import timedelta
 import logging
 
@@ -22,11 +24,6 @@ from homeassistant.helpers.event import async_call_later
 from .const import (
     CONF_DEVICE_BAUD,
     CONF_DEVICE_PATH,
-    DATA_AD,
-    DATA_REMOVE_STOP_LISTENER,
-    DATA_REMOVE_UPDATE_LISTENER,
-    DATA_RESTART,
-    DOMAIN,
     PROTOCOL_SERIAL,
     PROTOCOL_SOCKET,
     SIGNAL_PANEL_MESSAGE,
@@ -44,8 +41,22 @@ PLATFORMS = [
     Platform.SENSOR,
 ]
 
+type AlarmDecoderConfigEntry = ConfigEntry["AlarmDecoderData"]
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+
+@dataclass
+class AlarmDecoderData:
+    """Runtime data for the AlarmDecoder class."""
+
+    client: AdExt
+    remove_update_listener: Callable[[], None]
+    remove_stop_listener: Callable[[], None]
+    restart: bool
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: AlarmDecoderConfigEntry
+) -> bool:
     """Set up AlarmDecoder config flow."""
     undo_listener = entry.add_update_listener(_update_listener)
 
@@ -54,10 +65,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     def stop_alarmdecoder(event):
         """Handle the shutdown of AlarmDecoder."""
-        if not hass.data.get(DOMAIN):
+        if not entry.runtime_data:
             return
         _LOGGER.debug("Shutting down alarmdecoder")
-        hass.data[DOMAIN][entry.entry_id][DATA_RESTART] = False
+        entry.runtime_data.restart = False
         controller.close()
 
     async def open_connection(now=None):
@@ -69,13 +80,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             async_call_later(hass, timedelta(seconds=5), open_connection)
             return
         _LOGGER.debug("Established a connection with the alarmdecoder")
-        hass.data[DOMAIN][entry.entry_id][DATA_RESTART] = True
+        entry.runtime_data.restart = True
 
     def handle_closed_connection(event):
         """Restart after unexpected loss of connection."""
-        if not hass.data[DOMAIN][entry.entry_id][DATA_RESTART]:
+        if not entry.runtime_data.restart:
             return
-        hass.data[DOMAIN][entry.entry_id][DATA_RESTART] = False
+        entry.runtime_data.restart = False
         _LOGGER.warning("AlarmDecoder unexpectedly lost connection")
         hass.add_job(open_connection)
 
@@ -119,13 +130,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         EVENT_HOMEASSISTANT_STOP, stop_alarmdecoder
     )
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_AD: controller,
-        DATA_REMOVE_UPDATE_LISTENER: undo_listener,
-        DATA_REMOVE_STOP_LISTENER: remove_stop_listener,
-        DATA_RESTART: False,
-    }
+    entry.runtime_data = AlarmDecoderData(
+        controller, undo_listener, remove_stop_listener, False
+    )
 
     await open_connection()
 
@@ -136,28 +143,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(
+    hass: HomeAssistant, entry: AlarmDecoderConfigEntry
+) -> bool:
     """Unload a AlarmDecoder entry."""
-    hass.data[DOMAIN][entry.entry_id][DATA_RESTART] = False
+    data = entry.runtime_data
+    data.restart = False
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if not unload_ok:
         return False
 
-    hass.data[DOMAIN][entry.entry_id][DATA_REMOVE_UPDATE_LISTENER]()
-    hass.data[DOMAIN][entry.entry_id][DATA_REMOVE_STOP_LISTENER]()
-    await hass.async_add_executor_job(hass.data[DOMAIN][entry.entry_id][DATA_AD].close)
-
-    if hass.data[DOMAIN][entry.entry_id]:
-        hass.data[DOMAIN].pop(entry.entry_id)
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
+    data.remove_update_listener()
+    data.remove_stop_listener()
+    await hass.async_add_executor_job(data.client.close)
 
     return True
 
 
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _update_listener(hass: HomeAssistant, entry: AlarmDecoderConfigEntry) -> None:
     """Handle options update."""
     _LOGGER.debug("AlarmDecoder options updated: %s", entry.as_dict()["options"])
     await hass.config_entries.async_reload(entry.entry_id)

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -41,7 +41,7 @@ PLATFORMS = [
     Platform.SENSOR,
 ]
 
-type AlarmDecoderConfigEntry = ConfigEntry["AlarmDecoderData"]
+type AlarmDecoderConfigEntry = ConfigEntry[AlarmDecoderData]
 
 
 @dataclass

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -9,7 +9,6 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntityFeature,
     CodeFormat,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CODE,
     STATE_ALARM_ARMED_AWAY,
@@ -24,13 +23,12 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import AlarmDecoderConfigEntry
 from .const import (
     CONF_ALT_NIGHT_MODE,
     CONF_AUTO_BYPASS,
     CONF_CODE_ARM_REQUIRED,
-    DATA_AD,
     DEFAULT_ARM_OPTIONS,
-    DOMAIN,
     OPTIONS_ARM,
     SIGNAL_PANEL_MESSAGE,
 )
@@ -43,12 +41,14 @@ ATTR_KEYPRESS = "keypress"
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: AlarmDecoderConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up for AlarmDecoder alarm panels."""
     options = entry.options
     arm_options = options.get(OPTIONS_ARM, DEFAULT_ARM_OPTIONS)
-    client = hass.data[DOMAIN][entry.entry_id][DATA_AD]
+    client = entry.runtime_data.client
 
     entity = AlarmDecoderAlarmPanel(
         client=client,

--- a/homeassistant/components/alarmdecoder/alarm_control_panel.py
+++ b/homeassistant/components/alarmdecoder/alarm_control_panel.py
@@ -48,10 +48,9 @@ async def async_setup_entry(
     """Set up for AlarmDecoder alarm panels."""
     options = entry.options
     arm_options = options.get(OPTIONS_ARM, DEFAULT_ARM_OPTIONS)
-    client = entry.runtime_data.client
 
     entity = AlarmDecoderAlarmPanel(
-        client=client,
+        client=entry.runtime_data.client,
         auto_bypass=arm_options[CONF_AUTO_BYPASS],
         code_arm_required=arm_options[CONF_CODE_ARM_REQUIRED],
         alt_night_mode=arm_options[CONF_ALT_NIGHT_MODE],

--- a/homeassistant/components/alarmdecoder/binary_sensor.py
+++ b/homeassistant/components/alarmdecoder/binary_sensor.py
@@ -3,11 +3,11 @@
 import logging
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import AlarmDecoderConfigEntry
 from .const import (
     CONF_RELAY_ADDR,
     CONF_RELAY_CHAN,
@@ -16,9 +16,7 @@ from .const import (
     CONF_ZONE_NUMBER,
     CONF_ZONE_RFID,
     CONF_ZONE_TYPE,
-    DATA_AD,
     DEFAULT_ZONE_OPTIONS,
-    DOMAIN,
     OPTIONS_ZONES,
     SIGNAL_REL_MESSAGE,
     SIGNAL_RFX_MESSAGE,
@@ -40,11 +38,13 @@ ATTR_RF_LOOP1 = "rf_loop1"
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: AlarmDecoderConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up for AlarmDecoder sensor."""
 
-    client = hass.data[DOMAIN][entry.entry_id][DATA_AD]
+    client = entry.runtime_data.client
     zones = entry.options.get(OPTIONS_ZONES, DEFAULT_ZONE_OPTIONS)
 
     entities = []

--- a/homeassistant/components/alarmdecoder/const.py
+++ b/homeassistant/components/alarmdecoder/const.py
@@ -13,11 +13,6 @@ CONF_ZONE_NUMBER = "zone_number"
 CONF_ZONE_RFID = "zone_rfid"
 CONF_ZONE_TYPE = "zone_type"
 
-DATA_AD = "alarmdecoder"
-DATA_REMOVE_STOP_LISTENER = "rm_stop_listener"
-DATA_REMOVE_UPDATE_LISTENER = "rm_update_listener"
-DATA_RESTART = "restart"
-
 DEFAULT_ALT_NIGHT_MODE = False
 DEFAULT_AUTO_BYPASS = False
 DEFAULT_CODE_ARM_REQUIRED = True

--- a/homeassistant/components/alarmdecoder/sensor.py
+++ b/homeassistant/components/alarmdecoder/sensor.py
@@ -1,21 +1,23 @@
 """Support for AlarmDecoder sensors (Shows Panel Display)."""
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_AD, DOMAIN, SIGNAL_PANEL_MESSAGE
+from . import AlarmDecoderConfigEntry
+from .const import SIGNAL_PANEL_MESSAGE
 from .entity import AlarmDecoderEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: AlarmDecoderConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up for AlarmDecoder sensor."""
 
-    client = hass.data[DOMAIN][entry.entry_id][DATA_AD]
+    client = entry.runtime_data.client
     entity = AlarmDecoderSensor(client=client)
     async_add_entities([entity])
 

--- a/homeassistant/components/alarmdecoder/sensor.py
+++ b/homeassistant/components/alarmdecoder/sensor.py
@@ -17,8 +17,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up for AlarmDecoder sensor."""
 
-    client = entry.runtime_data.client
-    entity = AlarmDecoderSensor(client=client)
+    entity = AlarmDecoderSensor(client=entry.runtime_data.client)
     async_add_entities([entity])
 
 


### PR DESCRIPTION
Transition the AlarmDecoder integration to the new runtime entry model.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Transitions the AlarmDecoder integration to the new runtime_data entry model and moves away from hass.data

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/](https://developers.home-assistant.io/blog/2024/04/30/store-runtime-data-inside-config-entry/)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
