### PR TITLE
Allow llm API to render dynamic template prompt

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/const.py
+++ b/homeassistant/components/google_generative_ai_conversation/const.py
@@ -5,24 +5,7 @@ import logging
 DOMAIN = "google_generative_ai_conversation"
 LOGGER = logging.getLogger(__package__)
 CONF_PROMPT = "prompt"
-CONF_TONE_PROMPT = "tone_prompt"
-DEFAULT_PROMPT = """This smart home is controlled by Home Assistant.
-
-An overview of the areas and the devices in this smart home:
-{%- for area in areas() %}
-  {%- set area_info = namespace(printed=false) %}
-  {%- for device in area_devices(area) -%}
-    {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") and device_attr(device, "name") %}
-      {%- if not area_info.printed %}
-
-{{ area_name(area) }}:
-        {%- set area_info.printed = true %}
-      {%- endif %}
-- {{ device_attr(device, "name") }}{% if device_attr(device, "model") and (device_attr(device, "model") | string) not in (device_attr(device, "name") | string) %} ({{ device_attr(device, "model") }}){% endif %}
-    {%- endif %}
-  {%- endfor %}
-{%- endfor %}
-"""
+DEFAULT_PROMPT = "Answer in plain text. Keep it simple and to the point."
 
 CONF_RECOMMENDED = "recommended"
 CONF_CHAT_MODEL = "chat_model"

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -200,7 +200,9 @@ class GoogleGenerativeAIConversationEntity(
                     device_id=user_input.device_id,
                 )
 
-                prompt = llm_api.async_get_api_prompt(empty_tool_input) + "\n" + prompt
+                prompt = (
+                    await llm_api.async_get_api_prompt(empty_tool_input) + "\n" + prompt
+                )
 
         except TemplateError as err:
             LOGGER.error("Error rendering prompt: %s", err)

--- a/homeassistant/components/google_generative_ai_conversation/strings.json
+++ b/homeassistant/components/google_generative_ai_conversation/strings.json
@@ -18,9 +18,8 @@
     "step": {
       "init": {
         "data": {
-          "recommended": "Recommended settings",
-          "prompt": "Prompt",
-          "tone_prompt": "Tone",
+          "recommended": "Recommended model settings",
+          "prompt": "Instructions",
           "chat_model": "[%key:common::generic::model%]",
           "temperature": "Temperature",
           "top_p": "Top P",
@@ -29,8 +28,7 @@
           "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]"
         },
         "data_description": {
-          "prompt": "Extra data to provide to the LLM. This can be a template.",
-          "tone_prompt": "Instructions for the LLM on the style of the generated text. This can be a template."
+          "prompt": "Instruct how the LLM should respond. This can be a template."
         }
       }
     }

--- a/homeassistant/components/openai_conversation/const.py
+++ b/homeassistant/components/openai_conversation/const.py
@@ -5,23 +5,7 @@ import logging
 DOMAIN = "openai_conversation"
 LOGGER = logging.getLogger(__package__)
 CONF_PROMPT = "prompt"
-DEFAULT_PROMPT = """This smart home is controlled by Home Assistant.
-
-An overview of the areas and the devices in this smart home:
-{%- for area in areas() %}
-  {%- set area_info = namespace(printed=false) %}
-  {%- for device in area_devices(area) -%}
-    {%- if not device_attr(device, "disabled_by") and not device_attr(device, "entry_type") and device_attr(device, "name") %}
-      {%- if not area_info.printed %}
-
-{{ area_name(area) }}:
-        {%- set area_info.printed = true %}
-      {%- endif %}
-- {{ device_attr(device, "name") }}{% if device_attr(device, "model") and (device_attr(device, "model") | string) not in (device_attr(device, "name") | string) %} ({{ device_attr(device, "model") }}){% endif %}
-    {%- endif %}
-  {%- endfor %}
-{%- endfor %}
-"""
+DEFAULT_PROMPT = """Answer in plain text. Keep it simple and to the point."""
 CONF_CHAT_MODEL = "chat_model"
 DEFAULT_CHAT_MODEL = "gpt-3.5-turbo"
 CONF_MAX_TOKENS = "max_tokens"

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -110,7 +110,6 @@ class OpenAIConversationEntity(
                 )
             tools = [_format_tool(tool) for tool in llm_api.async_get_tools()]
 
-        raw_prompt = self.entry.options.get(CONF_PROMPT, DEFAULT_PROMPT)
         model = self.entry.options.get(CONF_CHAT_MODEL, DEFAULT_CHAT_MODEL)
         max_tokens = self.entry.options.get(CONF_MAX_TOKENS, DEFAULT_MAX_TOKENS)
         top_p = self.entry.options.get(CONF_TOP_P, DEFAULT_TOP_P)
@@ -122,10 +121,31 @@ class OpenAIConversationEntity(
         else:
             conversation_id = ulid.ulid_now()
             try:
-                prompt = self._async_generate_prompt(
-                    raw_prompt,
-                    llm_api,
+                prompt = template.Template(
+                    self.entry.options.get(CONF_PROMPT, DEFAULT_PROMPT), self.hass
+                ).async_render(
+                    {
+                        "ha_name": self.hass.config.location_name,
+                    },
+                    parse_result=False,
                 )
+
+                if llm_api:
+                    empty_tool_input = llm.ToolInput(
+                        tool_name="",
+                        tool_args={},
+                        platform=DOMAIN,
+                        context=user_input.context,
+                        user_prompt=user_input.text,
+                        language=user_input.language,
+                        assistant=conversation.DOMAIN,
+                        device_id=user_input.device_id,
+                    )
+
+                    prompt = (
+                        llm_api.async_get_api_prompt(empty_tool_input) + "\n" + prompt
+                    )
+
             except TemplateError as err:
                 LOGGER.error("Error rendering prompt: %s", err)
                 intent_response = intent.IntentResponse(language=user_input.language)
@@ -136,6 +156,7 @@ class OpenAIConversationEntity(
                 return conversation.ConversationResult(
                     response=intent_response, conversation_id=conversation_id
                 )
+
             messages = [{"role": "system", "content": prompt}]
 
         messages.append({"role": "user", "content": user_input.text})
@@ -212,23 +233,4 @@ class OpenAIConversationEntity(
         intent_response.async_set_speech(response.content)
         return conversation.ConversationResult(
             response=intent_response, conversation_id=conversation_id
-        )
-
-    def _async_generate_prompt(
-        self,
-        raw_prompt: str,
-        llm_api: llm.API | None,
-    ) -> str:
-        """Generate a prompt for the user."""
-        raw_prompt += "\n"
-        if llm_api:
-            raw_prompt += llm_api.prompt_template
-        else:
-            raw_prompt += llm.PROMPT_NO_API_CONFIGURED
-
-        return template.Template(raw_prompt, self.hass).async_render(
-            {
-                "ha_name": self.hass.config.location_name,
-            },
-            parse_result=False,
         )

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -143,7 +143,9 @@ class OpenAIConversationEntity(
                     )
 
                     prompt = (
-                        llm_api.async_get_api_prompt(empty_tool_input) + "\n" + prompt
+                        await llm_api.async_get_api_prompt(empty_tool_input)
+                        + "\n"
+                        + prompt
                     )
 
             except TemplateError as err:

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -17,12 +17,15 @@
     "step": {
       "init": {
         "data": {
-          "prompt": "Prompt Template",
+          "prompt": "Instructions",
           "chat_model": "[%key:common::generic::model%]",
           "max_tokens": "Maximum tokens to return in response",
           "temperature": "Temperature",
           "top_p": "Top P",
           "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]"
+        },
+        "data_description": {
+          "prompt": "Instruct how the LLM should respond. This can be a template."
         }
       }
     }

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -102,7 +102,12 @@ class API(ABC):
     hass: HomeAssistant
     id: str
     name: str
-    prompt_template: str
+
+    @abstractmethod
+    @callback
+    def async_get_api_prompt(self, tool_input: ToolInput) -> str:
+        """Return the prompt for the API."""
+        raise NotImplementedError
 
     @abstractmethod
     @callback
@@ -183,8 +188,12 @@ class AssistAPI(API):
             hass=hass,
             id=LLM_API_ASSIST,
             name="Assist",
-            prompt_template="Call the intent tools to control the system. Just pass the name to the intent.",
         )
+
+    @callback
+    def async_get_api_prompt(self, tool_input: ToolInput) -> str:
+        """Return the prompt for the API."""
+        return "Call the intent tools to control Home Assistant. Just pass the name to the intent."
 
     @callback
     def async_get_tools(self) -> list[Tool]:

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -104,8 +104,7 @@ class API(ABC):
     name: str
 
     @abstractmethod
-    @callback
-    def async_get_api_prompt(self, tool_input: ToolInput) -> str:
+    async def async_get_api_prompt(self, tool_input: ToolInput) -> str:
         """Return the prompt for the API."""
         raise NotImplementedError
 
@@ -190,8 +189,7 @@ class AssistAPI(API):
             name="Assist",
         )
 
-    @callback
-    def async_get_api_prompt(self, tool_input: ToolInput) -> str:
+    async def async_get_api_prompt(self, tool_input: ToolInput) -> str:
         """Return the prompt for the API."""
         return "Call the intent tools to control Home Assistant. Just pass the name to the intent."
 

--- a/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
+++ b/tests/components/google_generative_ai_conversation/snapshots/test_conversation.ambr
@@ -23,22 +23,7 @@
       dict({
         'history': list([
           dict({
-            'parts': '''
-              This smart home is controlled by Home Assistant.
-              
-              An overview of the areas and the devices in this smart home:
-              
-              Test Area:
-              - Test Device (Test Model)
-              
-              Test Area 2:
-              - Test Device 2
-              - Test Device 3 (Test Model 3A)
-              - Test Device 4
-              - 1 (3)
-              
-              Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
-            ''',
+            'parts': 'Answer in plain text. Keep it simple and to the point.',
             'role': 'user',
           }),
           dict({
@@ -82,22 +67,7 @@
       dict({
         'history': list([
           dict({
-            'parts': '''
-              This smart home is controlled by Home Assistant.
-              
-              An overview of the areas and the devices in this smart home:
-              
-              Test Area:
-              - Test Device (Test Model)
-              
-              Test Area 2:
-              - Test Device 2
-              - Test Device 3 (Test Model 3A)
-              - Test Device 4
-              - 1 (3)
-              
-              Only if the user wants to control a device, tell them to edit the AI configuration and allow access to Home Assistant.
-            ''',
+            'parts': 'Answer in plain text. Keep it simple and to the point.',
             'role': 'user',
           }),
           dict({
@@ -142,20 +112,8 @@
         'history': list([
           dict({
             'parts': '''
-              This smart home is controlled by Home Assistant.
-              
-              An overview of the areas and the devices in this smart home:
-              
-              Test Area:
-              - Test Device (Test Model)
-              
-              Test Area 2:
-              - Test Device 2
-              - Test Device 3 (Test Model 3A)
-              - Test Device 4
-              - 1 (3)
-              
-              Call the intent tools to control the system. Just pass the name to the intent.
+              Call the intent tools to control Home Assistant. Just pass the name to the intent.
+              Answer in plain text. Keep it simple and to the point.
             ''',
             'role': 'user',
           }),
@@ -201,20 +159,8 @@
         'history': list([
           dict({
             'parts': '''
-              This smart home is controlled by Home Assistant.
-              
-              An overview of the areas and the devices in this smart home:
-              
-              Test Area:
-              - Test Device (Test Model)
-              
-              Test Area 2:
-              - Test Device 2
-              - Test Device 3 (Test Model 3A)
-              - Test Device 4
-              - 1 (3)
-              
-              Call the intent tools to control the system. Just pass the name to the intent.
+              Call the intent tools to control Home Assistant. Just pass the name to the intent.
+              Answer in plain text. Keep it simple and to the point.
             ''',
             'role': 'user',
           }),

--- a/tests/components/google_generative_ai_conversation/test_config_flow.py
+++ b/tests/components/google_generative_ai_conversation/test_config_flow.py
@@ -13,7 +13,6 @@ from homeassistant.components.google_generative_ai_conversation.const import (
     CONF_PROMPT,
     CONF_RECOMMENDED,
     CONF_TEMPERATURE,
-    CONF_TONE_PROMPT,
     CONF_TOP_K,
     CONF_TOP_P,
     DOMAIN,
@@ -90,7 +89,7 @@ async def test_form(hass: HomeAssistant) -> None:
     assert result2["options"] == {
         CONF_RECOMMENDED: True,
         CONF_LLM_HASS_API: llm.LLM_API_ASSIST,
-        CONF_TONE_PROMPT: "",
+        CONF_PROMPT: "",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -102,7 +101,7 @@ async def test_form(hass: HomeAssistant) -> None:
             {
                 CONF_RECOMMENDED: True,
                 CONF_LLM_HASS_API: "none",
-                CONF_TONE_PROMPT: "bla",
+                CONF_PROMPT: "bla",
             },
             {
                 CONF_RECOMMENDED: False,
@@ -132,12 +131,12 @@ async def test_form(hass: HomeAssistant) -> None:
             {
                 CONF_RECOMMENDED: True,
                 CONF_LLM_HASS_API: "assist",
-                CONF_TONE_PROMPT: "",
+                CONF_PROMPT: "",
             },
             {
                 CONF_RECOMMENDED: True,
                 CONF_LLM_HASS_API: "assist",
-                CONF_TONE_PROMPT: "",
+                CONF_PROMPT: "",
             },
         ),
     ],

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -11,7 +11,6 @@ from openai.types.chat.chat_completion_message_tool_call import (
     Function,
 )
 from openai.types.completion_usage import CompletionUsage
-import pytest
 from syrupy.assertion import SnapshotAssertion
 import voluptuous as vol
 
@@ -19,146 +18,10 @@ from homeassistant.components import conversation
 from homeassistant.const import CONF_LLM_HASS_API
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import (
-    area_registry as ar,
-    device_registry as dr,
-    intent,
-    llm,
-)
+from homeassistant.helpers import intent, llm
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
-
-
-@pytest.mark.parametrize("agent_id", [None, "conversation.openai"])
-@pytest.mark.parametrize(
-    "config_entry_options", [{}, {CONF_LLM_HASS_API: llm.LLM_API_ASSIST}]
-)
-async def test_default_prompt(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_init_component,
-    area_registry: ar.AreaRegistry,
-    device_registry: dr.DeviceRegistry,
-    snapshot: SnapshotAssertion,
-    agent_id: str,
-    config_entry_options: dict,
-) -> None:
-    """Test that the default prompt works."""
-    entry = MockConfigEntry(title=None)
-    entry.add_to_hass(hass)
-    for i in range(3):
-        area_registry.async_create(f"{i}Empty Area")
-
-    if agent_id is None:
-        agent_id = mock_config_entry.entry_id
-
-    hass.config_entries.async_update_entry(
-        mock_config_entry,
-        options={
-            **mock_config_entry.options,
-            CONF_LLM_HASS_API: llm.LLM_API_ASSIST,
-        },
-    )
-
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "1234")},
-        name="Test Device",
-        manufacturer="Test Manufacturer",
-        model="Test Model",
-        suggested_area="Test Area",
-    )
-    for i in range(3):
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            connections={("test", f"{i}abcd")},
-            name="Test Service",
-            manufacturer="Test Manufacturer",
-            model="Test Model",
-            suggested_area="Test Area",
-            entry_type=dr.DeviceEntryType.SERVICE,
-        )
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "5678")},
-        name="Test Device 2",
-        manufacturer="Test Manufacturer 2",
-        model="Device 2",
-        suggested_area="Test Area 2",
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "9876")},
-        name="Test Device 3",
-        manufacturer="Test Manufacturer 3",
-        model="Test Model 3A",
-        suggested_area="Test Area 2",
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "qwer")},
-        name="Test Device 4",
-        suggested_area="Test Area 2",
-    )
-    device = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "9876-disabled")},
-        name="Test Device 3",
-        manufacturer="Test Manufacturer 3",
-        model="Test Model 3A",
-        suggested_area="Test Area 2",
-    )
-    device_registry.async_update_device(
-        device.id, disabled_by=dr.DeviceEntryDisabler.USER
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "9876-no-name")},
-        manufacturer="Test Manufacturer NoName",
-        model="Test Model NoName",
-        suggested_area="Test Area 2",
-    )
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        connections={("test", "9876-integer-values")},
-        name=1,
-        manufacturer=2,
-        model=3,
-        suggested_area="Test Area 2",
-    )
-    with patch(
-        "openai.resources.chat.completions.AsyncCompletions.create",
-        new_callable=AsyncMock,
-        return_value=ChatCompletion(
-            id="chatcmpl-1234567890ABCDEFGHIJKLMNOPQRS",
-            choices=[
-                Choice(
-                    finish_reason="stop",
-                    index=0,
-                    message=ChatCompletionMessage(
-                        content="Hello, how can I help you?",
-                        role="assistant",
-                        function_call=None,
-                        tool_calls=None,
-                    ),
-                )
-            ],
-            created=1700000000,
-            model="gpt-3.5-turbo-0613",
-            object="chat.completion",
-            system_fingerprint=None,
-            usage=CompletionUsage(
-                completion_tokens=9, prompt_tokens=8, total_tokens=17
-            ),
-        ),
-    ) as mock_create:
-        result = await conversation.async_converse(
-            hass, "hello", None, Context(), agent_id=agent_id
-        )
-
-    assert result.response.response_type == intent.IntentResponseType.ACTION_DONE
-    assert mock_create.mock_calls[0][2]["messages"] == snapshot
 
 
 async def test_error_handling(

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -20,11 +20,15 @@ async def test_register_api(hass: HomeAssistant) -> None:
     """Test registering an llm api."""
 
     class MyAPI(llm.API):
+        async def async_get_api_prompt(self, tool_input: llm.ToolInput) -> str:
+            """Return a prompt for the tool."""
+            return ""
+
         def async_get_tools(self) -> list[llm.Tool]:
             """Return a list of tools."""
             return []
 
-    api = MyAPI(hass=hass, id="test", name="Test", prompt_template="")
+    api = MyAPI(hass=hass, id="test", name="Test")
     llm.async_register_api(hass, api)
 
     assert llm.async_get_api(hass, "test") is api


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows LLM API to render dynamic prompt, so they can include the current device, area and user in it if needed. This required changing both OpenAI and Google, as both had migrated to the new API.

Their existing default prompts are no longer relevant. They were a placeholder for a real API that we have now.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
