### PR TITLE
Add `user_device_id` and `user_id` variables to the Ollama system prompt

### DIFF
--- a/homeassistant/components/ollama/const.py
+++ b/homeassistant/components/ollama/const.py
@@ -67,6 +67,10 @@ An overview of the areas and the devices in this smart home:
     {%- endif %}
 {%- endfor %}
 {%- endfor %}
+
+{% if user_device_id and area_name(device_attr(user_device_id, "area_id")) -%}
+You are in {{ area_name(device_attr(user_device_id, "area_id")) }}.
+{%- endif %}
 ```
 
 Answer the user's questions using the information about this smart home.

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -211,7 +211,7 @@ class OllamaConversationEntity(
                 "ha_name": self.hass.config.location_name,
                 "ha_language": self.hass.config.language,
                 "exposed_entities": self._get_exposed_entities(),
-                "device_id": device_id,
+                "user_device_id": device_id,
                 "user_id": user_id,
             },
             parse_result=False,

--- a/homeassistant/components/ollama/conversation.py
+++ b/homeassistant/components/ollama/conversation.py
@@ -102,7 +102,9 @@ class OllamaConversationEntity(
             # Render prompt and error out early if there's a problem
             raw_prompt = settings.get(CONF_PROMPT, DEFAULT_PROMPT)
             try:
-                prompt = self._generate_prompt(raw_prompt)
+                prompt = self._generate_prompt(
+                    raw_prompt, user_input.device_id, user_input.context.user_id
+                )
                 _LOGGER.debug("Prompt: %s", prompt)
             except TemplateError as err:
                 _LOGGER.error("Error rendering prompt: %s", err)
@@ -197,13 +199,20 @@ class OllamaConversationEntity(
                 message_history.messages[0]
             ] + message_history.messages[drop_index:]
 
-    def _generate_prompt(self, raw_prompt: str) -> str:
+    def _generate_prompt(
+        self,
+        raw_prompt: str,
+        device_id: str | None,
+        user_id: str | None,
+    ) -> str:
         """Generate a prompt for the user."""
         return template.Template(raw_prompt, self.hass).async_render(
             {
                 "ha_name": self.hass.config.location_name,
                 "ha_language": self.hass.config.language,
                 "exposed_entities": self._get_exposed_entities(),
+                "device_id": device_id,
+                "user_id": user_id,
             },
             parse_result=False,
         )

--- a/tests/components/ollama/test_conversation.py
+++ b/tests/components/ollama/test_conversation.py
@@ -87,6 +87,7 @@ async def test_chat(
             None,
             Context(),
             agent_id=agent_id,
+            device_id=kitchen_device.id,
         )
 
         assert mock_chat.call_count == 1
@@ -104,6 +105,7 @@ async def test_chat(
         assert "bedroom light" in prompt
         assert "office light" not in prompt
         assert "office" not in prompt
+        assert "You are in kitchen." in prompt
 
         assert (
             result.response.response_type == intent.IntentResponseType.ACTION_DONE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `user_device_id` and `user_id` variables to the system prompt. It would allow to let LLM know its location the user name.
Example:

```jinja
{% set users = {
  "2adbd618c4f44e28ae0915b107c59870": "Alice",
  "e46830ca0d344b8e8bfe877f376170b8": "Bob",
  "49c6cba386e64e7ba7d38b146f5a546c": "Charlie"
} %}{% if user_id is defined and user_id in users -%}
The user name is {{ users[user_id] }}.
{%- endif %}
{% if user_device_id and area_name(device_attr(user_device_id, "area_id")) -%}
You are in {{ area_name(device_attr(user_device_id, "area_id")) }}.
{%- endif %}
```

The `user_device_id` part has been added to the default prompt.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
