### PR TITLE
Tweak Assist LLM API prompt

### DIFF
--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -227,12 +227,13 @@ class AssistAPI(API):
 
         return APIInstance(
             api=self,
-            api_prompt=await self._async_get_api_prompt(tool_context, exposed_entities),
+            api_prompt=self._async_get_api_prompt(tool_context, exposed_entities),
             tool_context=tool_context,
             tools=self._async_get_tools(tool_context, exposed_entities),
         )
 
-    async def _async_get_api_prompt(
+    @callback
+    def _async_get_api_prompt(
         self, tool_context: ToolContext, exposed_entities: dict | None
     ) -> str:
         """Return the prompt for the API."""
@@ -269,14 +270,9 @@ class AssistAPI(API):
             prompt.append(f"You are in area {area.name} {extra}")
         else:
             prompt.append(
-                "Reject all generic commands like 'turn on the lights' because we "
-                "don't know in what area this conversation is happening."
+                "When a user asks to turn on all devices of a specific type, "
+                "ask user to specify an area."
             )
-
-        if tool_context.context and tool_context.context.user_id:
-            user = await self.hass.auth.async_get_user(tool_context.context.user_id)
-            if user:
-                prompt.append(f"The user name is {user.name}.")
 
         if not tool_context.device_id or not async_device_supports_timers(
             self.hass, tool_context.device_id

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -1,6 +1,6 @@
 """Tests for the llm helpers."""
 
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 import voluptuous as vol
@@ -430,8 +430,8 @@ async def test_assist_api_prompt(
     no_timer_prompt = "This device does not support timers."
 
     area_prompt = (
-        "Reject all generic commands like 'turn on the lights' because we don't know in what area "
-        "this conversation is happening."
+        "When a user asks to turn on all devices of a specific type, "
+        "ask user to specify an area."
     )
     api = await llm.async_get_api(hass, "assist", tool_context)
     assert api.api_prompt == (
@@ -478,19 +478,5 @@ async def test_assist_api_prompt(
     assert api.api_prompt == (
         f"""{first_part_prompt}
 {area_prompt}
-{exposed_entities_prompt}"""
-    )
-
-    # Add user
-    context.user_id = "12345"
-    mock_user = Mock()
-    mock_user.id = "12345"
-    mock_user.name = "Test User"
-    with patch("homeassistant.auth.AuthManager.async_get_user", return_value=mock_user):
-        api = await llm.async_get_api(hass, "assist", tool_context)
-    assert api.api_prompt == (
-        f"""{first_part_prompt}
-{area_prompt}
-The user name is Test User.
 {exposed_entities_prompt}"""
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tweak the LLM prompt based on manual testing:

- Improve the part that lets the LLM reject requests for all lights when it is not in an area
- Remove the user's name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
