### PR TITLE
Add snapshot platform tests to rainmachine

### DIFF
--- a/tests/components/rainmachine/snapshots/test_binary_sensor.ambr
+++ b/tests/components/rainmachine/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,277 @@
+# serializer version: 1
+# name: test_binary_sensors[binary_sensor.12345_freeze_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_freeze_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Freeze restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'freeze',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_freeze',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_freeze_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Freeze restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_freeze_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_hourly_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_hourly_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Hourly restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hourly',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_hourly',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_hourly_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Hourly restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_hourly_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_month_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_month_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Month restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'month',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_month',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_month_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Month restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_month_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_rain_delay_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_rain_delay_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Rain delay restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'raindelay',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_raindelay',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_rain_delay_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Rain delay restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_rain_delay_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_rain_sensor_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_rain_sensor_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Rain sensor restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'rainsensor',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_rainsensor',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_rain_sensor_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Rain sensor restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_rain_sensor_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_weekday_restrictions-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.12345_weekday_restrictions',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Weekday restrictions',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'weekday',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_weekday',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[binary_sensor.12345_weekday_restrictions-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Weekday restrictions',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.12345_weekday_restrictions',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/rainmachine/snapshots/test_button.ambr
+++ b/tests/components/rainmachine/snapshots/test_button.ambr
@@ -1,0 +1,48 @@
+# serializer version: 1
+# name: test_buttons[button.12345_restart-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.12345_restart',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
+    'original_icon': None,
+    'original_name': 'Restart',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_reboot',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_buttons[button.12345_restart-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'restart',
+      'friendly_name': '12345 Restart',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.12345_restart',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/rainmachine/snapshots/test_select.ambr
+++ b/tests/components/rainmachine/snapshots/test_select.ambr
@@ -1,0 +1,60 @@
+# serializer version: 1
+# name: test_select_entities[select.12345_freeze_protection_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': dict({
+      'options': list([
+        '0°C',
+        '2°C',
+        '5°C',
+        '10°C',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.12345_freeze_protection_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Freeze protection temperature',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'freeze_protection_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_freeze_protection_temperature',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_entities[select.12345_freeze_protection_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Freeze protection temperature',
+      'options': list([
+        '0°C',
+        '2°C',
+        '5°C',
+        '10°C',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.12345_freeze_protection_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2°C',
+  })
+# ---

--- a/tests/components/rainmachine/snapshots/test_sensor.ambr
+++ b/tests/components/rainmachine/snapshots/test_sensor.ambr
@@ -1,0 +1,707 @@
+# serializer version: 1
+# name: test_sensors[sensor.12345_evening_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_evening_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Evening Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_run_completion_time_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_evening_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Evening Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_evening_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_flower_box_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_flower_box_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Flower Box Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_flower_box_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Flower Box Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_flower_box_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_landscaping_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_landscaping_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Landscaping Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_landscaping_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Landscaping Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_landscaping_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_morning_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_morning_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Morning Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_run_completion_time_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_morning_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Morning Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_morning_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_rain_sensor_rain_start-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_rain_sensor_rain_start',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': 'mdi:weather-pouring',
+    'original_name': 'Rain sensor rain start',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'rain_sensor_rain_start',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_rain_sensor_rain_start',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_rain_sensor_rain_start-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Rain sensor rain start',
+      'icon': 'mdi:weather-pouring',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_rain_sensor_rain_start',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_test_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_test_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'TEST Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_test_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 TEST Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_test_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_10_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_10_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 10 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_10',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_10_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 10 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_10_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_11_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_11_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 11 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_11',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_11_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 11 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_11_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_12_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_12_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 12 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_12',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_12_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 12 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_12_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_4_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_4_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 4 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_4_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 4 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_4_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_5_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_5_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 5 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_5_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 5 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_5_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_6_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_6_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 6 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_6_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 6 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_6_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_7_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_7_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 7 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_7_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 7 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_7_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_8_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_8_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 8 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_8',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_8_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 8 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_8_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_9_run_completion_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.12345_zone_9_run_completion_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Zone 9 Run Completion Time',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_run_completion_time_9',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[sensor.12345_zone_9_run_completion_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': '12345 Zone 9 Run Completion Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.12345_zone_9_run_completion_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/rainmachine/snapshots/test_switch.ambr
+++ b/tests/components/rainmachine/snapshots/test_switch.ambr
@@ -1,0 +1,1615 @@
+# serializer version: 1
+# name: test_switches[switch.12345_evening-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_evening',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Evening',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_evening-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Evening',
+      'icon': 'mdi:water',
+      'id': 2,
+      'next_run': '2018-06-04T06:00:00',
+      'soak': 0,
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'zones': list([
+        dict({
+          'active': True,
+          'duration': 0,
+          'id': 1,
+          'minRuntimeCoef': 1,
+          'name': 'Landscaping',
+          'order': -1,
+          'userPercentage': 1,
+        }),
+        dict({
+          'active': True,
+          'duration': 0,
+          'id': 2,
+          'minRuntimeCoef': 1,
+          'name': 'Flower Box',
+          'order': -1,
+          'userPercentage': 1,
+        }),
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_evening',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_evening_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_evening_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Evening enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_2_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_evening_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Evening enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_evening_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_extra_water_on_hot_days-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_extra_water_on_hot_days',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:heat-wave',
+    'original_name': 'Extra water on hot days',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'hot_days_extra_watering',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_hot_days_extra_watering',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_extra_water_on_hot_days-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Extra water on hot days',
+      'icon': 'mdi:heat-wave',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_extra_water_on_hot_days',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_flower_box-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_flower_box',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Flower box',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_2',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_flower_box-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.17,
+      'friendly_name': '12345 Flower box',
+      'icon': 'mdi:water',
+      'id': 2,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Sandy Loam',
+      'sprinkler_head_precipitation_rate': 12.7,
+      'sprinkler_head_type': 'Surface Drip',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Vegetables',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_flower_box',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_flower_box_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_flower_box_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Flower box enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_2_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_flower_box_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Flower box enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_flower_box_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12345_freeze_protection-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_freeze_protection',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:snowflake-alert',
+    'original_name': 'Freeze protection',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': 'freeze_protect_enabled',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_freeze_protect_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_freeze_protection-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Freeze protection',
+      'icon': 'mdi:snowflake-alert',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_freeze_protection',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12345_landscaping-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_landscaping',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Landscaping',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_landscaping-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.17,
+      'friendly_name': '12345 Landscaping',
+      'icon': 'mdi:water',
+      'id': 1,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Sandy Loam',
+      'sprinkler_head_precipitation_rate': 25.4,
+      'sprinkler_head_type': 'Bubblers Drip',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Flowers',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_landscaping',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_landscaping_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_landscaping_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Landscaping enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_1_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_landscaping_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Landscaping enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_landscaping_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12345_morning-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_morning',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Morning',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_morning-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Morning',
+      'icon': 'mdi:water',
+      'id': 1,
+      'next_run': '2018-06-04T06:00:00',
+      'soak': 0,
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'zones': list([
+        dict({
+          'active': True,
+          'duration': 0,
+          'id': 1,
+          'minRuntimeCoef': 1,
+          'name': 'Landscaping',
+          'order': -1,
+          'userPercentage': 1,
+        }),
+        dict({
+          'active': True,
+          'duration': 0,
+          'id': 2,
+          'minRuntimeCoef': 1,
+          'name': 'Flower Box',
+          'order': -1,
+          'userPercentage': 1,
+        }),
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_morning',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_morning_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_morning_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Morning enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_program_1_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_morning_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Morning enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_morning_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switches[switch.12345_test-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_test',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Test',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_3',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_test-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Test',
+      'icon': 'mdi:water',
+      'id': 3,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Drought Tolerant Plants',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_test',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_test_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_test_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Test enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_3_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_test_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Test enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_test_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_10-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_10',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 10',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_10',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_10-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 10',
+      'icon': 'mdi:water',
+      'id': 10,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_10',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_10_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_10_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 10 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_10_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_10_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 10 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_10_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_11-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_11',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 11',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_11',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_11-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 11',
+      'icon': 'mdi:water',
+      'id': 11,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_11',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_11_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_11_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 11 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_11_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_11_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 11 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_11_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_12-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_12',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 12',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_12',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_12-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 12',
+      'icon': 'mdi:water',
+      'id': 12,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_12',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_12_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_12_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 12 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_12_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_12_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 12 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_12_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_4-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_4',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 4',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_4-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 4',
+      'icon': 'mdi:water',
+      'id': 4,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_4',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_4_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_4_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 4 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_4_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_4_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 4 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_4_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_5-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_5',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 5',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_5',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_5-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 5',
+      'icon': 'mdi:water',
+      'id': 5,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_5',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_5_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_5_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 5 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_5_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_5_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 5 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_5_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_6-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_6',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 6',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_6',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_6-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 6',
+      'icon': 'mdi:water',
+      'id': 6,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_6',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_6_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_6_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 6 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_6_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_6_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 6 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_6_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_7-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_7',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 7',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_7',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_7-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 7',
+      'icon': 'mdi:water',
+      'id': 7,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_7',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_7_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_7_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 7 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_7_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_7_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 7 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_7_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_8-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_8',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 8',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_8',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_8-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 8',
+      'icon': 'mdi:water',
+      'id': 8,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_8',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_8_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_8_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 8 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_8_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_8_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 8 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_8_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_9-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.12345_zone_9',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:water',
+    'original_name': 'Zone 9',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_9',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_9-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'area': 92.9,
+      'current_cycle': 0,
+      'field_capacity': 0.3,
+      'friendly_name': '12345 Zone 9',
+      'icon': 'mdi:water',
+      'id': 9,
+      'number_of_cycles': 0,
+      'restrictions': False,
+      'slope': 'Flat',
+      'soil_type': 'Clay Loam',
+      'sprinkler_head_precipitation_rate': 35.56,
+      'sprinkler_head_type': 'Popup Spray',
+      'status': <RunStates.NOT_RUNNING: 'Not Running'>,
+      'sun_exposure': 'Full Sun',
+      'vegetation_type': 'Cool Season Grass',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_9',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switches[switch.12345_zone_9_enabled-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.12345_zone_9_enabled',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:cog',
+    'original_name': 'Zone 9 enabled',
+    'platform': 'rainmachine',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'aa:bb:cc:dd:ee:ff_zone_9_enabled',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switches[switch.12345_zone_9_enabled-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': '12345 Zone 9 enabled',
+      'icon': 'mdi:cog',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.12345_zone_9_enabled',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/rainmachine/test_binary_sensor.py
+++ b/tests/components/rainmachine/test_binary_sensor.py
@@ -1,0 +1,36 @@
+"""Test RainMachine binary sensors."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+) -> None:
+    """Test binary sensors."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch(
+            "homeassistant.components.rainmachine.PLATFORMS", [Platform.BINARY_SENSOR]
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/rainmachine/test_button.py
+++ b/tests/components/rainmachine/test_button.py
@@ -1,0 +1,32 @@
+"""Test RainMachine buttons."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_buttons(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+) -> None:
+    """Test buttons."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.BUTTON]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/rainmachine/test_select.py
+++ b/tests/components/rainmachine/test_select.py
@@ -1,0 +1,32 @@
+"""Test RainMachine select entities."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+async def test_select_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+) -> None:
+    """Test select entities."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.SELECT]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/rainmachine/test_sensor.py
+++ b/tests/components/rainmachine/test_sensor.py
@@ -1,0 +1,34 @@
+"""Test RainMachine sensors."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+) -> None:
+    """Test sensors."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.SENSOR]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)

--- a/tests/components/rainmachine/test_switch.py
+++ b/tests/components/rainmachine/test_switch.py
@@ -1,0 +1,34 @@
+"""Test RainMachine switches."""
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.components.rainmachine import DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_switches(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    config: dict[str, Any],
+    config_entry: MockConfigEntry,
+    client: AsyncMock,
+) -> None:
+    """Test switches."""
+    with (
+        patch("homeassistant.components.rainmachine.Client", return_value=client),
+        patch("homeassistant.components.rainmachine.PLATFORMS", [Platform.SWITCH]),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        await hass.async_block_till_done()
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

```
---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                                    Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------------------
homeassistant/components/rainmachine/__init__.py          237     44    81%   185-197, 208-212, 230-231, 240, 267, 291-298, 343-354, 363, 370-374, 381, 398-399, 409, 414, 421, 458, 526, 572-573
homeassistant/components/rainmachine/binary_sensor.py      48      2    96%   170-171
homeassistant/components/rainmachine/button.py             35      6    83%   42, 76-83
homeassistant/components/rainmachine/config_flow.py        68      0   100%
homeassistant/components/rainmachine/const.py              16      0   100%
homeassistant/components/rainmachine/diagnostics.py        22      0   100%
homeassistant/components/rainmachine/model.py               5      0   100%
homeassistant/components/rainmachine/select.py             53      5    91%   124, 134-139
homeassistant/components/rainmachine/sensor.py             99     14    86%   255, 276, 278-290, 303, 329-331, 340, 346, 354
homeassistant/components/rainmachine/switch.py            210     51    76%   120-123, 237, 263, 296-304, 313-323, 349, 353, 358-359, 364-365, 376, 400-405, 410-411, 423-427, 432-436, 449, 453, 458-459, 465-480, 515-517, 530-535, 540-541
homeassistant/components/rainmachine/update.py             48     48     0%   3-110
homeassistant/components/rainmachine/util.py               81     14    83%   73-76, 131-134, 139-142, 156-157
-------------------------------------------------------------------------------------
TOTAL                                                     922    184    80%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
