### PR TITLE
Refactor state_reported listener setup to avoid merge in async_fire_internal

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1500,7 +1500,6 @@ class EventBus:
 
         This method must be run in the event loop.
         """
-
         if self._debug:
             _LOGGER.debug(
                 "Bus:Handling %s", _event_repr(event_type, origin, event_data)
@@ -1511,17 +1510,9 @@ class EventBus:
             match_all_listeners = self._match_all_listeners
         else:
             match_all_listeners = EMPTY_LIST
-        if event_type == EVENT_STATE_CHANGED:
-            aliased_listeners = self._listeners.get(EVENT_STATE_REPORTED, EMPTY_LIST)
-        else:
-            aliased_listeners = EMPTY_LIST
-        listeners = listeners + match_all_listeners + aliased_listeners
-        if not listeners:
-            return
 
         event: Event[_DataT] | None = None
-
-        for job, event_filter in listeners:
+        for job, event_filter in listeners + match_all_listeners:
             if event_filter is not None:
                 try:
                     if event_data is None or not event_filter(event_data):
@@ -1599,18 +1590,27 @@ class EventBus:
 
         if event_filter is not None and not is_callback_check_partial(event_filter):
             raise HomeAssistantError(f"Event filter {event_filter} is not a callback")
+        filterable_job = (HassJob(listener, f"listen {event_type}"), event_filter)
         if event_type == EVENT_STATE_REPORTED:
             if not event_filter:
                 raise HomeAssistantError(
                     f"Event filter is required for event {event_type}"
                 )
-        return self._async_listen_filterable_job(
-            event_type,
-            (
-                HassJob(listener, f"listen {event_type}"),
-                event_filter,
-            ),
-        )
+            # Special case for EVENT_STATE_REPORTED, we also want to listen to
+            # EVENT_STATE_CHANGED
+            self._listeners[EVENT_STATE_REPORTED].append(filterable_job)
+            self._listeners[EVENT_STATE_CHANGED].append(filterable_job)
+            return functools.partial(
+                self._async_remove_state_reported_listener, filterable_job
+            )
+        return self._async_listen_filterable_job(event_type, filterable_job)
+
+    def _async_remove_state_reported_listener(
+        self, filterable_job: _FilterableJobType[Any]
+    ) -> None:
+        """Remove a listener for a state_reported_event."""
+        self._async_remove_listener(EVENT_STATE_REPORTED, filterable_job)
+        self._async_remove_listener(EVENT_STATE_CHANGED, filterable_job)
 
     @callback
     def _async_listen_filterable_job(
@@ -1618,6 +1618,7 @@ class EventBus:
         event_type: EventType[_DataT] | str,
         filterable_job: _FilterableJobType[_DataT],
     ) -> CALLBACK_TYPE:
+        """Listen for all events or events of a specific type."""
         self._listeners[event_type].append(filterable_job)
         return functools.partial(
             self._async_remove_listener, event_type, filterable_job

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1613,7 +1613,7 @@ class EventBus:
         keys: Iterable[EventType[_DataT] | str],
         filterable_job: _FilterableJobType[Any],
     ) -> None:
-        """Remove a listener for a state_reported_event."""
+        """Remove multiple listeners for specific event_types."""
         for key in keys:
             self._async_remove_listener(key, filterable_job)
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1605,6 +1605,7 @@ class EventBus:
             )
         return self._async_listen_filterable_job(event_type, filterable_job)
 
+    @callback
     def _async_remove_state_reported_listener(
         self, filterable_job: _FilterableJobType[Any]
     ) -> None:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1601,17 +1601,21 @@ class EventBus:
             self._listeners[EVENT_STATE_REPORTED].append(filterable_job)
             self._listeners[EVENT_STATE_CHANGED].append(filterable_job)
             return functools.partial(
-                self._async_remove_state_reported_listener, filterable_job
+                self._async_remove_multiple_listeners,
+                (EVENT_STATE_REPORTED, EVENT_STATE_CHANGED),
+                filterable_job,
             )
         return self._async_listen_filterable_job(event_type, filterable_job)
 
     @callback
-    def _async_remove_state_reported_listener(
-        self, filterable_job: _FilterableJobType[Any]
+    def _async_remove_multiple_listeners(
+        self,
+        keys: Iterable[EventType[_DataT] | str],
+        filterable_job: _FilterableJobType[Any],
     ) -> None:
         """Remove a listener for a state_reported_event."""
-        self._async_remove_listener(EVENT_STATE_REPORTED, filterable_job)
-        self._async_remove_listener(EVENT_STATE_CHANGED, filterable_job)
+        for key in keys:
+            self._async_remove_listener(key, filterable_job)
 
     @callback
     def _async_listen_filterable_job(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3346,7 +3346,9 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     hass.states.async_set("light.bowl", "on", {})
     state_changed_events = async_capture_events(hass, EVENT_STATE_CHANGED)
     state_reported_events = []
-    unsub = hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=mock_filter)
+    unsub = hass.bus.async_listen(
+        EVENT_STATE_REPORTED, listener, event_filter=mock_filter
+    )
 
     hass.states.async_set("light.bowl", "on")
     await hass.async_block_till_done()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3372,6 +3372,11 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
 
     unsub()
 
+    hass.states.async_set("light.bowl", "on")
+    await hass.async_block_till_done()
+    assert len(state_changed_events) == 4
+    assert len(state_reported_events) == 4
+
 
 async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:
     """Test we enforce requirements for EVENT_STATE_REPORTED listeners."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3346,7 +3346,7 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     hass.states.async_set("light.bowl", "on", {})
     state_changed_events = async_capture_events(hass, EVENT_STATE_CHANGED)
     state_reported_events = []
-    hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=mock_filter)
+    unsub = hass.bus.async_listen(EVENT_STATE_REPORTED, listener, event_filter=mock_filter)
 
     hass.states.async_set("light.bowl", "on")
     await hass.async_block_till_done()
@@ -3367,6 +3367,8 @@ async def test_statemachine_report_state(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
     assert len(state_changed_events) == 3
     assert len(state_reported_events) == 4
+
+    unsub()
 
 
 async def test_report_state_listener_restrictions(hass: HomeAssistant) -> None:


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of merging the listeners in `async_fire_internal` which is called very frequently, set up the listener for state_changed at the same time so async_fire_internal can avoid having to copy another list

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
