### PR TITLE
Filter timers more when pausing/unpausing

### DIFF
--- a/tests/components/intent/test_timers.py
+++ b/tests/components/intent/test_timers.py
@@ -1,7 +1,7 @@
 """Tests for intent timers."""
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -910,13 +910,11 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     async with asyncio.timeout(1):
         await updated_event.wait()
 
-    # Pausing again will not fire the event
-    updated_event.clear()
-    result = await intent.async_handle(
-        hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
-    )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
-    assert not updated_event.is_set()
+    # Pausing again will fail because there are no running timers
+    with pytest.raises(TimerNotFoundError):
+        await intent.async_handle(
+            hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
+        )
 
     # Unpause the timer
     updated_event.clear()
@@ -929,13 +927,11 @@ async def test_pause_unpause_timer(hass: HomeAssistant, init_components) -> None
     async with asyncio.timeout(1):
         await updated_event.wait()
 
-    # Unpausing again will not fire the event
-    updated_event.clear()
-    result = await intent.async_handle(
-        hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
-    )
-    assert result.response_type == intent.IntentResponseType.ACTION_DONE
-    assert not updated_event.is_set()
+    # Unpausing again will fail because there are no paused timers
+    with pytest.raises(TimerNotFoundError):
+        await intent.async_handle(
+            hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
+        )
 
 
 async def test_timer_not_found(hass: HomeAssistant) -> None:
@@ -956,6 +952,48 @@ async def test_timer_not_found(hass: HomeAssistant) -> None:
 
     with pytest.raises(TimerNotFoundError):
         timer_manager.unpause_timer("does-not-exist")
+
+
+async def test_timer_manager_pause_unpause(hass: HomeAssistant) -> None:
+    """Test that pausing/unpausing again will not have an affect."""
+    timer_manager = TimerManager(hass)
+
+    # Start a timer
+    handle_timer = MagicMock()
+
+    device_id = "test_device"
+    timer_manager.register_handler(device_id, handle_timer)
+
+    timer_id = timer_manager.start_timer(
+        device_id,
+        hours=None,
+        minutes=5,
+        seconds=None,
+        language=hass.config.language,
+    )
+
+    assert timer_id in timer_manager.timers
+    assert timer_manager.timers[timer_id].is_active
+
+    # Pause
+    handle_timer.reset_mock()
+    timer_manager.pause_timer(timer_id)
+    handle_timer.assert_called_once()
+
+    # Pausing again does not call handler
+    handle_timer.reset_mock()
+    timer_manager.pause_timer(timer_id)
+    handle_timer.assert_not_called()
+
+    # Unpause
+    handle_timer.reset_mock()
+    timer_manager.unpause_timer(timer_id)
+    handle_timer.assert_called_once()
+
+    # Unpausing again does not call handler
+    handle_timer.reset_mock()
+    timer_manager.unpause_timer(timer_id)
+    handle_timer.assert_not_called()
 
 
 async def test_timers_not_supported(hass: HomeAssistant) -> None:
@@ -1381,3 +1419,108 @@ def test_round_time() -> None:
     assert _round_time(0, 0, 58) == (0, 1, 0)
     assert _round_time(0, 0, 25) == (0, 0, 20)
     assert _round_time(0, 0, 35) == (0, 0, 30)
+
+
+async def test_pause_unpause_timer_disambiguate(
+    hass: HomeAssistant, init_components
+) -> None:
+    """Test disamgibuating timers by their paused state."""
+    device_id = "test_device"
+    started_timer_ids: list[str] = []
+    paused_timer_ids: list[str] = []
+    unpaused_timer_ids: list[str] = []
+
+    started_event = asyncio.Event()
+    updated_event = asyncio.Event()
+
+    @callback
+    def handle_timer(event_type: TimerEventType, timer: TimerInfo) -> None:
+        if event_type == TimerEventType.STARTED:
+            started_event.set()
+            started_timer_ids.append(timer.id)
+        elif event_type == TimerEventType.UPDATED:
+            updated_event.set()
+            if timer.is_active:
+                unpaused_timer_ids.append(timer.id)
+            else:
+                paused_timer_ids.append(timer.id)
+
+    async_register_timer_handler(hass, device_id, handle_timer)
+
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {"minutes": {"value": 5}},
+        device_id=device_id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await started_event.wait()
+
+    # Pause the timer
+    result = await intent.async_handle(
+        hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await updated_event.wait()
+
+    # Start another timer
+    started_event.clear()
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_START_TIMER,
+        {"minutes": {"value": 10}},
+        device_id=device_id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await started_event.wait()
+        assert len(started_timer_ids) == 2
+
+    # We can pause the more recent timer without more information because the
+    # first one is paused.
+    updated_event.clear()
+    result = await intent.async_handle(
+        hass, "test", intent.INTENT_PAUSE_TIMER, {}, device_id=device_id
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await updated_event.wait()
+        assert len(paused_timer_ids) == 2
+        assert paused_timer_ids[1] == started_timer_ids[1]
+
+    # We have to explicitly unpause now
+    updated_event.clear()
+    result = await intent.async_handle(
+        hass,
+        "test",
+        intent.INTENT_UNPAUSE_TIMER,
+        {"start_minutes": {"value": 10}},
+        device_id=device_id,
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await updated_event.wait()
+        assert len(unpaused_timer_ids) == 1
+        assert unpaused_timer_ids[0] == started_timer_ids[1]
+
+    # We can resume the older timer without more information because the
+    # second one is running.
+    updated_event.clear()
+    result = await intent.async_handle(
+        hass, "test", intent.INTENT_UNPAUSE_TIMER, {}, device_id=device_id
+    )
+    assert result.response_type == intent.IntentResponseType.ACTION_DONE
+
+    async with asyncio.timeout(1):
+        await updated_event.wait()
+        assert len(unpaused_timer_ids) == 2
+        assert unpaused_timer_ids[1] == started_timer_ids[0]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Multiple intent timers cannot be targeted when pausing/unpausing, so extra information like a timer name or its start duration must be used to disambiguate.

This PR takes the state of all timers into account when matching as well, so pausing will only search running timers and unpausing will only search paused timers. This makes it easier to target the right timer without having to provide extra information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
