### PR TITLE
Require registered device id for all timer intents

### DIFF
--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -45,6 +45,8 @@ from .timers import (
     IncreaseTimerIntentHandler,
     PauseTimerIntentHandler,
     StartTimerIntentHandler,
+    TimerEventType,
+    TimerInfo,
     TimerManager,
     TimerStatusIntentHandler,
     UnpauseTimerIntentHandler,
@@ -57,6 +59,8 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 __all__ = [
     "async_register_timer_handler",
+    "TimerInfo",
+    "TimerEventType",
     "DOMAIN",
 ]
 

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -407,9 +407,6 @@ class TimerManager:
         """Call event handlers when a timer finishes."""
         timer = self.timers.pop(timer_id)
 
-        if not self.is_timer_device(timer.device_id):
-            raise TimersNotSupportedError(timer.device_id)
-
         timer.finish()
 
         self.handlers[timer.device_id](TimerEventType.FINISHED, timer)
@@ -420,11 +417,8 @@ class TimerManager:
             timer.device_id,
         )
 
-    def is_timer_device(self, device_id: str | None) -> bool:
+    def is_timer_device(self, device_id: str) -> bool:
         """Return True if device has been registered to handle timer events."""
-        if not device_id:
-            return False
-
         return device_id in self.handlers
 
 
@@ -732,11 +726,11 @@ class StartTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
-
-        assert intent_obj.device_id is not None
 
         name: str | None = None
         if "name" in slots:
@@ -783,7 +777,9 @@ class CancelTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 
@@ -812,7 +808,9 @@ class IncreaseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 
@@ -842,7 +840,9 @@ class DecreaseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 
@@ -871,7 +871,9 @@ class PauseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 
@@ -899,7 +901,9 @@ class UnpauseTimerIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 
@@ -927,7 +931,9 @@ class TimerStatusIntentHandler(intent.IntentHandler):
         timer_manager: TimerManager = hass.data[TIMER_DATA]
         slots = self.async_validate_slots(intent_obj.slots)
 
-        if not timer_manager.is_timer_device(intent_obj.device_id):
+        if not (
+            intent_obj.device_id and timer_manager.is_timer_device(intent_obj.device_id)
+        ):
             # Fail early
             raise TimersNotSupportedError(intent_obj.device_id)
 

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -716,37 +716,7 @@ def _round_time(hours: int, minutes: int, seconds: int) -> tuple[int, int, int]:
     return rounded_hours, rounded_minutes, rounded_seconds
 
 
-class BaseTimerIntentHandler(intent.IntentHandler):
-    """Base class for timer intent handlers."""
-
-    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
-        """Handle the intent."""
-        hass = intent_obj.hass
-        timer_manager: TimerManager = hass.data[TIMER_DATA]
-        slots = self.async_validate_slots(intent_obj.slots)
-
-        if not timer_manager.is_timer_device(intent_obj.device_id):
-            raise TimersNotSupportedError(intent_obj.device_id)
-
-        assert intent_obj.device_id is not None
-
-        return await self.async_handle_timer(
-            hass, intent_obj.device_id, slots, timer_manager, intent_obj
-        )
-
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
-        """Handle intent with relevant timer objects available."""
-        raise NotImplementedError
-
-
-class StartTimerIntentHandler(BaseTimerIntentHandler):
+class StartTimerIntentHandler(intent.IntentHandler):
     """Intent handler for starting a new timer."""
 
     intent_type = intent.INTENT_START_TIMER
@@ -756,15 +726,18 @@ class StartTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("name"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
         name: str | None = None
         if "name" in slots:
             name = slots["name"]["value"]
@@ -782,7 +755,7 @@ class StartTimerIntentHandler(BaseTimerIntentHandler):
             seconds = int(slots["seconds"]["value"])
 
         timer_manager.start_timer(
-            device_id,
+            intent_obj.device_id,
             hours,
             minutes,
             seconds,
@@ -793,7 +766,7 @@ class StartTimerIntentHandler(BaseTimerIntentHandler):
         return intent_obj.create_response()
 
 
-class CancelTimerIntentHandler(BaseTimerIntentHandler):
+class CancelTimerIntentHandler(intent.IntentHandler):
     """Intent handler for cancelling a timer."""
 
     intent_type = intent.INTENT_CANCEL_TIMER
@@ -804,21 +777,24 @@ class CancelTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
-        timer = _find_timer(hass, device_id, slots)
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
+        timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.cancel_timer(timer.id)
         return intent_obj.create_response()
 
 
-class IncreaseTimerIntentHandler(BaseTimerIntentHandler):
+class IncreaseTimerIntentHandler(intent.IntentHandler):
     """Intent handler for increasing the time of a timer."""
 
     intent_type = intent.INTENT_INCREASE_TIMER
@@ -830,22 +806,25 @@ class IncreaseTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
         total_seconds = _get_total_seconds(slots)
-        timer = _find_timer(hass, device_id, slots)
+        timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.add_time(timer.id, total_seconds)
         return intent_obj.create_response()
 
 
-class DecreaseTimerIntentHandler(BaseTimerIntentHandler):
+class DecreaseTimerIntentHandler(intent.IntentHandler):
     """Intent handler for decreasing the time of a timer."""
 
     intent_type = intent.INTENT_DECREASE_TIMER
@@ -857,22 +836,25 @@ class DecreaseTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
         total_seconds = _get_total_seconds(slots)
-        timer = _find_timer(hass, device_id, slots)
+        timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.remove_time(timer.id, total_seconds)
         return intent_obj.create_response()
 
 
-class PauseTimerIntentHandler(BaseTimerIntentHandler):
+class PauseTimerIntentHandler(intent.IntentHandler):
     """Intent handler for pausing a running timer."""
 
     intent_type = intent.INTENT_PAUSE_TIMER
@@ -883,21 +865,24 @@ class PauseTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
-        timer = _find_timer(hass, device_id, slots)
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
+        timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.pause_timer(timer.id)
         return intent_obj.create_response()
 
 
-class UnpauseTimerIntentHandler(BaseTimerIntentHandler):
+class UnpauseTimerIntentHandler(intent.IntentHandler):
     """Intent handler for unpausing a paused timer."""
 
     intent_type = intent.INTENT_UNPAUSE_TIMER
@@ -908,21 +893,24 @@ class UnpauseTimerIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
-        timer = _find_timer(hass, device_id, slots)
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
+        timer = _find_timer(hass, intent_obj.device_id, slots)
         timer_manager.unpause_timer(timer.id)
         return intent_obj.create_response()
 
 
-class TimerStatusIntentHandler(BaseTimerIntentHandler):
+class TimerStatusIntentHandler(intent.IntentHandler):
     """Intent handler for reporting the status of a timer."""
 
     intent_type = intent.INTENT_TIMER_STATUS
@@ -933,17 +921,20 @@ class TimerStatusIntentHandler(BaseTimerIntentHandler):
         vol.Optional("area"): cv.string,
     }
 
-    async def async_handle_timer(
-        self,
-        hass: HomeAssistant,
-        device_id: str,
-        slots: dict,
-        timer_manager: TimerManager,
-        intent_obj: intent.Intent,
-    ) -> intent.IntentResponse:
+    async def async_handle(self, intent_obj: intent.Intent) -> intent.IntentResponse:
         """Handle the intent."""
+        hass = intent_obj.hass
+        timer_manager: TimerManager = hass.data[TIMER_DATA]
+        slots = self.async_validate_slots(intent_obj.slots)
+
+        if not timer_manager.is_timer_device(intent_obj.device_id):
+            # Fail early
+            raise TimersNotSupportedError(intent_obj.device_id)
+
+        assert intent_obj.device_id is not None
+
         statuses: list[dict[str, Any]] = []
-        for timer in _find_timers(hass, device_id, slots):
+        for timer in _find_timers(hass, intent_obj.device_id, slots):
             total_seconds = timer.seconds_left
 
             minutes, seconds = divmod(total_seconds, 60)

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -16,7 +16,7 @@ from homeassistant.components.intent.timers import (
     async_register_timer_handler,
 )
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     area_registry as ar,
     device_registry as dr,
@@ -43,6 +43,7 @@ async def test_start_finish_timer(hass: HomeAssistant, init_components) -> None:
 
     timer_id: str | None = None
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_id
 
@@ -88,6 +89,7 @@ async def test_cancel_timer(hass: HomeAssistant, init_components) -> None:
 
     timer_id: str | None = None
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_id
 
@@ -194,6 +196,7 @@ async def test_increase_timer(hass: HomeAssistant, init_components) -> None:
     timer_id: str | None = None
     original_total_seconds = -1
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_id, original_total_seconds
 
@@ -309,6 +312,7 @@ async def test_decrease_timer(hass: HomeAssistant, init_components) -> None:
     timer_id: str | None = None
     original_total_seconds = 0
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_id, original_total_seconds
 
@@ -403,6 +407,7 @@ async def test_decrease_timer_below_zero(hass: HomeAssistant, init_components) -
     timer_id: str | None = None
     original_total_seconds = 0
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_id, original_total_seconds
 
@@ -497,6 +502,7 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
         )
 
     # Must register a handler before we can do anything with timers
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         pass
 
@@ -567,6 +573,7 @@ async def test_disambiguation(
     cancelled_event = asyncio.Event()
     timer_info: TimerInfo | None = None
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal timer_info
 
@@ -853,6 +860,7 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
 
     expected_active = True
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         if event_type == TimerEventType.STARTED:
             started_event.set()
@@ -946,6 +954,7 @@ async def test_timers_not_supported(hass: HomeAssistant) -> None:
         )
 
     # Start a timer
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         pass
 
@@ -1019,6 +1028,7 @@ async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> 
     started_event = asyncio.Event()
     num_started = 0
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 
@@ -1203,6 +1213,7 @@ async def test_area_filter(
     num_timers = 3
     num_started = 0
 
+    @callback
     def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
         nonlocal num_started
 

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -1006,38 +1006,6 @@ async def test_timers_not_supported(hass: HomeAssistant) -> None:
     with pytest.raises(TimersNotSupportedError):
         timer_manager.cancel_timer(timer_id)
 
-    # Register device again
-    timer_manager.register_handler(device_id, handle_timer)
-
-    original_timer_finished = timer_manager._timer_finished
-    timer_finished_event = asyncio.Event()
-
-    def _timer_finished(self, timer_id: str) -> None:
-        with pytest.raises(TimersNotSupportedError):
-            original_timer_finished(timer_id)
-        timer_finished_event.set()
-
-    # Ensure that a timer finishing with a device that has been unregistered will fail
-    with patch(
-        "homeassistant.components.intent.timers.TimerManager._timer_finished",
-        _timer_finished,
-    ):
-        timer_manager.start_timer(
-            device_id,
-            hours=None,
-            minutes=None,
-            seconds=0,
-            language=hass.config.language,
-        )
-
-        # Pretend device was unregistered while timer was running
-        with patch(
-            "homeassistant.components.intent.timers.TimerManager.is_timer_device",
-            return_value=False,
-        ):
-            async with asyncio.timeout(1):
-                await timer_finished_event.wait()
-
 
 async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> None:
     """Test getting the status of named timers."""

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -481,25 +481,43 @@ async def test_find_timer_failed(hass: HomeAssistant, init_components) -> None:
     """Test finding a timer with the wrong info."""
     device_id = "test_device"
 
-    # No device id
-    with pytest.raises(TimersNotSupportedError):
-        await intent.async_handle(
-            hass,
-            "test",
-            intent.INTENT_TIMER_STATUS,
-            {},
-            device_id=None,
-        )
+    for intent_name in (
+        intent.INTENT_START_TIMER,
+        intent.INTENT_CANCEL_TIMER,
+        intent.INTENT_PAUSE_TIMER,
+        intent.INTENT_UNPAUSE_TIMER,
+        intent.INTENT_INCREASE_TIMER,
+        intent.INTENT_DECREASE_TIMER,
+        intent.INTENT_TIMER_STATUS,
+    ):
+        if intent_name in (
+            intent.INTENT_START_TIMER,
+            intent.INTENT_INCREASE_TIMER,
+            intent.INTENT_DECREASE_TIMER,
+        ):
+            slots = {"minutes": {"value": 5}}
+        else:
+            slots = {}
 
-    # Unregistered device
-    with pytest.raises(TimersNotSupportedError):
-        await intent.async_handle(
-            hass,
-            "test",
-            intent.INTENT_TIMER_STATUS,
-            {},
-            device_id=device_id,
-        )
+        # No device id
+        with pytest.raises(TimersNotSupportedError):
+            await intent.async_handle(
+                hass,
+                "test",
+                intent_name,
+                slots,
+                device_id=None,
+            )
+
+        # Unregistered device
+        with pytest.raises(TimersNotSupportedError):
+            await intent.async_handle(
+                hass,
+                "test",
+                intent_name,
+                slots,
+                device_id=device_id,
+            )
 
     # Must register a handler before we can do anything with timers
     @callback


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Integrations that register handlers for voice timers should only receive events for devices that they control. This changes the `async_register_timer_handler` function to require a `device_id`.

Additionally, all timer intents now require that a device id has been previously registered to with a handler.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
