### PR TITLE
Avoid generating matchers that will never be used in MQTT

### DIFF
--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -309,11 +309,6 @@ class MqttClientSetup:
         return self._client
 
 
-def _is_simple_match(topic: str) -> bool:
-    """Return if a topic is a simple match."""
-    return not ("+" in topic or "#" in topic)
-
-
 class EnsureJobAfterCooldown:
     """Ensure a cool down period before executing a job.
 

--- a/homeassistant/components/mqtt/client.py
+++ b/homeassistant/components/mqtt/client.py
@@ -234,12 +234,13 @@ def subscribe(
     return remove
 
 
-@dataclass(frozen=True)
+@dataclass(slots=True, frozen=True)
 class Subscription:
     """Class to hold data about an active subscription."""
 
     topic: str
-    matcher: Any
+    is_simple_match: bool
+    complex_matcher: Callable[[str], bool] | None
     job: HassJob[[ReceiveMessage], Coroutine[Any, Any, None] | None]
     qos: int = 0
     encoding: str | None = "utf-8"
@@ -784,7 +785,7 @@ class MQTT:
 
         The caller is responsible clearing the cache of _matching_subscriptions.
         """
-        if _is_simple_match(subscription.topic):
+        if subscription.is_simple_match:
             self._simple_subscriptions.setdefault(subscription.topic, []).append(
                 subscription
             )
@@ -801,7 +802,7 @@ class MQTT:
         """
         topic = subscription.topic
         try:
-            if _is_simple_match(topic):
+            if subscription.is_simple_match:
                 simple_subscriptions = self._simple_subscriptions
                 simple_subscriptions[topic].remove(subscription)
                 if not simple_subscriptions[topic]:
@@ -842,8 +843,11 @@ class MQTT:
         if not isinstance(topic, str):
             raise HomeAssistantError("Topic needs to be a string!")
 
+        is_simple_match = not ("+" in topic or "#" in topic)
+        matcher = None if is_simple_match else _matcher_for_topic(topic)
+
         subscription = Subscription(
-            topic, _matcher_for_topic(topic), HassJob(msg_callback), qos, encoding
+            topic, is_simple_match, matcher, HassJob(msg_callback), qos, encoding
         )
         self._async_track_subscription(subscription)
         self._matching_subscriptions.cache_clear()
@@ -1044,7 +1048,9 @@ class MQTT:
         subscriptions.extend(
             subscription
             for subscription in self._wildcard_subscriptions
-            if subscription.matcher(topic)
+            # mypy doesn't know that complex_matcher is always set when
+            # is_simple_match is False
+            if subscription.complex_matcher(topic)  # type: ignore[misc]
         )
         return subscriptions
 
@@ -1232,7 +1238,7 @@ def _raise_on_error(result_code: int) -> None:
         raise HomeAssistantError(f"Error talking to MQTT: {message}")
 
 
-def _matcher_for_topic(subscription: str) -> Any:
+def _matcher_for_topic(subscription: str) -> Callable[[str], bool]:
     # pylint: disable-next=import-outside-toplevel
     from paho.mqtt.matcher import MQTTMatcher
 


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Avoid generating matchers that will never be used in MQTT

Nearly 40% of the overhead to subscribe was generating a matcher that is only used for the complex case where there is a `#` or `+` in the subscription.  If its a simple subscription do not generate the complex matcher since it will never be used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
