### PR TITLE
Fix flakey bootstrap test

### DIFF
--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1114,7 +1114,6 @@ async def test_tasks_logged_that_block_stage_2(
                 wait_task.cancel()
 
             hass.async_create_task(_not_marked_background_task())
-            await asyncio.sleep(0)
             return True
 
         return async_setup

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Generator, Iterable
 import contextlib
 import glob
+import logging
 import os
 import sys
 from typing import Any
@@ -1101,14 +1102,19 @@ async def test_tasks_logged_that_block_stage_2(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test we log tasks that delay stage 2 startup."""
+    done_future = hass.loop.create_future()
 
     def gen_domain_setup(domain):
         async def async_setup(hass, config):
             async def _not_marked_background_task():
-                await asyncio.sleep(0.2)
+                wait_task = asyncio.create_task(asyncio.sleep(1))
+                await asyncio.wait(
+                    [wait_task, done_future], return_when=asyncio.FIRST_COMPLETED
+                )
+                wait_task.cancel()
 
             hass.async_create_task(_not_marked_background_task())
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0)
             return True
 
         return async_setup
@@ -1122,16 +1128,36 @@ async def test_tasks_logged_that_block_stage_2(
         ),
     )
 
+    wanted_messages = {
+        "Setup timed out for stage 2 waiting on",
+        "waiting on",
+        "_not_marked_background_task",
+    }
+
+    def on_message_logged(log_record: logging.LogRecord, *args):
+        for message in list(wanted_messages):
+            if message in log_record.message:
+                wanted_messages.remove(message)
+        if not done_future.done() and not wanted_messages:
+            done_future.set_result(None)
+            return
+
     with (
         patch.object(bootstrap, "STAGE_2_TIMEOUT", 0),
         patch.object(bootstrap, "COOLDOWN_TIME", 0),
+        patch.object(
+            caplog.handler,
+            "emit",
+            wraps=caplog.handler.emit,
+            side_effect=on_message_logged,
+        ),
     ):
         await bootstrap._async_set_up_integrations(hass, {"normal_integration": {}})
+        async with asyncio.timeout(2):
+            await done_future
         await hass.async_block_till_done()
 
-    assert "Setup timed out for stage 2 waiting on" in caplog.text
-    assert "waiting on" in caplog.text
-    assert "_not_marked_background_task" in caplog.text
+    assert not wanted_messages
 
 
 @pytest.mark.parametrize("load_registries", [False])

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1107,11 +1107,7 @@ async def test_tasks_logged_that_block_stage_2(
     def gen_domain_setup(domain):
         async def async_setup(hass, config):
             async def _not_marked_background_task():
-                wait_task = asyncio.create_task(asyncio.sleep(1))
-                await asyncio.wait(
-                    [wait_task, done_future], return_when=asyncio.FIRST_COMPLETED
-                )
-                wait_task.cancel()
+                await done_future
 
             hass.async_create_task(_not_marked_background_task())
             return True


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/actions/runs/9262584291/job/25481305548?pr=118268


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
