### PR TITLE
Improve async_get_issue_tracker for custom integrations

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -421,6 +421,9 @@ async def async_from_config_dict(
     start = monotonic()
 
     hass.config_entries = config_entries.ConfigEntries(hass, config)
+    # Prime custom component cache early so we know if registry entries are tied
+    # to a custom integration
+    await loader.async_get_custom_components(hass)
     await async_load_base_functionality(hass)
 
     # Set up core.

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -1669,6 +1669,14 @@ def async_get_issue_tracker(
         # If we know nothing about the entity, suggest opening an issue on HA core
         return issue_tracker
 
+    if (
+        not integration
+        and (hass and integration_domain)
+        and (comps_or_future := hass.data.get(DATA_CUSTOM_COMPONENTS))
+        and not isinstance(comps_or_future, asyncio.Future)
+    ):
+        integration = comps_or_future.get(integration_domain)
+
     if not integration and (hass and integration_domain):
         with suppress(IntegrationNotLoaded):
             integration = async_get_loaded_integration(hass, integration_domain)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import pathlib
 import sys
 import threading
 from typing import Any
@@ -1108,14 +1109,18 @@ CUSTOM_ISSUE_TRACKER = "https://blablabla.com"
         # Integration domain is not currently deduced from module
         (None, "homeassistant.components.hue.sensor", CORE_ISSUE_TRACKER),
         ("hue", "homeassistant.components.mqtt.sensor", CORE_ISSUE_TRACKER_HUE),
-        # Custom integration with known issue tracker
+        # Loaded custom integration with known issue tracker
         ("bla_custom", "custom_components.bla_custom.sensor", CUSTOM_ISSUE_TRACKER),
         ("bla_custom", None, CUSTOM_ISSUE_TRACKER),
-        # Custom integration without known issue tracker
+        # Loaded custom integration without known issue tracker
         (None, "custom_components.bla.sensor", None),
         ("bla_custom_no_tracker", "custom_components.bla_custom.sensor", None),
         ("bla_custom_no_tracker", None, None),
         ("hue", "custom_components.bla.sensor", None),
+        # Unloaded custom integration with known issue tracker
+        ("bla_custom_not_loaded", None, CUSTOM_ISSUE_TRACKER),
+        # Unloaded custom integration without known issue tracker
+        ("bla_custom_not_loaded_no_tracker", None, None),
         # Integration domain has priority over module
         ("bla_custom_no_tracker", "homeassistant.components.bla_custom.sensor", None),
     ],
@@ -1133,6 +1138,32 @@ async def test_async_get_issue_tracker(
         built_in=False,
     )
     mock_integration(hass, MockModule("bla_custom_no_tracker"), built_in=False)
+
+    cust_unloaded_module = MockModule(
+        "bla_custom_not_loaded",
+        partial_manifest={"issue_tracker": CUSTOM_ISSUE_TRACKER},
+    )
+    cust_unloaded = loader.Integration(
+        hass,
+        f"{loader.PACKAGE_CUSTOM_COMPONENTS}.{cust_unloaded_module.DOMAIN}",
+        pathlib.Path(""),
+        cust_unloaded_module.mock_manifest(),
+        set(),
+    )
+
+    cust_unloaded_no_tracker_module = MockModule("bla_custom_not_loaded_no_tracker")
+    cust_unloaded_no_tracker = loader.Integration(
+        hass,
+        f"{loader.PACKAGE_CUSTOM_COMPONENTS}.{cust_unloaded_no_tracker_module.DOMAIN}",
+        pathlib.Path(""),
+        cust_unloaded_no_tracker_module.mock_manifest(),
+        set(),
+    )
+    hass.data["custom_components"] = {
+        "bla_custom_not_loaded": cust_unloaded,
+        "bla_custom_not_loaded_no_tracker": cust_unloaded_no_tracker,
+    }
+
     assert (
         loader.async_get_issue_tracker(hass, integration_domain=domain, module=module)
         == issue_tracker


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve `async_get_issue_tracker` for custom integrations which are not configures

This makes sure we use the correct link to custom integrations' issue trackers when restoring registries

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
