### PR TITLE
Fix performance regression with SignalType

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,15 +61,15 @@ repos:
         name: mypy
         entry: script/run-in-env.sh mypy
         language: script
-        types: [python]
+        types_or: [python, pyi]
         require_serial: true
         files: ^(homeassistant|pylint)/.+\.(py|pyi)$
       - id: pylint
         name: pylint
         entry: script/run-in-env.sh pylint -j 0 --ignore-missing-annotations=y
         language: script
-        types: [python]
-        files: ^homeassistant/.+\.py$
+        types_or: [python, pyi]
+        files: ^homeassistant/.+\.(py|pyi)$
       - id: gen_requirements_all
         name: gen_requirements_all
         entry: script/run-in-env.sh python3 -m script.gen_requirements_all

--- a/homeassistant/util/signal_type.py
+++ b/homeassistant/util/signal_type.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
-
 
 class _SignalTypeBase[*_Ts](str):
     """Generic base class for SignalType."""
@@ -21,7 +19,3 @@ class SignalTypeFormat[*_Ts](_SignalTypeBase[*_Ts]):
     """Generic string class for signal. Requires call to 'format' before use."""
 
     __slots__ = ()
-
-    def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]:
-        """Format name and return new SignalType instance."""
-        return SignalType(super().format(*args, **kwargs))

--- a/homeassistant/util/signal_type.py
+++ b/homeassistant/util/signal_type.py
@@ -2,40 +2,26 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 
-@dataclass(frozen=True)
-class _SignalTypeBase[*_Ts]:
+class _SignalTypeBase[*_Ts](str):
     """Generic base class for SignalType."""
 
-    name: str
-
-    def __hash__(self) -> int:
-        """Return hash of name."""
-
-        return hash(self.name)
-
-    def __eq__(self, other: object) -> bool:
-        """Check equality for dict keys to be compatible with str."""
-
-        if isinstance(other, str):
-            return self.name == other
-        if isinstance(other, SignalType):
-            return self.name == other.name
-        return False
+    __slots__ = ()
 
 
-@dataclass(frozen=True, eq=False)
 class SignalType[*_Ts](_SignalTypeBase[*_Ts]):
     """Generic string class for signal to improve typing."""
 
+    __slots__ = ()
 
-@dataclass(frozen=True, eq=False)
+
 class SignalTypeFormat[*_Ts](_SignalTypeBase[*_Ts]):
     """Generic string class for signal. Requires call to 'format' before use."""
 
+    __slots__ = ()
+
     def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]:
         """Format name and return new SignalType instance."""
-        return SignalType(self.name.format(*args, **kwargs))
+        return SignalType(super().format(*args, **kwargs))

--- a/homeassistant/util/signal_type.pyi
+++ b/homeassistant/util/signal_type.pyi
@@ -1,0 +1,68 @@
+"""Stub file for signal_type. Provide overload for type checking."""
+# ruff: noqa: PYI021  # Allow docstring
+
+from typing import Any, assert_type
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
+
+__all__ = [
+    "SignalType",
+    "SignalTypeFormat",
+]
+
+class _SignalTypeBase[*_Ts]:
+    """Custom base class for SignalType. At runtime delegate to str.
+
+    For type checkers pretend to be its own separate class.
+    """
+
+    def __init__(self, value: str, /) -> None: ...
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object, /) -> bool: ...
+
+class SignalType[*_Ts](_SignalTypeBase[*_Ts]):
+    """Generic string class for signal to improve typing."""
+
+class SignalTypeFormat[*_Ts](_SignalTypeBase[*_Ts]):
+    """Generic string class for signal. Requires call to 'format' before use."""
+
+    def format(self, *args: Any, **kwargs: Any) -> SignalType[*_Ts]: ...
+
+def _test_signal_type_typing() -> None:  # noqa: PYI048
+    """Test SignalType and dispatcher overloads work as intended.
+
+    This is tested during the mypy run. Do not move it to 'tests'!
+    """
+    hass: HomeAssistant
+    def test_func(a: int) -> None: ...
+    def test_func_other(a: int, b: str) -> None: ...
+
+    # No type validation for str signals
+    signal_str = "signal"
+    async_dispatcher_connect(hass, signal_str, test_func)
+    async_dispatcher_connect(hass, signal_str, test_func_other)
+    async_dispatcher_send(hass, signal_str, 2)
+    async_dispatcher_send(hass, signal_str, 2, "Hello World")
+
+    # Using SignalType will perform type validation on target and args
+    signal_1: SignalType[int] = SignalType("signal")
+    assert_type(signal_1, SignalType[int])
+    async_dispatcher_connect(hass, signal_1, test_func)
+    async_dispatcher_connect(hass, signal_1, test_func_other)  # type: ignore[arg-type]
+    async_dispatcher_send(hass, signal_1, 2)
+    async_dispatcher_send(hass, signal_1, "Hello World")  # type: ignore[misc]
+
+    # SignalTypeFormat cannot be used for dispatcher_connect / dispatcher_send
+    # Call format() on it first to convert it to a SignalType
+    signal_format: SignalTypeFormat[int] = SignalTypeFormat("signal_")
+    signal_2 = signal_format.format("2")
+    assert_type(signal_format, SignalTypeFormat[int])
+    assert_type(signal_2, SignalType[int])
+    async_dispatcher_connect(hass, signal_format, test_func)  # type: ignore[call-overload]
+    async_dispatcher_connect(hass, signal_2, test_func)
+    async_dispatcher_send(hass, signal_format, 2)  # type: ignore[call-overload]
+    async_dispatcher_send(hass, signal_2, 2)

--- a/homeassistant/util/signal_type.pyi
+++ b/homeassistant/util/signal_type.pyi
@@ -31,6 +31,7 @@ def _test_signal_type_typing() -> None:  # noqa: PYI048
 
     This is tested during the mypy run. Do not move it to 'tests'!
     """
+    # pylint: disable=import-outside-toplevel
     from homeassistant.core import HomeAssistant
     from homeassistant.helpers.dispatcher import (
         async_dispatcher_connect,

--- a/homeassistant/util/signal_type.pyi
+++ b/homeassistant/util/signal_type.pyi
@@ -3,12 +3,6 @@
 
 from typing import Any, assert_type
 
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import (
-    async_dispatcher_connect,
-    async_dispatcher_send,
-)
-
 __all__ = [
     "SignalType",
     "SignalTypeFormat",
@@ -37,6 +31,12 @@ def _test_signal_type_typing() -> None:  # noqa: PYI048
 
     This is tested during the mypy run. Do not move it to 'tests'!
     """
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.dispatcher import (
+        async_dispatcher_connect,
+        async_dispatcher_send,
+    )
+
     hass: HomeAssistant
     def test_func(a: int) -> None: ...
     def test_func_other(a: int, b: str) -> None: ...


### PR DESCRIPTION
## Proposed change
Followup to https://github.com/home-assistant/core/pull/109030#issuecomment-2123624492

Change `SignalType` to be a subclass of `str` instead of dataclass at runtime. At separate `pyi` file to keep type checking behavior.

/CC @jbouwh

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
