### PR TITLE
Use registry fixtures in tests (v-y)

### DIFF
--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -22,7 +22,9 @@ from tests.common import MockConfigEntry
 
 
 async def test_init(
-    hass: HomeAssistant, vera_component_factory: ComponentFactory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    vera_component_factory: ComponentFactory,
 ) -> None:
     """Test function."""
     vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
@@ -42,14 +44,15 @@ async def test_init(
         ),
     )
 
-    entity_registry = er.async_get(hass)
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1
     assert entry1.unique_id == "vera_first_serial_1"
 
 
 async def test_init_from_file(
-    hass: HomeAssistant, vera_component_factory: ComponentFactory
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    vera_component_factory: ComponentFactory,
 ) -> None:
     """Test function."""
     vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
@@ -69,7 +72,6 @@ async def test_init_from_file(
         ),
     )
 
-    entity_registry = er.async_get(hass)
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1
     assert entry1.unique_id == "vera_first_serial_1"
@@ -77,8 +79,8 @@ async def test_init_from_file(
 
 async def test_multiple_controllers_with_legacy_one(
     hass: HomeAssistant,
-    vera_component_factory: ComponentFactory,
     entity_registry: er.EntityRegistry,
+    vera_component_factory: ComponentFactory,
 ) -> None:
     """Test multiple controllers with one legacy controller."""
     vera_device1: pv.VeraBinarySensor = MagicMock(spec=pv.VeraBinarySensor)
@@ -119,8 +121,6 @@ async def test_multiple_controllers_with_legacy_one(
             devices=(vera_device2,),
         ),
     )
-
-    entity_registry = er.async_get(hass)
 
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1

--- a/tests/components/vesync/test_diagnostics.py
+++ b/tests/components/vesync/test_diagnostics.py
@@ -66,6 +66,7 @@ async def test_async_get_config_entry_diagnostics__single_humidifier(
 
 async def test_async_get_device_diagnostics__single_fan(
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     hass_client: ClientSessionGenerator,
     config_entry: ConfigEntry,
     config: ConfigType,
@@ -77,7 +78,6 @@ async def test_async_get_device_diagnostics__single_fan(
         assert await async_setup_component(hass, DOMAIN, config)
         await hass.async_block_till_done()
 
-    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={(DOMAIN, "abcdefghabcdefghabcdefghabcdefgh")},
     )

--- a/tests/components/waqi/test_sensor.py
+++ b/tests/components/waqi/test_sensor.py
@@ -20,7 +20,10 @@ from tests.common import MockConfigEntry, load_fixture
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensor(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry, snapshot: SnapshotAssertion
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test failed update."""
     mock_config_entry.add_to_hass(hass)
@@ -32,7 +35,6 @@ async def test_sensor(
     ):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
-    entity_registry = er.async_get(hass)
     for sensor in SENSORS:
         entity_id = entity_registry.async_get_entity_id(
             SENSOR_DOMAIN, DOMAIN, f"4584_{sensor.key}"

--- a/tests/components/weather/test_init.py
+++ b/tests/components/weather/test_init.py
@@ -413,7 +413,9 @@ async def test_humidity(
     assert float(state.attributes[ATTR_WEATHER_HUMIDITY]) == 80
 
 
-async def test_custom_units(hass: HomeAssistant, config_flow_fixture: None) -> None:
+async def test_custom_units(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, config_flow_fixture: None
+) -> None:
     """Test custom unit."""
     wind_speed_value = 5
     wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
@@ -433,8 +435,6 @@ async def test_custom_units(hass: HomeAssistant, config_flow_fixture: None) -> N
         "temperature_unit": UnitOfTemperature.FAHRENHEIT,
         "visibility_unit": UnitOfLength.MILES,
     }
-
-    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get_or_create("weather", "test", "very_unique")
     entity_registry.async_update_entity_options(entry.entity_id, "weather", set_options)

--- a/tests/components/whirlpool/test_climate.py
+++ b/tests/components/whirlpool/test_climate.py
@@ -74,6 +74,7 @@ async def test_no_appliances(
 
 async def test_static_attributes(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     mock_aircon1_api: MagicMock,
     mock_aircon_api_instances: MagicMock,
 ) -> None:
@@ -81,7 +82,7 @@ async def test_static_attributes(
     await init_integration(hass)
 
     for entity_id in ("climate.said1", "climate.said2"):
-        entry = er.async_get(hass).async_get(entity_id)
+        entry = entity_registry.async_get(entity_id)
         assert entry
         assert entry.unique_id == entity_id.split(".")[1]
 

--- a/tests/components/wilight/test_cover.py
+++ b/tests/components/wilight/test_cover.py
@@ -58,6 +58,7 @@ def mock_dummy_device_from_host_light_fan():
 
 async def test_loading_cover(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     dummy_device_from_host_cover,
 ) -> None:
     """Test the WiLight configuration entry loading."""
@@ -65,8 +66,6 @@ async def test_loading_cover(
     entry = await setup_integration(hass)
     assert entry
     assert entry.unique_id == WILIGHT_ID
-
-    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("cover.wl000000000099_1")

--- a/tests/components/wilight/test_fan.py
+++ b/tests/components/wilight/test_fan.py
@@ -58,6 +58,7 @@ def mock_dummy_device_from_host_light_fan():
 
 async def test_loading_light_fan(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     dummy_device_from_host_light_fan,
 ) -> None:
     """Test the WiLight configuration entry loading."""
@@ -65,8 +66,6 @@ async def test_loading_light_fan(
     entry = await setup_integration(hass)
     assert entry
     assert entry.unique_id == WILIGHT_ID
-
-    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("fan.wl000000000099_2")

--- a/tests/components/wilight/test_light.py
+++ b/tests/components/wilight/test_light.py
@@ -131,6 +131,7 @@ def mock_dummy_device_from_host_color():
 
 async def test_loading_light(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     dummy_device_from_host_light_fan,
     dummy_get_components_from_model_light,
 ) -> None:
@@ -141,8 +142,6 @@ async def test_loading_light(
     entry = await setup_integration(hass)
     assert entry
     assert entry.unique_id == WILIGHT_ID
-
-    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("light.wl000000000099_1")

--- a/tests/components/wilight/test_switch.py
+++ b/tests/components/wilight/test_switch.py
@@ -64,6 +64,7 @@ def mock_dummy_device_from_host_switch():
 
 async def test_loading_switch(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     dummy_device_from_host_switch,
 ) -> None:
     """Test the WiLight configuration entry loading."""
@@ -71,8 +72,6 @@ async def test_loading_switch(
     entry = await setup_integration(hass)
     assert entry
     assert entry.unique_id == WILIGHT_ID
-
-    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("switch.wl000000000099_1_watering")

--- a/tests/components/wiz/test_binary_sensor.py
+++ b/tests/components/wiz/test_binary_sensor.py
@@ -21,14 +21,15 @@ from . import (
 from tests.common import MockConfigEntry
 
 
-async def test_binary_sensor_created_from_push_updates(hass: HomeAssistant) -> None:
+async def test_binary_sensor_created_from_push_updates(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a binary sensor created from push updates."""
     bulb, _ = await async_setup_integration(hass)
 
     await async_push_update(hass, bulb, {"mac": FAKE_MAC, "src": "pir", "state": True})
 
     entity_id = "binary_sensor.mock_title_occupancy"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == f"{FAKE_MAC}_occupancy"
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
@@ -39,7 +40,9 @@ async def test_binary_sensor_created_from_push_updates(hass: HomeAssistant) -> N
     assert state.state == STATE_OFF
 
 
-async def test_binary_sensor_restored_from_registry(hass: HomeAssistant) -> None:
+async def test_binary_sensor_restored_from_registry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a binary sensor restored from registry with state unknown."""
     entry = MockConfigEntry(
         domain=wiz.DOMAIN,
@@ -49,7 +52,6 @@ async def test_binary_sensor_restored_from_registry(hass: HomeAssistant) -> None
     entry.add_to_hass(hass)
     bulb = _mocked_wizlight(None, None, None)
 
-    entity_registry = er.async_get(hass)
     reg_ent = entity_registry.async_get_or_create(
         Platform.BINARY_SENSOR, wiz.DOMAIN, OCCUPANCY_UNIQUE_ID.format(bulb.mac)
     )

--- a/tests/components/wiz/test_light.py
+++ b/tests/components/wiz/test_light.py
@@ -31,21 +31,23 @@ from . import (
 )
 
 
-async def test_light_unique_id(hass: HomeAssistant) -> None:
+async def test_light_unique_id(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light unique id."""
     await async_setup_integration(hass)
     entity_id = "light.mock_title"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
 
 
-async def test_light_operation(hass: HomeAssistant) -> None:
+async def test_light_operation(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test a light operation."""
     bulb, _ = await async_setup_integration(hass)
     entity_id = "light.mock_title"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON

--- a/tests/components/wiz/test_number.py
+++ b/tests/components/wiz/test_number.py
@@ -17,12 +17,13 @@ from . import (
 )
 
 
-async def test_speed_operation(hass: HomeAssistant) -> None:
+async def test_speed_operation(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test changing a speed."""
     bulb, _ = await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
     await async_push_update(hass, bulb, {"mac": FAKE_MAC})
     entity_id = "number.mock_title_effect_speed"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == f"{FAKE_MAC}_effect_speed"
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
@@ -40,12 +41,13 @@ async def test_speed_operation(hass: HomeAssistant) -> None:
     assert hass.states.get(entity_id).state == "30.0"
 
 
-async def test_ratio_operation(hass: HomeAssistant) -> None:
+async def test_ratio_operation(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test changing a dual head ratio."""
     bulb, _ = await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
     await async_push_update(hass, bulb, {"mac": FAKE_MAC})
     entity_id = "number.mock_title_dual_head_ratio"
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(entity_id).unique_id == f"{FAKE_MAC}_dual_head_ratio"
     )

--- a/tests/components/wiz/test_sensor.py
+++ b/tests/components/wiz/test_sensor.py
@@ -17,13 +17,14 @@ from . import (
 )
 
 
-async def test_signal_strength(hass: HomeAssistant) -> None:
+async def test_signal_strength(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test signal strength."""
     bulb, entry = await async_setup_integration(
         hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB
     )
     entity_id = "sensor.mock_title_signal_strength"
-    entity_registry = er.async_get(hass)
     reg_entry = entity_registry.async_get(entity_id)
     assert reg_entry.unique_id == f"{FAKE_MAC}_rssi"
     updated_entity = entity_registry.async_update_entity(
@@ -41,7 +42,9 @@ async def test_signal_strength(hass: HomeAssistant) -> None:
     assert hass.states.get(entity_id).state == "-50"
 
 
-async def test_power_monitoring(hass: HomeAssistant) -> None:
+async def test_power_monitoring(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test power monitoring."""
     socket = _mocked_wizlight(None, None, FAKE_SOCKET_WITH_POWER_MONITORING)
     socket.power_monitoring = None
@@ -50,7 +53,6 @@ async def test_power_monitoring(hass: HomeAssistant) -> None:
         hass, wizlight=socket, bulb_type=FAKE_SOCKET_WITH_POWER_MONITORING
     )
     entity_id = "sensor.mock_title_power"
-    entity_registry = er.async_get(hass)
     reg_entry = entity_registry.async_get(entity_id)
     assert reg_entry.unique_id == f"{FAKE_MAC}_power"
     updated_entity = entity_registry.async_update_entity(

--- a/tests/components/wiz/test_switch.py
+++ b/tests/components/wiz/test_switch.py
@@ -20,11 +20,12 @@ from . import FAKE_MAC, FAKE_SOCKET, async_push_update, async_setup_integration
 from tests.common import async_fire_time_changed
 
 
-async def test_switch_operation(hass: HomeAssistant) -> None:
+async def test_switch_operation(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test switch operation."""
     switch, _ = await async_setup_integration(hass, bulb_type=FAKE_SOCKET)
     entity_id = "switch.mock_title"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
     assert hass.states.get(entity_id).state == STATE_ON
 
@@ -45,11 +46,12 @@ async def test_switch_operation(hass: HomeAssistant) -> None:
     assert hass.states.get(entity_id).state == STATE_ON
 
 
-async def test_update_fails(hass: HomeAssistant) -> None:
+async def test_update_fails(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test switch update fails when push updates are not working."""
     switch, _ = await async_setup_integration(hass, bulb_type=FAKE_SOCKET)
     entity_id = "switch.mock_title"
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
     assert hass.states.get(entity_id).state == STATE_ON
 

--- a/tests/components/ws66i/test_media_player.py
+++ b/tests/components/ws66i/test_media_player.py
@@ -457,59 +457,59 @@ async def test_volume_while_mute(hass: HomeAssistant) -> None:
     assert not ws66i.zones[11].mute
 
 
-async def test_first_run_with_available_zones(hass: HomeAssistant) -> None:
+async def test_first_run_with_available_zones(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test first run with all zones available."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert not entry.disabled
 
 
-async def test_first_run_with_failing_zones(hass: HomeAssistant) -> None:
+async def test_first_run_with_failing_zones(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test first run with failed zones."""
     ws66i = MockWs66i()
 
     with patch.object(MockWs66i, "zone_status", return_value=None):
         await _setup_ws66i(hass, ws66i)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_1_ID)
+    entry = entity_registry.async_get(ZONE_1_ID)
     assert entry is None
 
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert entry is None
 
 
-async def test_register_all_entities(hass: HomeAssistant) -> None:
+async def test_register_all_entities(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test run with all entities registered."""
     ws66i = MockWs66i()
     await _setup_ws66i(hass, ws66i)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_1_ID)
+    entry = entity_registry.async_get(ZONE_1_ID)
     assert not entry.disabled
 
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert not entry.disabled
 
 
-async def test_register_entities_in_1_amp_only(hass: HomeAssistant) -> None:
+async def test_register_entities_in_1_amp_only(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test run with only zones 11-16 registered."""
     ws66i = MockWs66i(fail_zone_check=[21])
     await _setup_ws66i(hass, ws66i)
 
-    registry = er.async_get(hass)
-
-    entry = registry.async_get(ZONE_1_ID)
+    entry = entity_registry.async_get(ZONE_1_ID)
     assert not entry.disabled
 
-    entry = registry.async_get(ZONE_2_ID)
+    entry = entity_registry.async_get(ZONE_2_ID)
     assert not entry.disabled
 
-    entry = registry.async_get(ZONE_7_ID)
+    entry = entity_registry.async_get(ZONE_7_ID)
     assert entry is None

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -51,7 +51,9 @@ from . import (
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
-async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
+async def test_ip_changes_fallback_discovery(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test Yeelight ip changes and we fallback to discovery."""
     config_entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_ID: ID, CONF_HOST: "5.5.5.5"}, unique_id=ID
@@ -84,7 +86,6 @@ async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
     binary_sensor_entity_id = ENTITY_BINARY_SENSOR_TEMPLATE.format(
         f"yeelight_color_{SHORT_ID}"
     )
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(binary_sensor_entity_id) is not None
 
     # Make sure we can still reload with the new ip right after we change it
@@ -93,7 +94,6 @@ async def test_ip_changes_fallback_discovery(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.LOADED
-    entity_registry = er.async_get(hass)
     assert entity_registry.async_get(binary_sensor_entity_id) is not None
 
 
@@ -278,7 +278,9 @@ async def test_setup_import(hass: HomeAssistant) -> None:
     assert entry.data[CONF_ID] == "0x000000000015243f"
 
 
-async def test_unique_ids_device(hass: HomeAssistant) -> None:
+async def test_unique_ids_device(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test Yeelight unique IDs from yeelight device IDs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -293,7 +295,6 @@ async def test_unique_ids_device(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(ENTITY_BINARY_SENSOR).unique_id
         == f"{ID}-nightlight_sensor"
@@ -303,7 +304,9 @@ async def test_unique_ids_device(hass: HomeAssistant) -> None:
     assert entity_registry.async_get(ENTITY_AMBILIGHT).unique_id == f"{ID}-ambilight"
 
 
-async def test_unique_ids_entry(hass: HomeAssistant) -> None:
+async def test_unique_ids_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test Yeelight unique IDs from entry IDs."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -318,7 +321,6 @@ async def test_unique_ids_entry(hass: HomeAssistant) -> None:
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    entity_registry = er.async_get(hass)
     assert (
         entity_registry.async_get(ENTITY_BINARY_SENSOR).unique_id
         == f"{config_entry.entry_id}-nightlight_sensor"

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -776,7 +776,9 @@ async def test_state_already_set_avoid_ratelimit(hass: HomeAssistant) -> None:
 
 
 async def test_device_types(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test different device types."""
     mocked_bulb = _mocked_bulb()
@@ -825,8 +827,7 @@ async def test_device_types(
         assert dict(state.attributes) == target_properties
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.config_entries.async_remove(config_entry.entry_id)
-        registry = er.async_get(hass)
-        registry.async_clear_config_entry(config_entry.entry_id)
+        entity_registry.async_clear_config_entry(config_entry.entry_id)
         mocked_bulb.last_properties["nl_br"] = original_nightlight_brightness
 
         # nightlight as a setting of the main entity
@@ -847,7 +848,7 @@ async def test_device_types(
 
             await hass.config_entries.async_unload(config_entry.entry_id)
             await hass.config_entries.async_remove(config_entry.entry_id)
-            registry.async_clear_config_entry(config_entry.entry_id)
+            entity_registry.async_clear_config_entry(config_entry.entry_id)
             await hass.async_block_till_done()
             mocked_bulb.last_properties.pop("active_mode")
 
@@ -870,7 +871,7 @@ async def test_device_types(
 
             await hass.config_entries.async_unload(config_entry.entry_id)
             await hass.config_entries.async_remove(config_entry.entry_id)
-            registry.async_clear_config_entry(config_entry.entry_id)
+            entity_registry.async_clear_config_entry(config_entry.entry_id)
             await hass.async_block_till_done()
 
     bright = round(255 * int(PROPERTIES["bright"]) / 100)

--- a/tests/components/youtube/test_init.py
+++ b/tests/components/youtube/test_init.py
@@ -118,11 +118,12 @@ async def test_expired_token_refresh_client_error(
 
 
 async def test_device_info(
-    hass: HomeAssistant, setup_integration: ComponentSetup
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    setup_integration: ComponentSetup,
 ) -> None:
     """Test device info."""
     await setup_integration()
-    device_registry = dr.async_get(hass)
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     channel_id = entry.options[CONF_CHANNELS][0]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
