### PR TITLE
Improve annotation styling

### DIFF
--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -27,7 +27,7 @@ class HomeAssistantTCPSite(web.BaseSite):
     def __init__(
         self,
         runner: web.BaseRunner,
-        host: None | str | list[str],
+        host: str | list[str] | None,
         port: int,
         *,
         ssl_context: SSLContext | None = None,

--- a/homeassistant/components/motioneye/__init__.py
+++ b/homeassistant/components/motioneye/__init__.py
@@ -414,7 +414,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def handle_webhook(
     hass: HomeAssistant, webhook_id: str, request: Request
-) -> None | Response:
+) -> Response | None:
     """Handle webhook callback."""
 
     try:

--- a/homeassistant/components/mysensors/__init__.py
+++ b/homeassistant/components/mysensors/__init__.py
@@ -110,7 +110,7 @@ def setup_mysensors_platform(
     device_class: type[MySensorsChildEntity]
     | Mapping[SensorType, type[MySensorsChildEntity]],
     device_args: (
-        None | tuple
+        tuple | None
     ) = None,  # extra arguments that will be given to the entity constructor
     async_add_entities: Callable | None = None,
 ) -> list[MySensorsChildEntity] | None:

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -85,7 +85,7 @@ def _reset_enabled_adapters(adapters: list[Adapter]) -> None:
 
 
 def _ifaddr_adapter_to_ha(
-    adapter: ifaddr.Adapter, next_hop_address: None | IPv4Address | IPv6Address
+    adapter: ifaddr.Adapter, next_hop_address: IPv4Address | IPv6Address | None
 ) -> Adapter:
     """Convert an ifaddr adapter to ha."""
     ip_v4s: list[IPv4ConfiguredAddress] = []

--- a/homeassistant/components/nibe_heatpump/climate.py
+++ b/homeassistant/components/nibe_heatpump/climate.py
@@ -113,7 +113,7 @@ class NibeClimateEntity(CoordinatorEntity[Coordinator], ClimateEntity):
 
         self._coil_current = _get(climate.current)
         self._coil_setpoint_heat = _get(climate.setpoint_heat)
-        self._coil_setpoint_cool: None | Coil
+        self._coil_setpoint_cool: Coil | None
         try:
             self._coil_setpoint_cool = _get(climate.setpoint_cool)
         except CoilNotFoundException:

--- a/homeassistant/components/picnic/services.py
+++ b/homeassistant/components/picnic/services.py
@@ -76,7 +76,7 @@ async def handle_add_product(
     )
 
 
-def product_search(api_client: PicnicAPI, product_name: str | None) -> None | str:
+def product_search(api_client: PicnicAPI, product_name: str | None) -> str | None:
     """Query the api client for the product name."""
     if product_name is None:
         return None

--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -83,7 +83,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-async def _can_use_icmp_lib_with_privilege() -> None | bool:
+async def _can_use_icmp_lib_with_privilege() -> bool | None:
     """Verify we can create a raw socket."""
     try:
         await async_ping("127.0.0.1", count=0, timeout=0, privileged=True)

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -1,5 +1,7 @@
 """A pool for sqlite connections."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 import threading
@@ -51,7 +53,7 @@ class RecorderPool(SingletonThreadPool, NullPool):
         self.recorder_and_worker_thread_ids = recorder_and_worker_thread_ids
         SingletonThreadPool.__init__(self, creator, **kw)
 
-    def recreate(self) -> "RecorderPool":
+    def recreate(self) -> RecorderPool:
         """Recreate the pool."""
         self.logger.info("Pool recreating")
         return self.__class__(

--- a/homeassistant/components/sonos/media.py
+++ b/homeassistant/components/sonos/media.py
@@ -44,7 +44,7 @@ DURATION_SECONDS = "duration_in_s"
 POSITION_SECONDS = "position_in_s"
 
 
-def _timespan_secs(timespan: str | None) -> None | int:
+def _timespan_secs(timespan: str | None) -> int | None:
     """Parse a time-span into number of seconds."""
     if timespan in UNAVAILABLE_VALUES:
         return None

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -148,7 +148,7 @@ def _format_err(name: str, *args: Any) -> str:
 async def async_register_callback(
     hass: HomeAssistant,
     callback: Callable[[SsdpServiceInfo, SsdpChange], Coroutine[Any, Any, None] | None],
-    match_dict: None | dict[str, str] = None,
+    match_dict: dict[str, str] | None = None,
 ) -> Callable[[], None]:
     """Register to receive a callback on ssdp broadcast.
 
@@ -317,7 +317,7 @@ class Scanner:
         return list(self._device_tracker.devices.values())
 
     async def async_register_callback(
-        self, callback: SsdpHassJobCallback, match_dict: None | dict[str, str] = None
+        self, callback: SsdpHassJobCallback, match_dict: dict[str, str] | None = None
     ) -> Callable[[], None]:
         """Register a callback."""
         if match_dict is None:

--- a/homeassistant/components/subaru/sensor.py
+++ b/homeassistant/components/subaru/sensor.py
@@ -205,7 +205,7 @@ class SubaruSensor(
         self._attr_unique_id = f"{self.vin}_{description.key}"
 
     @property
-    def native_value(self) -> None | int | float:
+    def native_value(self) -> int | float | None:
         """Return the state of the sensor."""
         vehicle_data = self.coordinator.data[self.vin]
         current_value = vehicle_data[VEHICLE_STATUS].get(self.entity_description.key)

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -483,7 +483,7 @@ class AutoOffExtraStoredData(ExtraStoredData):
 
     def as_dict(self) -> dict[str, Any]:
         """Return a dict representation of additional data."""
-        auto_off_time: datetime | None | dict[str, str] = self.auto_off_time
+        auto_off_time: datetime | dict[str, str] | None = self.auto_off_time
         if isinstance(auto_off_time, datetime):
             auto_off_time = {
                 "__type": str(type(auto_off_time)),

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -257,7 +257,7 @@ class SensorTemplate(TemplateEntity, SensorEntity):
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)
         self._attr_state_class = config.get(CONF_STATE_CLASS)
         self._template: template.Template = config[CONF_STATE]
-        self._attr_last_reset_template: None | template.Template = config.get(
+        self._attr_last_reset_template: template.Template | None = config.get(
             ATTR_LAST_RESET
         )
         if (object_id := config.get(CONF_OBJECT_ID)) is not None:

--- a/homeassistant/components/template/template_entity.py
+++ b/homeassistant/components/template/template_entity.py
@@ -189,7 +189,7 @@ class _TemplateAttribute:
         self,
         event: Event[EventStateChangedData] | None,
         template: Template,
-        last_result: str | None | TemplateError,
+        last_result: str | TemplateError | None,
         result: str | TemplateError,
     ) -> None:
         """Handle a template result event callback."""

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -342,8 +342,8 @@ class TibberSensor(SensorEntity):
             self._home_name = tibber_home.info["viewer"]["home"]["address"].get(
                 "address1", ""
             )
-        self._device_name: None | str = None
-        self._model: None | str = None
+        self._device_name: str | None = None
+        self._model: str | None = None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -352,7 +352,7 @@ async def async_not_from_config(
 
 def numeric_state(
     hass: HomeAssistant,
-    entity: None | str | State,
+    entity: str | State | None,
     below: float | str | None = None,
     above: float | str | None = None,
     value_template: Template | None = None,
@@ -373,7 +373,7 @@ def numeric_state(
 
 def async_numeric_state(
     hass: HomeAssistant,
-    entity: None | str | State,
+    entity: str | State | None,
     below: float | str | None = None,
     above: float | str | None = None,
     value_template: Template | None = None,
@@ -545,7 +545,7 @@ def async_numeric_state_from_config(config: ConfigType) -> ConditionCheckerType:
 
 def state(
     hass: HomeAssistant,
-    entity: None | str | State,
+    entity: str | State | None,
     req_state: Any,
     for_period: timedelta | None = None,
     attribute: str | None = None,
@@ -803,7 +803,7 @@ def time(
     hass: HomeAssistant,
     before: dt_time | str | None = None,
     after: dt_time | str | None = None,
-    weekday: None | str | Container[str] = None,
+    weekday: str | Container[str] | None = None,
 ) -> bool:
     """Test if local time condition matches.
 
@@ -902,8 +902,8 @@ def time_from_config(config: ConfigType) -> ConditionCheckerType:
 
 def zone(
     hass: HomeAssistant,
-    zone_ent: None | str | State,
-    entity: None | str | State,
+    zone_ent: str | State | None,
+    entity: str | State | None,
 ) -> bool:
     """Test if zone-condition matches.
 

--- a/homeassistant/helpers/dispatcher.py
+++ b/homeassistant/helpers/dispatcher.py
@@ -164,7 +164,7 @@ def _format_err[*_Ts](
 
 def _generate_job[*_Ts](
     signal: SignalType[*_Ts] | str, target: Callable[[*_Ts], Any] | Callable[..., Any]
-) -> HassJob[..., None | Coroutine[Any, Any, None]]:
+) -> HassJob[..., Coroutine[Any, Any, None] | None]:
     """Generate a HassJob for a signal and target."""
     job_type = get_hassjob_callable_job_type(target)
     return HassJob(

--- a/homeassistant/helpers/event.py
+++ b/homeassistant/helpers/event.py
@@ -201,8 +201,8 @@ def async_track_state_change(
     action: Callable[
         [str, State | None, State | None], Coroutine[Any, Any, None] | None
     ],
-    from_state: None | str | Iterable[str] = None,
-    to_state: None | str | Iterable[str] = None,
+    from_state: str | Iterable[str] | None = None,
+    to_state: str | Iterable[str] | None = None,
 ) -> CALLBACK_TYPE:
     """Track specific state changes.
 
@@ -1866,7 +1866,7 @@ track_time_change = threaded_listener_factory(async_track_time_change)
 
 
 def process_state_match(
-    parameter: None | str | Iterable[str], invert: bool = False
+    parameter: str | Iterable[str] | None, invert: bool = False
 ) -> Callable[[str | None], bool]:
     """Convert parameter to function that matches input against parameter."""
     if parameter is None or parameter == MATCH_ALL:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -833,7 +833,7 @@ def async_set_service_schema(
 def _get_permissible_entity_candidates(
     call: ServiceCall,
     entities: dict[str, Entity],
-    entity_perms: None | (Callable[[str, str], bool]),
+    entity_perms: Callable[[str, str], bool] | None,
     target_all_entities: bool,
     all_referenced: set[str] | None,
 ) -> list[Entity]:
@@ -889,7 +889,7 @@ async def entity_service_call(
 
     Calls all platforms simultaneously.
     """
-    entity_perms: None | (Callable[[str, str], bool]) = None
+    entity_perms: Callable[[str, str], bool] | None = None
     return_response = call.return_response
 
     if call.context.user_id:

--- a/homeassistant/helpers/start.py
+++ b/homeassistant/helpers/start.py
@@ -36,7 +36,7 @@ def _async_at_core_state(
         hass.async_run_hass_job(at_start_job, hass)
         return lambda: None
 
-    unsub: None | CALLBACK_TYPE = None
+    unsub: CALLBACK_TYPE | None = None
 
     @callback
     def _matched_event(event: Event) -> None:

--- a/tests/components/anova/conftest.py
+++ b/tests/components/anova/conftest.py
@@ -1,5 +1,7 @@
 """Common fixtures for Anova."""
 
+from __future__ import annotations
+
 import asyncio
 from dataclasses import dataclass
 import json
@@ -40,7 +42,7 @@ class MockedAnovaWebsocketStream:
         """Initialize a Anova Websocket Stream that can be manipulated for tests."""
         self.messages = messages
 
-    def __aiter__(self) -> "MockedAnovaWebsocketStream":
+    def __aiter__(self) -> MockedAnovaWebsocketStream:
         """Handle async iteration."""
         return self
 

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -146,7 +146,7 @@ async def test_update_device(
     client: MockHAClientWebSocket,
     device_registry: dr.DeviceRegistry,
     payload_key: str,
-    payload_value: str | None | dr.DeviceEntryDisabler,
+    payload_value: str | dr.DeviceEntryDisabler | None,
 ) -> None:
     """Test update entry."""
     entry = MockConfigEntry(title=None)

--- a/tests/components/ruckus_unleashed/__init__.py
+++ b/tests/components/ruckus_unleashed/__init__.py
@@ -1,5 +1,7 @@
 """Tests for the Ruckus Unleashed integration."""
 
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, patch
 
 from aioruckus import AjaxSession, RuckusAjaxApi
@@ -181,7 +183,7 @@ class RuckusAjaxApiPatchContext:
 
         def _patched_async_create(
             host: str, username: str, password: str
-        ) -> "AjaxSession":
+        ) -> AjaxSession:
             return AjaxSession(None, host, username, password)
 
         self.patchers.append(

--- a/tests/components/uptimerobot/common.py
+++ b/tests/components/uptimerobot/common.py
@@ -81,10 +81,10 @@ class MockApiResponseKey(str, Enum):
 
 def mock_uptimerobot_api_response(
     data: dict[str, Any]
-    | None
     | list[UptimeRobotMonitor]
     | UptimeRobotAccount
-    | UptimeRobotApiError = None,
+    | UptimeRobotApiError
+    | None = None,
     status: APIStatus = APIStatus.OK,
     key: MockApiResponseKey = MockApiResponseKey.MONITORS,
 ) -> UptimeRobotApiResponse:


### PR DESCRIPTION
## Proposed change
Some minor changes to improve the style of annotations
- Remove quotes with `from __future__ import annotations`
- Move `None` to the end of union types.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
