### PR TITLE
Add async_get_hass_or_none

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -27,10 +27,9 @@ from homeassistant.core import (
     HassJob,
     HomeAssistant,
     ServiceCall,
-    async_get_hass,
+    async_get_hass_or_none,
     callback,
 )
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -160,10 +159,7 @@ VALID_ADDON_SLUG = vol.Match(re.compile(r"^[-_.A-Za-z0-9]+$"))
 def valid_addon(value: Any) -> str:
     """Validate value is a valid addon slug."""
     value = VALID_ADDON_SLUG(value)
-
-    hass: HomeAssistant | None = None
-    with suppress(HomeAssistantError):
-        hass = async_get_hass()
+    hass = async_get_hass_or_none()
 
     if hass and (addons := get_addons_info(hass)) is not None and value not in addons:
         raise vol.Invalid("Not a valid add-on slug")

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -15,8 +15,13 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODE, CONF_UNIT_OF_MEASUREMENT, UnitOfTemperature
-from homeassistant.core import HomeAssistant, ServiceCall, async_get_hass, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.core import (
+    HomeAssistant,
+    ServiceCall,
+    async_get_hass_or_none,
+    callback,
+)
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.config_validation import (
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,
@@ -213,10 +218,9 @@ class NumberEntity(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
                 "value",
             )
         ):
-            hass: HomeAssistant | None = None
-            with suppress(HomeAssistantError):
-                hass = async_get_hass()
-            report_issue = async_suggest_report_issue(hass, module=cls.__module__)
+            report_issue = async_suggest_report_issue(
+                async_get_hass_or_none(), module=cls.__module__
+            )
             _LOGGER.warning(
                 (
                     "%s::%s is overriding deprecated methods on an instance of "

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -268,8 +268,16 @@ def async_get_hass() -> HomeAssistant:
     This should be used where it's very cumbersome or downright impossible to pass
     hass to the code which needs it.
     """
-    if not _hass.hass:
+    if not (hass := async_get_hass_or_none()):
         raise HomeAssistantError("async_get_hass called from the wrong thread")
+    return hass
+
+
+def async_get_hass_or_none() -> HomeAssistant | None:
+    """Return the HomeAssistant instance or None.
+
+    Returns None when called from the wrong thread.
+    """
     return _hass.hass
 
 

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -93,8 +93,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
-    HomeAssistant,
     async_get_hass,
+    async_get_hass_or_none,
     split_entity_id,
     valid_entity_id,
 )
@@ -662,11 +662,7 @@ def template(value: Any | None) -> template_helper.Template:
     if isinstance(value, (list, dict, template_helper.Template)):
         raise vol.Invalid("template value should be a string")
 
-    hass: HomeAssistant | None = None
-    with contextlib.suppress(HomeAssistantError):
-        hass = async_get_hass()
-
-    template_value = template_helper.Template(str(value), hass)
+    template_value = template_helper.Template(str(value), async_get_hass_or_none())
 
     try:
         template_value.ensure_valid()
@@ -684,11 +680,7 @@ def dynamic_template(value: Any | None) -> template_helper.Template:
     if not template_helper.is_template_string(str(value)):
         raise vol.Invalid("template value does not contain a dynamic template")
 
-    hass: HomeAssistant | None = None
-    with contextlib.suppress(HomeAssistantError):
-        hass = async_get_hass()
-
-    template_value = template_helper.Template(str(value), hass)
+    template_value = template_helper.Template(str(value), async_get_hass_or_none())
 
     try:
         template_value.ensure_valid()

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from contextlib import suppress
 from enum import Enum
 import functools
 import inspect
@@ -167,8 +166,7 @@ def _print_deprecation_warning_internal(
     log_when_no_integration_is_found: bool,
 ) -> None:
     # pylint: disable=import-outside-toplevel
-    from homeassistant.core import HomeAssistant, async_get_hass
-    from homeassistant.exceptions import HomeAssistantError
+    from homeassistant.core import async_get_hass_or_none
     from homeassistant.loader import async_suggest_report_issue
 
     from .frame import MissingIntegrationFrame, get_integration_frame
@@ -191,11 +189,8 @@ def _print_deprecation_warning_internal(
             )
     else:
         if integration_frame.custom_integration:
-            hass: HomeAssistant | None = None
-            with suppress(HomeAssistantError):
-                hass = async_get_hass()
             report_issue = async_suggest_report_issue(
-                hass,
+                async_get_hass_or_none(),
                 integration_domain=integration_frame.integration,
                 module=integration_frame.module,
             )

--- a/homeassistant/helpers/frame.py
+++ b/homeassistant/helpers/frame.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
-from contextlib import suppress
 from dataclasses import dataclass
 import functools
 from functools import cached_property
@@ -14,7 +13,7 @@ import sys
 from types import FrameType
 from typing import Any, cast
 
-from homeassistant.core import HomeAssistant, async_get_hass
+from homeassistant.core import async_get_hass_or_none
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import async_suggest_report_issue
 
@@ -176,11 +175,8 @@ def _report_integration(
         return
     _REPORTED_INTEGRATIONS.add(key)
 
-    hass: HomeAssistant | None = None
-    with suppress(HomeAssistantError):
-        hass = async_get_hass()
     report_issue = async_suggest_report_issue(
-        hass,
+        async_get_hass_or_none(),
         integration_domain=integration_frame.integration,
         module=integration_frame.module,
     )

--- a/homeassistant/util/loop.py
+++ b/homeassistant/util/loop.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from contextlib import suppress
 import functools
 import linecache
 import logging
 import threading
 from typing import Any
 
-from homeassistant.core import HomeAssistant, async_get_hass
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.core import async_get_hass_or_none
 from homeassistant.helpers.frame import (
     MissingIntegrationFrame,
     get_current_frame,
@@ -74,11 +72,8 @@ def raise_for_blocking_call(
                 f"https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue"
             )
 
-    hass: HomeAssistant | None = None
-    with suppress(HomeAssistantError):
-        hass = async_get_hass()
     report_issue = async_suggest_report_issue(
-        hass,
+        async_get_hass_or_none(),
         integration_domain=integration_frame.integration,
         module=integration_frame.module,
     )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Almost all the calls to `async_get_hass` in core and base platforms suppress `HomeAssistantError`, instead make a new function, `async_get_hass_or_none`, that returns `None` when called from the wrong thread and use it to implement `async_get_hass`.

Impact: switching `async_get_hass` to `async_get_hass_or_none` reduced the `cv.template` run time for `mqtt` by ~47% since the `suppress` call and the code around it was no longer needed and most of the templates are cached. Anything that creates a lot of templates will benefit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
