### PR TITLE
Use entry.runtime_data in Tessie

### DIFF
--- a/homeassistant/components/tessie/binary_sensor.py
+++ b/homeassistant/components/tessie/binary_sensor.py
@@ -10,12 +10,12 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieState
+from . import TessieConfigEntry
+from .const import TessieState
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -159,16 +159,18 @@ DESCRIPTIONS: tuple[TessieBinarySensorEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie binary sensor platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        TessieBinarySensorEntity(vehicle.state_coordinator, description)
-        for vehicle in data
+        TessieBinarySensorEntity(vehicle, description)
+        for vehicle in data.vehicles
         for description in DESCRIPTIONS
-        if description.key in vehicle.state_coordinator.data
+        if description.key in vehicle.data
     )
 
 

--- a/homeassistant/components/tessie/button.py
+++ b/homeassistant/components/tessie/button.py
@@ -15,11 +15,10 @@ from tessie_api import (
 )
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TessieConfigEntry
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -47,14 +46,16 @@ DESCRIPTIONS: tuple[TessieButtonEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie Button platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        TessieButtonEntity(vehicle.state_coordinator, description)
-        for vehicle in data
+        TessieButtonEntity(vehicle, description)
+        for vehicle in data.vehicles
         for description in DESCRIPTIONS
     )
 

--- a/homeassistant/components/tessie/climate.py
+++ b/homeassistant/components/tessie/climate.py
@@ -17,25 +17,25 @@ from homeassistant.components.climate import (
     ClimateEntityFeature,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieClimateKeeper
+from . import TessieConfigEntry
+from .const import TessieClimateKeeper
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie Climate platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
-    async_add_entities(
-        TessieClimateEntity(vehicle.state_coordinator) for vehicle in data
-    )
+    async_add_entities(TessieClimateEntity(vehicle) for vehicle in data.vehicles)
 
 
 class TessieClimateEntity(TessieEntity, ClimateEntity):

--- a/homeassistant/components/tessie/config_flow.py
+++ b/homeassistant/components/tessie/config_flow.py
@@ -10,10 +10,11 @@ from aiohttp import ClientConnectionError, ClientResponseError
 from tessie_api import get_state_of_all_vehicles
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from . import TessieConfigEntry
 from .const import DOMAIN
 
 TESSIE_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
@@ -29,7 +30,7 @@ class TessieConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def __init__(self) -> None:
         """Initialize."""
-        self._reauth_entry: ConfigEntry | None = None
+        self._reauth_entry: TessieConfigEntry | None = None
 
     async def async_step_user(
         self, user_input: Mapping[str, Any] | None = None

--- a/homeassistant/components/tessie/cover.py
+++ b/homeassistant/components/tessie/cover.py
@@ -18,30 +18,32 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieCoverStates
+from . import TessieConfigEntry
+from .const import TessieCoverStates
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie sensor platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        klass(vehicle.state_coordinator)
+        klass(vehicle)
         for klass in (
             TessieWindowEntity,
             TessieChargePortEntity,
             TessieFrontTrunkEntity,
             TessieRearTrunkEntity,
         )
-        for vehicle in data
+        for vehicle in data.vehicles
     )
 
 

--- a/homeassistant/components/tessie/device_tracker.py
+++ b/homeassistant/components/tessie/device_tracker.py
@@ -4,29 +4,30 @@ from __future__ import annotations
 
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN
+from . import TessieConfigEntry
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie device tracker platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        klass(vehicle.state_coordinator)
+        klass(vehicle)
         for klass in (
             TessieDeviceTrackerLocationEntity,
             TessieDeviceTrackerRouteEntity,
         )
-        for vehicle in data
+        for vehicle in data.vehicles
     )
 
 

--- a/homeassistant/components/tessie/media_player.py
+++ b/homeassistant/components/tessie/media_player.py
@@ -7,11 +7,10 @@ from homeassistant.components.media_player import (
     MediaPlayerEntity,
     MediaPlayerState,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TessieConfigEntry
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -23,12 +22,14 @@ STATES = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie Media platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
-    async_add_entities(TessieMediaEntity(vehicle.state_coordinator) for vehicle in data)
+    async_add_entities(TessieMediaEntity(vehicle) for vehicle in data.vehicles)
 
 
 class TessieMediaEntity(TessieEntity, MediaPlayerEntity):

--- a/homeassistant/components/tessie/models.py
+++ b/homeassistant/components/tessie/models.py
@@ -8,7 +8,7 @@ from .coordinator import TessieStateUpdateCoordinator
 
 
 @dataclass
-class TessieVehicle:
+class TessieData:
     """Data for the Tessie integration."""
 
-    state_coordinator: TessieStateUpdateCoordinator
+    vehicles: list[TessieStateUpdateCoordinator]

--- a/homeassistant/components/tessie/number.py
+++ b/homeassistant/components/tessie/number.py
@@ -13,7 +13,6 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     PRECISION_WHOLE,
@@ -23,7 +22,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TessieConfigEntry
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -81,16 +80,18 @@ DESCRIPTIONS: tuple[TessieNumberEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie sensor platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        TessieNumberEntity(vehicle.state_coordinator, description)
-        for vehicle in data
+        TessieNumberEntity(vehicle, description)
+        for vehicle in data.vehicles
         for description in DESCRIPTIONS
-        if description.key in vehicle.state_coordinator.data
+        if description.key in vehicle.data
     )
 
 

--- a/homeassistant/components/tessie/select.py
+++ b/homeassistant/components/tessie/select.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from tessie_api import set_seat_heat
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieSeatHeaterOptions
+from . import TessieConfigEntry
+from .const import TessieSeatHeaterOptions
 from .entity import TessieEntity
 
 SEAT_HEATERS = {
@@ -24,16 +24,18 @@ SEAT_HEATERS = {
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie select platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        TessieSeatHeaterSelectEntity(vehicle.state_coordinator, key)
-        for vehicle in data
+        TessieSeatHeaterSelectEntity(vehicle, key)
+        for vehicle in data.vehicles
         for key in SEAT_HEATERS
-        if key in vehicle.state_coordinator.data
+        if key in vehicle.data
     )
 
 

--- a/homeassistant/components/tessie/sensor.py
+++ b/homeassistant/components/tessie/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
@@ -33,7 +32,8 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.util import dt as dt_util
 from homeassistant.util.variance import ignore_variance
 
-from .const import DOMAIN, TessieChargeStates
+from . import TessieConfigEntry
+from .const import TessieChargeStates
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -259,14 +259,16 @@ DESCRIPTIONS: tuple[TessieSensorEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie sensor platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
-        TessieSensorEntity(vehicle.state_coordinator, description)
-        for vehicle in data
+        TessieSensorEntity(vehicle, description)
+        for vehicle in data.vehicles
         for description in DESCRIPTIONS
     )
 

--- a/homeassistant/components/tessie/switch.py
+++ b/homeassistant/components/tessie/switch.py
@@ -24,11 +24,10 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from . import TessieConfigEntry
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
@@ -71,17 +70,19 @@ DESCRIPTIONS: tuple[TessieSwitchEntityDescription, ...] = (
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie Switch platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
     async_add_entities(
         [
-            TessieSwitchEntity(vehicle.state_coordinator, description)
-            for vehicle in data
+            TessieSwitchEntity(vehicle, description)
+            for vehicle in data.vehicles
             for description in DESCRIPTIONS
-            if description.key in vehicle.state_coordinator.data
+            if description.key in vehicle.data
         ]
     )
 

--- a/homeassistant/components/tessie/update.py
+++ b/homeassistant/components/tessie/update.py
@@ -7,24 +7,24 @@ from typing import Any
 from tessie_api import schedule_software_update
 
 from homeassistant.components.update import UpdateEntity, UpdateEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN, TessieUpdateStatus
+from . import TessieConfigEntry
+from .const import TessieUpdateStatus
 from .coordinator import TessieStateUpdateCoordinator
 from .entity import TessieEntity
 
 
 async def async_setup_entry(
-    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+    hass: HomeAssistant,
+    entry: TessieConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Tessie Update platform from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
+    data = entry.runtime_data
 
-    async_add_entities(
-        TessieUpdateEntity(vehicle.state_coordinator) for vehicle in data
-    )
+    async_add_entities(TessieUpdateEntity(vehicle) for vehicle in data.vehicles)
 
 
 class TessieUpdateEntity(TessieEntity, UpdateEntity):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate Tessie to `entry.runtime_data` and also restructed the data model ready for new features.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
