### PR TITLE
Enforce namespace import in core

### DIFF
--- a/homeassistant/auth/permissions/events.py
+++ b/homeassistant/auth/permissions/events.py
@@ -17,21 +17,23 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     EVENT_THEMES_UPDATED,
 )
-from homeassistant.helpers.area_registry import EVENT_AREA_REGISTRY_UPDATED
-from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
-from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
-from homeassistant.helpers.issue_registry import EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.util.event_type import EventType
 
 # These are events that do not contain any sensitive data
 # Except for state_changed, which is handled accordingly.
 SUBSCRIBE_ALLOWLIST: Final[set[EventType[Any] | str]] = {
-    EVENT_AREA_REGISTRY_UPDATED,
+    ar.EVENT_AREA_REGISTRY_UPDATED,
     EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,
-    EVENT_DEVICE_REGISTRY_UPDATED,
-    EVENT_ENTITY_REGISTRY_UPDATED,
-    EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED,
+    dr.EVENT_DEVICE_REGISTRY_UPDATED,
+    er.EVENT_ENTITY_REGISTRY_UPDATED,
+    ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED,
     EVENT_LOVELACE_UPDATED,
     EVENT_PANELS_UPDATED,
     EVENT_RECORDER_5MIN_STATISTICS_GENERATED,

--- a/homeassistant/auth/permissions/events.py
+++ b/homeassistant/auth/permissions/events.py
@@ -17,23 +17,21 @@ from homeassistant.const import (
     EVENT_STATE_CHANGED,
     EVENT_THEMES_UPDATED,
 )
-from homeassistant.helpers import (
-    area_registry as ar,
-    device_registry as dr,
-    entity_registry as er,
-    issue_registry as ir,
-)
+from homeassistant.helpers.area_registry import EVENT_AREA_REGISTRY_UPDATED
+from homeassistant.helpers.device_registry import EVENT_DEVICE_REGISTRY_UPDATED
+from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
+from homeassistant.helpers.issue_registry import EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED
 from homeassistant.util.event_type import EventType
 
 # These are events that do not contain any sensitive data
 # Except for state_changed, which is handled accordingly.
 SUBSCRIBE_ALLOWLIST: Final[set[EventType[Any] | str]] = {
-    ar.EVENT_AREA_REGISTRY_UPDATED,
+    EVENT_AREA_REGISTRY_UPDATED,
     EVENT_COMPONENT_LOADED,
     EVENT_CORE_CONFIG_UPDATE,
-    dr.EVENT_DEVICE_REGISTRY_UPDATED,
-    er.EVENT_ENTITY_REGISTRY_UPDATED,
-    ir.EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED,
+    EVENT_DEVICE_REGISTRY_UPDATED,
+    EVENT_ENTITY_REGISTRY_UPDATED,
+    EVENT_REPAIRS_ISSUE_REGISTRY_UPDATED,
     EVENT_LOVELACE_UPDATED,
     EVENT_PANELS_UPDATED,
     EVENT_RECORDER_5MIN_STATISTICS_GENERATED,

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 
 from homeassistant.core import async_get_hass, callback
 from homeassistant.exceptions import HomeAssistantError
-import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
 
 from ..models import AuthFlowResult, Credentials, UserMeta
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -28,13 +27,13 @@ _CONFIG_SCHEMA = AUTH_PROVIDER_SCHEMA.extend(
 
 
 def _create_repair_and_validate(config: dict[str, Any]) -> dict[str, Any]:
-    async_create_issue(
+    ir.async_create_issue(
         async_get_hass(),
         "auth",
         "deprecated_legacy_api_password",
         breaks_in_ha_version="2024.6.0",
         is_fixable=False,
-        severity=IssueSeverity.WARNING,
+        severity=ir.IssueSeverity.WARNING,
         translation_key="deprecated_legacy_api_password",
     )
 

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -14,6 +14,7 @@ import voluptuous as vol
 from homeassistant.core import async_get_hass, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.issue_registry import IssueSeverity
 
 from ..models import AuthFlowResult, Credentials, UserMeta
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -33,7 +34,7 @@ def _create_repair_and_validate(config: dict[str, Any]) -> dict[str, Any]:
         "deprecated_legacy_api_password",
         breaks_in_ha_version="2024.6.0",
         is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
+        severity=IssueSeverity.WARNING,
         translation_key="deprecated_legacy_api_password",
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118215

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
