### PR TITLE
Fix turbojpeg init doing blocking I/O in the event loop

### DIFF
--- a/homeassistant/components/camera/img_util.py
+++ b/homeassistant/components/camera/img_util.py
@@ -13,6 +13,7 @@ with suppress(Exception):
     # in the import executor and not in the event loop.
     from turbojpeg import TurboJPEG
 
+
 if TYPE_CHECKING:
     from . import Image
 

--- a/homeassistant/components/camera/img_util.py
+++ b/homeassistant/components/camera/img_util.py
@@ -13,7 +13,6 @@ with suppress(Exception):
     # in the import executor and not in the event loop.
     from turbojpeg import TurboJPEG
 
-
 if TYPE_CHECKING:
     from . import Image
 
@@ -103,3 +102,9 @@ class TurboJPEGSingleton:
                 "Error loading libturbojpeg; Camera snapshot performance will be sub-optimal"
             )
             TurboJPEGSingleton.__instance = False
+
+
+with suppress(Exception):
+    # TurboJPEG loads libraries that do blocking I/O,
+    # initialize it in the executor to avoid blocking the event loop.
+    TurboJPEGSingleton.instance()

--- a/homeassistant/components/camera/img_util.py
+++ b/homeassistant/components/camera/img_util.py
@@ -106,6 +106,7 @@ class TurboJPEGSingleton:
 
 
 with suppress(Exception):
-    # TurboJPEG loads libraries that do blocking I/O,
-    # initialize it in the executor to avoid blocking the event loop.
+    # TurboJPEG loads libraries that do blocking I/O.
+    # Initialize TurboJPEGSingleton in the executor to avoid
+    # blocking the event loop.
     TurboJPEGSingleton.instance()

--- a/homeassistant/components/camera/img_util.py
+++ b/homeassistant/components/camera/img_util.py
@@ -105,8 +105,7 @@ class TurboJPEGSingleton:
             TurboJPEGSingleton.__instance = False
 
 
-with suppress(Exception):
-    # TurboJPEG loads libraries that do blocking I/O.
-    # Initialize TurboJPEGSingleton in the executor to avoid
-    # blocking the event loop.
-    TurboJPEGSingleton.instance()
+# TurboJPEG loads libraries that do blocking I/O.
+# Initialize TurboJPEGSingleton in the executor to avoid
+# blocking the event loop.
+TurboJPEGSingleton.instance()


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
fixes
`Detected blocking call to open inside the event loop by integration camera at homeassistant/components/camera/img_util.py, line 100: TurboJPEGSingleton.__instance = TurboJPEG() (offender: /usr/local/lib/python3.12/ctypes/util.py, line 276: with open(filepath, rb) as fh:), please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+camera%22`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
