### PR TITLE
Reduce overhead to validate mqtt topics

### DIFF
--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -126,7 +126,10 @@ def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter.
 
     This function is not cached and is not expected to be called
-    directly. If it gets used outside of valid_subscribe_topic and
+    directly outside of this module. It is not marked as protected
+    only because its tested directly in test_util.py.
+
+    If it gets used outside of valid_subscribe_topic and
     valid_publish_topic, it may need an lru_cache decorator or
     an lru_cache decorator on the function where its used.
     """

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -122,7 +122,6 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
 
-@lru_cache
 def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter."""
     validated_topic = cv.string(topic)
@@ -150,7 +149,7 @@ def valid_topic(topic: Any) -> str:
     return validated_topic
 
 
-@lru_cache
+@lru_cache(maxsize=512)
 def valid_subscribe_topic(topic: Any) -> str:
     """Validate that we can subscribe using this MQTT topic."""
     validated_topic = valid_topic(topic)
@@ -188,6 +187,7 @@ def valid_subscribe_topic_template(value: Any) -> template.Template:
     return tpl
 
 
+@lru_cache(maxsize=512)
 def valid_publish_topic(topic: Any) -> str:
     """Validate that we can publish using this MQTT topic."""
     validated_topic = valid_topic(topic)

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -123,7 +123,13 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
 
 
 def valid_topic(topic: Any) -> str:
-    """Validate that this is a valid topic name/filter."""
+    """Validate that this is a valid topic name/filter.
+
+    This function is not cached and is not expected to be called
+    directly. If it gets used outside of valid_subscribe_topic and
+    valid_publish_topic, it may need an lru_cache decorator or
+    an lru_cache decorator on the function where its used.
+    """
     validated_topic = cv.string(topic)
     try:
         raw_validated_topic = validated_topic.encode("utf-8")

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -158,7 +158,7 @@ def valid_topic(topic: Any) -> str:
     return validated_topic
 
 
-@lru_cache(maxsize=512)
+@lru_cache
 def valid_subscribe_topic(topic: Any) -> str:
     """Validate that we can subscribe using this MQTT topic."""
     validated_topic = valid_topic(topic)
@@ -196,7 +196,7 @@ def valid_subscribe_topic_template(value: Any) -> template.Template:
     return tpl
 
 
-@lru_cache(maxsize=512)
+@lru_cache
 def valid_publish_topic(topic: Any) -> str:
     """Validate that we can publish using this MQTT topic."""
     validated_topic = valid_topic(topic)

--- a/homeassistant/components/mqtt/util.py
+++ b/homeassistant/components/mqtt/util.py
@@ -122,6 +122,7 @@ async def async_wait_for_mqtt_client(hass: HomeAssistant) -> bool:
         return False
 
 
+@lru_cache
 def valid_topic(topic: Any) -> str:
     """Validate that this is a valid topic name/filter."""
     validated_topic = cv.string(topic)
@@ -149,6 +150,7 @@ def valid_topic(topic: Any) -> str:
     return validated_topic
 
 
+@lru_cache
 def valid_subscribe_topic(topic: Any) -> str:
     """Validate that we can subscribe using this MQTT topic."""
     validated_topic = valid_topic(topic)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
valid_topic would iterate all the chars 4x (technically 5x, but one of those was in native code so it was fast), refactor to only do it 1x

valid_subscribe_topic would enumerate all the chars when there was no + in the string

This is roughly a ~50% reduction in run time with just the refactoring and no LRU, and ~80% reduction with the LRU. Note that python does not inline genexpr so the genexprs in the profile below are actually inside valid_topic

before
<img width="615" alt="Screenshot 2024-05-21 at 3 37 41 PM" src="https://github.com/home-assistant/core/assets/663432/428d33e3-ba54-45dd-b365-34e0de563bfe">

after
<img width="601" alt="Screenshot 2024-05-21 at 3 37 46 PM" src="https://github.com/home-assistant/core/assets/663432/0ecfd4c4-f6fe-4087-8005-4586f1d7fcbb">

after with LRU
<img width="591" alt="Screenshot 2024-05-21 at 3 46 06 PM" src="https://github.com/home-assistant/core/assets/663432/1b6ae3cd-6fa6-4317-88fa-d45ee296e527">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
