### PR TITLE
Simplify SkyConnect setup flow

### DIFF
--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -538,17 +538,7 @@ class HomeAssistantSkyConnectConfigFlow(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm a discovery."""
-        self._set_confirm_only()
-
-        # Without confirmation, discovery can automatically progress into parts of the
-        # config flow logic that interacts with hardware.
-        if user_input is not None:
-            return await self.async_step_pick_firmware()
-
-        return self.async_show_form(
-            step_id="confirm",
-            description_placeholders=self._get_translation_placeholders(),
-        )
+        return await self.async_step_pick_firmware()
 
     def _async_flow_finished(self) -> ConfigFlowResult:
         """Create the config entry."""

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -670,17 +670,16 @@ class HomeAssistantSkyConnectOptionsFlowHandler(
         """Pick Thread firmware."""
         assert self._usb_info is not None
 
-        zha_entries = self.hass.config_entries.async_entries(
+        for zha_entry in self.hass.config_entries.async_entries(
             ZHA_DOMAIN,
             include_ignore=False,
             include_disabled=True,
-        )
-
-        if zha_entries and get_zha_device_path(zha_entries[0]) == self._usb_info.device:
-            raise AbortFlow(
-                "zha_still_using_stick",
-                description_placeholders=self._get_translation_placeholders(),
-            )
+        ):
+            if get_zha_device_path(zha_entry) == self._usb_info.device:
+                raise AbortFlow(
+                    "zha_still_using_stick",
+                    description_placeholders=self._get_translation_placeholders(),
+                )
 
         return await super().async_step_pick_firmware_thread(user_input)
 

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -641,15 +641,7 @@ class HomeAssistantSkyConnectOptionsFlowHandler(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options flow."""
-        # Don't probe the running firmware, we load it from the config entry
-        return self.async_show_menu(
-            step_id="pick_firmware",
-            menu_options=[
-                STEP_PICK_FIRMWARE_THREAD,
-                STEP_PICK_FIRMWARE_ZIGBEE,
-            ],
-            description_placeholders=self._get_translation_placeholders(),
-        )
+        return await self.async_step_pick_firmware()
 
     async def async_step_pick_firmware_zigbee(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/homeassistant_sky_connect/config_flow.py
+++ b/homeassistant/components/homeassistant_sky_connect/config_flow.py
@@ -124,8 +124,8 @@ class BaseFirmwareInstallFlow(ConfigEntryBaseFlow, ABC):
         return self.async_show_menu(
             step_id="pick_firmware",
             menu_options=[
-                STEP_PICK_FIRMWARE_THREAD,
                 STEP_PICK_FIRMWARE_ZIGBEE,
+                STEP_PICK_FIRMWARE_THREAD,
             ],
             description_placeholders=self._get_translation_placeholders(),
         )

--- a/homeassistant/components/homeassistant_sky_connect/strings.json
+++ b/homeassistant/components/homeassistant_sky_connect/strings.json
@@ -58,10 +58,6 @@
         "title": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::start_flasher_addon::title%]",
         "description": "[%key:component::homeassistant_hardware::silabs_multiprotocol_hardware::options::step::start_flasher_addon::description%]"
       },
-      "confirm": {
-        "title": "[%key:component::homeassistant_sky_connect::config::step::confirm::title%]",
-        "description": "[%key:component::homeassistant_sky_connect::config::step::confirm::description%]"
-      },
       "pick_firmware": {
         "title": "[%key:component::homeassistant_sky_connect::config::step::pick_firmware::title%]",
         "description": "[%key:component::homeassistant_sky_connect::config::step::pick_firmware::description%]",
@@ -131,16 +127,12 @@
   "config": {
     "flow_title": "{model}",
     "step": {
-      "confirm": {
-        "title": "Set up the {model}",
-        "description": "The {model} can be used as either a Thread border router or a Zigbee coordinator. In the next step, you will choose which firmware will be configured."
-      },
       "pick_firmware": {
         "title": "Pick your firmware",
-        "description": "The {model} can be used as a Thread border router or a Zigbee coordinator.",
+        "description": "Let's get started with setting up your {model}. Do you want to use it to set up a Zigbee or Thread network?",
         "menu_options": {
-          "pick_firmware_thread": "Use as a Thread border router",
-          "pick_firmware_zigbee": "Use as a Zigbee coordinator"
+          "pick_firmware_zigbee": "Zigbee",
+          "pick_firmware_thread": "Thread"
         }
       },
       "install_zigbee_flasher_addon": {

--- a/tests/components/homeassistant_sky_connect/test_config_flow.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
+import contextlib
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call, patch
 
@@ -57,6 +58,77 @@ def delayed_side_effect() -> Callable[..., Awaitable[None]]:
     return side_effect
 
 
+@contextlib.contextmanager
+def mock_addon_info(
+    hass: HomeAssistant,
+    *,
+    is_hassio: bool = True,
+    app_type: ApplicationType = ApplicationType.EZSP,
+    otbr_addon_info: AddonInfo = AddonInfo(
+        available=True,
+        hostname=None,
+        options={},
+        state=AddonState.NOT_INSTALLED,
+        update_available=False,
+        version=None,
+    ),
+    flasher_addon_info: AddonInfo = AddonInfo(
+        available=True,
+        hostname=None,
+        options={},
+        state=AddonState.NOT_INSTALLED,
+        update_available=False,
+        version=None,
+    ),
+):
+    """Mock the main addon states for the config flow."""
+    mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
+    mock_flasher_manager.addon_name = "Silicon Labs Flasher"
+    mock_flasher_manager.async_start_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_flasher_manager.async_install_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_flasher_manager.async_uninstall_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_flasher_manager.async_get_addon_info.return_value = flasher_addon_info
+
+    mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
+    mock_otbr_manager.addon_name = "OpenThread Border Router"
+    mock_otbr_manager.async_install_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_otbr_manager.async_uninstall_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_otbr_manager.async_start_addon_waiting = AsyncMock(
+        side_effect=delayed_side_effect()
+    )
+    mock_otbr_manager.async_get_addon_info.return_value = otbr_addon_info
+
+    with (
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.get_otbr_addon_manager",
+            return_value=mock_otbr_manager,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.get_zigbee_flasher_addon_manager",
+            return_value=mock_flasher_manager,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
+            return_value=is_hassio,
+        ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=app_type,
+        ),
+    ):
+        yield mock_otbr_manager, mock_flasher_manager
+
+
 @pytest.mark.parametrize(
     ("usb_data", "model"),
     [
@@ -75,42 +147,10 @@ async def test_config_flow_zigbee(
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
 
-    # Set up Zigbee firmware
-    mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
-    mock_flasher_manager.async_install_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_flasher_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_flasher_manager.async_uninstall_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_zigbee_flasher_addon_manager",
-            return_value=mock_flasher_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.SPINEL,  # Ensure we re-install it
-        ),
-    ):
-        mock_flasher_manager.addon_name = "Silicon Labs Flasher"
-        mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
-            available=True,
-            hostname=None,
-            options={},
-            state=AddonState.NOT_INSTALLED,
-            update_available=False,
-            version=None,
-        )
-
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.SPINEL,
+    ) as (mock_otbr_manager, mock_flasher_manager):
         # Pick the menu option: we are now installing the addon
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -200,31 +240,10 @@ async def test_config_flow_zigbee_skip_step_if_installed(
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
 
-    # Set up Zigbee firmware
-    mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
-    mock_flasher_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_flasher_manager.async_uninstall_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_zigbee_flasher_addon_manager",
-            return_value=mock_flasher_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.SPINEL,  # Ensure we re-install it
-        ),
-    ):
-        mock_flasher_manager.addon_name = "Silicon Labs Flasher"
-        mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.SPINEL,
+        flasher_addon_info=AddonInfo(
             available=True,
             hostname=None,
             options={
@@ -236,8 +255,8 @@ async def test_config_flow_zigbee_skip_step_if_installed(
             state=AddonState.NOT_RUNNING,
             update_available=False,
             version="1.2.3",
-        )
-
+        ),
+    ) as (mock_otbr_manager, mock_flasher_manager):
         # Pick the menu option: we skip installation, instead we directly run it
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -288,39 +307,10 @@ async def test_config_flow_thread(
     assert result["type"] is FlowResultType.MENU
     assert result["step_id"] == "pick_firmware"
 
-    # Set up Thread firmware
-    mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
-    mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_otbr_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_otbr_addon_manager",
-            return_value=mock_otbr_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.EZSP,
-        ),
-    ):
-        mock_otbr_manager.addon_name = "OpenThread Border Router"
-        mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-            available=True,
-            hostname=None,
-            options={},
-            state=AddonState.NOT_INSTALLED,
-            update_available=False,
-            version=None,
-        )
-
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.EZSP,
+    ) as (mock_otbr_manager, mock_flasher_manager):
         # Pick the menu option
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -407,37 +397,18 @@ async def test_config_flow_thread_addon_already_installed(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
-    mock_otbr_manager.addon_name = "OpenThread Border Router"
-    mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_otbr_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-        available=True,
-        hostname=None,
-        options={},
-        state=AddonState.NOT_RUNNING,
-        update_available=False,
-        version=None,
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_otbr_addon_manager",
-            return_value=mock_otbr_manager,
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.EZSP,
+        otbr_addon_info=AddonInfo(
+            available=True,
+            hostname=None,
+            options={},
+            state=AddonState.NOT_RUNNING,
+            update_available=False,
+            version=None,
         ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.EZSP,
-        ),
-    ):
+    ) as (mock_otbr_manager, mock_flasher_manager):
         # Pick the menu option
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -485,16 +456,11 @@ async def test_config_flow_zigbee_not_hassio(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=False,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.EZSP,
-        ),
-    ):
+    with mock_addon_info(
+        hass,
+        is_hassio=False,
+        app_type=ApplicationType.EZSP,
+    ) as (mock_otbr_manager, mock_flasher_manager):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -565,39 +531,10 @@ async def test_options_flow_zigbee_to_thread(
     assert result["description_placeholders"]["firmware_type"] == "ezsp"
     assert result["description_placeholders"]["model"] == model
 
-    # Pick Thread
-    mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
-    mock_otbr_manager.async_install_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_otbr_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_otbr_addon_manager",
-            return_value=mock_otbr_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.EZSP,
-        ),
-    ):
-        mock_otbr_manager.addon_name = "OpenThread Border Router"
-        mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-            available=True,
-            hostname=None,
-            options={},
-            state=AddonState.NOT_INSTALLED,
-            update_available=False,
-            version=None,
-        )
-
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.EZSP,
+    ) as (mock_otbr_manager, mock_flasher_manager):
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -695,57 +632,10 @@ async def test_options_flow_thread_to_zigbee(
     assert result["description_placeholders"]["firmware_type"] == "spinel"
     assert result["description_placeholders"]["model"] == model
 
-    # Set up Zigbee firmware
-    mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
-    mock_flasher_manager.async_install_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_flasher_manager.async_start_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-    mock_flasher_manager.async_uninstall_addon_waiting = AsyncMock(
-        side_effect=delayed_side_effect()
-    )
-
-    # OTBR is not installed
-    mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
-    mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
-        available=True,
-        hostname=None,
-        options={},
-        state=AddonState.NOT_INSTALLED,
-        update_available=False,
-        version=None,
-    )
-
-    with (
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_zigbee_flasher_addon_manager",
-            return_value=mock_flasher_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.get_otbr_addon_manager",
-            return_value=mock_otbr_manager,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
-            return_value=True,
-        ),
-        patch(
-            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-            return_value=ApplicationType.SPINEL,
-        ),
-    ):
-        mock_flasher_manager.addon_name = "Silicon Labs Flasher"
-        mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
-            available=True,
-            hostname=None,
-            options={},
-            state=AddonState.NOT_INSTALLED,
-            update_available=False,
-            version=None,
-        )
-
+    with mock_addon_info(
+        hass,
+        app_type=ApplicationType.SPINEL,
+    ) as (mock_otbr_manager, mock_flasher_manager):
         # Pick the menu option: we are now installing the addon
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],

--- a/tests/components/homeassistant_sky_connect/test_config_flow_failures.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow_failures.py
@@ -48,9 +48,9 @@ async def test_config_flow_cannot_probe_firmware(
             DOMAIN, context={"source": "usb"}, data=usb_data
         )
 
-        # Probing fails
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
+            result["flow_id"],
+            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
         )
 
         assert result["type"] == FlowResultType.ABORT
@@ -71,20 +71,20 @@ async def test_config_flow_zigbee_not_hassio_wrong_firmware(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     with (
         patch(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=False,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -107,14 +107,6 @@ async def test_config_flow_zigbee_flasher_addon_already_running(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
     mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
@@ -135,7 +127,15 @@ async def test_config_flow_zigbee_flasher_addon_already_running(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -160,14 +160,6 @@ async def test_config_flow_zigbee_flasher_addon_info_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
     mock_flasher_manager.async_get_addon_info.side_effect = AddonError()
@@ -181,7 +173,14 @@ async def test_config_flow_zigbee_flasher_addon_info_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -206,14 +205,6 @@ async def test_config_flow_zigbee_flasher_addon_install_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
     mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
@@ -237,7 +228,15 @@ async def test_config_flow_zigbee_flasher_addon_install_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -261,14 +260,6 @@ async def test_config_flow_zigbee_flasher_addon_set_config_fails(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
-
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
 
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
@@ -294,7 +285,14 @@ async def test_config_flow_zigbee_flasher_addon_set_config_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -321,14 +319,6 @@ async def test_config_flow_zigbee_flasher_run_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
     mock_flasher_manager.async_get_addon_info.return_value = AddonInfo(
@@ -353,7 +343,14 @@ async def test_config_flow_zigbee_flasher_run_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -379,14 +376,6 @@ async def test_config_flow_zigbee_flasher_uninstall_fails(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
-
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.SPINEL,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
 
     mock_flasher_manager = Mock(spec_set=get_zigbee_flasher_addon_manager(hass))
     mock_flasher_manager.addon_name = "Silicon Labs Flasher"
@@ -417,7 +406,14 @@ async def test_config_flow_zigbee_flasher_uninstall_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.SPINEL,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
@@ -448,20 +444,20 @@ async def test_config_flow_thread_not_hassio(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     with (
         patch(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=False,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -484,14 +480,6 @@ async def test_config_flow_thread_addon_info_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
     mock_otbr_manager.async_get_addon_info.side_effect = AddonError()
@@ -505,7 +493,14 @@ async def test_config_flow_thread_addon_info_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -530,14 +525,6 @@ async def test_config_flow_thread_addon_already_running(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
     mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
@@ -559,7 +546,14 @@ async def test_config_flow_thread_addon_already_running(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -584,14 +578,6 @@ async def test_config_flow_thread_addon_install_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
     mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
@@ -613,7 +599,14 @@ async def test_config_flow_thread_addon_install_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -637,14 +630,6 @@ async def test_config_flow_thread_addon_set_config_fails(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
-
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
 
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
@@ -670,7 +655,14 @@ async def test_config_flow_thread_addon_set_config_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -697,14 +689,6 @@ async def test_config_flow_thread_flasher_run_fails(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
 
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
-
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
     mock_otbr_manager.async_get_addon_info.return_value = AddonInfo(
@@ -729,7 +713,14 @@ async def test_config_flow_thread_flasher_run_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},
@@ -755,14 +746,6 @@ async def test_config_flow_thread_flasher_uninstall_fails(
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "usb"}, data=usb_data
     )
-
-    with patch(
-        "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
-        return_value=ApplicationType.EZSP,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={}
-        )
 
     mock_otbr_manager = Mock(spec_set=get_otbr_addon_manager(hass))
     mock_otbr_manager.addon_name = "OpenThread Border Router"
@@ -793,7 +776,14 @@ async def test_config_flow_thread_flasher_uninstall_fails(
             "homeassistant.components.homeassistant_sky_connect.config_flow.is_hassio",
             return_value=True,
         ),
+        patch(
+            "homeassistant.components.homeassistant_sky_connect.config_flow.probe_silabs_firmware_type",
+            return_value=ApplicationType.EZSP,
+        ),
     ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
+        )
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"next_step_id": STEP_PICK_FIRMWARE_THREAD},

--- a/tests/components/homeassistant_sky_connect/test_config_flow_failures.py
+++ b/tests/components/homeassistant_sky_connect/test_config_flow_failures.py
@@ -25,13 +25,14 @@ from tests.common import MockConfigEntry
 
 
 @pytest.mark.parametrize(
-    ("usb_data", "model"),
+    ("usb_data", "model", "next_step"),
     [
-        (USB_DATA_ZBT1, "Home Assistant Connect ZBT-1"),
+        (USB_DATA_ZBT1, "Home Assistant Connect ZBT-1", STEP_PICK_FIRMWARE_ZIGBEE),
+        (USB_DATA_ZBT1, "Home Assistant Connect ZBT-1", STEP_PICK_FIRMWARE_THREAD),
     ],
 )
 async def test_config_flow_cannot_probe_firmware(
-    usb_data: usb.UsbServiceInfo, model: str, hass: HomeAssistant
+    usb_data: usb.UsbServiceInfo, model: str, next_step: str, hass: HomeAssistant
 ) -> None:
     """Test failure case when firmware cannot be probed."""
 
@@ -46,7 +47,7 @@ async def test_config_flow_cannot_probe_firmware(
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            user_input={"next_step_id": STEP_PICK_FIRMWARE_ZIGBEE},
+            user_input={"next_step_id": next_step},
         )
 
         assert result["type"] == FlowResultType.ABORT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Simplify the SkyConnect setup flow:

 - simplify the wording in firmware selection dialog.
 - replace the extraneous confirmation step with the firmware selection screen.
 - defer firmware probing until after a firmware selection is made.

I've also cleaned up the unit tests and removed significant duplication.

<img width="518" alt="image" src="https://github.com/home-assistant/core/assets/32534428/6220901a-0533-442b-b6c6-d0f8b37bef96">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
