### PR TITLE
Skip validation of disabled triggers

### DIFF
--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -240,6 +240,10 @@ async def async_validate_trigger_config(
     """Validate triggers."""
     config = []
     for conf in trigger_config:
+        if CONF_ENABLED in conf and not conf[CONF_ENABLED]:
+            # skip validation of disabled triggers
+            config.append(conf)
+            continue
         platform = await _async_get_trigger_platform(hass, conf)
         if hasattr(platform, "async_validate_trigger_config"):
             conf = await platform.async_validate_trigger_config(hass, conf)

--- a/tests/helpers/test_trigger.py
+++ b/tests/helpers/test_trigger.py
@@ -31,6 +31,13 @@ async def test_bad_trigger_platform(hass: HomeAssistant) -> None:
     assert "Invalid platform 'not_a_platform' specified" in str(ex)
 
 
+async def test_bad_trigger_platform_disabled(hass: HomeAssistant) -> None:
+    """Test bad trigger platform disabled."""
+    assert await async_validate_trigger_config(
+        hass, [{"platform": "not_a_platform", "enabled": False}]
+    )
+
+
 async def test_trigger_subtype(hass: HomeAssistant) -> None:
     """Test trigger subtypes."""
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If a trigger is not enabled, its config doesn't need to be validated. 

In an automation a user would then be able to save a disabled trigger with invalid configuration (to do some more research later).
```yaml
trigger:
  - platform: time_pattern
    hours: hello
    enabled: false
```
But, more importantly, a blueprint can use an input to disable a trigger while using the same input for the trigger itself - even if `False` would not validate for the trigger use.
```yaml
blueprint:
  name: Input test
  description: test
  domain: automation
  input:
    entity_1:
      name: Entity one (required)
      selector:
        entity:
    entity_2:
      name: Entity two (optional)
      selector: 
        entity:
      default: False  # used to disable the trigger

trigger:
  - platform: state
    entity_id: !input entity_1
  - platform: state
    entity_id: !input entity_1  # `False` is not valid here, but it doesn't matter since the trigger is not attached anyway.
    enabled: !input entity_1
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
