### PR TITLE
Convert Feedreader to use an update coordinator

### DIFF
--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -2,37 +2,23 @@
 
 from __future__ import annotations
 
-from calendar import timegm
-from datetime import datetime, timedelta
-from logging import getLogger
-import os
-import pickle
-from time import gmtime, struct_time
+from datetime import timedelta
 
-import feedparser
 import voluptuous as vol
 
-from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.const import CONF_SCAN_INTERVAL
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
 
-_LOGGER = getLogger(__name__)
-
-CONF_URLS = "urls"
-CONF_MAX_ENTRIES = "max_entries"
-
-DEFAULT_MAX_ENTRIES = 20
-DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
-DELAY_SAVE = 30
-
-DOMAIN = "feedreader"
-
-EVENT_FEEDREADER = "feedreader"
-STORAGE_VERSION = 1
+from .const import (
+    CONF_MAX_ENTRIES,
+    CONF_URLS,
+    DEFAULT_MAX_ENTRIES,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .coordinator import FeedManager, StoredData
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -69,229 +55,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         feed.async_setup()
 
     return True
-
-
-class FeedManager:
-    """Abstraction over Feedparser module."""
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        url: str,
-        scan_interval: timedelta,
-        max_entries: int,
-        storage: StoredData,
-    ) -> None:
-        """Initialize the FeedManager object, poll as per scan interval."""
-        self._hass = hass
-        self._url = url
-        self._scan_interval = scan_interval
-        self._max_entries = max_entries
-        self._feed: feedparser.FeedParserDict | None = None
-        self._firstrun = True
-        self._storage = storage
-        self._last_entry_timestamp: struct_time | None = None
-        self._has_published_parsed = False
-        self._has_updated_parsed = False
-        self._event_type = EVENT_FEEDREADER
-        self._feed_id = url
-
-    @callback
-    def async_setup(self) -> None:
-        """Set up the feed manager."""
-        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, self._async_update)
-        async_track_time_interval(
-            self._hass, self._async_update, self._scan_interval, cancel_on_shutdown=True
-        )
-
-    def _log_no_entries(self) -> None:
-        """Send no entries log at debug level."""
-        _LOGGER.debug("No new entries to be published in feed %s", self._url)
-
-    async def _async_update(self, _: datetime | Event) -> None:
-        """Update the feed and publish new entries to the event bus."""
-        last_entry_timestamp = await self._hass.async_add_executor_job(self._update)
-        if last_entry_timestamp:
-            self._storage.async_put_timestamp(self._feed_id, last_entry_timestamp)
-
-    def _update(self) -> struct_time | None:
-        """Update the feed and publish new entries to the event bus."""
-        _LOGGER.debug("Fetching new data from feed %s", self._url)
-        self._feed = feedparser.parse(
-            self._url,
-            etag=None if not self._feed else self._feed.get("etag"),
-            modified=None if not self._feed else self._feed.get("modified"),
-        )
-        if not self._feed:
-            _LOGGER.error("Error fetching feed data from %s", self._url)
-            return None
-        # The 'bozo' flag really only indicates that there was an issue
-        # during the initial parsing of the XML, but it doesn't indicate
-        # whether this is an unrecoverable error. In this case the
-        # feedparser lib is trying a less strict parsing approach.
-        # If an error is detected here, log warning message but continue
-        # processing the feed entries if present.
-        if self._feed.bozo != 0:
-            _LOGGER.warning(
-                "Possible issue parsing feed %s: %s",
-                self._url,
-                self._feed.bozo_exception,
-            )
-        # Using etag and modified, if there's no new data available,
-        # the entries list will be empty
-        _LOGGER.debug(
-            "%s entri(es) available in feed %s",
-            len(self._feed.entries),
-            self._url,
-        )
-        if not self._feed.entries:
-            self._log_no_entries()
-            return None
-
-        self._filter_entries()
-        self._publish_new_entries()
-
-        _LOGGER.debug("Fetch from feed %s completed", self._url)
-
-        if (
-            self._has_published_parsed or self._has_updated_parsed
-        ) and self._last_entry_timestamp:
-            return self._last_entry_timestamp
-
-        return None
-
-    def _filter_entries(self) -> None:
-        """Filter the entries provided and return the ones to keep."""
-        assert self._feed is not None
-        if len(self._feed.entries) > self._max_entries:
-            _LOGGER.debug(
-                "Processing only the first %s entries in feed %s",
-                self._max_entries,
-                self._url,
-            )
-            self._feed.entries = self._feed.entries[0 : self._max_entries]
-
-    def _update_and_fire_entry(self, entry: feedparser.FeedParserDict) -> None:
-        """Update last_entry_timestamp and fire entry."""
-        # Check if the entry has a updated or published date.
-        # Start from a updated date because generally `updated` > `published`.
-        if "updated_parsed" in entry and entry.updated_parsed:
-            # We are lucky, `updated_parsed` data available, let's make use of
-            # it to publish only new available entries since the last run
-            self._has_updated_parsed = True
-            self._last_entry_timestamp = max(
-                entry.updated_parsed, self._last_entry_timestamp
-            )
-        elif "published_parsed" in entry and entry.published_parsed:
-            # We are lucky, `published_parsed` data available, let's make use of
-            # it to publish only new available entries since the last run
-            self._has_published_parsed = True
-            self._last_entry_timestamp = max(
-                entry.published_parsed, self._last_entry_timestamp
-            )
-        else:
-            self._has_updated_parsed = False
-            self._has_published_parsed = False
-            _LOGGER.debug(
-                "No updated_parsed or published_parsed info available for entry %s",
-                entry,
-            )
-        entry.update({"feed_url": self._url})
-        self._hass.bus.fire(self._event_type, entry)
-        _LOGGER.debug("New event fired for entry %s", entry.get("link"))
-
-    def _publish_new_entries(self) -> None:
-        """Publish new entries to the event bus."""
-        assert self._feed is not None
-        new_entry_count = 0
-        self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
-        if self._last_entry_timestamp:
-            self._firstrun = False
-        else:
-            # Set last entry timestamp as epoch time if not available
-            self._last_entry_timestamp = dt_util.utc_from_timestamp(0).timetuple()
-        # locally cache self._last_entry_timestamp so that entries published at identical times can be processed
-        last_entry_timestamp = self._last_entry_timestamp
-        for entry in self._feed.entries:
-            if (
-                self._firstrun
-                or (
-                    "published_parsed" in entry
-                    and entry.published_parsed > last_entry_timestamp
-                )
-                or (
-                    "updated_parsed" in entry
-                    and entry.updated_parsed > last_entry_timestamp
-                )
-            ):
-                self._update_and_fire_entry(entry)
-                new_entry_count += 1
-            else:
-                _LOGGER.debug("Already processed entry %s", entry.get("link"))
-        if new_entry_count == 0:
-            self._log_no_entries()
-        else:
-            _LOGGER.debug("%d entries published in feed %s", new_entry_count, self._url)
-        self._firstrun = False
-
-
-class StoredData:
-    """Represent a data storage."""
-
-    def __init__(self, hass: HomeAssistant, legacy_data_file: str) -> None:
-        """Initialize data storage."""
-        self._legacy_data_file = legacy_data_file
-        self._data: dict[str, struct_time] = {}
-        self._hass = hass
-        self._store: Store[dict[str, str]] = Store(hass, STORAGE_VERSION, DOMAIN)
-
-    async def async_setup(self) -> None:
-        """Set up storage."""
-        if not os.path.exists(self._store.path):
-            # Remove the legacy store loading after deprecation period.
-            data = await self._hass.async_add_executor_job(self._legacy_fetch_data)
-        else:
-            if (store_data := await self._store.async_load()) is None:
-                return
-            # Make sure that dst is set to 0, by using gmtime() on the timestamp.
-            data = {
-                feed_id: gmtime(datetime.fromisoformat(timestamp_string).timestamp())
-                for feed_id, timestamp_string in store_data.items()
-            }
-
-        self._data = data
-
-    def _legacy_fetch_data(self) -> dict[str, struct_time]:
-        """Fetch data stored in pickle file."""
-        _LOGGER.debug("Fetching data from legacy file %s", self._legacy_data_file)
-        try:
-            with open(self._legacy_data_file, "rb") as myfile:
-                return pickle.load(myfile) or {}
-        except FileNotFoundError:
-            pass
-        except (OSError, pickle.PickleError) as err:
-            _LOGGER.error(
-                "Error loading data from pickled file %s: %s",
-                self._legacy_data_file,
-                err,
-            )
-
-        return {}
-
-    def get_timestamp(self, feed_id: str) -> struct_time | None:
-        """Return stored timestamp for given feed id."""
-        return self._data.get(feed_id)
-
-    @callback
-    def async_put_timestamp(self, feed_id: str, timestamp: struct_time) -> None:
-        """Update timestamp for given feed id."""
-        self._data[feed_id] = timestamp
-        self._store.async_delay_save(self._async_save_data, DELAY_SAVE)
-
-    @callback
-    def _async_save_data(self) -> dict[str, str]:
-        """Save feed data to storage."""
-        return {
-            feed_id: dt_util.utc_from_timestamp(timegm(struct_utc)).isoformat()
-            for feed_id, struct_utc in self._data.items()
-        }

--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -55,7 +55,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     await asyncio.gather(*[feed.async_refresh() for feed in feeds])
 
-    # workaround until we have entities to update
+    # workaround because coordinators without listeners won't update
+    # can be removed when we have entities to update
     [feed.async_add_listener(lambda: None) for feed in feeds]
 
     return True

--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -12,14 +12,15 @@ from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (
-    CONF_MAX_ENTRIES,
-    CONF_URLS,
-    DEFAULT_MAX_ENTRIES,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-)
+from .const import DOMAIN
 from .coordinator import FeedReaderCoordinator, StoredData
+
+CONF_URLS = "urls"
+CONF_MAX_ENTRIES = "max_entries"
+
+DEFAULT_MAX_ENTRIES = 20
+DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
+
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/feedreader/__init__.py
+++ b/homeassistant/components/feedreader/__init__.py
@@ -46,8 +46,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     scan_interval: timedelta = config[DOMAIN][CONF_SCAN_INTERVAL]
     max_entries: int = config[DOMAIN][CONF_MAX_ENTRIES]
-    old_data_file = hass.config.path(f"{DOMAIN}.pickle")
-    storage = StoredData(hass, old_data_file)
+    storage = StoredData(hass)
     await storage.async_setup()
     feeds = [
         FeedReaderCoordinator(hass, url, scan_interval, max_entries, storage)

--- a/homeassistant/components/feedreader/const.py
+++ b/homeassistant/components/feedreader/const.py
@@ -1,0 +1,15 @@
+"""Constants for RSS/Atom feeds."""
+
+from datetime import timedelta
+
+CONF_URLS = "urls"
+CONF_MAX_ENTRIES = "max_entries"
+
+DEFAULT_MAX_ENTRIES = 20
+DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
+DELAY_SAVE = 30
+
+DOMAIN = "feedreader"
+
+EVENT_FEEDREADER = "feedreader"
+STORAGE_VERSION = 1

--- a/homeassistant/components/feedreader/const.py
+++ b/homeassistant/components/feedreader/const.py
@@ -1,15 +1,3 @@
 """Constants for RSS/Atom feeds."""
 
-from datetime import timedelta
-
-CONF_URLS = "urls"
-CONF_MAX_ENTRIES = "max_entries"
-
-DEFAULT_MAX_ENTRIES = 20
-DEFAULT_SCAN_INTERVAL = timedelta(hours=1)
-DELAY_SAVE = 30
-
 DOMAIN = "feedreader"
-
-EVENT_FEEDREADER = "feedreader"
-STORAGE_VERSION = 1

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -1,0 +1,248 @@
+"""Data update coordinator for RSS/Atom feeds."""
+
+from __future__ import annotations
+
+from calendar import timegm
+from datetime import datetime, timedelta
+from logging import getLogger
+import os
+import pickle
+from time import gmtime, struct_time
+
+import feedparser
+
+from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import DELAY_SAVE, DOMAIN, EVENT_FEEDREADER, STORAGE_VERSION
+
+_LOGGER = getLogger(__name__)
+
+
+class FeedManager:
+    """Abstraction over Feedparser module."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        url: str,
+        scan_interval: timedelta,
+        max_entries: int,
+        storage: StoredData,
+    ) -> None:
+        """Initialize the FeedManager object, poll as per scan interval."""
+        self._hass = hass
+        self._url = url
+        self._scan_interval = scan_interval
+        self._max_entries = max_entries
+        self._feed: feedparser.FeedParserDict | None = None
+        self._firstrun = True
+        self._storage = storage
+        self._last_entry_timestamp: struct_time | None = None
+        self._has_published_parsed = False
+        self._has_updated_parsed = False
+        self._event_type = EVENT_FEEDREADER
+        self._feed_id = url
+
+    @callback
+    def async_setup(self) -> None:
+        """Set up the feed manager."""
+        self._hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, self._async_update)
+        async_track_time_interval(
+            self._hass, self._async_update, self._scan_interval, cancel_on_shutdown=True
+        )
+
+    def _log_no_entries(self) -> None:
+        """Send no entries log at debug level."""
+        _LOGGER.debug("No new entries to be published in feed %s", self._url)
+
+    async def _async_update(self, _: datetime | Event) -> None:
+        """Update the feed and publish new entries to the event bus."""
+        last_entry_timestamp = await self._hass.async_add_executor_job(self._update)
+        if last_entry_timestamp:
+            self._storage.async_put_timestamp(self._feed_id, last_entry_timestamp)
+
+    def _update(self) -> struct_time | None:
+        """Update the feed and publish new entries to the event bus."""
+        _LOGGER.debug("Fetching new data from feed %s", self._url)
+        self._feed = feedparser.parse(
+            self._url,
+            etag=None if not self._feed else self._feed.get("etag"),
+            modified=None if not self._feed else self._feed.get("modified"),
+        )
+        if not self._feed:
+            _LOGGER.error("Error fetching feed data from %s", self._url)
+            return None
+        # The 'bozo' flag really only indicates that there was an issue
+        # during the initial parsing of the XML, but it doesn't indicate
+        # whether this is an unrecoverable error. In this case the
+        # feedparser lib is trying a less strict parsing approach.
+        # If an error is detected here, log warning message but continue
+        # processing the feed entries if present.
+        if self._feed.bozo != 0:
+            _LOGGER.warning(
+                "Possible issue parsing feed %s: %s",
+                self._url,
+                self._feed.bozo_exception,
+            )
+        # Using etag and modified, if there's no new data available,
+        # the entries list will be empty
+        _LOGGER.debug(
+            "%s entri(es) available in feed %s",
+            len(self._feed.entries),
+            self._url,
+        )
+        if not self._feed.entries:
+            self._log_no_entries()
+            return None
+
+        self._filter_entries()
+        self._publish_new_entries()
+
+        _LOGGER.debug("Fetch from feed %s completed", self._url)
+
+        if (
+            self._has_published_parsed or self._has_updated_parsed
+        ) and self._last_entry_timestamp:
+            return self._last_entry_timestamp
+
+        return None
+
+    def _filter_entries(self) -> None:
+        """Filter the entries provided and return the ones to keep."""
+        assert self._feed is not None
+        if len(self._feed.entries) > self._max_entries:
+            _LOGGER.debug(
+                "Processing only the first %s entries in feed %s",
+                self._max_entries,
+                self._url,
+            )
+            self._feed.entries = self._feed.entries[0 : self._max_entries]
+
+    def _update_and_fire_entry(self, entry: feedparser.FeedParserDict) -> None:
+        """Update last_entry_timestamp and fire entry."""
+        # Check if the entry has a updated or published date.
+        # Start from a updated date because generally `updated` > `published`.
+        if "updated_parsed" in entry and entry.updated_parsed:
+            # We are lucky, `updated_parsed` data available, let's make use of
+            # it to publish only new available entries since the last run
+            self._has_updated_parsed = True
+            self._last_entry_timestamp = max(
+                entry.updated_parsed, self._last_entry_timestamp
+            )
+        elif "published_parsed" in entry and entry.published_parsed:
+            # We are lucky, `published_parsed` data available, let's make use of
+            # it to publish only new available entries since the last run
+            self._has_published_parsed = True
+            self._last_entry_timestamp = max(
+                entry.published_parsed, self._last_entry_timestamp
+            )
+        else:
+            self._has_updated_parsed = False
+            self._has_published_parsed = False
+            _LOGGER.debug(
+                "No updated_parsed or published_parsed info available for entry %s",
+                entry,
+            )
+        entry.update({"feed_url": self._url})
+        self._hass.bus.fire(self._event_type, entry)
+        _LOGGER.debug("New event fired for entry %s", entry.get("link"))
+
+    def _publish_new_entries(self) -> None:
+        """Publish new entries to the event bus."""
+        assert self._feed is not None
+        new_entry_count = 0
+        self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
+        if self._last_entry_timestamp:
+            self._firstrun = False
+        else:
+            # Set last entry timestamp as epoch time if not available
+            self._last_entry_timestamp = dt_util.utc_from_timestamp(0).timetuple()
+        # locally cache self._last_entry_timestamp so that entries published at identical times can be processed
+        last_entry_timestamp = self._last_entry_timestamp
+        for entry in self._feed.entries:
+            if (
+                self._firstrun
+                or (
+                    "published_parsed" in entry
+                    and entry.published_parsed > last_entry_timestamp
+                )
+                or (
+                    "updated_parsed" in entry
+                    and entry.updated_parsed > last_entry_timestamp
+                )
+            ):
+                self._update_and_fire_entry(entry)
+                new_entry_count += 1
+            else:
+                _LOGGER.debug("Already processed entry %s", entry.get("link"))
+        if new_entry_count == 0:
+            self._log_no_entries()
+        else:
+            _LOGGER.debug("%d entries published in feed %s", new_entry_count, self._url)
+        self._firstrun = False
+
+
+class StoredData:
+    """Represent a data storage."""
+
+    def __init__(self, hass: HomeAssistant, legacy_data_file: str) -> None:
+        """Initialize data storage."""
+        self._legacy_data_file = legacy_data_file
+        self._data: dict[str, struct_time] = {}
+        self._hass = hass
+        self._store: Store[dict[str, str]] = Store(hass, STORAGE_VERSION, DOMAIN)
+
+    async def async_setup(self) -> None:
+        """Set up storage."""
+        if not os.path.exists(self._store.path):
+            # Remove the legacy store loading after deprecation period.
+            data = await self._hass.async_add_executor_job(self._legacy_fetch_data)
+        else:
+            if (store_data := await self._store.async_load()) is None:
+                return
+            # Make sure that dst is set to 0, by using gmtime() on the timestamp.
+            data = {
+                feed_id: gmtime(datetime.fromisoformat(timestamp_string).timestamp())
+                for feed_id, timestamp_string in store_data.items()
+            }
+
+        self._data = data
+
+    def _legacy_fetch_data(self) -> dict[str, struct_time]:
+        """Fetch data stored in pickle file."""
+        _LOGGER.debug("Fetching data from legacy file %s", self._legacy_data_file)
+        try:
+            with open(self._legacy_data_file, "rb") as myfile:
+                return pickle.load(myfile) or {}
+        except FileNotFoundError:
+            pass
+        except (OSError, pickle.PickleError) as err:
+            _LOGGER.error(
+                "Error loading data from pickled file %s: %s",
+                self._legacy_data_file,
+                err,
+            )
+
+        return {}
+
+    def get_timestamp(self, feed_id: str) -> struct_time | None:
+        """Return stored timestamp for given feed id."""
+        return self._data.get(feed_id)
+
+    @callback
+    def async_put_timestamp(self, feed_id: str, timestamp: struct_time) -> None:
+        """Update timestamp for given feed id."""
+        self._data[feed_id] = timestamp
+        self._store.async_delay_save(self._async_save_data, DELAY_SAVE)
+
+    @callback
+    def _async_save_data(self) -> dict[str, str]:
+        """Save feed data to storage."""
+        return {
+            feed_id: dt_util.utc_from_timestamp(timegm(struct_utc)).isoformat()
+            for feed_id, struct_utc in self._data.items()
+        }

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -21,7 +21,7 @@ from .const import DELAY_SAVE, DOMAIN, EVENT_FEEDREADER, STORAGE_VERSION
 _LOGGER = getLogger(__name__)
 
 
-class FeedReaderCoordinator(DataUpdateCoordinator):
+class FeedReaderCoordinator(DataUpdateCoordinator[None]):
     """Abstraction over Feedparser module."""
 
     def __init__(
@@ -57,12 +57,11 @@ class FeedReaderCoordinator(DataUpdateCoordinator):
         """Send no entries log at debug level."""
         _LOGGER.debug("No new entries to be published in feed %s", self._url)
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> None:
         """Update the feed and publish new entries to the event bus."""
         last_entry_timestamp = await self.hass.async_add_executor_job(self._update)
         if last_entry_timestamp:
             self._storage.async_put_timestamp(self._feed_id, last_entry_timestamp)
-        return {}
 
     def _update(self) -> struct_time | None:
         """Update the feed and publish new entries to the event bus."""

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -49,9 +49,6 @@ class FeedReaderCoordinator(DataUpdateCoordinator[None]):
         self._has_updated_parsed = False
         self._event_type = EVENT_FEEDREADER
         self._feed_id = url
-        _LOGGER.debug(
-            "coordinator initi with url:%s scan_interval:%s", url, scan_interval
-        )
 
     def _log_no_entries(self) -> None:
         """Send no entries log at debug level."""

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -16,7 +16,12 @@ from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
-from .const import DELAY_SAVE, DOMAIN, EVENT_FEEDREADER, STORAGE_VERSION
+from .const import DOMAIN
+
+DELAY_SAVE = 30
+EVENT_FEEDREADER = "feedreader"
+STORAGE_VERSION = 1
+
 
 _LOGGER = getLogger(__name__)
 

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -135,26 +135,22 @@ class FeedReaderCoordinator(DataUpdateCoordinator[None]):
         """Publish new entries to the event bus."""
         assert self._feed is not None
         new_entry_count = 0
-        firstrun = True
+        firstrun = False
         self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
-        if self._last_entry_timestamp:
-            firstrun = False
+        if not self._last_entry_timestamp:
+            firstrun = True
         else:
             # Set last entry timestamp as epoch time if not available
             self._last_entry_timestamp = dt_util.utc_from_timestamp(0).timetuple()
         # locally cache self._last_entry_timestamp so that entries published at identical times can be processed
         last_entry_timestamp = self._last_entry_timestamp
         for entry in self._feed.entries:
-            if (
-                firstrun
-                or (
-                    "published_parsed" in entry
-                    and entry.published_parsed > last_entry_timestamp
+            if firstrun or (
+                (
+                    time_stamp := entry.get("updated_parsed")
+                    or entry.get("published_parsed")
                 )
-                or (
-                    "updated_parsed" in entry
-                    and entry.updated_parsed > last_entry_timestamp
-                )
+                and time_stamp > last_entry_timestamp
             ):
                 self._update_and_fire_entry(entry)
                 new_entry_count += 1

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -139,7 +139,6 @@ class FeedReaderCoordinator(DataUpdateCoordinator[None]):
         self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
         if not self._last_entry_timestamp:
             firstrun = True
-        else:
             # Set last entry timestamp as epoch time if not available
             self._last_entry_timestamp = dt_util.utc_from_timestamp(0).timetuple()
         # locally cache self._last_entry_timestamp so that entries published at identical times can be processed

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -9,12 +9,9 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
-from homeassistant.components.feedreader.const import (
-    CONF_MAX_ENTRIES,
-    CONF_URLS,
-    DOMAIN,
-    EVENT_FEEDREADER,
-)
+from homeassistant.components.feedreader import CONF_MAX_ENTRIES, CONF_URLS
+from homeassistant.components.feedreader.const import DOMAIN
+from homeassistant.components.feedreader.coordinator import EVENT_FEEDREADER
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_START
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.setup import async_setup_component


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The old pickle storage helper has been removed, after it has been deprecated and superseded in 2023.9 by our modern json storage helper.
There is nothing to do by the user.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will convert the `FeedManager` class into an update coordinator and is intended as pre-work for upcoming improvements like adding config flow and event entity.

Tested with:
```yaml
feedreader:
  urls:
    - https://www.home-assistant.io/atom.xml
    - https://developers.home-assistant.io/blog/rss.xml
  max_entries: 5
  scan_interval:
    seconds: 5
```

Further the deprecated pickle storage helpers (#98754) has been removed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
