### PR TITLE
Convert remaining mqtt attrs classes to dataclasses

### DIFF
--- a/homeassistant/components/mqtt/device_trigger.py
+++ b/homeassistant/components/mqtt/device_trigger.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass, field
 import logging
 from typing import TYPE_CHECKING, Any
 
-import attr
 import voluptuous as vol
 
 from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
@@ -84,14 +84,14 @@ TRIGGER_DISCOVERY_SCHEMA = MQTT_BASE_SCHEMA.extend(
 LOG_NAME = "Device trigger"
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class TriggerInstance:
     """Attached trigger settings."""
 
-    action: TriggerActionType = attr.ib()
-    trigger_info: TriggerInfo = attr.ib()
-    trigger: Trigger = attr.ib()
-    remove: CALLBACK_TYPE | None = attr.ib(default=None)
+    action: TriggerActionType
+    trigger_info: TriggerInfo
+    trigger: Trigger
+    remove: CALLBACK_TYPE | None = None
 
     async def async_attach_trigger(self) -> None:
         """Attach MQTT trigger."""
@@ -117,21 +117,21 @@ class TriggerInstance:
         )
 
 
-@attr.s(slots=True)
+@dataclass(slots=True, kw_only=True)
 class Trigger:
     """Device trigger settings."""
 
-    device_id: str = attr.ib()
-    discovery_data: DiscoveryInfoType | None = attr.ib()
-    discovery_id: str | None = attr.ib()
-    hass: HomeAssistant = attr.ib()
-    payload: str | None = attr.ib()
-    qos: int | None = attr.ib()
-    subtype: str = attr.ib()
-    topic: str | None = attr.ib()
-    type: str = attr.ib()
-    value_template: str | None = attr.ib()
-    trigger_instances: list[TriggerInstance] = attr.ib(factory=list)
+    device_id: str
+    discovery_data: DiscoveryInfoType | None = None
+    discovery_id: str | None = None
+    hass: HomeAssistant
+    payload: str | None
+    qos: int | None
+    subtype: str
+    topic: str | None
+    type: str
+    value_template: str | None
+    trigger_instances: list[TriggerInstance] = field(default_factory=list)
 
     async def add_trigger(
         self, action: TriggerActionType, trigger_info: TriggerInfo

--- a/homeassistant/components/mqtt/subscription.py
+++ b/homeassistant/components/mqtt/subscription.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Coroutine
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
-
-import attr
 
 from homeassistant.core import HomeAssistant
 
@@ -15,18 +14,18 @@ from .const import DEFAULT_QOS
 from .models import MessageCallbackType
 
 
-@attr.s(slots=True)
+@dataclass(slots=True)
 class EntitySubscription:
     """Class to hold data about an active entity topic subscription."""
 
-    hass: HomeAssistant = attr.ib()
-    topic: str | None = attr.ib()
-    message_callback: MessageCallbackType = attr.ib()
-    subscribe_task: Coroutine[Any, Any, Callable[[], None]] | None = attr.ib()
-    unsubscribe_callback: Callable[[], None] | None = attr.ib()
-    qos: int = attr.ib(default=0)
-    encoding: str = attr.ib(default="utf-8")
-    entity_id: str | None = attr.ib(default=None)
+    hass: HomeAssistant
+    topic: str | None
+    message_callback: MessageCallbackType
+    subscribe_task: Coroutine[Any, Any, Callable[[], None]] | None
+    unsubscribe_callback: Callable[[], None] | None
+    qos: int = 0
+    encoding: str = "utf-8"
+    entity_id: str | None = None
 
     def resubscribe_if_necessary(
         self, hass: HomeAssistant, other: EntitySubscription | None


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Convert remaining mqtt attrs classes to dataclasses

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
