### PR TITLE
Add cache to more complex entity filters

### DIFF
--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 from collections.abc import Callable
 import fnmatch
+from functools import lru_cache
 import re
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_DOMAINS, CONF_ENTITIES, CONF_EXCLUDE, CONF_INCLUDE
+from homeassistant.const import (
+    CONF_DOMAINS,
+    CONF_ENTITIES,
+    CONF_EXCLUDE,
+    CONF_INCLUDE,
+    MAX_EXPECTED_ENTITY_IDS,
+)
 from homeassistant.core import split_entity_id
 
 from . import config_validation as cv
@@ -197,6 +204,7 @@ def _generate_filter_from_sets_and_pattern_lists(
     # - Otherwise: exclude
     if have_include and not have_exclude:
 
+        @lru_cache(maxsize=MAX_EXPECTED_ENTITY_IDS)
         def entity_included(entity_id: str) -> bool:
             """Return true if entity matches inclusion filters."""
             return (
@@ -215,6 +223,7 @@ def _generate_filter_from_sets_and_pattern_lists(
     # - Otherwise: include
     if not have_include and have_exclude:
 
+        @lru_cache(maxsize=MAX_EXPECTED_ENTITY_IDS)
         def entity_not_excluded(entity_id: str) -> bool:
             """Return true if entity matches exclusion filters."""
             return not (
@@ -234,6 +243,7 @@ def _generate_filter_from_sets_and_pattern_lists(
     # - Otherwise: exclude
     if include_d or include_eg:
 
+        @lru_cache(maxsize=MAX_EXPECTED_ENTITY_IDS)
         def entity_filter_4a(entity_id: str) -> bool:
             """Return filter function for case 4a."""
             return entity_id in include_e or (
@@ -257,6 +267,7 @@ def _generate_filter_from_sets_and_pattern_lists(
     # - Otherwise: include
     if exclude_d or exclude_eg:
 
+        @lru_cache(maxsize=MAX_EXPECTED_ENTITY_IDS)
         def entity_filter_4b(entity_id: str) -> bool:
             """Return filter function for case 4b."""
             domain = split_entity_id(entity_id)[0]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Many of these do regexes and since the entity_ids are almost always the same we should cache these.

I didn't have any regexes on my production, and didn't notice how much overhead was here until I received a user profile that had multiple globs in their config.

The hit rate is spectacular:
`2024-05-28 16:43:15.751 CRITICAL (SyncWorker_20) [homeassistant.components.profiler] Cache stats for lru_cache <function _generate_filter_from_sets_and_pattern_lists.<locals>.entity_not_excluded at 0x7f783199f6a0> at /usr/src/homeassistant/homeassistant/helpers/entityfilter.py: CacheInfo(hits=277919, misses=12672, maxsize=16384, currsize=12672)`
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
