### PR TITLE
Adjust conftest type hints

### DIFF
--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -1,5 +1,7 @@
 """Fixtures for component testing."""
 
+from __future__ import annotations
+
 from collections.abc import Callable, Generator
 from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
@@ -9,13 +11,12 @@ import pytest
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
-from tests.components.conversation import MockAgent
-
 if TYPE_CHECKING:
-    from tests.components.device_tracker.common import MockScanner
-    from tests.components.light.common import MockLight
-    from tests.components.sensor.common import MockSensor
-    from tests.components.switch.common import MockSwitch
+    from .conversation import MockAgent
+    from .device_tracker.common import MockScanner
+    from .light.common import MockLight
+    from .sensor.common import MockSensor
+    from .switch.common import MockSwitch
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -125,7 +126,7 @@ def prevent_ffmpeg_subprocess() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def mock_light_entities() -> list["MockLight"]:
+def mock_light_entities() -> list[MockLight]:
     """Return mocked light entities."""
     from tests.components.light.common import MockLight
 
@@ -137,7 +138,7 @@ def mock_light_entities() -> list["MockLight"]:
 
 
 @pytest.fixture
-def mock_sensor_entities() -> dict[str, "MockSensor"]:
+def mock_sensor_entities() -> dict[str, MockSensor]:
     """Return mocked sensor entities."""
     from tests.components.sensor.common import get_mock_sensor_entities
 
@@ -145,7 +146,7 @@ def mock_sensor_entities() -> dict[str, "MockSensor"]:
 
 
 @pytest.fixture
-def mock_switch_entities() -> list["MockSwitch"]:
+def mock_switch_entities() -> list[MockSwitch]:
     """Return mocked toggle entities."""
     from tests.components.switch.common import get_mock_switch_entities
 
@@ -153,7 +154,7 @@ def mock_switch_entities() -> list["MockSwitch"]:
 
 
 @pytest.fixture
-def mock_legacy_device_scanner() -> "MockScanner":
+def mock_legacy_device_scanner() -> MockScanner:
     """Return mocked legacy device scanner entity."""
     from tests.components.device_tracker.common import MockScanner
 
@@ -161,9 +162,7 @@ def mock_legacy_device_scanner() -> "MockScanner":
 
 
 @pytest.fixture
-def mock_legacy_device_tracker_setup() -> (
-    Callable[[HomeAssistant, "MockScanner"], None]
-):
+def mock_legacy_device_tracker_setup() -> Callable[[HomeAssistant, MockScanner], None]:
     """Return setup callable for legacy device tracker setup."""
     from tests.components.device_tracker.common import mock_legacy_device_tracker_setup
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
