### PR TITLE
Remove translation and icon component path functions

### DIFF
--- a/homeassistant/helpers/icon.py
+++ b/homeassistant/helpers/icon.py
@@ -21,15 +21,6 @@ ICON_CACHE: HassKey[_IconsCache] = HassKey("icon_cache")
 _LOGGER = logging.getLogger(__name__)
 
 
-@callback
-def _component_icons_path(integration: Integration) -> pathlib.Path:
-    """Return the icons json file location for a component.
-
-    Ex: components/hue/icons.json
-    """
-    return integration.file_path / "icons.json"
-
-
 def _load_icons_files(
     icons_files: dict[str, pathlib.Path],
 ) -> dict[str, dict[str, Any]]:
@@ -50,7 +41,7 @@ async def _async_get_component_icons(
 
     # Determine files to load
     files_to_load = {
-        comp: _component_icons_path(integrations[comp]) for comp in components
+        comp: integrations[comp].file_path / "icons.json" for comp in components
     }
 
     # Load files

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -46,17 +46,6 @@ def recursive_flatten(
     return output
 
 
-@callback
-def component_translation_path(language: str, integration: Integration) -> pathlib.Path:
-    """Return the translation json file location for a component.
-
-    For component:
-     - components/hue/translations/nl.json
-
-    """
-    return integration.file_path / "translations" / f"{language}.json"
-
-
 def _load_translations_files_by_language(
     translation_files: dict[str, dict[str, pathlib.Path]],
 ) -> dict[str, dict[str, Any]]:
@@ -110,8 +99,9 @@ async def _async_get_component_strings(
     loaded_translations_by_language: dict[str, dict[str, Any]] = {}
     has_files_to_load = False
     for language in languages:
+        file_name = f"{language}.json"
         files_to_load: dict[str, pathlib.Path] = {
-            domain: component_translation_path(language, integration)
+            domain: integration.file_path / "translations" / file_name
             for domain in components
             if (
                 (integration := integrations.get(domain))

--- a/tests/helpers/test_icon.py
+++ b/tests/helpers/test_icon.py
@@ -163,10 +163,6 @@ async def test_get_icons_while_loading_components(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.helpers.icon._component_icons_path",
-            return_value="choochoo.json",
-        ),
-        patch(
             "homeassistant.helpers.icon._load_icons_files",
             mock_load_icons_files,
         ),

--- a/tests/helpers/test_translation.py
+++ b/tests/helpers/test_translation.py
@@ -1,7 +1,6 @@
 """Test the translation helper."""
 
 import asyncio
-from os import path
 import pathlib
 from typing import Any
 from unittest.mock import Mock, call, patch
@@ -12,7 +11,6 @@ from homeassistant import loader
 from homeassistant.const import EVENT_CORE_CONFIG_UPDATE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import translation
-from homeassistant.loader import async_get_integration
 from homeassistant.setup import async_setup_component
 
 
@@ -40,25 +38,6 @@ def test_recursive_flatten() -> None:
         "prefix.parent1.child2": "data2",
         "prefix.parent2": "data3",
     }
-
-
-async def test_component_translation_path(
-    hass: HomeAssistant, enable_custom_integrations: None
-) -> None:
-    """Test the component translation file function."""
-    assert await async_setup_component(
-        hass,
-        "switch",
-        {"switch": [{"platform": "test"}, {"platform": "test_embedded"}]},
-    )
-    assert await async_setup_component(hass, "test_package", {"test_package": None})
-    int_test_package = await async_get_integration(hass, "test_package")
-
-    assert path.normpath(
-        translation.component_translation_path("en", int_test_package)
-    ) == path.normpath(
-        hass.config.path("custom_components", "test_package", "translations", "en.json")
-    )
 
 
 def test_load_translations_files_by_language(
@@ -243,10 +222,6 @@ async def test_get_translations_loads_config_flows(
 
     with (
         patch(
-            "homeassistant.helpers.translation.component_translation_path",
-            return_value="bla.json",
-        ),
-        patch(
             "homeassistant.helpers.translation._load_translations_files_by_language",
             return_value={"en": {"component1": {"title": "world"}}},
         ),
@@ -275,10 +250,6 @@ async def test_get_translations_loads_config_flows(
     integration.name = "Component 2"
 
     with (
-        patch(
-            "homeassistant.helpers.translation.component_translation_path",
-            return_value="bla.json",
-        ),
         patch(
             "homeassistant.helpers.translation._load_translations_files_by_language",
             return_value={"en": {"component2": {"title": "world"}}},
@@ -329,10 +300,6 @@ async def test_get_translations_while_loading_components(hass: HomeAssistant) ->
         return {language: {"component1": {"title": "world"}} for language in files}
 
     with (
-        patch(
-            "homeassistant.helpers.translation.component_translation_path",
-            return_value="bla.json",
-        ),
         patch(
             "homeassistant.helpers.translation._load_translations_files_by_language",
             mock_load_translation_files,
@@ -697,10 +664,6 @@ async def test_get_translations_still_has_title_without_translations_files(
     integration.name = "Component 1"
 
     with (
-        patch(
-            "homeassistant.helpers.translation.component_translation_path",
-            return_value="bla.json",
-        ),
         patch(
             "homeassistant.helpers.translation._load_translations_files_by_language",
             return_value={},


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

These functions have been stripped down to always return the same path so there was no longer a need to have a function for this. This is left-over cleanup from previous refactoring that was deferred to keep previous PRs smaller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
