### PR TITLE
Add snapshot tests to plaato

### DIFF
--- a/tests/components/plaato/__init__.py
+++ b/tests/components/plaato/__init__.py
@@ -17,6 +17,8 @@ from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
+# Note: It would be good to replace this test data
+# with actual data from the API
 AIRLOCK_DATA = {}
 KEG_DATA = {}
 

--- a/tests/components/plaato/__init__.py
+++ b/tests/components/plaato/__init__.py
@@ -1,1 +1,51 @@
 """Tests for the Plaato integration."""
+
+from unittest.mock import patch
+
+from pyplaato.models.airlock import PlaatoAirlock
+from pyplaato.models.device import PlaatoDeviceType
+from pyplaato.models.keg import PlaatoKeg
+
+from homeassistant.components.plaato.const import (
+    CONF_DEVICE_NAME,
+    CONF_DEVICE_TYPE,
+    CONF_USE_WEBHOOK,
+    DOMAIN,
+)
+from homeassistant.const import CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+AIRLOCK_DATA = {}
+KEG_DATA = {}
+
+
+async def init_integration(
+    hass: HomeAssistant, device_type: PlaatoDeviceType
+) -> MockConfigEntry:
+    """Mock integration setup."""
+    with (
+        patch(
+            "homeassistant.components.plaato.Plaato.get_airlock_data",
+            return_value=PlaatoAirlock(AIRLOCK_DATA),
+        ),
+        patch(
+            "homeassistant.components.plaato.Plaato.get_keg_data",
+            return_value=PlaatoKeg(KEG_DATA),
+        ),
+    ):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                CONF_USE_WEBHOOK: False,
+                CONF_TOKEN: "valid_token",
+                CONF_DEVICE_TYPE: device_type,
+                CONF_DEVICE_NAME: "device_name",
+            },
+            entry_id="123456",
+        )
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry

--- a/tests/components/plaato/snapshots/test_binary_sensor.ambr
+++ b/tests/components/plaato/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,101 @@
+# serializer version: 1
+# name: test_binary_sensors[Keg][binary_sensor.plaato_plaatodevicetype_keg_device_name_leaking-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.plaato_plaatodevicetype_keg_device_name_leaking',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Leaking',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.LEAK_DETECTION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[Keg][binary_sensor.plaato_plaatodevicetype_keg_device_name_leaking-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'device_class': 'problem',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Leaking',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.plaato_plaatodevicetype_keg_device_name_leaking',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[Keg][binary_sensor.plaato_plaatodevicetype_keg_device_name_pouring-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.plaato_plaatodevicetype_keg_device_name_pouring',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.OPENING: 'opening'>,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Pouring',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.POURING',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[Keg][binary_sensor.plaato_plaatodevicetype_keg_device_name_pouring-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'device_class': 'opening',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Pouring',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.plaato_plaatodevicetype_keg_device_name_pouring',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/plaato/snapshots/test_sensor.ambr
+++ b/tests/components/plaato/snapshots/test_sensor.ambr
@@ -1,0 +1,574 @@
+# serializer version: 1
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_alcohol_by_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_alcohol_by_volume',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Alcohol By Volume',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.ABV',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_alcohol_by_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Alcohol By Volume',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_alcohol_by_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_batch_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_batch_volume',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Batch Volume',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.BATCH_VOLUME',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_batch_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Batch Volume',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_batch_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_bubbles-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_bubbles',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Bubbles',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.BUBBLES',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_bubbles-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Bubbles',
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_bubbles',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_bubbles_per_minute-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_bubbles_per_minute',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Bubbles Per Minute',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.BPM',
+    'unit_of_measurement': 'bpm',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_bubbles_per_minute-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Bubbles Per Minute',
+      'unit_of_measurement': 'bpm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_bubbles_per_minute',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_co2_volume-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_co2_volume',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Co2 Volume',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.CO2_VOLUME',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_co2_volume-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Co2 Volume',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_co2_volume',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_original_gravity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_original_gravity',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Original Gravity',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.OG',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_original_gravity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Original Gravity',
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_original_gravity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_specific_gravity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_specific_gravity',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Specific Gravity',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.SG',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_specific_gravity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Specific Gravity',
+      'unit_of_measurement': '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_specific_gravity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Airlock Device_Name Temperature',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.TEMPERATURE',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[Airlock][sensor.plaato_plaatodevicetype_airlock_device_name_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Plaato Plaatodevicetype.Airlock Device_Name Temperature',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_airlock_device_name_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_beer_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_beer_left',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Beer Left',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.BEER_LEFT',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_beer_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Beer Left',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_beer_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_last_pour_amount-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_last_pour_amount',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Last Pour Amount',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.LAST_POUR',
+    'unit_of_measurement': 'oz',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_last_pour_amount-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Last Pour Amount',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+      'unit_of_measurement': 'oz',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_last_pour_amount',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_percent_beer_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_percent_beer_left',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Percent Beer Left',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.PERCENT_BEER_LEFT',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_percent_beer_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Percent Beer Left',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+      'unit_of_measurement': '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_percent_beer_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': set({
+    }),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_temperature',
+    'has_entity_name': False,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Plaato Plaatodevicetype.Keg Device_Name Temperature',
+    'platform': 'plaato',
+    'previous_unique_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'valid_token_Pins.TEMPERATURE',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[Keg][sensor.plaato_plaatodevicetype_keg_device_name_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'beer_name': 'Beer',
+      'device_class': 'temperature',
+      'friendly_name': 'Plaato Plaatodevicetype.Keg Device_Name Temperature',
+      'keg_date': '05/24/24',
+      'mode': 'Co2',
+      'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.plaato_plaatodevicetype_keg_device_name_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/plaato/test_binary_sensor.py
+++ b/tests/components/plaato/test_binary_sensor.py
@@ -1,0 +1,33 @@
+"""Tests for the plaato binary sensors."""
+
+from unittest.mock import patch
+
+from pyplaato.models.device import PlaatoDeviceType
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import snapshot_platform
+
+
+# note: PlaatoDeviceType.Airlock does not provide binary sensors
+@pytest.mark.parametrize("device_type", [PlaatoDeviceType.Keg])
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device_type: PlaatoDeviceType,
+) -> None:
+    """Test binary sensors."""
+    with patch(
+        "homeassistant.components.plaato.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        entry = await init_integration(hass, device_type)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)

--- a/tests/components/plaato/test_sensor.py
+++ b/tests/components/plaato/test_sensor.py
@@ -1,0 +1,34 @@
+"""Tests for the plaato sensors."""
+
+from unittest.mock import patch
+
+from pyplaato.models.device import PlaatoDeviceType
+import pytest
+from syrupy import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration
+
+from tests.common import snapshot_platform
+
+
+@pytest.mark.parametrize(
+    "device_type", [PlaatoDeviceType.Airlock, PlaatoDeviceType.Keg]
+)
+async def test_sensors(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    device_type: PlaatoDeviceType,
+) -> None:
+    """Test sensors."""
+    with patch(
+        "homeassistant.components.plaato.PLATFORMS",
+        [Platform.SENSOR],
+    ):
+        entry = await init_integration(hass, device_type)
+
+    await snapshot_platform(hass, entity_registry, snapshot, entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

```
---------- coverage: platform linux, python 3.12.3-final-0 -----------
Name                                               Stmts   Miss  Cover   Missing
--------------------------------------------------------------------------------
homeassistant/components/plaato/__init__.py           90     21    77%   94, 108-113, 124, 159, 166-168, 188, 193-204, 209
homeassistant/components/plaato/binary_sensor.py      25      2    92%   27, 56
homeassistant/components/plaato/config_flow.py        92      0   100%
homeassistant/components/plaato/const.py              26      0   100%
homeassistant/components/plaato/entity.py             47      4    91%   38, 59, 77, 86
homeassistant/components/plaato/sensor.py             38      7    82%   49-61, 64
--------------------------------------------------------------------------------
TOTAL                                                318     34    89%
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
