### PR TITLE
Fix parallel script execution in queued mode

### DIFF
--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -609,6 +609,16 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         )
         coro = self._async_run(variables, context)
         if wait:
+            # If we are executing in parallel, we need to copy the script stack
+            # so that if this script is being called in parallel it will not
+            # be seen in the stack of the other parallel calls and hit the
+            # disallowed recursion check as each parallel call would otherwise
+            # be appending to the same stack. We do not wipe the stack in this
+            # case because we still want to be able to detect if there is
+            # disallowed recursion.
+            if script_stack := script_stack_cv.get():
+                script_stack_cv.set(script_stack.copy())
+
             script_result = await coro
             return script_result.service_response if script_result else None
 

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -609,13 +609,12 @@ class ScriptEntity(BaseScriptEntity, RestoreEntity):
         )
         coro = self._async_run(variables, context)
         if wait:
-            # If we are executing in parallel, we need to copy the script stack
-            # so that if this script is being called in parallel it will not
-            # be seen in the stack of the other parallel calls and hit the
-            # disallowed recursion check as each parallel call would otherwise
-            # be appending to the same stack. We do not wipe the stack in this
-            # case because we still want to be able to detect if there is
-            # disallowed recursion.
+            # If we are executing in parallel, we need to copy the script stack so
+            # that if this script is called in parallel, it will not be seen in the
+            # stack of the other parallel calls and hit the disallowed recursion
+            # check as each parallel call would otherwise be appending to the same
+            # stack. We do not wipe the stack in this case because we still want to
+            # be able to detect if there is a disallowed recursion.
             if script_stack := script_stack_cv.get():
                 script_stack_cv.set(script_stack.copy())
 

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1765,6 +1765,8 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
                             "parallel": [
                                 {"service": "script.test_sub"},
                                 {"service": "script.test_sub"},
+                                {"service": "script.test_sub"},
+                                {"service": "script.test_sub"},
                             ]
                         }
                     ]

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1751,7 +1751,6 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
         """Service that simulates doing background I/O."""
         nonlocal calls
         calls += 1
-        await asyncio.sleep(0)
 
     hass.services.async_register("test", "simulated_remote", async_service_handler)
     assert await async_setup_component(

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1783,8 +1783,6 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
     await hass.services.async_call(
         "script",
         "test_main",
-        blocking=False,
+        blocking=True,
     )
-
-    await hass.async_block_till_done()
     assert calls == 2

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1741,3 +1741,50 @@ async def test_responses_no_response(hass: HomeAssistant) -> None:
         )
         is None
     )
+
+
+async def test_script_queued_mode(hass: HomeAssistant) -> None:
+    """Test calling a script in queued mode in multiple tasks."""
+    calls = 0
+
+    async def async_service_handler(*args, **kwargs) -> None:
+        """Service that simulates doing background I/O."""
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(0)
+
+    hass.services.async_register("test", "simulated_remote", async_service_handler)
+    assert await async_setup_component(
+        hass,
+        script.DOMAIN,
+        {
+            script.DOMAIN: {
+                "test_main": {
+                    "sequence": [
+                        {
+                            "parallel": [
+                                {"service": "script.test_sub"},
+                                {"service": "script.test_sub"},
+                            ]
+                        }
+                    ]
+                },
+                "test_sub": {
+                    "mode": "queued",
+                    "sequence": [
+                        {"service": "test.simulated_remote"},
+                    ],
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "script",
+        "test_main",
+        blocking=False,
+    )
+
+    await hass.async_block_till_done()
+    assert calls == 2

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1783,4 +1783,4 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
     await hass.services.async_call("script", "test_main", blocking=True)
-    assert calls == 2
+    assert calls == 4

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1751,6 +1751,7 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
         """Service that simulates doing background I/O."""
         nonlocal calls
         calls += 1
+        await asyncio.sleep(0)
 
     hass.services.async_register("test", "simulated_remote", async_service_handler)
     assert await async_setup_component(
@@ -1781,9 +1782,5 @@ async def test_script_queued_mode(hass: HomeAssistant) -> None:
     )
     await hass.async_block_till_done()
 
-    await hass.services.async_call(
-        "script",
-        "test_main",
-        blocking=True,
-    )
+    await hass.services.async_call("script", "test_main", blocking=True)
     assert calls == 2

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -1744,7 +1744,7 @@ async def test_responses_no_response(hass: HomeAssistant) -> None:
 
 
 async def test_script_queued_mode(hass: HomeAssistant) -> None:
-    """Test calling a script in queued mode in multiple tasks."""
+    """Test calling a queued mode script called in parallel."""
     calls = 0
 
     async def async_service_handler(*args, **kwargs) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix parallel script execution in queued mode

If we are executing in parallel, we need to copy the script stack so that if this script is called in parallel, it will not be seen in the stack of the other parallel calls and hit the disallowed recursion check as each parallel call would otherwise be appending to the same stack. We do not wipe the stack in this case because we still want to be able to detect if there is a disallowed recursion.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #117251 fixes #117745
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
