### PR TITLE
Don't crash when firing event for timer for unregistered device

### DIFF
--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -292,7 +292,8 @@ class TimerManager:
 
         timer.cancel()
 
-        self.handlers[timer.device_id](TimerEventType.CANCELLED, timer)
+        if timer.device_id in self.handlers:
+            self.handlers[timer.device_id](TimerEventType.CANCELLED, timer)
         _LOGGER.debug(
             "Timer cancelled: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -320,7 +321,8 @@ class TimerManager:
                 name=f"Timer {timer_id}",
             )
 
-        self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+        if timer.device_id in self.handlers:
+            self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
 
         if seconds > 0:
             log_verb = "increased"
@@ -357,7 +359,8 @@ class TimerManager:
         task = self.timer_tasks.pop(timer_id)
         task.cancel()
 
-        self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+        if timer.device_id in self.handlers:
+            self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
         _LOGGER.debug(
             "Timer paused: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -382,7 +385,8 @@ class TimerManager:
             name=f"Timer {timer.id}",
         )
 
-        self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
+        if timer.device_id in self.handlers:
+            self.handlers[timer.device_id](TimerEventType.UPDATED, timer)
         _LOGGER.debug(
             "Timer unpaused: id=%s, name=%s, seconds_left=%s, device_id=%s",
             timer_id,
@@ -397,7 +401,8 @@ class TimerManager:
 
         timer.finish()
 
-        self.handlers[timer.device_id](TimerEventType.FINISHED, timer)
+        if timer.device_id in self.handlers:
+            self.handlers[timer.device_id](TimerEventType.FINISHED, timer)
         _LOGGER.debug(
             "Timer finished: id=%s, name=%s, device_id=%s",
             timer_id,

--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -971,6 +971,36 @@ async def test_timers_not_supported(hass: HomeAssistant) -> None:
             language=hass.config.language,
         )
 
+    # Start a timer
+    @callback
+    def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
+        pass
+
+    device_id = "test_device"
+    unregister = timer_manager.register_handler(device_id, handle_timer)
+
+    timer_id = timer_manager.start_timer(
+        device_id,
+        hours=None,
+        minutes=5,
+        seconds=None,
+        language=hass.config.language,
+    )
+
+    # Unregister handler so device no longer "supports" timers
+    unregister()
+
+    # All operations on the timer should not crash
+    timer_manager.add_time(timer_id, 1)
+
+    timer_manager.remove_time(timer_id, 1)
+
+    timer_manager.pause_timer(timer_id)
+
+    timer_manager.unpause_timer(timer_id)
+
+    timer_manager.cancel_timer(timer_id)
+
 
 async def test_timer_status_with_names(hass: HomeAssistant, init_components) -> None:
     """Test getting the status of named timers."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #118056 I removed the check for timer ID to be still registered. But actually, it would now fail because device was not registered. This restores the test in adjusted shape, to test that we don't crash when this happens.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
