### PR TITLE
Switcher - use single_config_entry and register_discovery_flow in con…

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 
-from .const import DATA_DEVICE, DATA_DISCOVERY, DOMAIN
+from .const import DATA_DEVICE, DOMAIN
 from .coordinator import SwitcherDataUpdateCoordinator
 from .utils import async_start_bridge, async_stop_bridge
 
@@ -59,12 +59,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Must be ready before dispatcher is called
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-
-    discovery_task = hass.data[DOMAIN].pop(DATA_DISCOVERY, None)
-    if discovery_task is not None:
-        discovered_devices = await discovery_task
-        for device in discovered_devices.values():
-            on_device_data_callback(device)
 
     await async_start_bridge(hass, on_device_data_callback)
 

--- a/homeassistant/components/switcher_kis/config_flow.py
+++ b/homeassistant/components/switcher_kis/config_flow.py
@@ -2,40 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any
+from homeassistant.helpers import config_entry_flow
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from .const import DOMAIN
+from .utils import async_has_devices
 
-from .const import DATA_DISCOVERY, DOMAIN
-from .utils import async_discover_devices
-
-
-class SwitcherFlowHandler(ConfigFlow, domain=DOMAIN):
-    """Handle Switcher config flow."""
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle the start of the config flow."""
-        if self._async_current_entries(True):
-            return self.async_abort(reason="single_instance_allowed")
-
-        self.hass.data.setdefault(DOMAIN, {})
-        if DATA_DISCOVERY not in self.hass.data[DOMAIN]:
-            self.hass.data[DOMAIN][DATA_DISCOVERY] = self.hass.async_create_task(
-                async_discover_devices()
-            )
-
-        return self.async_show_form(step_id="confirm")
-
-    async def async_step_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Handle user-confirmation of the config flow."""
-        discovered_devices = await self.hass.data[DOMAIN][DATA_DISCOVERY]
-
-        if len(discovered_devices) == 0:
-            self.hass.data[DOMAIN].pop(DATA_DISCOVERY)
-            return self.async_abort(reason="no_devices_found")
-
-        return self.async_create_entry(title="Switcher", data={})
+config_entry_flow.register_discovery_flow(DOMAIN, "Switcher", async_has_devices)

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -4,7 +4,6 @@ DOMAIN = "switcher_kis"
 
 DATA_BRIDGE = "bridge"
 DATA_DEVICE = "device"
-DATA_DISCOVERY = "discovery"
 
 DISCOVERY_TIME_SEC = 12
 

--- a/homeassistant/components/switcher_kis/manifest.json
+++ b/homeassistant/components/switcher_kis/manifest.json
@@ -7,5 +7,6 @@
   "iot_class": "local_push",
   "loggers": ["aioswitcher"],
   "quality_scale": "platinum",
-  "requirements": ["aioswitcher==3.4.1"]
+  "requirements": ["aioswitcher==3.4.1"],
+  "single_config_entry": true
 }

--- a/homeassistant/components/switcher_kis/utils.py
+++ b/homeassistant/components/switcher_kis/utils.py
@@ -36,7 +36,7 @@ async def async_stop_bridge(hass: HomeAssistant) -> None:
         hass.data[DOMAIN].pop(DATA_BRIDGE)
 
 
-async def async_discover_devices() -> dict[str, SwitcherBase]:
+async def async_has_devices(hass: HomeAssistant) -> bool:
     """Discover Switcher devices."""
     _LOGGER.debug("Starting discovery")
     discovered_devices = {}
@@ -55,7 +55,7 @@ async def async_discover_devices() -> dict[str, SwitcherBase]:
     await bridge.stop()
 
     _LOGGER.debug("Finished discovery, discovered devices: %s", len(discovered_devices))
-    return discovered_devices
+    return len(discovered_devices) > 0
 
 
 @singleton.singleton("switcher_breeze_remote_manager")

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5894,7 +5894,8 @@
       "name": "Switcher",
       "integration_type": "hub",
       "config_flow": true,
-      "iot_class": "local_push"
+      "iot_class": "local_push",
+      "single_config_entry": true
     },
     "switchmate": {
       "name": "Switchmate SimplySmart Home",

--- a/tests/components/switcher_kis/conftest.py
+++ b/tests/components/switcher_kis/conftest.py
@@ -1,8 +1,18 @@
 """Common fixtures and objects for the Switcher integration tests."""
 
+from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock, None, None]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.switcher_kis.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
 
 
 @pytest.fixture

--- a/tests/components/switcher_kis/test_config_flow.py
+++ b/tests/components/switcher_kis/test_config_flow.py
@@ -1,11 +1,11 @@
 """Test the Switcher config flow."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.switcher_kis.const import DATA_DISCOVERY, DOMAIN
+from homeassistant.components.switcher_kis.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -26,52 +26,51 @@ from tests.common import MockConfigEntry
     ],
     indirect=True,
 )
-async def test_user_setup(hass: HomeAssistant, mock_bridge) -> None:
+async def test_user_setup(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_bridge
+) -> None:
     """Test we can finish a config flow."""
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        await hass.async_block_till_done()
 
-    assert mock_bridge.is_running is False
-    assert len(hass.data[DOMAIN][DATA_DISCOVERY].result()) == 2
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "confirm"
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] is None
-
-    with patch(
-        "homeassistant.components.switcher_kis.async_setup_entry", return_value=True
-    ):
         result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
 
-    assert result2["type"] is FlowResultType.CREATE_ENTRY
-    assert result2["title"] == "Switcher"
-    assert result2["result"].data == {}
+        assert mock_bridge.is_running is False
+        assert result2["type"] is FlowResultType.CREATE_ENTRY
+        assert result2["title"] == "Switcher"
+        assert result2["result"].data == {}
+
+        await hass.async_block_till_done()
+
+        assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_user_setup_abort_no_devices_found(
-    hass: HomeAssistant, mock_bridge
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_bridge
 ) -> None:
     """Test we abort a config flow if no devices found."""
     with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "confirm"
+
+        result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+
+        assert mock_bridge.is_running is False
+        assert result2["type"] is FlowResultType.ABORT
+        assert result2["reason"] == "no_devices_found"
+
         await hass.async_block_till_done()
 
-    assert mock_bridge.is_running is False
-    assert len(hass.data[DOMAIN][DATA_DISCOVERY].result()) == 0
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
-    assert result["errors"] is None
-
-    result2 = await hass.config_entries.flow.async_configure(result["flow_id"], {})
-
-    assert result2["type"] is FlowResultType.ABORT
-    assert result2["reason"] == "no_devices_found"
+        assert len(mock_setup_entry.mock_calls) == 0
 
 
 async def test_single_instance(hass: HomeAssistant) -> None:

--- a/tests/components/switcher_kis/test_init.py
+++ b/tests/components/switcher_kis/test_init.py
@@ -1,11 +1,9 @@
 """Test cases for the switcher_kis component."""
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 
-from homeassistant import config_entries
 from homeassistant.components.switcher_kis.const import (
     DATA_DEVICE,
     DOMAIN,
@@ -20,23 +18,6 @@ from . import init_integration
 from .consts import DUMMY_SWITCHER_DEVICES
 
 from tests.common import async_fire_time_changed
-
-
-@pytest.mark.parametrize("mock_bridge", [DUMMY_SWITCHER_DEVICES], indirect=True)
-async def test_async_setup_user_config_flow(hass: HomeAssistant, mock_bridge) -> None:
-    """Test setup started by user config flow."""
-    with patch("homeassistant.components.switcher_kis.utils.DISCOVERY_TIME_SEC", 0):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        await hass.async_block_till_done()
-
-    await hass.config_entries.flow.async_configure(result["flow_id"], {})
-    await hass.async_block_till_done()
-
-    assert mock_bridge.is_running is True
-    assert len(hass.data[DOMAIN]) == 2
-    assert len(hass.data[DOMAIN][DATA_DEVICE]) == 2
 
 
 async def test_update_fail(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
YAML import removed in https://github.com/home-assistant/core/pull/117994, it is now possible to use a simple config flow by using `single_config_entry` and `register_discovery_flow`

Note: can remove usage of `hass.data` and use `entry.runtime_data` but to limit the PR size it will be in a future PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
