### PR TITLE
Add `async_turn_on/off` methods for KNX climate entities

### DIFF
--- a/tests/components/knx/test_climate.py
+++ b/tests/components/knx/test_climate.py
@@ -1,5 +1,7 @@
 """Test KNX climate."""
 
+import pytest
+
 from homeassistant.components.climate import PRESET_ECO, PRESET_SLEEP, HVACMode
 from homeassistant.components.knx.schema import ClimateSchema
 from homeassistant.const import CONF_NAME, STATE_IDLE
@@ -52,6 +54,94 @@ async def test_climate_basic_temperature_set(
     assert len(events) == 1
 
 
+@pytest.mark.parametrize("heat_cool", [False, True])
+async def test_climate_on_off(
+    hass: HomeAssistant, knx: KNXTestKit, heat_cool: bool
+) -> None:
+    """Test KNX climate on/off."""
+    await knx.setup_integration(
+        {
+            ClimateSchema.PLATFORM: {
+                CONF_NAME: "test",
+                ClimateSchema.CONF_TEMPERATURE_ADDRESS: "1/2/3",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS: "1/2/4",
+                ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS: "1/2/5",
+                ClimateSchema.CONF_ON_OFF_ADDRESS: "1/2/8",
+                ClimateSchema.CONF_ON_OFF_STATE_ADDRESS: "1/2/9",
+            }
+            | (
+                {
+                    ClimateSchema.CONF_HEAT_COOL_ADDRESS: "1/2/10",
+                    ClimateSchema.CONF_HEAT_COOL_STATE_ADDRESS: "1/2/11",
+                }
+                if heat_cool
+                else {}
+            )
+        }
+    )
+
+    await hass.async_block_till_done()
+    # read heat/cool state
+    if heat_cool:
+        await knx.assert_read("1/2/11")
+        await knx.receive_response("1/2/11", 0)  # cool
+    # read temperature state
+    await knx.assert_read("1/2/3")
+    await knx.receive_response("1/2/3", RAW_FLOAT_20_0)
+    # read target temperature state
+    await knx.assert_read("1/2/5")
+    await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
+    # read on/off state
+    await knx.assert_read("1/2/9")
+    await knx.receive_response("1/2/9", 1)
+
+    # turn off
+    await hass.services.async_call(
+        "climate",
+        "turn_off",
+        {"entity_id": "climate.test"},
+        blocking=True,
+    )
+    await knx.assert_write("1/2/8", 0)
+    assert hass.states.get("climate.test").state == "off"
+
+    # turn on
+    await hass.services.async_call(
+        "climate",
+        "turn_on",
+        {"entity_id": "climate.test"},
+        blocking=True,
+    )
+    await knx.assert_write("1/2/8", 1)
+    if heat_cool:
+        # does not fall back to default hvac mode after turn_on
+        assert hass.states.get("climate.test").state == "cool"
+    else:
+        assert hass.states.get("climate.test").state == "heat"
+
+    # set hvac mode to off triggers turn_off if no controller_mode is available
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": "climate.test", "hvac_mode": HVACMode.OFF},
+        blocking=True,
+    )
+    await knx.assert_write("1/2/8", 0)
+
+    # set hvac mode to heat
+    await hass.services.async_call(
+        "climate",
+        "set_hvac_mode",
+        {"entity_id": "climate.test", "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    if heat_cool:
+        # only set new hvac_mode without changing on/off - actuator shall handle that
+        await knx.assert_write("1/2/10", 1)
+    else:
+        await knx.assert_write("1/2/8", 1)
+
+
 async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX climate hvac mode."""
     await knx.setup_integration(
@@ -68,7 +158,6 @@ async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
             }
         }
     )
-    async_capture_events(hass, "state_changed")
 
     await hass.async_block_till_done()
     # read states state updater
@@ -82,14 +171,14 @@ async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_read("1/2/5")
     await knx.receive_response("1/2/5", RAW_FLOAT_22_0)
 
-    # turn hvac off
+    # turn hvac mode to off
     await hass.services.async_call(
         "climate",
         "set_hvac_mode",
         {"entity_id": "climate.test", "hvac_mode": HVACMode.OFF},
         blocking=True,
     )
-    await knx.assert_write("1/2/8", False)
+    await knx.assert_write("1/2/6", (0x06,))
 
     # turn hvac on
     await hass.services.async_call(
@@ -98,7 +187,6 @@ async def test_climate_hvac_mode(hass: HomeAssistant, knx: KNXTestKit) -> None:
         {"entity_id": "climate.test", "hvac_mode": HVACMode.HEAT},
         blocking=True,
     )
-    await knx.assert_write("1/2/8", True)
     await knx.assert_write("1/2/6", (0x01,))
 
 
@@ -182,7 +270,6 @@ async def test_update_entity(hass: HomeAssistant, knx: KNXTestKit) -> None:
     )
     assert await async_setup_component(hass, "homeassistant", {})
     await hass.async_block_till_done()
-    async_capture_events(hass, "state_changed")
 
     await hass.async_block_till_done()
     # read states state updater


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add async_turn_on/off methods for KNX climate entities 
to avoid setting the wrong mode when turned on via dedicated on/off address. Now either the previous mode is set (if no on/off address is set) or the controllers mode is used (as there is no mode sent but only turn_on signal).

Also `async_set_hvac_mode()` doesn't explicitly turn on now when there is a dedicated on/off address. This should be handled by the actuator - depending on its setting (or the user by using `async_turn_on()`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/109138
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
