### PR TITLE
Remove deprecated services from AVM Fritz!Box Tools

### DIFF
--- a/homeassistant/components/fritz/button.py
+++ b/homeassistant/components/fritz/button.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 import logging
-from typing import Final
+from typing import Any, Final
 
 from homeassistant.components.button import (
     ButtonDeviceClass,
@@ -30,7 +30,7 @@ _LOGGER = logging.getLogger(__name__)
 class FritzButtonDescription(ButtonEntityDescription):
     """Class to describe a Button entity."""
 
-    press_action: Callable
+    press_action: Callable[[AvmWrapper], Any]
 
 
 BUTTONS: Final = [

--- a/homeassistant/components/fritz/const.py
+++ b/homeassistant/components/fritz/const.py
@@ -57,9 +57,6 @@ ERROR_UPNP_NOT_CONFIGURED = "upnp_not_configured"
 ERROR_UNKNOWN = "unknown_error"
 
 FRITZ_SERVICES = "fritz_services"
-SERVICE_REBOOT = "reboot"
-SERVICE_RECONNECT = "reconnect"
-SERVICE_CLEANUP = "cleanup"
 SERVICE_SET_GUEST_WIFI_PW = "set_guest_wifi_password"
 
 SWITCH_TYPE_DEFLECTION = "CallDeflection"

--- a/homeassistant/components/fritz/coordinator.py
+++ b/homeassistant/components/fritz/coordinator.py
@@ -46,9 +46,6 @@ from .const import (
     DEFAULT_USERNAME,
     DOMAIN,
     FRITZ_EXCEPTIONS,
-    SERVICE_CLEANUP,
-    SERVICE_REBOOT,
-    SERVICE_RECONNECT,
     SERVICE_SET_GUEST_WIFI_PW,
     MeshRoles,
 )
@@ -730,30 +727,6 @@ class FritzBoxTools(DataUpdateCoordinator[UpdateCoordinatorDataType]):
             )
 
         try:
-            if service_call.service == SERVICE_REBOOT:
-                _LOGGER.warning(
-                    'Service "fritz.reboot" is deprecated, please use the corresponding'
-                    " button entity instead"
-                )
-                await self.async_trigger_reboot()
-                return
-
-            if service_call.service == SERVICE_RECONNECT:
-                _LOGGER.warning(
-                    'Service "fritz.reconnect" is deprecated, please use the'
-                    " corresponding button entity instead"
-                )
-                await self.async_trigger_reconnect()
-                return
-
-            if service_call.service == SERVICE_CLEANUP:
-                _LOGGER.warning(
-                    'Service "fritz.cleanup" is deprecated, please use the'
-                    " corresponding button entity instead"
-                )
-                await self.async_trigger_cleanup(config_entry)
-                return
-
             if service_call.service == SERVICE_SET_GUEST_WIFI_PW:
                 await self.async_trigger_set_guest_password(
                     service_call.data.get("password"),

--- a/homeassistant/components/fritz/services.py
+++ b/homeassistant/components/fritz/services.py
@@ -11,14 +11,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.service import async_extract_config_entry_ids
 
-from .const import (
-    DOMAIN,
-    FRITZ_SERVICES,
-    SERVICE_CLEANUP,
-    SERVICE_REBOOT,
-    SERVICE_RECONNECT,
-    SERVICE_SET_GUEST_WIFI_PW,
-)
+from .const import DOMAIN, FRITZ_SERVICES, SERVICE_SET_GUEST_WIFI_PW
 from .coordinator import AvmWrapper
 
 _LOGGER = logging.getLogger(__name__)
@@ -32,9 +25,6 @@ SERVICE_SCHEMA_SET_GUEST_WIFI_PW = vol.Schema(
 )
 
 SERVICE_LIST: list[tuple[str, vol.Schema | None]] = [
-    (SERVICE_CLEANUP, None),
-    (SERVICE_REBOOT, None),
-    (SERVICE_RECONNECT, None),
     (SERVICE_SET_GUEST_WIFI_PW, SERVICE_SCHEMA_SET_GUEST_WIFI_PW),
 ]
 

--- a/homeassistant/components/fritz/services.yaml
+++ b/homeassistant/components/fritz/services.yaml
@@ -1,31 +1,3 @@
-reconnect:
-  fields:
-    device_id:
-      required: true
-      selector:
-        device:
-          integration: fritz
-          entity:
-            device_class: connectivity
-reboot:
-  fields:
-    device_id:
-      required: true
-      selector:
-        device:
-          integration: fritz
-          entity:
-            device_class: connectivity
-
-cleanup:
-  fields:
-    device_id:
-      required: true
-      selector:
-        device:
-          integration: fritz
-          entity:
-            device_class: connectivity
 set_guest_wifi_password:
   fields:
     device_id:

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -144,42 +144,12 @@
     }
   },
   "services": {
-    "reconnect": {
-      "name": "[%key:component::fritz::entity::button::reconnect::name%]",
-      "description": "Reconnects your FRITZ!Box internet connection.",
-      "fields": {
-        "device_id": {
-          "name": "Fritz!Box Device",
-          "description": "Select the Fritz!Box to reconnect."
-        }
-      }
-    },
-    "reboot": {
-      "name": "Reboot",
-      "description": "Reboots your FRITZ!Box.",
-      "fields": {
-        "device_id": {
-          "name": "[%key:component::fritz::services::reconnect::fields::device_id::name%]",
-          "description": "Select the Fritz!Box to reboot."
-        }
-      }
-    },
-    "cleanup": {
-      "name": "Remove stale device tracker entities",
-      "description": "Remove FRITZ!Box stale device_tracker entities.",
-      "fields": {
-        "device_id": {
-          "name": "[%key:component::fritz::services::reconnect::fields::device_id::name%]",
-          "description": "Select the Fritz!Box to check."
-        }
-      }
-    },
     "set_guest_wifi_password": {
       "name": "Set guest Wi-Fi password",
       "description": "Sets a new password for the guest Wi-Fi. The password must be between 8 and 63 characters long. If no additional parameter is set, the password will be auto-generated with a length of 12 characters.",
       "fields": {
         "device_id": {
-          "name": "[%key:component::fritz::services::reconnect::fields::device_id::name%]",
+          "name": "Fritz!Box Device",
           "description": "Select the Fritz!Box to configure."
         },
         "password": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The former deprecated services `reboot`, `reconnect` and `cleanup` has been removed. Please use the corresponding button entities instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
These services has already been deprecated and superseded by button entities back in 2022 (_#61483 and #63692_)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
  - #61483
  - #63692
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/32940

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
