### PR TITLE
Migrate mqtt mixin async_added_to_hass inner functions to bound methods

### DIFF
--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -823,105 +823,99 @@ class MqttDiscoveryUpdateMixin(Entity):
         """Subscribe to discovery updates."""
         await super().async_added_to_hass()
         self._removed_from_hass = False
-        discovery_hash: tuple[str, str] | None = (
-            self._discovery_data[ATTR_DISCOVERY_HASH] if self._discovery_data else None
+        if not self._discovery_data:
+            return
+        discovery_hash: tuple[str, str] = self._discovery_data[ATTR_DISCOVERY_HASH]
+        debug_info.add_entity_discovery_data(
+            self.hass, self._discovery_data, self.entity_id
+        )
+        # Set in case the entity has been removed and is re-added,
+        # for example when changing entity_id
+        set_discovery_hash(self.hass, discovery_hash)
+        self._remove_discovery_updated = async_dispatcher_connect(
+            self.hass,
+            MQTT_DISCOVERY_UPDATED.format(*discovery_hash),
+            self._async_discovery_callback,
         )
 
-        async def _async_remove_state_and_registry_entry(
-            self: MqttDiscoveryUpdateMixin,
-        ) -> None:
-            """Remove entity's state and entity registry entry.
+    async def _async_remove_state_and_registry_entry(
+        self: MqttDiscoveryUpdateMixin,
+    ) -> None:
+        """Remove entity's state and entity registry entry.
 
-            Remove entity from entity registry if it is registered,
-            this also removes the state. If the entity is not in the entity
-            registry, just remove the state.
-            """
-            entity_registry = er.async_get(self.hass)
-            if entity_entry := entity_registry.async_get(self.entity_id):
-                entity_registry.async_remove(self.entity_id)
-                await cleanup_device_registry(
-                    self.hass, entity_entry.device_id, entity_entry.config_entry_id
-                )
-            else:
-                await self.async_remove(force_remove=True)
+        Remove entity from entity registry if it is registered,
+        this also removes the state. If the entity is not in the entity
+        registry, just remove the state.
+        """
+        entity_registry = er.async_get(self.hass)
+        if entity_entry := entity_registry.async_get(self.entity_id):
+            entity_registry.async_remove(self.entity_id)
+            await cleanup_device_registry(
+                self.hass, entity_entry.device_id, entity_entry.config_entry_id
+            )
+        else:
+            await self.async_remove(force_remove=True)
 
-        async def _async_process_discovery_update(
-            payload: MQTTDiscoveryPayload,
-            discovery_update: Callable[
-                [MQTTDiscoveryPayload], Coroutine[Any, Any, None]
-            ],
-            discovery_data: DiscoveryInfoType,
-        ) -> None:
-            """Process discovery update."""
-            try:
-                await discovery_update(payload)
-            finally:
-                send_discovery_done(self.hass, discovery_data)
-
-        async def _async_process_discovery_update_and_remove(
-            payload: MQTTDiscoveryPayload, discovery_data: DiscoveryInfoType
-        ) -> None:
-            """Process discovery update and remove entity."""
-            self._cleanup_discovery_on_remove()
-            await _async_remove_state_and_registry_entry(self)
+    async def _async_process_discovery_update(
+        self,
+        payload: MQTTDiscoveryPayload,
+        discovery_update: Callable[[MQTTDiscoveryPayload], Coroutine[Any, Any, None]],
+        discovery_data: DiscoveryInfoType,
+    ) -> None:
+        """Process discovery update."""
+        try:
+            await discovery_update(payload)
+        finally:
             send_discovery_done(self.hass, discovery_data)
 
-        @callback
-        def discovery_callback(payload: MQTTDiscoveryPayload) -> None:
-            """Handle discovery update.
+    async def _async_process_discovery_update_and_remove(self) -> None:
+        """Process discovery update and remove entity."""
+        if TYPE_CHECKING:
+            assert self._discovery_data
+        self._cleanup_discovery_on_remove()
+        await self._async_remove_state_and_registry_entry()
+        send_discovery_done(self.hass, self._discovery_data)
 
-            If the payload has changed we will create a task to
-            do the discovery update.
+    @callback
+    def _async_discovery_callback(self, payload: MQTTDiscoveryPayload) -> None:
+        """Handle discovery update.
 
-            As this callback can fire when nothing has changed, this
-            is a normal function to avoid task creation until it is needed.
-            """
-            _LOGGER.debug(
-                "Got update for entity with hash: %s '%s'",
-                discovery_hash,
-                payload,
+        If the payload has changed we will create a task to
+        do the discovery update.
+
+        As this callback can fire when nothing has changed, this
+        is a normal function to avoid task creation until it is needed.
+        """
+        if TYPE_CHECKING:
+            assert self._discovery_data
+        discovery_hash: tuple[str, str] = self._discovery_data[ATTR_DISCOVERY_HASH]
+        _LOGGER.debug(
+            "Got update for entity with hash: %s '%s'",
+            discovery_hash,
+            payload,
+        )
+        old_payload: DiscoveryInfoType
+        old_payload = self._discovery_data[ATTR_DISCOVERY_PAYLOAD]
+        debug_info.update_entity_discovery_data(self.hass, payload, self.entity_id)
+        if not payload:
+            # Empty payload: Remove component
+            _LOGGER.info("Removing component: %s", self.entity_id)
+            self.hass.async_create_task(
+                self._async_process_discovery_update_and_remove()
             )
-            if TYPE_CHECKING:
-                assert self._discovery_data
-            old_payload: DiscoveryInfoType
-            old_payload = self._discovery_data[ATTR_DISCOVERY_PAYLOAD]
-            debug_info.update_entity_discovery_data(self.hass, payload, self.entity_id)
-            if not payload:
-                # Empty payload: Remove component
-                _LOGGER.info("Removing component: %s", self.entity_id)
+        elif self._discovery_update:
+            if old_payload != self._discovery_data[ATTR_DISCOVERY_PAYLOAD]:
+                # Non-empty, changed payload: Notify component
+                _LOGGER.info("Updating component: %s", self.entity_id)
                 self.hass.async_create_task(
-                    _async_process_discovery_update_and_remove(
-                        payload, self._discovery_data
+                    self._async_process_discovery_update(
+                        payload, self._discovery_update, self._discovery_data
                     )
                 )
-            elif self._discovery_update:
-                if old_payload != self._discovery_data[ATTR_DISCOVERY_PAYLOAD]:
-                    # Non-empty, changed payload: Notify component
-                    _LOGGER.info("Updating component: %s", self.entity_id)
-                    self.hass.async_create_task(
-                        _async_process_discovery_update(
-                            payload, self._discovery_update, self._discovery_data
-                        )
-                    )
-                else:
-                    # Non-empty, unchanged payload: Ignore to avoid changing states
-                    _LOGGER.debug("Ignoring unchanged update for: %s", self.entity_id)
-                    send_discovery_done(self.hass, self._discovery_data)
-
-        if discovery_hash:
-            if TYPE_CHECKING:
-                assert self._discovery_data is not None
-            debug_info.add_entity_discovery_data(
-                self.hass, self._discovery_data, self.entity_id
-            )
-            # Set in case the entity has been removed and is re-added,
-            # for example when changing entity_id
-            set_discovery_hash(self.hass, discovery_hash)
-            self._remove_discovery_updated = async_dispatcher_connect(
-                self.hass,
-                MQTT_DISCOVERY_UPDATED.format(*discovery_hash),
-                discovery_callback,
-            )
+            else:
+                # Non-empty, unchanged payload: Ignore to avoid changing states
+                _LOGGER.debug("Ignoring unchanged update for: %s", self.entity_id)
+                send_discovery_done(self.hass, self._discovery_data)
 
     async def async_removed_from_registry(self) -> None:
         """Clear retained discovery topic in broker."""

--- a/homeassistant/components/mqtt/mixins.py
+++ b/homeassistant/components/mqtt/mixins.py
@@ -904,7 +904,7 @@ class MqttDiscoveryUpdateMixin(Entity):
                 self._async_process_discovery_update_and_remove()
             )
         elif self._discovery_update:
-            if old_payload != self._discovery_data[ATTR_DISCOVERY_PAYLOAD]:
+            if old_payload != payload:
                 # Non-empty, changed payload: Notify component
                 _LOGGER.info("Updating component: %s", self.entity_id)
                 self.hass.async_create_task(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
These functions did not need to capture any variables so they can be bound methods instead which avoids running their decorators every time an entity was added to hass.

Its a modest speed up as well

before
<img width="580" alt="Screenshot 2024-05-27 at 5 54 15 PM" src="https://github.com/home-assistant/core/assets/663432/01851641-a417-4364-b95e-2824841f3650">

after
<img width="486" alt="Screenshot 2024-05-27 at 5 54 21 PM" src="https://github.com/home-assistant/core/assets/663432/5b41eb90-609a-4765-a7e6-4498a67bc502">



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
