### PR TITLE
Move Jewish calendar constants to const file

### DIFF
--- a/homeassistant/components/jewish_calendar/__init__.py
+++ b/homeassistant/components/jewish_calendar/__init__.py
@@ -20,15 +20,17 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.typing import ConfigType
 
-DOMAIN = "jewish_calendar"
-CONF_DIASPORA = "diaspora"
-CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
-CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
-DEFAULT_NAME = "Jewish Calendar"
-DEFAULT_CANDLE_LIGHT = 18
-DEFAULT_DIASPORA = False
-DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
-DEFAULT_LANGUAGE = "english"
+from .const import (
+    CONF_CANDLE_LIGHT_MINUTES,
+    CONF_DIASPORA,
+    CONF_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_CANDLE_LIGHT,
+    DEFAULT_DIASPORA,
+    DEFAULT_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_LANGUAGE,
+    DEFAULT_NAME,
+    DOMAIN,
+)
 
 PLATFORMS: list[Platform] = [Platform.BINARY_SENSOR, Platform.SENSOR]
 

--- a/homeassistant/components/jewish_calendar/binary_sensor.py
+++ b/homeassistant/components/jewish_calendar/binary_sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from . import DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
 
 
 @dataclass(frozen=True)

--- a/homeassistant/components/jewish_calendar/config_flow.py
+++ b/homeassistant/components/jewish_calendar/config_flow.py
@@ -32,15 +32,17 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.typing import ConfigType
 
-DOMAIN = "jewish_calendar"
-CONF_DIASPORA = "diaspora"
-CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
-CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
-DEFAULT_NAME = "Jewish Calendar"
-DEFAULT_CANDLE_LIGHT = 18
-DEFAULT_DIASPORA = False
-DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
-DEFAULT_LANGUAGE = "english"
+from .const import (
+    CONF_CANDLE_LIGHT_MINUTES,
+    CONF_DIASPORA,
+    CONF_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_CANDLE_LIGHT,
+    DEFAULT_DIASPORA,
+    DEFAULT_HAVDALAH_OFFSET_MINUTES,
+    DEFAULT_LANGUAGE,
+    DEFAULT_NAME,
+    DOMAIN,
+)
 
 LANGUAGE = [
     SelectOptionDict(value="hebrew", label="Hebrew"),

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -1,0 +1,11 @@
+"""Jewish Calendar constants."""
+
+DOMAIN = "jewish_calendar"
+CONF_DIASPORA = "diaspora"
+CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
+CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
+DEFAULT_NAME = "Jewish Calendar"
+DEFAULT_CANDLE_LIGHT = 18
+DEFAULT_DIASPORA = False
+DEFAULT_HAVDALAH_OFFSET_MINUTES = 0
+DEFAULT_LANGUAGE = "english"

--- a/homeassistant/components/jewish_calendar/const.py
+++ b/homeassistant/components/jewish_calendar/const.py
@@ -1,9 +1,11 @@
 """Jewish Calendar constants."""
 
 DOMAIN = "jewish_calendar"
+
 CONF_DIASPORA = "diaspora"
 CONF_CANDLE_LIGHT_MINUTES = "candle_lighting_minutes_before_sunset"
 CONF_HAVDALAH_OFFSET_MINUTES = "havdalah_minutes_after_sunset"
+
 DEFAULT_NAME = "Jewish Calendar"
 DEFAULT_CANDLE_LIGHT = 18
 DEFAULT_DIASPORA = False

--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -22,7 +22,7 @@ from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.dt as dt_util
 
-from . import DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.jewish_calendar import const
+from homeassistant.components.jewish_calendar.const import DEFAULT_NAME, DOMAIN
 
 from tests.common import MockConfigEntry
 
@@ -14,8 +14,8 @@ from tests.common import MockConfigEntry
 def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        title=const.DEFAULT_NAME,
-        domain=const.DOMAIN,
+        title=DEFAULT_NAME,
+        domain=DOMAIN,
     )
 
 

--- a/tests/components/jewish_calendar/conftest.py
+++ b/tests/components/jewish_calendar/conftest.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from homeassistant.components.jewish_calendar import config_flow
+from homeassistant.components.jewish_calendar import const
 
 from tests.common import MockConfigEntry
 
@@ -14,8 +14,8 @@ from tests.common import MockConfigEntry
 def mock_config_entry() -> MockConfigEntry:
     """Return the default mocked config entry."""
     return MockConfigEntry(
-        title=config_flow.DEFAULT_NAME,
-        domain=config_flow.DOMAIN,
+        title=const.DEFAULT_NAME,
+        domain=const.DOMAIN,
     )
 
 

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from homeassistant import config_entries, setup
-from homeassistant.components.jewish_calendar import (
+from homeassistant.components.jewish_calendar.const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_DIASPORA,
     CONF_HAVDALAH_OFFSET_MINUTES,

--- a/tests/components/jewish_calendar/test_config_flow.py
+++ b/tests/components/jewish_calendar/test_config_flow.py
@@ -9,7 +9,6 @@ from homeassistant.components.jewish_calendar.const import (
     CONF_CANDLE_LIGHT_MINUTES,
     CONF_DIASPORA,
     CONF_HAVDALAH_OFFSET_MINUTES,
-    CONF_LANGUAGE,
     DEFAULT_CANDLE_LIGHT,
     DEFAULT_DIASPORA,
     DEFAULT_HAVDALAH_OFFSET_MINUTES,
@@ -19,6 +18,7 @@ from homeassistant.components.jewish_calendar.const import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import (
     CONF_ELEVATION,
+    CONF_LANGUAGE,
     CONF_LATITUDE,
     CONF_LONGITUDE,
     CONF_NAME,

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -4,8 +4,8 @@ from datetime import datetime as dt, timedelta
 
 import pytest
 
-from homeassistant.components import jewish_calendar
 from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.jewish_calendar.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -17,7 +17,7 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 async def test_jewish_calendar_min_config(hass: HomeAssistant) -> None:
     """Test minimum jewish calendar configuration."""
-    entry = MockConfigEntry(domain=jewish_calendar.DOMAIN, data={})
+    entry = MockConfigEntry(domain=DOMAIN, data={})
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -26,7 +26,7 @@ async def test_jewish_calendar_min_config(hass: HomeAssistant) -> None:
 
 async def test_jewish_calendar_hebrew(hass: HomeAssistant) -> None:
     """Test jewish calendar sensor with language set to hebrew."""
-    entry = MockConfigEntry(domain=jewish_calendar.DOMAIN, data={"language": "hebrew"})
+    entry = MockConfigEntry(domain=DOMAIN, data={"language": "hebrew"})
     entry.add_to_hass(hass)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
@@ -167,7 +167,7 @@ async def test_jewish_calendar_sensor(
 
     with alter_time(test_time):
         entry = MockConfigEntry(
-            domain=jewish_calendar.DOMAIN,
+            domain=DOMAIN,
             data={
                 "language": language,
                 "diaspora": diaspora,
@@ -509,7 +509,7 @@ async def test_shabbat_times_sensor(
 
     with alter_time(test_time):
         entry = MockConfigEntry(
-            domain=jewish_calendar.DOMAIN,
+            domain=DOMAIN,
             data={
                 "language": language,
                 "diaspora": diaspora,
@@ -566,7 +566,7 @@ async def test_omer_sensor(hass: HomeAssistant, test_time, result) -> None:
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))
 
     with alter_time(test_time):
-        entry = MockConfigEntry(domain=jewish_calendar.DOMAIN)
+        entry = MockConfigEntry(domain=DOMAIN)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -600,7 +600,7 @@ async def test_dafyomi_sensor(hass: HomeAssistant, test_time, result) -> None:
     test_time = test_time.replace(tzinfo=dt_util.get_time_zone(hass.config.time_zone))
 
     with alter_time(test_time):
-        entry = MockConfigEntry(domain=jewish_calendar.DOMAIN)
+        entry = MockConfigEntry(domain=DOMAIN)
         entry.add_to_hass(hass)
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -620,7 +620,7 @@ async def test_no_discovery_info(
     assert await async_setup_component(
         hass,
         SENSOR_DOMAIN,
-        {SENSOR_DOMAIN: {"platform": jewish_calendar.DOMAIN}},
+        {SENSOR_DOMAIN: {"platform": DOMAIN}},
     )
     await hass.async_block_till_done()
     assert SENSOR_DOMAIN in hass.config.components


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Move all jewish calendar constants to a single const file to avoid code duplication.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
