### PR TITLE
Improve nws tests by centralizing and removing unneeded `patch`ing

### DIFF
--- a/tests/components/nws/conftest.py
+++ b/tests/components/nws/conftest.py
@@ -11,8 +11,12 @@ from .const import DEFAULT_FORECAST, DEFAULT_OBSERVATION
 @pytest.fixture
 def mock_simple_nws():
     """Mock pynws SimpleNWS with default values."""
-
-    with patch("homeassistant.components.nws.SimpleNWS") as mock_nws:
+    # set RETRY_STOP and RETRY_INTERVAL to avoid retries inside pynws in tests
+    with (
+        patch("homeassistant.components.nws.SimpleNWS") as mock_nws,
+        patch("homeassistant.components.nws.coordinator.RETRY_STOP", 0),
+        patch("homeassistant.components.nws.coordinator.RETRY_INTERVAL", 0),
+    ):
         instance = mock_nws.return_value
         instance.set_station = AsyncMock(return_value=None)
         instance.update_observation = AsyncMock(return_value=None)
@@ -29,7 +33,12 @@ def mock_simple_nws():
 @pytest.fixture
 def mock_simple_nws_times_out():
     """Mock pynws SimpleNWS that times out."""
-    with patch("homeassistant.components.nws.SimpleNWS") as mock_nws:
+    # set RETRY_STOP and RETRY_INTERVAL to avoid retries inside pynws in tests
+    with (
+        patch("homeassistant.components.nws.SimpleNWS") as mock_nws,
+        patch("homeassistant.components.nws.coordinator.RETRY_STOP", 0),
+        patch("homeassistant.components.nws.coordinator.RETRY_INTERVAL", 0),
+    ):
         instance = mock_nws.return_value
         instance.set_station = AsyncMock(side_effect=asyncio.TimeoutError)
         instance.update_observation = AsyncMock(side_effect=asyncio.TimeoutError)

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -1,7 +1,6 @@
 """Tests for the NWS weather component."""
 
 from datetime import timedelta
-from unittest.mock import patch
 
 import aiohttp
 from freezegun.api import FrozenDateTimeFactory
@@ -24,7 +23,6 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import METRIC_SYSTEM, US_CUSTOMARY_SYSTEM
 
 from .const import (
@@ -127,47 +125,43 @@ async def test_data_caching_error_observation(
     caplog,
 ) -> None:
     """Test caching of data with errors."""
-    with (
-        patch("homeassistant.components.nws.coordinator.RETRY_STOP", 0),
-        patch("homeassistant.components.nws.coordinator.RETRY_INTERVAL", 0),
-    ):
-        instance = mock_simple_nws.return_value
+    instance = mock_simple_nws.return_value
 
-        entry = MockConfigEntry(
-            domain=nws.DOMAIN,
-            data=NWS_CONFIG,
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    entry = MockConfigEntry(
+        domain=nws.DOMAIN,
+        data=NWS_CONFIG,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-        state = hass.states.get("weather.abc")
-        assert state.state == "sunny"
+    state = hass.states.get("weather.abc")
+    assert state.state == "sunny"
 
-        # data is still valid even when update fails
-        instance.update_observation.side_effect = NwsNoDataError("Test")
+    # data is still valid even when update fails
+    instance.update_observation.side_effect = NwsNoDataError("Test")
 
-        freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=100))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=100))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
-        state = hass.states.get("weather.abc")
-        assert state.state == "sunny"
+    state = hass.states.get("weather.abc")
+    assert state.state == "sunny"
 
-        assert (
-            "NWS observation update failed, but data still valid. Last success: "
-            in caplog.text
-        )
+    assert (
+        "NWS observation update failed, but data still valid. Last success: "
+        in caplog.text
+    )
 
-        # data is no longer valid after OBSERVATION_VALID_TIME
-        freezer.tick(OBSERVATION_VALID_TIME + timedelta(seconds=1))
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
+    # data is no longer valid after OBSERVATION_VALID_TIME
+    freezer.tick(OBSERVATION_VALID_TIME + timedelta(seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
-        state = hass.states.get("weather.abc")
-        assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get("weather.abc")
+    assert state.state == STATE_UNAVAILABLE
 
-        assert "Error fetching NWS observation station ABC data: Test" in caplog.text
+    assert "Error fetching NWS observation station ABC data: Test" in caplog.text
 
 
 async def test_no_data_error_observation(
@@ -302,26 +296,23 @@ async def test_error_observation(
     hass: HomeAssistant, mock_simple_nws, no_sensor
 ) -> None:
     """Test error during update observation."""
-    utc_time = dt_util.utcnow()
-    with patch("homeassistant.components.nws.coordinator.utcnow") as mock_utc:
-        mock_utc.return_value = utc_time
-        instance = mock_simple_nws.return_value
-        # first update fails
-        instance.update_observation.side_effect = aiohttp.ClientError
+    instance = mock_simple_nws.return_value
+    # first update fails
+    instance.update_observation.side_effect = aiohttp.ClientError
 
-        entry = MockConfigEntry(
-            domain=nws.DOMAIN,
-            data=NWS_CONFIG,
-        )
-        entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
+    entry = MockConfigEntry(
+        domain=nws.DOMAIN,
+        data=NWS_CONFIG,
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
 
-        instance.update_observation.assert_called_once()
+    instance.update_observation.assert_called_once()
 
-        state = hass.states.get("weather.abc")
-        assert state
-        assert state.state == STATE_UNAVAILABLE
+    state = hass.states.get("weather.abc")
+    assert state
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_new_config_entry(hass: HomeAssistant, no_sensor) -> None:


### PR DESCRIPTION
## Proposed change
Cleanup and improve tests for NWS.

- Remove use of patch of `utcnow` as test no longer utilizes it.  This test used to have other logic that required updating the time, but it is no longer needed.  From https://github.com/home-assistant/core/pull/117109#discussion_r1609408714.
- Move patching of `RETRY_INTERVAL` and `RETRY_STOP` into the setup fixtures so that is present in every test that uses it.

The majority of the diff is indentation changes due to patching removal/reorg.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
