### PR TITLE
Fix Sonos album images with special characters not displaying in media browser UI

### DIFF
--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -53,8 +53,8 @@ def fix_image_url(url: str) -> str:
     """
 
     # Before parsing encode the plus sign; otherwise it'll be interpreted as a space.
-    ori_url: str = urllib.parse.unquote(url).replace("+", "%2B")
-    parsed_url = urllib.parse.urlparse(ori_url)
+    original_uri: str = urllib.parse.unquote(url).replace("+", "%2B")
+    parsed_url = urllib.parse.urlparse(original_uri)
     query_params = urllib.parse.parse_qsl(parsed_url.query)
     new_url = urllib.parse.urlunsplit(
         (
@@ -67,8 +67,8 @@ def fix_image_url(url: str) -> str:
             "",
         )
     )
-    if ori_url != new_url:
-        _LOGGER.debug("fix_sonos_image_url original: %s new: %s", ori_url, new_url)
+    if original_uri != new_url:
+        _LOGGER.debug("fix_sonos_image_url original: %s new: %s", original_uri, new_url)
     return new_url
 
 

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -53,8 +53,8 @@ def fix_image_url(url: str) -> str:
     """
 
     # Before parsing encode the plus sign; otherwise it'll be interpreted as a space.
-    original_uri: str = urllib.parse.unquote(url).replace("+", "%2B")
-    parsed_url = urllib.parse.urlparse(original_uri)
+    original_url: str = urllib.parse.unquote(url).replace("+", "%2B")
+    parsed_url = urllib.parse.urlparse(original_url)
     query_params = urllib.parse.parse_qsl(parsed_url.query)
     new_url = urllib.parse.urlunsplit(
         (
@@ -67,7 +67,7 @@ def fix_image_url(url: str) -> str:
             "",
         )
     )
-    if original_uri != new_url:
+    if original_url != new_url:
         _LOGGER.debug("fix_sonos_image_url original: %s new: %s", original_uri, new_url)
     return new_url
 

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -68,7 +68,7 @@ def fix_image_url(url: str) -> str:
         )
     )
     if original_url != new_url:
-        _LOGGER.debug("fix_sonos_image_url original: %s new: %s", original_uri, new_url)
+        _LOGGER.debug("fix_sonos_image_url original: %s new: %s", original_url, new_url)
     return new_url
 
 

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -46,6 +46,32 @@ _LOGGER = logging.getLogger(__name__)
 type GetBrowseImageUrlType = Callable[[str, str, str | None], str]
 
 
+def fix_image_url(url: str) -> str:
+    """Update the image url to fully encode characters that need to be escaped for the media_browser UI.
+
+    Images whose file path contains characters such as ',()+ are not loaded without escaping them.
+    """
+
+    # Before parsing encode the plus sign; otherwise it'll be interpreted as a space.
+    ori_url: str = urllib.parse.unquote(url).replace("+", "%2B")
+    parsed_url = urllib.parse.urlparse(ori_url)
+    query_params = urllib.parse.parse_qsl(parsed_url.query)
+    new_url = urllib.parse.urlunsplit(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            urllib.parse.urlencode(
+                query_params, quote_via=urllib.parse.quote, safe="/:"
+            ),
+            "",
+        )
+    )
+    if ori_url != new_url:
+        _LOGGER.debug("fix_sonos_image_url original: %s new: %s", ori_url, new_url)
+    return new_url
+
+
 def get_thumbnail_url_full(
     media: SonosMedia,
     is_internal: bool,
@@ -63,7 +89,7 @@ def get_thumbnail_url_full(
                 media_content_id,
                 media_content_type,
             )
-        return urllib.parse.unquote(getattr(item, "album_art_uri", ""))
+        return fix_image_url(getattr(item, "album_art_uri", ""))
 
     return urllib.parse.unquote(
         get_browse_image_url(

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -47,7 +47,7 @@ type GetBrowseImageUrlType = Callable[[str, str, str | None], str]
 
 
 def fix_image_url(url: str) -> str:
-    """Update the image url to fully encode characters that need to be escaped for the media_browser UI.
+    """Update the image url to fully encode characters to allow image display in media_browser UI.
 
     Images whose file path contains characters such as ',()+ are not loaded without escaping them.
     """

--- a/tests/components/sonos/fixtures/music_library_albums.json
+++ b/tests/components/sonos/fixtures/music_library_albums.json
@@ -19,5 +19,12 @@
     "parent_id": "A:ALBUM",
     "item_class": "object.container.album.musicAlbum",
     "album_art_uri": "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fSantana%2fA%2520Between%2520Good%2520And%2520Evil%2f02%2520A%2520Persuasion.m4a&v=53"
+  },
+  {
+    "title": "Special Characters,'()+",
+    "item_id": "A:ALBUM/Special%20Characters,'()+",
+    "parent_id": "A:ALBUM",
+    "item_class": "object.container.album.musicAlbum",
+    "album_art_uri": "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fSpecial%2fA%2520Special%2520Characters,()+%2f01%2520A%2520TheFirstTrack.m4a&v=53"
   }
 ]

--- a/tests/components/sonos/snapshots/test_media_browser.ambr
+++ b/tests/components/sonos/snapshots/test_media_browser.ambr
@@ -82,7 +82,7 @@
       'media_class': 'album',
       'media_content_id': "A:ALBUM/A%20Hard%20Day's%20Night",
       'media_content_type': 'album',
-      'thumbnail': "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/The%20Beatles/A%20Hard%20Day's%20Night/01%20A%20Hard%20Day's%20Night%201.m4a&v=53",
+      'thumbnail': 'http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/The%20Beatles/A%20Hard%20Day%27s%20Night/01%20A%20Hard%20Day%27s%20Night%201.m4a&v=53',
       'title': "A Hard Day's Night",
     }),
     dict({

--- a/tests/components/sonos/snapshots/test_media_browser.ambr
+++ b/tests/components/sonos/snapshots/test_media_browser.ambr
@@ -105,6 +105,16 @@
       'thumbnail': 'http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/Santana/A%20Between%20Good%20And%20Evil/02%20A%20Persuasion.m4a&v=53',
       'title': 'Between Good And Evil',
     }),
+    dict({
+      'can_expand': True,
+      'can_play': True,
+      'children_media_class': None,
+      'media_class': 'album',
+      'media_content_id': "A:ALBUM/Special%20Characters,'()+",
+      'media_content_type': 'album',
+      'thumbnail': 'http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/Special/A%20Special%20Characters%2C%28%29%2B/01%20A%20TheFirstTrack.m4a&v=53',
+      'title': "Special Characters,'()+",
+    }),
   ])
 # ---
 # name: test_browse_media_root

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -2,14 +2,12 @@
 
 from functools import partial
 
-import pytest
 from syrupy import SnapshotAssertion
 
 from homeassistant.components.media_player.browse_media import BrowseMedia
 from homeassistant.components.media_player.const import MediaClass, MediaType
 from homeassistant.components.sonos.media_browser import (
     build_item_response,
-    fix_image_url,
     get_thumbnail_url_full,
 )
 from homeassistant.core import HomeAssistant
@@ -179,33 +177,3 @@ async def test_browse_media_library_albums(
     assert response["success"]
     assert response["result"]["children"] == snapshot
     assert soco_mock.music_library.browse_by_idstring.call_count == 1
-
-
-@pytest.mark.parametrize(
-    ("album_art_uri", "expected_result"),
-    [
-        (
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fCarpenters%2f_Avenue%2520Q_'s%2520Playlist%2f01%2520Rainy%2520Days%2520and%2520Mondays.m4a&v=56",
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/Carpenters/_Avenue%20Q_%27s%20Playlist/01%20Rainy%20Days%20and%20Mondays.m4a&v=56",
-        ),
-        (
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fOasis%2f(What's%2520the%2520Story)%2520Morning%2520Glory_%2f03%2520Wonderwall.m4a&v=56",
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/Oasis/%28What%27s%20the%20Story%29%20Morning%20Glory_/03%20Wonderwall.m4a&v=56",
-        ),
-        (
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fThe%2520Grateful%2520Dead%2fShakedown%2520Street%2520%2b%2520Bonus%2520Material%2f01%2520Good%2520Lovin'.m4a&v=56",
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/The%20Grateful%20Dead/Shakedown%20Street%20%2B%20Bonus%20Material/01%20Good%20Lovin%27.m4a&v=56",
-        ),
-        (
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fiTunes%2520Music%2fSantana%2fAbraxas%2f01%2520Singing%2520Winds,%2520Crying%2520Beasts.m4a&v=56",
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/iTunes%20Music/Santana/Abraxas/01%20Singing%20Winds%2C%20Crying%20Beasts.m4a&v=56",
-        ),
-        (
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs%3a%2f%2f192.168.42.100%2fmusic%2fCarlos%2520Santana%2520%2526%2520Buddy%2520Miles%2fCarlos%2520Santana%2520%2526%2520Buddy%2520Miles!%2520Live!%2f01%2520Marbles%2520(Live).m4a&v=56",
-            "http://192.168.42.2:1400/getaa?u=x-file-cifs://192.168.42.100/music/Carlos%20Santana%20%26%20Buddy%20Miles/Carlos%20Santana%20%26%20Buddy%20Miles%21%20Live%21/01%20Marbles%20%28Live%29.m4a&v=56",
-        ),
-    ],
-)
-def test_fix_sonos_image_url(album_art_uri: str, expected_result: str) -> None:
-    """Tests processing the image URL targeting specific characters that need encoding."""
-    assert fix_image_url(album_art_uri) == expected_result


### PR DESCRIPTION
## Proposed change
Sonos Album Artwork that contains special characters are not displayed in the media browser UI. The fix is to encode these characters which allows the artwork to be displayed,

Sonos is returning album artwork URIs with special characters such as '(),+ unencoded in the URL. This change processes those URIs to make sure they are properly encoded, as the media browser UI is expecting it to be formatted this way.

Prior to the change roughly 30% of the album artwork in my media library (320 albums) were not being displayed; other have reported the same issue.

https://community.home-assistant.io/t/media-player-shows-some-but-not-all-cover-art-from-sonos-music-library/391240/14

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
