### PR TITLE
LLM Assist API to ignore intents if not needed for exposed entities or calling device

### DIFF
--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -157,9 +157,7 @@ class GoogleGenerativeAIConversationEntity(
                 llm_api = await llm.async_get_api(
                     self.hass,
                     self.entry.options[CONF_LLM_HASS_API],
-                    llm.ToolInput(
-                        tool_name="",
-                        tool_args={},
+                    llm.ToolContext(
                         platform=DOMAIN,
                         context=user_input.context,
                         user_prompt=user_input.text,
@@ -308,12 +306,6 @@ class GoogleGenerativeAIConversationEntity(
                 tool_input = llm.ToolInput(
                     tool_name=tool_call.name,
                     tool_args=dict(tool_call.args),
-                    platform=DOMAIN,
-                    context=user_input.context,
-                    user_prompt=user_input.text,
-                    language=user_input.language,
-                    assistant=conversation.DOMAIN,
-                    device_id=user_input.device_id,
                 )
                 LOGGER.debug(
                     "Tool call: %s(%s)", tool_input.tool_name, tool_input.tool_args

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -149,13 +149,24 @@ class GoogleGenerativeAIConversationEntity(
     ) -> conversation.ConversationResult:
         """Process a sentence."""
         intent_response = intent.IntentResponse(language=user_input.language)
-        llm_api: llm.API | None = None
+        llm_api: llm.APIInstance | None = None
         tools: list[dict[str, Any]] | None = None
 
         if self.entry.options.get(CONF_LLM_HASS_API):
             try:
-                llm_api = llm.async_get_api(
-                    self.hass, self.entry.options[CONF_LLM_HASS_API]
+                llm_api = await llm.async_get_api(
+                    self.hass,
+                    self.entry.options[CONF_LLM_HASS_API],
+                    llm.ToolInput(
+                        tool_name="",
+                        tool_args={},
+                        platform=DOMAIN,
+                        context=user_input.context,
+                        user_prompt=user_input.text,
+                        language=user_input.language,
+                        assistant=conversation.DOMAIN,
+                        device_id=user_input.device_id,
+                    ),
                 )
             except HomeAssistantError as err:
                 LOGGER.error("Error getting LLM API: %s", err)
@@ -166,19 +177,7 @@ class GoogleGenerativeAIConversationEntity(
                 return conversation.ConversationResult(
                     response=intent_response, conversation_id=user_input.conversation_id
                 )
-            empty_tool_input = llm.ToolInput(
-                tool_name="",
-                tool_args={},
-                platform=DOMAIN,
-                context=user_input.context,
-                user_prompt=user_input.text,
-                language=user_input.language,
-                assistant=conversation.DOMAIN,
-                device_id=user_input.device_id,
-            )
-            tools = [
-                _format_tool(tool) for tool in llm_api.async_get_tools(empty_tool_input)
-            ]
+            tools = [_format_tool(tool) for tool in llm_api.tools]
 
         model = genai.GenerativeModel(
             model_name=self.entry.options.get(CONF_CHAT_MODEL, RECOMMENDED_CHAT_MODEL),
@@ -218,8 +217,7 @@ class GoogleGenerativeAIConversationEntity(
 
         try:
             if llm_api:
-                api_prompt = await llm_api.async_get_api_prompt(empty_tool_input)
-
+                api_prompt = llm_api.api_prompt
             else:
                 api_prompt = llm.async_render_no_api_prompt(self.hass)
 

--- a/homeassistant/components/google_generative_ai_conversation/conversation.py
+++ b/homeassistant/components/google_generative_ai_conversation/conversation.py
@@ -166,7 +166,19 @@ class GoogleGenerativeAIConversationEntity(
                 return conversation.ConversationResult(
                     response=intent_response, conversation_id=user_input.conversation_id
                 )
-            tools = [_format_tool(tool) for tool in llm_api.async_get_tools()]
+            empty_tool_input = llm.ToolInput(
+                tool_name="",
+                tool_args={},
+                platform=DOMAIN,
+                context=user_input.context,
+                user_prompt=user_input.text,
+                language=user_input.language,
+                assistant=conversation.DOMAIN,
+                device_id=user_input.device_id,
+            )
+            tools = [
+                _format_tool(tool) for tool in llm_api.async_get_tools(empty_tool_input)
+            ]
 
         model = genai.GenerativeModel(
             model_name=self.entry.options.get(CONF_CHAT_MODEL, RECOMMENDED_CHAT_MODEL),
@@ -206,17 +218,6 @@ class GoogleGenerativeAIConversationEntity(
 
         try:
             if llm_api:
-                empty_tool_input = llm.ToolInput(
-                    tool_name="",
-                    tool_args={},
-                    platform=DOMAIN,
-                    context=user_input.context,
-                    user_prompt=user_input.text,
-                    language=user_input.language,
-                    assistant=conversation.DOMAIN,
-                    device_id=user_input.device_id,
-                )
-
                 api_prompt = await llm_api.async_get_api_prompt(empty_tool_input)
 
             else:

--- a/homeassistant/components/intent/__init__.py
+++ b/homeassistant/components/intent/__init__.py
@@ -50,6 +50,7 @@ from .timers import (
     TimerManager,
     TimerStatusIntentHandler,
     UnpauseTimerIntentHandler,
+    async_device_supports_timers,
     async_register_timer_handler,
 )
 
@@ -59,6 +60,7 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 __all__ = [
     "async_register_timer_handler",
+    "async_device_supports_timers",
     "TimerInfo",
     "TimerEventType",
     "DOMAIN",

--- a/homeassistant/components/intent/timers.py
+++ b/homeassistant/components/intent/timers.py
@@ -416,6 +416,15 @@ class TimerManager:
 
 
 @callback
+def async_device_supports_timers(hass: HomeAssistant, device_id: str) -> bool:
+    """Return True if device has been registered to handle timer events."""
+    timer_manager: TimerManager | None = hass.data.get(TIMER_DATA)
+    if timer_manager is None:
+        return False
+    return timer_manager.is_timer_device(device_id)
+
+
+@callback
 def async_register_timer_handler(
     hass: HomeAssistant, device_id: str, handler: TimerHandler
 ) -> Callable[[], None]:

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -114,7 +114,19 @@ class OpenAIConversationEntity(
                 return conversation.ConversationResult(
                     response=intent_response, conversation_id=user_input.conversation_id
                 )
-            tools = [_format_tool(tool) for tool in llm_api.async_get_tools()]
+            empty_tool_input = llm.ToolInput(
+                tool_name="",
+                tool_args={},
+                platform=DOMAIN,
+                context=user_input.context,
+                user_prompt=user_input.text,
+                language=user_input.language,
+                assistant=conversation.DOMAIN,
+                device_id=user_input.device_id,
+            )
+            tools = [
+                _format_tool(tool) for tool in llm_api.async_get_tools(empty_tool_input)
+            ]
 
         if user_input.conversation_id in self.history:
             conversation_id = user_input.conversation_id
@@ -123,17 +135,6 @@ class OpenAIConversationEntity(
             conversation_id = ulid.ulid_now()
             try:
                 if llm_api:
-                    empty_tool_input = llm.ToolInput(
-                        tool_name="",
-                        tool_args={},
-                        platform=DOMAIN,
-                        context=user_input.context,
-                        user_prompt=user_input.text,
-                        language=user_input.language,
-                        assistant=conversation.DOMAIN,
-                        device_id=user_input.device_id,
-                    )
-
                     api_prompt = await llm_api.async_get_api_prompt(empty_tool_input)
 
                 else:

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -107,9 +107,7 @@ class OpenAIConversationEntity(
                 llm_api = await llm.async_get_api(
                     self.hass,
                     options[CONF_LLM_HASS_API],
-                    llm.ToolInput(
-                        tool_name="",
-                        tool_args={},
+                    llm.ToolContext(
                         platform=DOMAIN,
                         context=user_input.context,
                         user_prompt=user_input.text,
@@ -211,12 +209,6 @@ class OpenAIConversationEntity(
                 tool_input = llm.ToolInput(
                     tool_name=tool_call.function.name,
                     tool_args=json.loads(tool_call.function.arguments),
-                    platform=DOMAIN,
-                    context=user_input.context,
-                    user_prompt=user_input.text,
-                    language=user_input.language,
-                    assistant=conversation.DOMAIN,
-                    device_id=user_input.device_id,
                 )
                 LOGGER.debug(
                     "Tool call: %s(%s)", tool_input.tool_name, tool_input.tool_args

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -310,11 +310,25 @@ class AssistAPI(API):
                 intent.INTENT_TIMER_STATUS,
             }
 
-        return [
-            IntentTool(intent_handler)
+        intent_handlers = [
+            intent_handler
             for intent_handler in intent.async_get(self.hass)
             if intent_handler.intent_type not in ignore_intents
         ]
+
+        exposed_domains: set[str] | None = None
+        if exposed_entities is not None:
+            exposed_domains = {
+                entity_id.split(".")[0] for entity_id in exposed_entities
+            }
+            intent_handlers = [
+                intent_handler
+                for intent_handler in intent_handlers
+                if intent_handler.platforms is None
+                or intent_handler.platforms & exposed_domains
+            ]
+
+        return [IntentTool(intent_handler) for intent_handler in intent_handlers]
 
 
 def _get_exposed_entities(

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -61,11 +61,11 @@ async def test_default_prompt(
     with (
         patch("google.generativeai.GenerativeModel") as mock_model,
         patch(
-            "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI.async_get_tools",
+            "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI._async_get_tools",
             return_value=[],
         ) as mock_get_tools,
         patch(
-            "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI.async_get_api_prompt",
+            "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI._async_get_api_prompt",
             return_value="<api_prompt>",
         ),
         patch(
@@ -148,7 +148,7 @@ async def test_chat_history(
 
 
 @patch(
-    "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI.async_get_tools"
+    "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI._async_get_tools"
 )
 async def test_function_call(
     mock_get_tools,
@@ -246,7 +246,7 @@ async def test_function_call(
 
 
 @patch(
-    "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI.async_get_tools"
+    "homeassistant.components.google_generative_ai_conversation.conversation.llm.AssistAPI._async_get_tools"
 )
 async def test_function_exception(
     mock_get_tools,

--- a/tests/components/google_generative_ai_conversation/test_conversation.py
+++ b/tests/components/google_generative_ai_conversation/test_conversation.py
@@ -182,7 +182,7 @@ async def test_function_call(
         mock_part.function_call.name = "test_tool"
         mock_part.function_call.args = {"param1": ["test_value"]}
 
-        def tool_call(hass, tool_input):
+        def tool_call(hass, tool_input, tool_context):
             mock_part.function_call = None
             mock_part.text = "Hi there!"
             return {"result": "Test response"}
@@ -221,6 +221,8 @@ async def test_function_call(
         llm.ToolInput(
             tool_name="test_tool",
             tool_args={"param1": ["test_value"]},
+        ),
+        llm.ToolContext(
             platform="google_generative_ai_conversation",
             context=context,
             user_prompt="Please call the test function",
@@ -280,7 +282,7 @@ async def test_function_exception(
         mock_part.function_call.name = "test_tool"
         mock_part.function_call.args = {"param1": 1}
 
-        def tool_call(hass, tool_input):
+        def tool_call(hass, tool_input, tool_context):
             mock_part.function_call = None
             mock_part.text = "Hi there!"
             raise HomeAssistantError("Test tool exception")
@@ -319,6 +321,8 @@ async def test_function_exception(
         llm.ToolInput(
             tool_name="test_tool",
             tool_args={"param1": 1},
+        ),
+        llm.ToolContext(
             platform="google_generative_ai_conversation",
             context=context,
             user_prompt="Please call the test function",

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -192,6 +192,8 @@ async def test_function_call(
         llm.ToolInput(
             tool_name="test_tool",
             tool_args={"param1": "test_value"},
+        ),
+        llm.ToolContext(
             platform="openai_conversation",
             context=context,
             user_prompt="Please call the test function",
@@ -323,6 +325,8 @@ async def test_function_exception(
         llm.ToolInput(
             tool_name="test_tool",
             tool_args={"param1": "test_value"},
+        ),
+        llm.ToolContext(
             platform="openai_conversation",
             context=context,
             user_prompt="Please call the test function",

--- a/tests/components/openai_conversation/test_conversation.py
+++ b/tests/components/openai_conversation/test_conversation.py
@@ -86,7 +86,7 @@ async def test_conversation_agent(
 
 
 @patch(
-    "homeassistant.components.openai_conversation.conversation.llm.AssistAPI.async_get_tools"
+    "homeassistant.components.openai_conversation.conversation.llm.AssistAPI._async_get_tools"
 )
 async def test_function_call(
     mock_get_tools,
@@ -217,7 +217,7 @@ async def test_function_call(
 
 
 @patch(
-    "homeassistant.components.openai_conversation.conversation.llm.AssistAPI.async_get_tools"
+    "homeassistant.components.openai_conversation.conversation.llm.AssistAPI._async_get_tools"
 )
 async def test_function_exception(
     mock_get_tools,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Timer intents work by sending timer events to the device that started it. This means that if a device does not support timers, it is not able to start a timer and we should not tell the LLM about those tools.

We don't need to teach the LLM about domain-specific tools if none of those entities are exposed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
