### PR TITLE
Slide add Local API, removed deprecated Cloud API 

### DIFF
--- a/homeassistant/components/slide/__init__.py
+++ b/homeassistant/components/slide/__init__.py
@@ -1,177 +1,51 @@
 """Component for the Slide API."""
 
-from datetime import timedelta
 import logging
 
-from goslideapi import GoSlideCloud, goslideapi
 import voluptuous as vol
 
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-    STATE_CLOSED,
-    STATE_CLOSING,
-    STATE_OPEN,
-    STATE_OPENING,
-)
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
-from homeassistant.helpers.event import async_call_later, async_track_time_interval
-from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    API,
-    COMPONENT_PLATFORM,
-    CONF_INVERT_POSITION,
-    DEFAULT_OFFSET,
-    DEFAULT_RETRY,
-    DOMAIN,
-    SLIDES,
-)
+from .const import COMPONENT_PLATFORM, CONF_API_VERSION, CONF_INVERT_POSITION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
+COVER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_PASSWORD, default=""): cv.string,
+        vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
+        vol.Optional(CONF_API_VERSION, default=2): cv.byte,
+    },
+    extra=vol.ALLOW_EXTRA,
+)
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Optional(
-                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
-                ): cv.time_period,
-                vol.Optional(CONF_INVERT_POSITION, default=False): cv.boolean,
-            }
-        )
+        DOMAIN: vol.All(cv.ensure_list, [vol.Any(COVER_SCHEMA)]),
     },
     extra=vol.ALLOW_EXTRA,
 )
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Slide platform."""
+#################################################################
+async def async_setup(hass, config):
+    """Set up the local Slide platform."""
 
-    async def update_slides(now=None):
-        """Update slide information."""
-        result = await hass.data[DOMAIN][API].slides_overview()
-
-        if result is None:
-            _LOGGER.error("Slide API does not work or returned an error")
-            return
-
-        if result:
-            _LOGGER.debug("Slide API returned %d slide(s)", len(result))
-        else:
-            _LOGGER.warning("Slide API returned 0 slides")
-
-        for slide in result:
-            if "device_id" not in slide:
-                _LOGGER.error(
-                    "Found invalid Slide entry, device_id is missing. Entry=%s", slide
-                )
-                continue
-
-            uid = slide["device_id"].replace("slide_", "")
-            slidenew = hass.data[DOMAIN][SLIDES].setdefault(uid, {})
-            slidenew["mac"] = uid
-            slidenew["id"] = slide["id"]
-            slidenew["name"] = slide["device_name"]
-            slidenew["state"] = None
-            oldpos = slidenew.get("pos")
-            slidenew["pos"] = None
-            slidenew["online"] = False
-            slidenew["invert"] = config[DOMAIN][CONF_INVERT_POSITION]
-
-            if "device_info" not in slide:
-                _LOGGER.error(
-                    "Slide %s (%s) has no device_info Entry=%s",
-                    slide["id"],
-                    slidenew["mac"],
-                    slide,
-                )
-                continue
-
-            # Check if we have pos (OK) or code (NOK)
-            if "pos" in slide["device_info"]:
-                slidenew["online"] = True
-                slidenew["pos"] = slide["device_info"]["pos"]
-                slidenew["pos"] = max(0, min(1, slidenew["pos"]))
-
-                if oldpos is None or oldpos == slidenew["pos"]:
-                    slidenew["state"] = (
-                        STATE_CLOSED
-                        if slidenew["pos"] > (1 - DEFAULT_OFFSET)
-                        else STATE_OPEN
-                    )
-                elif oldpos < slidenew["pos"]:
-                    slidenew["state"] = (
-                        STATE_CLOSED
-                        if slidenew["pos"] >= (1 - DEFAULT_OFFSET)
-                        else STATE_CLOSING
-                    )
-                else:
-                    slidenew["state"] = (
-                        STATE_OPEN
-                        if slidenew["pos"] <= DEFAULT_OFFSET
-                        else STATE_OPENING
-                    )
-            elif "code" in slide["device_info"]:
-                _LOGGER.warning(
-                    "Slide %s (%s) is offline with code=%s",
-                    slide["id"],
-                    slidenew["mac"],
-                    slide["device_info"]["code"],
-                )
-            else:
-                _LOGGER.error(
-                    "Slide %s (%s) has invalid device_info %s",
-                    slide["id"],
-                    slidenew["mac"],
-                    slide["device_info"],
-                )
-
-            _LOGGER.debug("Updated entry=%s", slidenew)
-
-    async def retry_setup(now):
-        """Retry setup if a connection/timeout happens on Slide API."""
-        await async_setup(hass, config)
-
-    hass.data[DOMAIN] = {}
-    hass.data[DOMAIN][SLIDES] = {}
-
-    username = config[DOMAIN][CONF_USERNAME]
-    password = config[DOMAIN][CONF_PASSWORD]
-    scaninterval = config[DOMAIN][CONF_SCAN_INTERVAL]
-
-    hass.data[DOMAIN][API] = GoSlideCloud(username, password)
-
-    try:
-        result = await hass.data[DOMAIN][API].login()
-    except (goslideapi.ClientConnectionError, goslideapi.ClientTimeoutError) as err:
-        _LOGGER.error(
-            "Error connecting to Slide Cloud: %s, going to retry in %s second(s)",
-            err,
-            DEFAULT_RETRY,
-        )
-        async_call_later(hass, DEFAULT_RETRY, retry_setup)
+    if DOMAIN not in config:
+        _LOGGER.info("Slide not configured")
         return True
 
-    if not result:
-        _LOGGER.error("Slide API returned unknown error during authentication")
-        return False
+    _LOGGER.debug("Initializing Slide platform")
 
-    _LOGGER.debug("Slide API successfully authenticated")
+    hass.data[DOMAIN] = {}
+    hass.data[DOMAIN][COMPONENT_PLATFORM] = False
 
-    await update_slides()
-
-    hass.async_create_task(
-        async_load_platform(hass, COMPONENT_PLATFORM, DOMAIN, {}, config)
-    )
-
-    async_track_time_interval(hass, update_slides, scaninterval)
+    for cover in config[DOMAIN]:
+        hass.async_create_task(
+            async_load_platform(hass, COMPONENT_PLATFORM, DOMAIN, cover, config)
+        )
 
     return True

--- a/homeassistant/components/slide/const.py
+++ b/homeassistant/components/slide/const.py
@@ -3,9 +3,11 @@
 from homeassistant.const import Platform
 
 API = "api"
+ATTR_TOUCHGO = "touchgo"
 COMPONENT_PLATFORM = Platform.COVER
+CONF_API = "api"
+CONF_API_VERSION = "api_version"
 CONF_INVERT_POSITION = "invert_position"
 DOMAIN = "slide"
-SLIDES = "slides"
 DEFAULT_OFFSET = 0.15
-DEFAULT_RETRY = 120
+SERVICE_CALIBRATE = "calibrate"

--- a/homeassistant/components/slide/icons.json
+++ b/homeassistant/components/slide/icons.json
@@ -1,0 +1,5 @@
+{
+  "services": {
+    "calibrate": "mdi:restart"
+  }
+}

--- a/homeassistant/components/slide/manifest.json
+++ b/homeassistant/components/slide/manifest.json
@@ -3,7 +3,7 @@
   "name": "Slide",
   "codeowners": ["@ualex73"],
   "documentation": "https://www.home-assistant.io/integrations/slide",
-  "iot_class": "cloud_polling",
-  "loggers": ["goslideapi"],
-  "requirements": ["goslide-api==0.5.1"]
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/ualex73/slide/issues",
+  "requirements": ["goslide-api==0.6.8"]
 }

--- a/homeassistant/components/slide/services.yaml
+++ b/homeassistant/components/slide/services.yaml
@@ -1,0 +1,8 @@
+calibrate:
+  fields:
+    entity_id:
+      required: true
+      selector:
+        entity:
+          integration: slide
+          domain: cover

--- a/homeassistant/components/slide/strings.json
+++ b/homeassistant/components/slide/strings.json
@@ -1,0 +1,14 @@
+{
+  "services": {
+    "calibrate": {
+      "name": "Calibrate",
+      "description": "Calibrate a Slide.",
+      "fields": {
+        "entity_id": {
+          "description": "Entity id of the Slide cover to calibrate.",
+          "name": "Entity"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5477,7 +5477,7 @@
       "name": "Slide",
       "integration_type": "hub",
       "config_flow": false,
-      "iot_class": "cloud_polling"
+      "iot_class": "local_polling"
     },
     "slimproto": {
       "name": "SlimProto (Squeezebox players)",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -977,7 +977,7 @@ google-nest-sdm==3.0.4
 googlemaps==2.5.1
 
 # homeassistant.components.slide
-goslide-api==0.5.1
+goslide-api==0.6.8
 
 # homeassistant.components.tailwind
 gotailwind==0.2.3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Slide company In Motion has stopped, this means the Cloud API will stop (or has stopped) working. Remove the Cloud API as follows:
```
slide:
  username: YOUR_SLIDE_APP_USERNAME
  password: YOUR_SLIDE_APP_PASSWORD
```
Add your current slides, with the Local API as follows:
```
slide:
  - host: 192.168.1.51
    api_version: 2
  - host: 192.168.1.52
    api_version: 2
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will remove the Slide Cloud API and adds the Slide Local API to Home Assistant. This means you need to re-add your Slides.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://github.com/home-assistant/home-assistant.io/pull/32888

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
