### PR TITLE
OpenAI Conversation: Add `user_device_id` and `user_id` variables to the system prompt

### DIFF
--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -21,6 +21,10 @@ An overview of the areas and the devices in this smart home:
     {%- endif %}
   {%- endfor %}
 {%- endfor %}
+
+{% if user_device_id and area_name(device_attr(user_device_id, "area_id")) -%}
+You are in {{ area_name(device_attr(user_device_id, "area_id")) }}.
+{%- endif %}
 """
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -233,7 +233,7 @@ class OpenAIConversationEntity(
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
-                "device_id": device_id,
+                "user_device_id": device_id,
                 "user_id": user_id,
             },
             parse_result=False,

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -125,6 +125,8 @@ class OpenAIConversationEntity(
                 prompt = self._async_generate_prompt(
                     raw_prompt,
                     llm_api,
+                    user_input.device_id,
+                    user_input.context.user_id,
                 )
             except TemplateError as err:
                 LOGGER.error("Error rendering prompt: %s", err)
@@ -218,6 +220,8 @@ class OpenAIConversationEntity(
         self,
         raw_prompt: str,
         llm_api: llm.API | None,
+        device_id: str | None,
+        user_id: str | None,
     ) -> str:
         """Generate a prompt for the user."""
         raw_prompt += "\n"
@@ -229,6 +233,8 @@ class OpenAIConversationEntity(
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
+                "device_id": device_id,
+                "user_id": user_id,
             },
             parse_result=False,
         )

--- a/tests/components/openai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/openai_conversation/snapshots/test_conversation.ambr
@@ -16,6 +16,8 @@
         - Test Device 4
         - 1 (3)
         
+        You are in Test Area.
+        
         If the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
       ''',
       'role': 'system',
@@ -43,6 +45,8 @@
         - Test Device 3 (Test Model 3A)
         - Test Device 4
         - 1 (3)
+        
+        You are in Test Area.
         
         Call the intent tools to control the system. Just pass the name to the intent.
       ''',
@@ -72,6 +76,8 @@
         - Test Device 4
         - 1 (3)
         
+        You are in Test Area.
+        
         Call the intent tools to control the system. Just pass the name to the intent.
       ''',
       'role': 'system',
@@ -99,6 +105,8 @@
         - Test Device 3 (Test Model 3A)
         - Test Device 4
         - 1 (3)
+        
+        You are in Test Area.
         
         Call the intent tools to control the system. Just pass the name to the intent.
       ''',
@@ -128,6 +136,8 @@
         - Test Device 4
         - 1 (3)
         
+        You are in Test Area.
+        
         Call the intent tools to control the system. Just pass the name to the intent.
       ''',
       'role': 'system',
@@ -155,6 +165,8 @@
         - Test Device 3 (Test Model 3A)
         - Test Device 4
         - 1 (3)
+        
+        You are in Test Area.
         
         If the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
       ''',

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -502,7 +502,9 @@ async def test_assist_api_tools_conversion(
             ),
         ),
     ) as mock_create:
-        await conversation.async_converse(hass, "hello", None, None, agent_id=agent_id)
+        await conversation.async_converse(
+            hass, "hello", None, Context(), agent_id=agent_id
+        )
 
     tools = mock_create.mock_calls[0][2]["tools"]
     assert tools

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -61,14 +61,14 @@ async def test_default_prompt(
         },
     )
 
-    device_registry.async_get_or_create(
+    device_id = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         connections={("test", "1234")},
         name="Test Device",
         manufacturer="Test Manufacturer",
         model="Test Model",
         suggested_area="Test Area",
-    )
+    ).id
     for i in range(3):
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -154,7 +154,7 @@ async def test_default_prompt(
         ),
     ) as mock_create:
         result = await conversation.async_converse(
-            hass, "hello", None, Context(), agent_id=agent_id
+            hass, "hello", None, Context(), agent_id=agent_id, device_id=device_id
         )
 
     assert result.response.response_type == intent.IntentResponseType.ACTION_DONE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `user_device_id` and `user_id` variables to the system prompt. It would allow to let LLM know its location the user name.
Example:

```jinja
{% set users = {
  "2adbd618c4f44e28ae0915b107c59870": "Alice",
  "e46830ca0d344b8e8bfe877f376170b8": "Bob",
  "49c6cba386e64e7ba7d38b146f5a546c": "Charlie"
} %}{% if user_id is defined and user_id in users -%}
The user name is {{ users[user_id] }}.
{%- endif %}
{% if user_device_id and area_name(device_attr(user_device_id, "area_id")) -%}
You are in {{ area_name(device_attr(user_device_id, "area_id")) }}.
{%- endif %}
```

The `user_device_id` part has been added to the default prompt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
