### PR TITLE
Speed up registry indices

### DIFF
--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Iterable
 import dataclasses
 from functools import cached_property
@@ -135,15 +136,19 @@ class AreaRegistryItems(NormalizedNameBaseRegistryItems[AreaEntry]):
     def __init__(self) -> None:
         """Initialize the area registry items."""
         super().__init__()
-        self._labels_index: dict[str, dict[str, Literal[True]]] = {}
-        self._floors_index: dict[str, dict[str, Literal[True]]] = {}
+        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
+        self._floors_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
 
     def _index_entry(self, key: str, entry: AreaEntry) -> None:
         """Index an entry."""
         if entry.floor_id is not None:
-            self._floors_index.setdefault(entry.floor_id, {})[key] = True
+            self._floors_index[entry.floor_id][key] = True
         for label in entry.labels:
-            self._labels_index.setdefault(label, {})[key] = True
+            self._labels_index[label][key] = True
         super()._index_entry(key, entry)
 
     def _unindex_entry(

--- a/homeassistant/helpers/area_registry.py
+++ b/homeassistant/helpers/area_registry.py
@@ -20,7 +20,7 @@ from .normalized_name_base_registry import (
     NormalizedNameBaseRegistryItems,
     normalize_name,
 )
-from .registry import BaseRegistry
+from .registry import BaseRegistry, RegistryIndexType
 from .singleton import singleton
 from .storage import Store
 from .typing import UNDEFINED, UndefinedType
@@ -136,12 +136,8 @@ class AreaRegistryItems(NormalizedNameBaseRegistryItems[AreaEntry]):
     def __init__(self) -> None:
         """Initialize the area registry items."""
         super().__init__()
-        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
-        self._floors_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
+        self._labels_index: RegistryIndexType = defaultdict(dict)
+        self._floors_index: RegistryIndexType = defaultdict(dict)
 
     def _index_entry(self, key: str, entry: AreaEntry) -> None:
         """Index an entry."""

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Mapping
 from enum import StrEnum
 from functools import cached_property, lru_cache, partial
@@ -513,19 +514,25 @@ class ActiveDeviceRegistryItems(DeviceRegistryItems[DeviceEntry]):
         - label -> dict[key, True]
         """
         super().__init__()
-        self._area_id_index: dict[str, dict[str, Literal[True]]] = {}
-        self._config_entry_id_index: dict[str, dict[str, Literal[True]]] = {}
-        self._labels_index: dict[str, dict[str, Literal[True]]] = {}
+        self._area_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
+        self._config_entry_id_index: defaultdict[str, dict[str, Literal[True]]] = (
+            defaultdict(dict)
+        )
+        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
 
     def _index_entry(self, key: str, entry: DeviceEntry) -> None:
         """Index an entry."""
         super()._index_entry(key, entry)
         if (area_id := entry.area_id) is not None:
-            self._area_id_index.setdefault(area_id, {})[key] = True
+            self._area_id_index[area_id][key] = True
         for label in entry.labels:
-            self._labels_index.setdefault(label, {})[key] = True
+            self._labels_index[label][key] = True
         for config_entry_id in entry.config_entries:
-            self._config_entry_id_index.setdefault(config_entry_id, {})[key] = True
+            self._config_entry_id_index[config_entry_id][key] = True
 
     def _unindex_entry(
         self, key: str, replacement_entry: DeviceEntry | None = None

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -38,7 +38,7 @@ from .deprecation import (
 )
 from .frame import report
 from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes, json_fragment
-from .registry import BaseRegistry, BaseRegistryItems
+from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
 from .singleton import singleton
 from .typing import UNDEFINED, UndefinedType
 
@@ -514,15 +514,9 @@ class ActiveDeviceRegistryItems(DeviceRegistryItems[DeviceEntry]):
         - label -> dict[key, True]
         """
         super().__init__()
-        self._area_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
-        self._config_entry_id_index: defaultdict[str, dict[str, Literal[True]]] = (
-            defaultdict(dict)
-        )
-        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
+        self._area_id_index: RegistryIndexType = defaultdict(dict)
+        self._config_entry_id_index: RegistryIndexType = defaultdict(dict)
+        self._labels_index: RegistryIndexType = defaultdict(dict)
 
     def _index_entry(self, key: str, entry: DeviceEntry) -> None:
         """Index an entry."""

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -59,7 +59,7 @@ from .device_registry import (
     EventDeviceRegistryUpdatedData,
 )
 from .json import JSON_DUMP, find_paths_unserializable_data, json_bytes, json_fragment
-from .registry import BaseRegistry, BaseRegistryItems
+from .registry import BaseRegistry, BaseRegistryItems, RegistryIndexType
 from .singleton import singleton
 from .typing import UNDEFINED, UndefinedType
 
@@ -534,18 +534,10 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         super().__init__()
         self._entry_ids: dict[str, RegistryEntry] = {}
         self._index: dict[tuple[str, str, str], str] = {}
-        self._config_entry_id_index: defaultdict[str, dict[str, Literal[True]]] = (
-            defaultdict(dict)
-        )
-        self._device_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
-        self._area_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
-        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
-            dict
-        )
+        self._config_entry_id_index: RegistryIndexType = defaultdict(dict)
+        self._device_id_index: RegistryIndexType = defaultdict(dict)
+        self._area_id_index: RegistryIndexType = defaultdict(dict)
+        self._labels_index: RegistryIndexType = defaultdict(dict)
 
     def _index_entry(self, key: str, entry: RegistryEntry) -> None:
         """Index an entry."""

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -10,6 +10,7 @@ timer.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from collections.abc import Callable, Container, Hashable, KeysView, Mapping
 from datetime import datetime, timedelta
 from enum import StrEnum
@@ -533,10 +534,18 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         super().__init__()
         self._entry_ids: dict[str, RegistryEntry] = {}
         self._index: dict[tuple[str, str, str], str] = {}
-        self._config_entry_id_index: dict[str, dict[str, Literal[True]]] = {}
-        self._device_id_index: dict[str, dict[str, Literal[True]]] = {}
-        self._area_id_index: dict[str, dict[str, Literal[True]]] = {}
-        self._labels_index: dict[str, dict[str, Literal[True]]] = {}
+        self._config_entry_id_index: defaultdict[str, dict[str, Literal[True]]] = (
+            defaultdict(dict)
+        )
+        self._device_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
+        self._area_id_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
+        self._labels_index: defaultdict[str, dict[str, Literal[True]]] = defaultdict(
+            dict
+        )
 
     def _index_entry(self, key: str, entry: RegistryEntry) -> None:
         """Index an entry."""
@@ -545,13 +554,13 @@ class EntityRegistryItems(BaseRegistryItems[RegistryEntry]):
         # python has no ordered set, so we use a dict with True values
         # https://discuss.python.org/t/add-orderedset-to-stdlib/12730
         if (config_entry_id := entry.config_entry_id) is not None:
-            self._config_entry_id_index.setdefault(config_entry_id, {})[key] = True
+            self._config_entry_id_index[config_entry_id][key] = True
         if (device_id := entry.device_id) is not None:
-            self._device_id_index.setdefault(device_id, {})[key] = True
+            self._device_id_index[device_id][key] = True
         if (area_id := entry.area_id) is not None:
-            self._area_id_index.setdefault(area_id, {})[key] = True
+            self._area_id_index[area_id][key] = True
         for label in entry.labels:
-            self._labels_index.setdefault(label, {})[key] = True
+            self._labels_index[label][key] = True
 
     def _unindex_entry(
         self, key: str, replacement_entry: RegistryEntry | None = None

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
 SAVE_DELAY = 10
 SAVE_DELAY_LONG = 180
 
+type RegistryIndexType = defaultdict[str, dict[str, Literal[True]]]
+
 
 class BaseRegistryItems[_DataT](UserDict[str, _DataT], ABC):
     """Base class for registry items."""
@@ -42,7 +44,7 @@ class BaseRegistryItems[_DataT](UserDict[str, _DataT], ABC):
         self._index_entry(key, entry)
 
     def _unindex_entry_value(
-        self, key: str, value: str, index: defaultdict[str, dict[str, Literal[True]]]
+        self, key: str, value: str, index: RegistryIndexType
     ) -> None:
         """Unindex an entry value.
 

--- a/homeassistant/helpers/registry.py
+++ b/homeassistant/helpers/registry.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from collections import UserDict
+from collections import UserDict, defaultdict
 from collections.abc import Mapping, Sequence, ValuesView
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -42,7 +42,7 @@ class BaseRegistryItems[_DataT](UserDict[str, _DataT], ABC):
         self._index_entry(key, entry)
 
     def _unindex_entry_value(
-        self, key: str, value: str, index: dict[str, dict[str, Literal[True]]]
+        self, key: str, value: str, index: defaultdict[str, dict[str, Literal[True]]]
     ) -> None:
         """Unindex an entry value.
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
defaultdict is faster and does not have to create an empty dict that gets throw away when the key is already present

This ~40% speed up to index the entries

before
<img width="381" alt="Screenshot 2024-05-21 at 7 02 33 PM" src="https://github.com/home-assistant/core/assets/663432/c0ac448b-5e38-4a99-8323-6dbd055973d8">


after
<img width="302" alt="Screenshot 2024-05-21 at 7 02 30 PM" src="https://github.com/home-assistant/core/assets/663432/e290bbdc-34f2-42db-8f1d-2987fa0bd0bf">

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
