### PR TITLE
Speed up mqtt debug info on message callback

### DIFF
--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -58,7 +58,7 @@ class PublishMessage:
     retain: bool
 
 
-@dataclass(slots=True, frozen=True)
+@dataclass(slots=True, frozen=True, eq=False)
 class ReceiveMessage:
     """MQTT Message received."""
 

--- a/homeassistant/components/mqtt/models.py
+++ b/homeassistant/components/mqtt/models.py
@@ -58,6 +58,9 @@ class PublishMessage:
     retain: bool
 
 
+# eq=False so we use the id() of the object for comparison
+# since client will only generate one instance of this object
+# per messages/subscribed_topic.
 @dataclass(slots=True, frozen=True, eq=False)
 class ReceiveMessage:
     """MQTT Message received."""

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -3527,66 +3527,6 @@ async def test_debug_info_wildcard(
     } in debug_info_data["entities"][0]["subscriptions"]
 
 
-async def test_debug_info_filter_same(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mqtt_mock_entry: MqttMockHAClientGenerator,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test debug info removes messages with same timestamp."""
-    await mqtt_mock_entry()
-    config = {
-        "device": {"identifiers": ["helloworld"]},
-        "name": "test",
-        "state_topic": "sensor/#",
-        "unique_id": "veryunique",
-    }
-
-    data = json.dumps(config)
-    async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
-    await hass.async_block_till_done()
-
-    device = device_registry.async_get_device(identifiers={("mqtt", "helloworld")})
-    assert device is not None
-
-    debug_info_data = debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["subscriptions"]) >= 1
-    assert {"topic": "sensor/#", "messages": []} in debug_info_data["entities"][0][
-        "subscriptions"
-    ]
-
-    dt1 = datetime(2019, 1, 1, 0, 0, 0, tzinfo=dt_util.UTC)
-    dt2 = datetime(2019, 1, 1, 0, 0, 1, tzinfo=dt_util.UTC)
-    freezer.move_to(dt1)
-    async_fire_mqtt_message(hass, "sensor/abc", "123")
-    async_fire_mqtt_message(hass, "sensor/abc", "123")
-    freezer.move_to(dt2)
-    async_fire_mqtt_message(hass, "sensor/abc", "123")
-
-    debug_info_data = debug_info.info_for_device(hass, device.id)
-    assert len(debug_info_data["entities"][0]["subscriptions"]) == 1
-    assert len(debug_info_data["entities"][0]["subscriptions"][0]["messages"]) == 2
-    assert {
-        "topic": "sensor/#",
-        "messages": [
-            {
-                "payload": "123",
-                "qos": 0,
-                "retain": False,
-                "time": dt1,
-                "topic": "sensor/abc",
-            },
-            {
-                "payload": "123",
-                "qos": 0,
-                "retain": False,
-                "time": dt2,
-                "topic": "sensor/abc",
-            },
-        ],
-    } == debug_info_data["entities"][0]["subscriptions"][0]
-
-
 async def test_debug_info_same_topic(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The message_callback function is the most expensive call in mixins for mqtt.

Currently every item in the `deque` has to be competed with the `__eq__` method which compares each value. Since we changed the client to only make one `ReceiveMessage` per message/subscription_topic in https://github.com/home-assistant/core/pull/114769 we can compare them by `id`.

This cuts the run time of the function nearly in half.

before
<img width="507" alt="Screenshot 2024-05-27 at 11 52 48 PM" src="https://github.com/home-assistant/core/assets/663432/0e1aae54-aef8-47b8-8309-f0a697df18a4">

after
<img width="379" alt="Screenshot 2024-05-27 at 11 52 51 PM" src="https://github.com/home-assistant/core/assets/663432/3a14656c-97a5-4806-813c-3f00529800ff">

The tests/components/mqtt/test_init.py::test_debug_info_filter_same test fails and needs to be fixed. Its currently setting the timestamp to simulate a different message.  We should instead have an entity that subscribes to the same topic and verify the message is only saved once. We need to make sure we don't regress the light case in https://github.com/home-assistant/core/pull/34511

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
