### PR TITLE
Fix Jewish calendar unique id's

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -37,10 +37,6 @@ from .const import (
 from .sensor import INFO_SENSORS, TIME_SENSORS
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
-PLATFORM_DESCRIPTIONS = {
-    Platform.BINARY_SENSOR: BINARY_SENSORS,
-    Platform.SENSOR: (*INFO_SENSORS, *TIME_SENSORS),
-}
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -180,12 +176,13 @@ def async_update_unique_ids(
 
     Introduced with release 2024.6
     """
-    for platform, descriptions in PLATFORM_DESCRIPTIONS.items():
+    platform_descriptions = {
+        Platform.BINARY_SENSOR: BINARY_SENSORS,
+        Platform.SENSOR: (*INFO_SENSORS, *TIME_SENSORS),
+    }
+    for platform, descriptions in platform_descriptions.items():
         for description in descriptions:
             new_unique_id = f"{new_prefix}-{description.key}"
-            if ent_reg.async_get_entity_id(platform, DOMAIN, new_unique_id):
-                return
-
             old_unique_id = f"{old_prefix}_{description.key}"
             if entity_id := ent_reg.async_get_entity_id(
                 platform, DOMAIN, old_unique_id

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -178,7 +178,7 @@ def async_update_unique_ids(
 ) -> None:
     """Update unique ID to be unrelated to user defined options.
 
-    Introduced with release 2024.5
+    Introduced with release 2024.6
     """
     for platform, descriptions in PLATFORM_DESCRIPTIONS.items():
         for description in descriptions:

--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -132,7 +132,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         timezone=config_entry.data.get(CONF_TIME_ZONE, hass.config.time_zone),
     )
 
-    prefix = get_unique_prefix(
+    old_prefix = get_unique_prefix(
         location, language, candle_lighting_offset, havdalah_offset
     )
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {
@@ -141,7 +141,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         CONF_LOCATION: location,
         CONF_CANDLE_LIGHT_MINUTES: candle_lighting_offset,
         CONF_HAVDALAH_OFFSET_MINUTES: havdalah_offset,
-        "prefix": prefix,
+        "old_prefix": old_prefix,
     }
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -72,19 +72,18 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Jewish Calendar binary sensors."""
+    entry = hass.data[DOMAIN][config.entry_id]
     for description in BINARY_SENSORS:
         async_update_unique_id(
             hass,
             config.entry_id,
-            hass.data[DOMAIN]["prefix"],
+            entry["old_prefix"],
             BINARY_SENSOR_DOMAIN,
             description.key,
         )
 
     async_add_entities(
-        JewishCalendarBinarySensor(
-            config.entry_id, hass.data[DOMAIN][config.entry_id], description
-        )
+        JewishCalendarBinarySensor(config.entry_id, entry, description)
         for description in BINARY_SENSORS
     )
 

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -66,14 +66,14 @@ BINARY_SENSORS: tuple[JewishCalendarBinarySensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Jewish Calendar binary sensors."""
-    entry = hass.data[DOMAIN][config.entry_id]
+    entry = hass.data[DOMAIN][config_entry.entry_id]
 
     async_add_entities(
-        JewishCalendarBinarySensor(config.entry_id, entry, description)
+        JewishCalendarBinarySensor(config_entry.entry_id, entry, description)
         for description in BINARY_SENSORS
     )
 

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -12,7 +12,6 @@ import hdate
 from hdate.zmanim import Zmanim
 
 from homeassistant.components.binary_sensor import (
-    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
@@ -23,7 +22,6 @@ from homeassistant.helpers import event
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import homeassistant.util.dt as dt_util
 
-from . import async_update_unique_id
 from .const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_HAVDALAH_OFFSET_MINUTES,
@@ -73,14 +71,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Jewish Calendar binary sensors."""
     entry = hass.data[DOMAIN][config.entry_id]
-    for description in BINARY_SENSORS:
-        async_update_unique_id(
-            hass,
-            config.entry_id,
-            entry["old_prefix"],
-            BINARY_SENSOR_DOMAIN,
-            description.key,
-        )
 
     async_add_entities(
         JewishCalendarBinarySensor(config.entry_id, entry, description)

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -10,7 +10,6 @@ from hdate import HDate
 from hdate.zmanim import Zmanim
 
 from homeassistant.components.sensor import (
-    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -22,7 +21,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.sun import get_astral_event_date
 import homeassistant.util.dt as dt_util
 
-from . import async_update_unique_id
 from .const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_DIASPORA,
@@ -157,15 +155,6 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Jewish calendar sensors ."""
     entry = hass.data[DOMAIN][config.entry_id]
-    for sensor in (*INFO_SENSORS, *TIME_SENSORS):
-        async_update_unique_id(
-            hass,
-            config.entry_id,
-            entry["old_prefix"],
-            SENSOR_DOMAIN,
-            sensor.key,
-        )
-
     sensors = [
         JewishCalendarSensor(config.entry_id, entry, description)
         for description in INFO_SENSORS

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -150,17 +150,17 @@ TIME_SENSORS: tuple[SensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config: ConfigEntry,
+    config_entry: ConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Jewish calendar sensors ."""
-    entry = hass.data[DOMAIN][config.entry_id]
+    entry = hass.data[DOMAIN][config_entry.entry_id]
     sensors = [
-        JewishCalendarSensor(config.entry_id, entry, description)
+        JewishCalendarSensor(config_entry.entry_id, entry, description)
         for description in INFO_SENSORS
     ]
     sensors.extend(
-        JewishCalendarTimeSensor(config.entry_id, entry, description)
+        JewishCalendarTimeSensor(config_entry.entry_id, entry, description)
         for description in TIME_SENSORS
     )
 

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -157,6 +157,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Jewish calendar sensors ."""
     entry = hass.data[DOMAIN][config.entry_id]
+    for sensor in (*INFO_SENSORS, *TIME_SENSORS):
+        async_update_unique_id(
+            hass,
+            config.entry_id,
+            entry["old_prefix"],
+            SENSOR_DOMAIN,
+            sensor.key,
+        )
+
     sensors = [
         JewishCalendarSensor(config.entry_id, entry, description)
         for description in INFO_SENSORS
@@ -165,15 +174,6 @@ async def async_setup_entry(
         JewishCalendarTimeSensor(config.entry_id, entry, description)
         for description in TIME_SENSORS
     )
-
-    for sensor in sensors:
-        async_update_unique_id(
-            hass,
-            config.entry_id,
-            hass.data[DOMAIN]["prefix"],
-            SENSOR_DOMAIN,
-            sensor.entity_description.key,
-        )
 
     async_add_entities(sensors)
 

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -2,9 +2,12 @@
 
 from unittest.mock import AsyncMock
 
+from hdate import Location
 import pytest
 
 from homeassistant import config_entries, setup
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSORS
+from homeassistant.components.jewish_calendar import get_unique_prefix
 from homeassistant.components.jewish_calendar.const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_DIASPORA,
@@ -26,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+import homeassistant.helpers.entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -92,13 +96,35 @@ async def test_import_with_options(hass: HomeAssistant) -> None:
             CONF_LONGITUDE: 35.235,
         }
     }
+    # Create an entry in the entity registry with the data from conf
+    ent_reg = er.async_get(hass)
+    location = Location(
+        latitude=31.76,
+        longitude=35.235,
+        timezone=hass.config.time_zone,
+        altitude=hass.config.elevation,
+        diaspora=DEFAULT_DIASPORA,
+    )
+    old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)
+    old_entity = ent_reg.async_get_or_create(
+        BINARY_SENSORS, DOMAIN, unique_id=f"{old_prefix}_erev_shabbat_hag"
+    )
 
+    # Save the existing unique_id, DEFAULT_LANGUAGE should be part of it
+    old_unique_id = old_entity.unique_id
+    assert DEFAULT_LANGUAGE in old_unique_id
+
+    # Simulate HomeAssistant setting up the component
     assert await async_setup_component(hass, DOMAIN, conf.copy())
     await hass.async_block_till_done()
 
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].data == conf[DOMAIN]
+
+    # Assert that the unique_id was updated
+    assert ent_reg.async_get(old_entity.entity_id).unique_id != old_unique_id
+    assert DEFAULT_LANGUAGE not in ent_reg.async_get(old_entity.entity_id).unique_id
 
 
 async def test_single_instance_allowed(

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -106,12 +106,15 @@ async def test_import_with_options(hass: HomeAssistant) -> None:
         diaspora=DEFAULT_DIASPORA,
     )
     old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)
-    old_entity = ent_reg.async_get_or_create(
-        BINARY_SENSORS, DOMAIN, unique_id=f"{old_prefix}_erev_shabbat_hag"
+    sample_entity = ent_reg.async_get_or_create(
+        BINARY_SENSORS,
+        DOMAIN,
+        unique_id=f"{old_prefix}_erev_shabbat_hag",
+        suggested_object_id=f"{DOMAIN}_erev_shabbat_hag",
     )
 
     # Save the existing unique_id, DEFAULT_LANGUAGE should be part of it
-    old_unique_id = old_entity.unique_id
+    old_unique_id = sample_entity.unique_id
     assert DEFAULT_LANGUAGE in old_unique_id
 
     # Simulate HomeAssistant setting up the component
@@ -123,8 +126,13 @@ async def test_import_with_options(hass: HomeAssistant) -> None:
     assert entries[0].data == conf[DOMAIN]
 
     # Assert that the unique_id was updated
-    assert ent_reg.async_get(old_entity.entity_id).unique_id != old_unique_id
-    assert DEFAULT_LANGUAGE not in ent_reg.async_get(old_entity.entity_id).unique_id
+    new_unique_id = ent_reg.async_get(sample_entity.entity_id).unique_id
+    assert new_unique_id != old_unique_id
+    assert DEFAULT_LANGUAGE not in new_unique_id
+
+    # Confirm that when the component is reloaded, the unique_id is not changed
+    await hass.config_entries.async_reload(entries[0].entry_id)
+    assert ent_reg.async_get(sample_entity.entity_id).unique_id == new_unique_id
 
 
 async def test_single_instance_allowed(

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -66,6 +66,9 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
     assert DEFAULT_LANGUAGE not in new_unique_id
 
     # Confirm that when the component is reloaded, the unique_id is not changed
+    assert ent_reg.async_get(sample_entity.entity_id).unique_id == new_unique_id
+
+    # Confirm that all the unique_ids are prefixed correctly
     await hass.config_entries.async_reload(entries[0].entry_id)
     er_entries = er.async_entries_for_config_entry(ent_reg, entries[0].entry_id)
     assert all(entry.unique_id.startswith(entries[0].entry_id) for entry in er_entries)

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -67,4 +67,5 @@ async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
 
     # Confirm that when the component is reloaded, the unique_id is not changed
     await hass.config_entries.async_reload(entries[0].entry_id)
-    assert ent_reg.async_get(sample_entity.entity_id).unique_id == new_unique_id
+    er_entries = er.async_entries_for_config_entry(ent_reg, entries[0].entry_id)
+    assert all(entry.unique_id.startswith(entries[0].entry_id) for entry in er_entries)

--- a/tests/components/jewish_calendar/test_init.py
+++ b/tests/components/jewish_calendar/test_init.py
@@ -1,0 +1,70 @@
+"""Tests for the Jewish Calendar component's init."""
+
+from hdate import Location
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSORS
+from homeassistant.components.jewish_calendar import get_unique_prefix
+from homeassistant.components.jewish_calendar.const import (
+    CONF_CANDLE_LIGHT_MINUTES,
+    CONF_DIASPORA,
+    CONF_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_DIASPORA,
+    DEFAULT_LANGUAGE,
+    DOMAIN,
+)
+from homeassistant.const import CONF_LANGUAGE, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.core import HomeAssistant
+import homeassistant.helpers.entity_registry as er
+from homeassistant.setup import async_setup_component
+
+
+async def test_import_unique_id_migration(hass: HomeAssistant) -> None:
+    """Test unique_id migration."""
+    yaml_conf = {
+        DOMAIN: {
+            CONF_NAME: "test",
+            CONF_DIASPORA: DEFAULT_DIASPORA,
+            CONF_LANGUAGE: DEFAULT_LANGUAGE,
+            CONF_CANDLE_LIGHT_MINUTES: 20,
+            CONF_HAVDALAH_OFFSET_MINUTES: 50,
+            CONF_LATITUDE: 31.76,
+            CONF_LONGITUDE: 35.235,
+        }
+    }
+
+    # Create an entry in the entity registry with the data from conf
+    ent_reg = er.async_get(hass)
+    location = Location(
+        latitude=yaml_conf[DOMAIN][CONF_LATITUDE],
+        longitude=yaml_conf[DOMAIN][CONF_LONGITUDE],
+        timezone=hass.config.time_zone,
+        altitude=hass.config.elevation,
+        diaspora=DEFAULT_DIASPORA,
+    )
+    old_prefix = get_unique_prefix(location, DEFAULT_LANGUAGE, 20, 50)
+    sample_entity = ent_reg.async_get_or_create(
+        BINARY_SENSORS,
+        DOMAIN,
+        unique_id=f"{old_prefix}_erev_shabbat_hag",
+        suggested_object_id=f"{DOMAIN}_erev_shabbat_hag",
+    )
+    # Save the existing unique_id, DEFAULT_LANGUAGE should be part of it
+    old_unique_id = sample_entity.unique_id
+    assert DEFAULT_LANGUAGE in old_unique_id
+
+    # Simulate HomeAssistant setting up the component
+    assert await async_setup_component(hass, DOMAIN, yaml_conf.copy())
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == yaml_conf[DOMAIN]
+
+    # Assert that the unique_id was updated
+    new_unique_id = ent_reg.async_get(sample_entity.entity_id).unique_id
+    assert new_unique_id != old_unique_id
+    assert DEFAULT_LANGUAGE not in new_unique_id
+
+    # Confirm that when the component is reloaded, the unique_id is not changed
+    await hass.config_entries.async_reload(entries[0].entry_id)
+    assert ent_reg.async_get(sample_entity.entity_id).unique_id == new_unique_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This should go into 2024.6


This PR fixes a long-standing issue with the Jewish calendar integration.
The current unique ID implementation uses the configuration settings of the integration with some configuration of Home Assistant (location and altitude). If the user changed the location or some of the relevant settings in the config, all the sensors would become unavailable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #61555, fixes #73153, fixes #76194, fixes #80591, fixes home-assistant/home-assistant.io#27109, fixes #88777, fixes #102803, fixes #114446 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
