### PR TITLE
Remove unneeded dispatcher in mqtt discovery

### DIFF
--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -109,23 +109,29 @@ async def async_start(  # noqa: C901
     mqtt_data = hass.data[DATA_MQTT]
     platform_setup_lock: dict[str, asyncio.Lock] = {}
 
-    async def _async_component_setup(discovery_payload: MQTTDiscoveryPayload) -> None:
-        """Perform component set up."""
+    @callback
+    def _async_add_component(discovery_payload: MQTTDiscoveryPayload) -> None:
+        """Add a component from a discovery message."""
         discovery_hash = discovery_payload.discovery_data[ATTR_DISCOVERY_HASH]
         component, discovery_id = discovery_hash
-        platform_setup_lock.setdefault(component, asyncio.Lock())
-        async with platform_setup_lock[component]:
-            if component not in mqtt_data.platforms_loaded:
-                await async_forward_entry_setup_and_setup_discovery(
-                    hass, config_entry, {component}
-                )
-        # Add component
         message = f"Found new component: {component} {discovery_id}"
         async_log_discovery_origin_info(message, discovery_payload)
         mqtt_data.discovery_already_discovered.add(discovery_hash)
         async_dispatcher_send(
             hass, MQTT_DISCOVERY_NEW.format(component, "mqtt"), discovery_payload
         )
+
+    async def _async_component_setup(discovery_payload: MQTTDiscoveryPayload) -> None:
+        """Perform component set up."""
+        discovery_hash = discovery_payload.discovery_data[ATTR_DISCOVERY_HASH]
+        component, _ = discovery_hash
+        platform_setup_lock.setdefault(component, asyncio.Lock())
+        async with platform_setup_lock[component]:
+            if component not in mqtt_data.platforms_loaded:
+                await async_forward_entry_setup_and_setup_discovery(
+                    hass, config_entry, {component}
+                )
+        _async_add_component(discovery_payload)
 
     @callback
     def async_discovery_message_received(msg: ReceiveMessage) -> None:  # noqa: C901
@@ -299,13 +305,7 @@ async def async_start(  # noqa: C901
                 hass, MQTT_DISCOVERY_UPDATED.format(*discovery_hash), payload
             )
         elif payload:
-            # Add component
-            message = f"Found new component: {component} {discovery_id}"
-            async_log_discovery_origin_info(message, payload)
-            mqtt_data.discovery_already_discovered.add(discovery_hash)
-            async_dispatcher_send(
-                hass, MQTT_DISCOVERY_NEW.format(component, "mqtt"), payload
-            )
+            _async_add_component(payload)
         else:
             # Unhandled discovery message
             async_dispatcher_send(

--- a/homeassistant/components/mqtt/discovery.py
+++ b/homeassistant/components/mqtt/discovery.py
@@ -54,7 +54,6 @@ MQTT_DISCOVERY_UPDATED: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeForma
 MQTT_DISCOVERY_NEW: SignalTypeFormat[MQTTDiscoveryPayload] = SignalTypeFormat(
     "mqtt_discovery_new_{}_{}"
 )
-MQTT_DISCOVERY_NEW_COMPONENT = "mqtt_discovery_new_component"
 MQTT_DISCOVERY_DONE: SignalTypeFormat[Any] = SignalTypeFormat(
     "mqtt_discovery_done_{}_{}"
 )
@@ -127,12 +126,6 @@ async def async_start(  # noqa: C901
         async_dispatcher_send(
             hass, MQTT_DISCOVERY_NEW.format(component, "mqtt"), discovery_payload
         )
-
-    mqtt_data.reload_dispatchers.append(
-        async_dispatcher_connect(
-            hass, MQTT_DISCOVERY_NEW_COMPONENT, _async_component_setup
-        )
-    )
 
     @callback
     def async_discovery_message_received(msg: ReceiveMessage) -> None:  # noqa: C901
@@ -297,7 +290,7 @@ async def async_start(  # noqa: C901
 
         if component not in mqtt_data.platforms_loaded and payload:
             # Load component first
-            async_dispatcher_send(hass, MQTT_DISCOVERY_NEW_COMPONENT, payload)
+            config_entry.async_create_task(hass, _async_component_setup(payload))
         elif already_discovered:
             # Dispatch update
             message = f"Component has already been discovered: {component} {discovery_id}, sending update"

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -18,7 +18,6 @@ from homeassistant.components.mqtt.abbreviations import (
 from homeassistant.components.mqtt.discovery import (
     MQTT_DISCOVERY_DONE,
     MQTT_DISCOVERY_NEW,
-    MQTT_DISCOVERY_NEW_COMPONENT,
     MQTT_DISCOVERY_UPDATED,
     MQTTDiscoveryPayload,
     async_start,
@@ -1783,7 +1782,6 @@ async def test_update_with_bad_config_not_breaks_discovery(
     "signal_message",
     [
         MQTT_DISCOVERY_NEW,
-        MQTT_DISCOVERY_NEW_COMPONENT,
         MQTT_DISCOVERY_UPDATED,
         MQTT_DISCOVERY_DONE,
     ],


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The dispatcher was only ever calling an inner function


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
