### PR TITLE
Validate existing ESPHome config entry before DHCP based update

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -288,8 +288,8 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
-    async def try_connect(self, entry) -> str | None:
-        """Try conecting to a device and return any errors."""
+    async def try_connect(self, entry: ConfigEntry) -> str | None:
+        """Try connecting to a device and return any errors."""
         host = entry.data[CONF_HOST]
         port = entry.data[CONF_PORT]
         password = entry.data[CONF_PASSWORD]
@@ -312,14 +312,12 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             await cli.disconnect(force=True)
 
         return None
-    
+
     async def async_step_dhcp(
         self, discovery_info: dhcp.DhcpServiceInfo
     ) -> ConfigFlowResult:
         """Handle DHCP discovery."""
-        entry = await self.async_set_unique_id(
-            format_mac(discovery_info.macaddress)
-        )
+        entry = await self.async_set_unique_id(format_mac(discovery_info.macaddress))
         # entry should always be valid since we only listen to DHCP requests
         # for configured devices.
 
@@ -328,20 +326,15 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         if error is not None:
             _LOGGER.debug(
-                "Invalidated config entry with error %s." +
-                  " Reconfiguring with address %s",
+                "Invalidated config entry with error %s."
+                + " Reconfiguring with address %s",
                 error,
-                discovery_info.ip
+                discovery_info.ip,
             )
             # Update with new connection information if we can't connect
-            self._abort_if_unique_id_configured(
-                updates={CONF_HOST: discovery_info.ip}
-            )
+            self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
         else:
-            _LOGGER.debug(
-                "Config entry with address %s still valid",
-                discovery_info.ip
-            )
+            _LOGGER.debug("Config entry with address %s still valid", discovery_info.ip)
 
         return self.async_abort(reason="already_configured")
 

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -318,23 +318,23 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle DHCP discovery."""
         entry = await self.async_set_unique_id(format_mac(discovery_info.macaddress))
-        # entry should always be valid since we only listen to DHCP requests
+
+        # entry should never be None since we only listen to DHCP requests
         # for configured devices.
-
-        # Check if the existing entry is still valid
-        error = await self.try_connect(entry)
-
-        if error is not None:
-            _LOGGER.debug(
-                "Invalidated config entry with error %s."
-                + " Reconfiguring with address %s",
-                error,
-                discovery_info.ip,
-            )
-            # Update with new connection information if we can't connect
-            self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
-        else:
-            _LOGGER.debug("Config entry with address %s still valid", discovery_info.ip)
+        if entry is not None: 
+            # Check if the existing entry is still valid
+            error = await self.try_connect(entry)
+    
+            if error is not None:
+                _LOGGER.debug(
+                    "Invalidated config entry with error %s. Reconfiguring with address %s",
+                    error,
+                    discovery_info.ip,
+                )
+                # Update with new connection information if we can't connect
+                self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+            else:
+                _LOGGER.debug("Config entry with address %s still valid", discovery_info.ip)
 
         return self.async_abort(reason="already_configured")
 

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -293,9 +293,10 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         host = entry.data[CONF_HOST]
         port = entry.data[CONF_PORT]
         password = entry.data[CONF_PASSWORD]
-        psk = entry.data[CONF_NOISE_PSK]
+        psk = entry.data.get(CONF_NOISE_PSK, "")
 
         zeroconf_instance = await zeroconf.async_get_instance(self.hass)
+
         cli = APIClient(
             host,
             port,

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -321,20 +321,21 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # entry should never be None since we only listen to DHCP requests
         # for configured devices.
-        if entry is not None: 
-            # Check if the existing entry is still valid
-            error = await self.try_connect(entry)
-    
-            if error is not None:
-                _LOGGER.debug(
-                    "Invalidated config entry with error %s. Reconfiguring with address %s",
-                    error,
-                    discovery_info.ip,
-                )
-                # Update with new connection information if we can't connect
-                self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
-            else:
-                _LOGGER.debug("Config entry with address %s still valid", discovery_info.ip)
+        assert entry is not None
+
+        # Check if the existing entry is still valid
+        error = await self.try_connect(entry)
+
+        if error is not None:
+            _LOGGER.debug(
+                "Invalidated config entry with error %s. Reconfiguring with address %s",
+                error,
+                discovery_info.ip,
+            )
+            # Update with new connection information if we can't connect
+            self._abort_if_unique_id_configured(updates={CONF_HOST: discovery_info.ip})
+        else:
+            _LOGGER.debug("Config entry with address %s still valid", discovery_info.ip)
 
         return self.async_abort(reason="already_configured")
 

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Mapping
+from contextlib import asynccontextmanager
 import json
 import logging
 from typing import Any, cast
@@ -24,6 +25,7 @@ from homeassistant.components import dhcp, zeroconf
 from homeassistant.components.hassio import HassioServiceInfo
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlow,
     ConfigFlowResult,
     OptionsFlow,
@@ -50,6 +52,11 @@ ESPHOME_URL = "https://esphome.io/"
 _LOGGER = logging.getLogger(__name__)
 
 ZERO_NOISE_PSK = "MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDA="
+
+ENTRY_FAILURE_STATES = {
+    ConfigEntryState.SETUP_ERROR,
+    ConfigEntryState.SETUP_RETRY,
+}
 
 
 class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -288,13 +295,15 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
-    async def try_connect(self, entry: ConfigEntry) -> str | None:
-        """Try connecting to a device and return any errors."""
-        host = entry.data[CONF_HOST]
-        port = entry.data[CONF_PORT]
-        password = entry.data[CONF_PASSWORD]
-        psk = entry.data.get(CONF_NOISE_PSK, "")
-
+    @asynccontextmanager
+    async def _connect_api_client(
+        self,
+        host: str,
+        port: int,
+        password: str | None,
+        *,
+        noise_psk: str | None = None,
+    ) -> APIClient:
         zeroconf_instance = await zeroconf.async_get_instance(self.hass)
 
         cli = APIClient(
@@ -302,17 +311,39 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             port,
             password,
             zeroconf_instance=zeroconf_instance,
-            noise_psk=psk,
+            noise_psk=noise_psk,
         )
 
         try:
-            await cli.connect()
-        except APIConnectionError:
-            return "connection_error"
+            login = password is not None and password != ""
+            await cli.connect(login=login)
+            yield cli
         finally:
             await cli.disconnect(force=True)
 
+    async def try_connect(self, entry: ConfigEntry) -> str | None:
+        """Try connecting to a device and return any errors."""
+        host = entry.data[CONF_HOST]
+        port = entry.data[CONF_PORT]
+        password = entry.data[CONF_PASSWORD]
+        psk = entry.data.get(CONF_NOISE_PSK, "")
+
+        try:
+            async with self._connect_api_client(host, port, password, noise_psk=psk):
+                pass
+        except APIConnectionError:
+            return "connection_error"
+
         return None
+
+    async def _async_node_is_offline(self, entry: ConfigEntry) -> bool:
+        return (
+            entry.state in ENTRY_FAILURE_STATES
+            and not await self._async_node_is_reachable(entry)
+        )
+
+    async def _async_node_is_reachable(self, entry: ConfigEntry) -> bool:
+        return await self.try_connect(entry) is None
 
     async def async_step_dhcp(
         self, discovery_info: dhcp.DhcpServiceInfo
@@ -324,13 +355,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
         # for configured devices.
         assert entry is not None
 
-        # Check if the existing entry is still valid
-        error = await self.try_connect(entry)
-
-        if error is not None:
+        if await self._async_node_is_offline(entry):
             _LOGGER.debug(
-                "Invalidated config entry with error %s. Reconfiguring with address %s",
-                error,
+                "Node offline. Reconfiguring with address %s",
                 discovery_info.ip,
             )
             # Update with new connection information if we can't connect
@@ -420,20 +447,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def fetch_device_info(self) -> str | None:
         """Fetch device info from API and return any errors."""
-        zeroconf_instance = await zeroconf.async_get_instance(self.hass)
         assert self._host is not None
         assert self._port is not None
-        cli = APIClient(
-            self._host,
-            self._port,
-            "",
-            zeroconf_instance=zeroconf_instance,
-            noise_psk=self._noise_psk,
-        )
 
         try:
-            await cli.connect()
-            self._device_info = await cli.device_info()
+            async with self._connect_api_client(
+                self._host, self._port, "", noise_psk=self._noise_psk
+            ) as cli:
+                self._device_info = await cli.device_info()
         except RequiresEncryptionAPIError:
             return ERROR_REQUIRES_ENCRYPTION_KEY
         except InvalidEncryptionKeyAPIError as ex:
@@ -445,8 +466,6 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             return "resolve_error"
         except APIConnectionError:
             return "connection_error"
-        finally:
-            await cli.disconnect(force=True)
 
         self._name = self._device_info.friendly_name or self._device_info.name
         self._device_name = self._device_info.name
@@ -461,25 +480,18 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def try_login(self) -> str | None:
         """Try logging in to device and return any errors."""
-        zeroconf_instance = await zeroconf.async_get_instance(self.hass)
         assert self._host is not None
         assert self._port is not None
-        cli = APIClient(
-            self._host,
-            self._port,
-            self._password,
-            zeroconf_instance=zeroconf_instance,
-            noise_psk=self._noise_psk,
-        )
 
         try:
-            await cli.connect(login=True)
+            async with self._connect_api_client(
+                self._host, self._port, self._password, noise_psk=self._noise_psk
+            ):
+                pass
         except InvalidAuthAPIError:
             return "invalid_auth"
         except APIConnectionError:
             return "connection_error"
-        finally:
-            await cli.disconnect(force=True)
 
         return None
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -1092,6 +1092,7 @@ async def test_discovery_dhcp_updates_host(
     """Test dhcp discovery updates host and aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        state=config_entries.ConfigEntryState.SETUP_ERROR,
         data={CONF_HOST: "192.168.43.183", CONF_PORT: 6053, CONF_PASSWORD: ""},
         unique_id="11:22:33:44:55:aa",
     )
@@ -1121,6 +1122,7 @@ async def test_discovery_dhcp_no_changes(
     """Test dhcp discovery updates host and aborts."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        state=config_entries.ConfigEntryState.SETUP_RETRY,
         data={CONF_HOST: "test8266.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
         unique_id="11:22:33:44:55:aa",
     )

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -602,6 +602,7 @@ async def test_connection_aborted_wrong_device(
     new_info = AsyncMock(
         return_value=DeviceInfo(mac_address="1122334455aa", name="test")
     )
+    mock_client.connect.side_effect = APIConnectionError
     mock_client.device_info = new_info
     result = await hass.config_entries.flow.async_init(
         "esphome", context={"source": config_entries.SOURCE_DHCP}, data=service_info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
When the DHCP component notifies the ESPHome integration about a changed or updated IP address, we should validate the old entry first. If it still works, we will skip updating to the new entry. This ensures that the config entry doesn't get overridden in situations where it's configured in a way in which local IP address updates are irrelevant, like via a domain name or behind a NAT.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: See https://community.home-assistant.io/t/refining-automatic-config-entry-updating-via-device-discovery/731881/6
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
