### PR TITLE
Remove Switcher YAML import support

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -5,21 +5,12 @@ from __future__ import annotations
 import logging
 
 from aioswitcher.device import SwitcherBase
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import CONF_DEVICE_ID, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_DEVICE_PASSWORD,
-    CONF_PHONE_ID,
-    DATA_DEVICE,
-    DATA_DISCOVERY,
-    DOMAIN,
-)
+from .const import DATA_DEVICE, DATA_DISCOVERY, DOMAIN
 from .coordinator import SwitcherDataUpdateCoordinator
 from .utils import async_start_bridge, async_stop_bridge
 
@@ -33,40 +24,10 @@ PLATFORMS = [
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_PHONE_ID): cv.string,
-                    vol.Required(CONF_DEVICE_ID): cv.string,
-                    vol.Required(CONF_DEVICE_PASSWORD): cv.string,
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the switcher component."""
-    hass.data.setdefault(DOMAIN, {})
-
-    if DOMAIN not in config:
-        return True
-
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data={}
-        )
-    )
-    return True
-
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Switcher from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][DATA_DEVICE] = {}
 
     @callback

--- a/homeassistant/components/switcher_kis/config_flow.py
+++ b/homeassistant/components/switcher_kis/config_flow.py
@@ -13,15 +13,6 @@ from .utils import async_discover_devices
 class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle Switcher config flow."""
 
-    async def async_step_import(
-        self, import_config: dict[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle a flow initiated by import."""
-        if self._async_current_entries(True):
-            return self.async_abort(reason="single_instance_allowed")
-
-        return self.async_create_entry(title="Switcher", data={})
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -2,9 +2,6 @@
 
 DOMAIN = "switcher_kis"
 
-CONF_DEVICE_PASSWORD = "device_password"
-CONF_PHONE_ID = "phone_id"
-
 DATA_BRIDGE = "bridge"
 DATA_DEVICE = "device"
 DATA_DISCOVERY = "discovery"

--- a/tests/components/switcher_kis/consts.py
+++ b/tests/components/switcher_kis/consts.py
@@ -13,13 +13,6 @@ from aioswitcher.device import (
     ThermostatSwing,
 )
 
-from homeassistant.components.switcher_kis import (
-    CONF_DEVICE_ID,
-    CONF_DEVICE_PASSWORD,
-    CONF_PHONE_ID,
-    DOMAIN,
-)
-
 DUMMY_AUTO_OFF_SET = "01:30:00"
 DUMMY_AUTO_SHUT_DOWN = "02:00:00"
 DUMMY_DEVICE_ID1 = "a123bc"
@@ -58,14 +51,6 @@ DUMMY_SWING = ThermostatSwing.OFF
 DUMMY_REMOTE_ID = "ELEC7001"
 DUMMY_POSITION = 54
 DUMMY_DIRECTION = ShutterDirection.SHUTTER_STOP
-
-YAML_CONFIG = {
-    DOMAIN: {
-        CONF_PHONE_ID: DUMMY_PHONE_ID,
-        CONF_DEVICE_ID: DUMMY_DEVICE_ID1,
-        CONF_DEVICE_PASSWORD: DUMMY_DEVICE_PASSWORD,
-    }
-}
 
 DUMMY_PLUG_DEVICE = SwitcherPowerPlug(
     DeviceType.POWER_PLUG,

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -14,20 +14,6 @@ from .consts import DUMMY_PLUG_DEVICE, DUMMY_WATER_HEATER_DEVICE
 from tests.common import MockConfigEntry
 
 
-async def test_import(hass: HomeAssistant) -> None:
-    """Test import step."""
-    with patch(
-        "homeassistant.components.switcher_kis.async_setup_entry", return_value=True
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}
-        )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Switcher"
-    assert result["data"] == {}
-
-
 @pytest.mark.parametrize(
     "mock_bridge",
     [
@@ -88,20 +74,13 @@ async def test_user_setup_abort_no_devices_found(
     assert result2["reason"] == "no_devices_found"
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        config_entries.SOURCE_IMPORT,
-        config_entries.SOURCE_USER,
-    ],
-)
-async def test_single_instance(hass: HomeAssistant, source) -> None:
+async def test_single_instance(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
     await hass.async_block_till_done()
 
     result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": source}
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
     assert result["type"] is FlowResultType.ABORT

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -14,24 +14,12 @@ from homeassistant.components.switcher_kis.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util, slugify
 
 from . import init_integration
-from .consts import DUMMY_SWITCHER_DEVICES, YAML_CONFIG
+from .consts import DUMMY_SWITCHER_DEVICES
 
 from tests.common import async_fire_time_changed
-
-
-@pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)
-async def test_async_setup_yaml_config(hass: HomeAssistant, mock_bridge) -> None:
-    """Test setup started by configuration from YAML."""
-    assert await async_setup_component(hass, DOMAIN, YAML_CONFIG)
-    await hass.async_block_till_done()
-
-    assert mock_bridge.is_running is True
-    assert len(hass.data[DOMAIN]) == 2
-    assert len(hass.data[DOMAIN][DATA_DEVICE]) == 2
 
 
 @pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
YAML configuration for Switcher deprecated in 2021.8.0. This is now removed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove YAML configuration from Switcher.

Note: Switcher config flow is outdated and can be migrated to use `single_config_entry` and `register_discovery_flow` but I limited this PR to the breaking change only. Config flow update will be on a following PR after this one.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
