### PR TITLE
Enforce namespace import in core

### DIFF
--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.area_registry import async_get
+from homeassistant.helpers import area_registry as ar
 
 
 @callback
@@ -29,7 +29,7 @@ def websocket_list_areas(
     msg: dict[str, Any],
 ) -> None:
     """Handle list areas command."""
-    registry = async_get(hass)
+    registry = ar.async_get(hass)
     connection.send_result(
         msg["id"],
         [entry.json_fragment for entry in registry.async_list_areas()],
@@ -55,7 +55,7 @@ def websocket_create_area(
     msg: dict[str, Any],
 ) -> None:
     """Create area command."""
-    registry = async_get(hass)
+    registry = ar.async_get(hass)
 
     data = dict(msg)
     data.pop("type")
@@ -91,7 +91,7 @@ def websocket_delete_area(
     msg: dict[str, Any],
 ) -> None:
     """Delete area command."""
-    registry = async_get(hass)
+    registry = ar.async_get(hass)
 
     try:
         registry.async_delete(msg["area_id"])
@@ -121,7 +121,7 @@ def websocket_update_area(
     msg: dict[str, Any],
 ) -> None:
     """Handle update area websocket command."""
-    registry = async_get(hass)
+    registry = ar.async_get(hass)
 
     data = dict(msg)
     data.pop("type")

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -11,11 +11,8 @@ from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.decorators import require_admin
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import (
-    DeviceEntry,
-    DeviceEntryDisabler,
-    async_get,
-)
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler
 
 
 @callback
@@ -42,7 +39,7 @@ def websocket_list_devices(
     msg: dict[str, Any],
 ) -> None:
     """Handle list devices command."""
-    registry = async_get(hass)
+    registry = dr.async_get(hass)
     # Build start of response message
     msg_json_prefix = (
         f'{{"id":{msg["id"]},"type": "{websocket_api.const.TYPE_RESULT}",'
@@ -80,7 +77,7 @@ def websocket_update_device(
     msg: dict[str, Any],
 ) -> None:
     """Handle update device websocket command."""
-    registry = async_get(hass)
+    registry = dr.async_get(hass)
 
     msg.pop("type")
     msg_id = msg.pop("id")
@@ -112,7 +109,7 @@ async def websocket_remove_config_entry_from_device(
     msg: dict[str, Any],
 ) -> None:
     """Remove config entry from a device."""
-    registry = async_get(hass)
+    registry = dr.async_get(hass)
     config_entry_id = msg["config_entry_id"]
     device_id = msg["device_id"]
 

--- a/homeassistant/components/config/floor_registry.py
+++ b/homeassistant/components/config/floor_registry.py
@@ -7,7 +7,8 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.floor_registry import FloorEntry, async_get
+from homeassistant.helpers import floor_registry as fr
+from homeassistant.helpers.floor_registry import FloorEntry
 
 
 @callback
@@ -30,7 +31,7 @@ def websocket_list_floors(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle list floors command."""
-    registry = async_get(hass)
+    registry = fr.async_get(hass)
     connection.send_result(
         msg["id"],
         [_entry_dict(entry) for entry in registry.async_list_floors()],
@@ -52,7 +53,7 @@ def websocket_create_floor(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Create floor command."""
-    registry = async_get(hass)
+    registry = fr.async_get(hass)
 
     data = dict(msg)
     data.pop("type")
@@ -82,7 +83,7 @@ def websocket_delete_floor(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Delete floor command."""
-    registry = async_get(hass)
+    registry = fr.async_get(hass)
 
     try:
         registry.async_delete(msg["floor_id"])
@@ -108,7 +109,7 @@ def websocket_update_floor(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle update floor websocket command."""
-    registry = async_get(hass)
+    registry = fr.async_get(hass)
 
     data = dict(msg)
     data.pop("type")

--- a/homeassistant/components/config/label_registry.py
+++ b/homeassistant/components/config/label_registry.py
@@ -7,8 +7,8 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.label_registry import LabelEntry, async_get
+from homeassistant.helpers import config_validation as cv, label_registry as lr
+from homeassistant.helpers.label_registry import LabelEntry
 
 SUPPORTED_LABEL_THEME_COLORS = {
     "primary",
@@ -60,7 +60,7 @@ def websocket_list_labels(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle list labels command."""
-    registry = async_get(hass)
+    registry = lr.async_get(hass)
     connection.send_result(
         msg["id"],
         [_entry_dict(entry) for entry in registry.async_list_labels()],
@@ -84,7 +84,7 @@ def websocket_create_label(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Create label command."""
-    registry = async_get(hass)
+    registry = lr.async_get(hass)
 
     data = dict(msg)
     data.pop("type")
@@ -110,7 +110,7 @@ def websocket_delete_label(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Delete label command."""
-    registry = async_get(hass)
+    registry = lr.async_get(hass)
 
     try:
         registry.async_delete(msg["label_id"])
@@ -138,7 +138,7 @@ def websocket_update_label(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Handle update label websocket command."""
-    registry = async_get(hass)
+    registry = lr.async_get(hass)
 
     data = dict(msg)
     data.pop("type")

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -45,13 +45,12 @@ from homeassistant.core import (
     callback,
 )
 from homeassistant.data_entry_flow import BaseServiceInfo
-from homeassistant.helpers import config_validation as cv, discovery_flow
-from homeassistant.helpers.device_registry import (
-    CONNECTION_NETWORK_MAC,
-    DeviceRegistry,
-    async_get,
-    format_mac,
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    discovery_flow,
 )
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, format_mac
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import (
     async_track_state_added_domain,
@@ -243,7 +242,7 @@ class WatcherBase:
         matchers = self._integration_matchers
         registered_devices_domains = matchers.registered_devices_domains
 
-        dev_reg: DeviceRegistry = async_get(self.hass)
+        dev_reg = dr.async_get(self.hass)
         if device := dev_reg.async_get_device(
             connections={(CONNECTION_NETWORK_MAC, formatted_mac)}
         ):

--- a/homeassistant/components/diagnostics/__init__.py
+++ b/homeassistant/components/diagnostics/__init__.py
@@ -15,8 +15,12 @@ import voluptuous as vol
 from homeassistant.components import http, websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, integration_platform
-from homeassistant.helpers.device_registry import DeviceEntry, async_get
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    integration_platform,
+)
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.json import (
     ExtendedJSONEncoder,
     find_paths_unserializable_data,
@@ -280,7 +284,7 @@ class DownloadDiagnosticsView(http.HomeAssistantView):
             )
 
         # Device diagnostics
-        dev_reg = async_get(hass)
+        dev_reg = dr.async_get(hass)
         if sub_id is None:
             return web.Response(status=HTTPStatus.BAD_REQUEST)
 

--- a/homeassistant/components/mqtt/__init__.py
+++ b/homeassistant/components/mqtt/__init__.py
@@ -24,15 +24,12 @@ from homeassistant.helpers import (
     config_validation as cv,
     entity_registry as er,
     event as ev,
+    issue_registry as ir,
     template,
 )
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import async_get_platforms
-from homeassistant.helpers.issue_registry import (
-    async_delete_issue,
-    async_get as async_get_issue_registry,
-)
 from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
@@ -186,14 +183,14 @@ async def _async_config_entry_updated(hass: HomeAssistant, entry: ConfigEntry) -
 @callback
 def _async_remove_mqtt_issues(hass: HomeAssistant, mqtt_data: MqttData) -> None:
     """Unregister open config issues."""
-    issue_registry = async_get_issue_registry(hass)
+    issue_registry = ir.async_get(hass)
     open_issues = [
         issue_id
         for (domain, issue_id), issue_entry in issue_registry.issues.items()
         if domain == DOMAIN and issue_entry.translation_key == "invalid_platform_config"
     ]
     for issue in open_issues:
-        async_delete_issue(hass, DOMAIN, issue)
+        ir.async_delete_issue(hass, DOMAIN, issue)
 
 
 async def async_check_config_schema(

--- a/homeassistant/components/repairs/websocket_api.py
+++ b/homeassistant/components/repairs/websocket_api.py
@@ -15,13 +15,10 @@ from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.decorators import require_admin
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.data_entry_flow import (
     FlowManagerIndexView,
     FlowManagerResourceView,
-)
-from homeassistant.helpers.issue_registry import (
-    async_get as async_get_issue_registry,
-    async_ignore_issue,
 )
 
 from .const import DOMAIN
@@ -50,7 +47,7 @@ def ws_get_issue_data(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Fix an issue."""
-    issue_registry = async_get_issue_registry(hass)
+    issue_registry = ir.async_get(hass)
     if not (issue := issue_registry.async_get_issue(msg["domain"], msg["issue_id"])):
         connection.send_error(
             msg["id"],
@@ -74,7 +71,7 @@ def ws_ignore_issue(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Fix an issue."""
-    async_ignore_issue(hass, msg["domain"], msg["issue_id"], msg["ignore"])
+    ir.async_ignore_issue(hass, msg["domain"], msg["issue_id"], msg["ignore"])
 
     connection.send_result(msg["id"])
 
@@ -89,7 +86,7 @@ def ws_list_issues(
     hass: HomeAssistant, connection: websocket_api.ActiveConnection, msg: dict[str, Any]
 ) -> None:
     """Return a list of issues."""
-    issue_registry = async_get_issue_registry(hass)
+    issue_registry = ir.async_get(hass)
     issues = [
         {
             "breaks_in_ha_version": issue.breaks_in_ha_version,

--- a/tests/components/mqtt/test_alarm_control_panel.py
+++ b/tests/components/mqtt/test_alarm_control_panel.py
@@ -1290,7 +1290,7 @@ async def test_reload_after_invalid_config(
 ) -> None:
     """Test reloading yaml config fails."""
     with patch(
-        "homeassistant.components.mqtt.async_delete_issue"
+        "homeassistant.components.mqtt.ir.async_delete_issue"
     ) as mock_async_remove_issue:
         assert await mqtt_mock_entry()
         assert hass.states.get("alarm_control_panel.test") is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, linked to #118215

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
