### PR TITLE
Fix freezing on HA startup when there are multiple Google Generative AI config entries

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/__init__.py
+++ b/homeassistant/components/google_generative_ai_conversation/__init__.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from functools import partial
 import mimetypes
 from pathlib import Path
 
+from google.ai import generativelanguage_v1beta
+from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import ClientError, DeadlineExceeded, GoogleAPICallError
 import google.generativeai as genai
 import google.generativeai.types as genai_types
@@ -105,12 +106,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     genai.configure(api_key=entry.data[CONF_API_KEY])
 
     try:
-        await hass.async_add_executor_job(
-            partial(
-                genai.get_model,
-                entry.options.get(CONF_CHAT_MODEL, RECOMMENDED_CHAT_MODEL),
-                request_options={"timeout": 5.0},
-            )
+        client = generativelanguage_v1beta.ModelServiceAsyncClient(
+            client_options=ClientOptions(api_key=entry.data[CONF_API_KEY])
+        )
+        await client.get_model(
+            name=entry.options.get(CONF_CHAT_MODEL, RECOMMENDED_CHAT_MODEL), timeout=5.0
         )
     except (GoogleAPICallError, ValueError) as err:
         if isinstance(err, ClientError) and err.reason == "API_KEY_INVALID":

--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -8,6 +8,8 @@ import logging
 from types import MappingProxyType
 from typing import Any
 
+from google.ai import generativelanguage_v1beta
+from google.api_core.client_options import ClientOptions
 from google.api_core.exceptions import ClientError, GoogleAPICallError
 import google.generativeai as genai
 import voluptuous as vol
@@ -72,12 +74,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
 
     Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
     """
-    genai.configure(api_key=data[CONF_API_KEY])
-
-    def get_first_model():
-        return next(genai.list_models(request_options={"timeout": 5.0}), None)
-
-    await hass.async_add_executor_job(partial(get_first_model))
+    client = generativelanguage_v1beta.ModelServiceAsyncClient(
+        client_options=ClientOptions(api_key=data[CONF_API_KEY])
+    )
+    await client.list_models()
 
 
 class GoogleGenerativeAIConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/google_generative_ai_conversation/config_flow.py
+++ b/homeassistant/components/google_generative_ai_conversation/config_flow.py
@@ -77,7 +77,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> None:
     client = generativelanguage_v1beta.ModelServiceAsyncClient(
         client_options=ClientOptions(api_key=data[CONF_API_KEY])
     )
-    await client.list_models()
+    await client.list_models(timeout=5.0)
 
 
 class GoogleGenerativeAIConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/tests/components/google_generative_ai_conversation/conftest.py
+++ b/tests/components/google_generative_ai_conversation/conftest.py
@@ -16,9 +16,7 @@ from tests.common import MockConfigEntry
 @pytest.fixture
 def mock_genai():
     """Mock the genai call in async_setup_entry."""
-    with patch(
-        "homeassistant.components.google_generative_ai_conversation.genai.get_model"
-    ):
+    with patch("google.ai.generativelanguage_v1beta.ModelServiceAsyncClient.get_model"):
         yield
 
 
@@ -48,11 +46,8 @@ def mock_config_entry_with_assist(hass, mock_config_entry):
 @pytest.fixture
 async def mock_init_component(hass: HomeAssistant, mock_config_entry: ConfigEntry):
     """Initialize integration."""
-    with patch("google.generativeai.get_model"):
-        assert await async_setup_component(
-            hass, "google_generative_ai_conversation", {}
-        )
-        await hass.async_block_till_done()
+    assert await async_setup_component(hass, "google_generative_ai_conversation", {})
+    await hass.async_block_till_done()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/google_generative_ai_conversation/test_config_flow.py
+++ b/tests/components/google_generative_ai_conversation/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Google Generative AI Conversation config flow."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from google.api_core.exceptions import ClientError, DeadlineExceeded
 from google.rpc.error_details_pb2 import ErrorInfo
@@ -74,7 +74,7 @@ async def test_form(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.components.google_generative_ai_conversation.config_flow.genai.list_models",
+            "google.ai.generativelanguage_v1beta.ModelServiceAsyncClient.list_models",
         ),
         patch(
             "homeassistant.components.google_generative_ai_conversation.async_setup_entry",
@@ -205,9 +205,11 @@ async def test_form_errors(hass: HomeAssistant, side_effect, error) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    mock_client = AsyncMock()
+    mock_client.list_models.side_effect = side_effect
     with patch(
-        "homeassistant.components.google_generative_ai_conversation.config_flow.genai.list_models",
-        side_effect=side_effect,
+        "google.ai.generativelanguage_v1beta.ModelServiceAsyncClient",
+        return_value=mock_client,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -245,7 +247,7 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.components.google_generative_ai_conversation.config_flow.genai.list_models",
+            "google.ai.generativelanguage_v1beta.ModelServiceAsyncClient.list_models",
         ),
         patch(
             "homeassistant.components.google_generative_ai_conversation.async_setup_entry",

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -537,12 +537,7 @@ async def test_template_error(
             "prompt": "talk like a {% if True %}smarthome{% else %}pirate please.",
         },
     )
-    with (
-        patch(
-            "google.generativeai.get_model",
-        ),
-        patch("google.generativeai.GenerativeModel"),
-    ):
+    with patch("google.generativeai.GenerativeModel"):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
         result = await conversation.async_converse(

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -247,13 +247,14 @@ async def test_config_entry_error(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry, side_effect, state, reauth
 ) -> None:
     """Test different configuration entry errors."""
+    mock_client = AsyncMock()
+    mock_client.get_model.side_effect = side_effect
     with patch(
-        "homeassistant.components.google_generative_ai_conversation.genai.get_model",
-        side_effect=side_effect,
+        "google.ai.generativelanguage_v1beta.ModelServiceAsyncClient",
+        return_value=mock_client,
     ):
-        mock_config_entry.add_to_hass(hass)
-        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
-        assert mock_config_entry.state is state
+        assert mock_config_entry.state == state
         mock_config_entry.async_get_active_flows(hass, {"reauth"})
-        assert any(mock_config_entry.async_get_active_flows(hass, {"reauth"})) is reauth
+        assert any(mock_config_entry.async_get_active_flows(hass, {"reauth"})) == reauth


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix freezing on HA startup when there are multiple Google Generative AI config entries. It seems there is some race condition inside the library. Fix it by using the internal client which supports async and passing its own api key. Unfortunately I cannot do the same for the chat API. I'd have to call the internal GenerateConent service and we would lose all the functionality the library provides for chat history and function calling. Luckily that doesn't seem to be affected by the race condition issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
