### PR TITLE
Fix SharkIQ go-to-room functionality

### DIFF
--- a/homeassistant/components/sharkiq/strings.json
+++ b/homeassistant/components/sharkiq/strings.json
@@ -43,7 +43,7 @@
   },
   "exceptions": {
     "invalid_room": {
-      "message": "The room { room } is unavailable to your vacuum. Make sure all rooms match the Shark App, including capitalization."
+      "message": "The room { room } is unavailable to your vacuum. Make sure all room IDs also exist in the Shark App."
     }
   },
   "services": {

--- a/homeassistant/components/sharkiq/vacuum.py
+++ b/homeassistant/components/sharkiq/vacuum.py
@@ -211,7 +211,13 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
     async def async_clean_room(self, rooms: list[str], **kwargs: Any) -> None:
         """Clean specific rooms."""
         rooms_to_clean = []
-        valid_rooms = self.available_rooms or []
+        available_rooms: list[str] | None = self.available_rooms
+
+        if available_rooms is None:
+            valid_rooms: list[str] = []
+        else:
+            valid_rooms = [room.lower() for room in available_rooms]
+
         for room in rooms:
             if room in valid_rooms:
                 rooms_to_clean.append(room)

--- a/homeassistant/components/sharkiq/vacuum.py
+++ b/homeassistant/components/sharkiq/vacuum.py
@@ -262,7 +262,10 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
     @property
     def available_rooms(self) -> list | None:
         """Return a list of rooms available to clean."""
-        return self.sharkiq.get_room_list()
+        room_list = self.sharkiq.get_property_value(Properties.ROBOT_ROOM_LIST)
+        if room_list:
+            return room_list.split(':')[1:]
+        return []
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/homeassistant/components/sharkiq/vacuum.py
+++ b/homeassistant/components/sharkiq/vacuum.py
@@ -264,7 +264,7 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
         """Return a list of rooms available to clean."""
         room_list = self.sharkiq.get_property_value(Properties.ROBOT_ROOM_LIST)
         if room_list:
-            return room_list.split(':')[1:]
+            return room_list.split(":")[1:]
         return []
 
     @property

--- a/homeassistant/components/sharkiq/vacuum.py
+++ b/homeassistant/components/sharkiq/vacuum.py
@@ -216,7 +216,7 @@ class SharkVacuumEntity(CoordinatorEntity[SharkIqUpdateCoordinator], StateVacuum
         if available_rooms is None:
             valid_rooms: list[str] = []
         else:
-            valid_rooms = [room.lower() for room in available_rooms]
+            valid_rooms = [room.lower().replace(" ", "_") for room in available_rooms]
 
         for room in rooms:
             if room in valid_rooms:

--- a/tests/components/sharkiq/const.py
+++ b/tests/components/sharkiq/const.py
@@ -68,7 +68,7 @@ SHARK_PROPERTIES_DICT = {
     "Robot_Room_List": {
         "base_type": "string",
         "read_only": True,
-        "value": "Kitchen",
+        "value": "AY001MRT1:Kitchen:Living Room",
     },
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR fixes an issue with SharkIQ go-to-room functionality wherein the comparison against SharkIQ's known rooms and the requested rooms IDs in HASS always returns empty due to SharkIQ's internal room naming scheme being camel case and HASS's area IDs being snake case.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Please note that tests on this will fail until [my other PR](https://github.com/home-assistant/core/pull/118209) is merged. Rest assured, I have tested the code locally and it works perfectly fine regardless.

- This PR fixes or closes issue: fixes #117277 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
