### PR TITLE
Fix Matter device ID for non-bridged composed device

### DIFF
--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -59,12 +59,12 @@ def get_device_id(
 ) -> str:
     """Return HA device_id for the given MatterEndpoint."""
     operational_instance_id = get_operational_instance_id(server_info, endpoint.node)
-    # Append endpoint ID if this endpoint is a bridged or composed device
-    if endpoint.is_composed_device:
-        compose_parent = endpoint.node.get_compose_parent(endpoint.endpoint_id)
-        assert compose_parent is not None
-        postfix = str(compose_parent.endpoint_id)
-    elif endpoint.is_bridged_device:
+    # if this is a composed device we need to get the compose parent
+    # example: Philips Hue motion sensor on Hue Hub (bridged to Matter)
+    if compose_parent := endpoint.node.get_compose_parent(endpoint.endpoint_id):
+        endpoint = compose_parent
+    if endpoint.is_bridged_device:
+        # Append endpoint ID if this endpoint is a bridged device
         postfix = str(endpoint.endpoint_id)
     else:
         # this should be compatible with previous versions

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -172,6 +172,20 @@ async def test_node_added_subscription(
     assert entity_state
 
 
+async def test_device_registry_single_node_composed_device(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+) -> None:
+    """Test that a composed device within a standalone node only creates one HA device entry."""
+    await setup_integration_with_node_fixture(
+        hass,
+        "air-purifier",
+        matter_client,
+    )
+    dev_reg = dr.async_get(hass)
+    assert len(dev_reg.devices) == 1
+
+
 async def test_get_clean_name_() -> None:
     """Test get_clean_name helper.
 


### PR DESCRIPTION
## Proposed change
There was a small oversight in the helper calculating the device ID to attach to each entity.
A composed device endpoint is only useful in case a device is bridged, otherwise it makes no sense to create separate HA devices for composed devices within a physical device. 

Fixes the issue where a duplicate device is created in HA where this makes no sense.
I accidentally ran into this while testing with an Air Purifier device type.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
