### PR TITLE
Improve typing for `calls` fixture in tests (a-l)

### DIFF
--- a/tests/components/arcam_fmj/test_device_trigger.py
+++ b/tests/components/arcam_fmj/test_device_trigger.py
@@ -5,7 +5,7 @@ import pytest
 from homeassistant.components import automation
 from homeassistant.components.arcam_fmj.const import DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -22,7 +22,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -67,7 +67,11 @@ async def test_get_triggers(
 
 
 async def test_if_fires_on_turn_on_request(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, player_setup, state
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    player_setup,
+    state,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get(player_setup)
@@ -113,7 +117,11 @@ async def test_if_fires_on_turn_on_request(
 
 
 async def test_if_fires_on_turn_on_request_legacy(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, player_setup, state
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    player_setup,
+    state,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get(player_setup)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -99,7 +99,9 @@ async def test_service_data_not_a_dict(
     assert "Result is not a Dictionary" in caplog.text
 
 
-async def test_service_data_single_template(hass: HomeAssistant, calls) -> None:
+async def test_service_data_single_template(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test service data not dict."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -122,7 +124,9 @@ async def test_service_data_single_template(hass: HomeAssistant, calls) -> None:
     assert calls[0].data["foo"] == "bar"
 
 
-async def test_service_specify_data(hass: HomeAssistant, calls) -> None:
+async def test_service_specify_data(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test service data."""
     assert await async_setup_component(
         hass,
@@ -156,7 +160,9 @@ async def test_service_specify_data(hass: HomeAssistant, calls) -> None:
     assert state.attributes.get("last_triggered") == time
 
 
-async def test_service_specify_entity_id(hass: HomeAssistant, calls) -> None:
+async def test_service_specify_entity_id(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test service data."""
     assert await async_setup_component(
         hass,
@@ -175,7 +181,9 @@ async def test_service_specify_entity_id(hass: HomeAssistant, calls) -> None:
     assert ["hello.world"] == calls[0].data.get(ATTR_ENTITY_ID)
 
 
-async def test_service_specify_entity_id_list(hass: HomeAssistant, calls) -> None:
+async def test_service_specify_entity_id_list(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test service data."""
     assert await async_setup_component(
         hass,
@@ -197,7 +205,7 @@ async def test_service_specify_entity_id_list(hass: HomeAssistant, calls) -> Non
     assert ["hello.world", "hello.world2"] == calls[0].data.get(ATTR_ENTITY_ID)
 
 
-async def test_two_triggers(hass: HomeAssistant, calls) -> None:
+async def test_two_triggers(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test triggers."""
     assert await async_setup_component(
         hass,
@@ -274,7 +282,9 @@ async def test_trigger_service_ignoring_condition(
     assert len(calls) == 2
 
 
-async def test_two_conditions_with_and(hass: HomeAssistant, calls) -> None:
+async def test_two_conditions_with_and(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test two and conditions."""
     entity_id = "test.entity"
     assert await async_setup_component(
@@ -312,7 +322,9 @@ async def test_two_conditions_with_and(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_shorthand_conditions_template(hass: HomeAssistant, calls) -> None:
+async def test_shorthand_conditions_template(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test shorthand nation form in conditions."""
     assert await async_setup_component(
         hass,
@@ -337,7 +349,9 @@ async def test_shorthand_conditions_template(hass: HomeAssistant, calls) -> None
     assert len(calls) == 1
 
 
-async def test_automation_list_setting(hass: HomeAssistant, calls) -> None:
+async def test_automation_list_setting(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Event is not a valid condition."""
     assert await async_setup_component(
         hass,
@@ -365,7 +379,9 @@ async def test_automation_list_setting(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 2
 
 
-async def test_automation_calling_two_actions(hass: HomeAssistant, calls) -> None:
+async def test_automation_calling_two_actions(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test if we can call two actions from automation async definition."""
     assert await async_setup_component(
         hass,
@@ -389,7 +405,7 @@ async def test_automation_calling_two_actions(hass: HomeAssistant, calls) -> Non
     assert calls[1].data["position"] == 1
 
 
-async def test_shared_context(hass: HomeAssistant, calls) -> None:
+async def test_shared_context(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test that the shared context is passed down the chain."""
     assert await async_setup_component(
         hass,
@@ -456,7 +472,7 @@ async def test_shared_context(hass: HomeAssistant, calls) -> None:
     assert calls[0].context is second_trigger_context
 
 
-async def test_services(hass: HomeAssistant, calls) -> None:
+async def test_services(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the automation services for turning entities on/off."""
     entity_id = "automation.hello"
 
@@ -621,7 +637,9 @@ async def test_reload_config_service(
     assert calls[1].data.get("event") == "test_event2"
 
 
-async def test_reload_config_when_invalid_config(hass: HomeAssistant, calls) -> None:
+async def test_reload_config_when_invalid_config(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the reload config service handling invalid config."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -660,7 +678,9 @@ async def test_reload_config_when_invalid_config(hass: HomeAssistant, calls) -> 
     assert len(calls) == 1
 
 
-async def test_reload_config_handles_load_fails(hass: HomeAssistant, calls) -> None:
+async def test_reload_config_handles_load_fails(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the reload config service."""
     assert await async_setup_component(
         hass,
@@ -875,7 +895,9 @@ async def test_reload_single_unchanged_does_not_stop(
     assert len(calls) == 1
 
 
-async def test_reload_single_add_automation(hass: HomeAssistant, calls) -> None:
+async def test_reload_single_add_automation(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test that reloading a single automation."""
     config1 = {automation.DOMAIN: {}}
     config2 = {
@@ -909,7 +931,9 @@ async def test_reload_single_add_automation(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_reload_single_parallel_calls(hass: HomeAssistant, calls) -> None:
+async def test_reload_single_parallel_calls(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test reloading single automations in parallel."""
     config1 = {automation.DOMAIN: {}}
     config2 = {
@@ -1022,7 +1046,9 @@ async def test_reload_single_parallel_calls(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 4
 
 
-async def test_reload_single_remove_automation(hass: HomeAssistant, calls) -> None:
+async def test_reload_single_remove_automation(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test that reloading a single automation."""
     config1 = {
         automation.DOMAIN: {
@@ -2414,7 +2440,9 @@ async def test_automation_this_var_always(
     assert "Error rendering variables" not in caplog.text
 
 
-async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
+async def test_blueprint_automation(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test blueprint automation."""
     assert await async_setup_component(
         hass,
@@ -2532,7 +2560,7 @@ async def test_blueprint_automation_fails_substitution(
     ) in caplog.text
 
 
-async def test_trigger_service(hass: HomeAssistant, calls) -> None:
+async def test_trigger_service(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the automation trigger service."""
     assert await async_setup_component(
         hass,
@@ -2562,7 +2590,9 @@ async def test_trigger_service(hass: HomeAssistant, calls) -> None:
     assert calls[0].context.parent_id is context.id
 
 
-async def test_trigger_condition_implicit_id(hass: HomeAssistant, calls) -> None:
+async def test_trigger_condition_implicit_id(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test triggers."""
     assert await async_setup_component(
         hass,
@@ -2612,7 +2642,9 @@ async def test_trigger_condition_implicit_id(hass: HomeAssistant, calls) -> None
     assert calls[-1].data.get("param") == "one"
 
 
-async def test_trigger_condition_explicit_id(hass: HomeAssistant, calls) -> None:
+async def test_trigger_condition_explicit_id(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test triggers."""
     assert await async_setup_component(
         hass,

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -72,13 +72,13 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
 
 async def test_service_data_not_a_dict(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls: list[ServiceCall]
 ) -> None:
     """Test service data not dict."""
     with assert_setup_component(1, automation.DOMAIN):
@@ -222,7 +222,7 @@ async def test_two_triggers(hass: HomeAssistant, calls) -> None:
 
 
 async def test_trigger_service_ignoring_condition(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls: list[ServiceCall]
 ) -> None:
     """Test triggers."""
     assert await async_setup_component(
@@ -539,7 +539,10 @@ async def test_services(hass: HomeAssistant, calls) -> None:
 
 
 async def test_reload_config_service(
-    hass: HomeAssistant, calls, hass_admin_user: MockUser, hass_read_only_user: MockUser
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
 ) -> None:
     """Test the reload config service."""
     assert await async_setup_component(
@@ -697,7 +700,9 @@ async def test_reload_config_handles_load_fails(hass: HomeAssistant, calls) -> N
 @pytest.mark.parametrize(
     "service", ["turn_off_stop", "turn_off_no_stop", "reload", "reload_single"]
 )
-async def test_automation_stops(hass: HomeAssistant, calls, service) -> None:
+async def test_automation_stops(
+    hass: HomeAssistant, calls: list[ServiceCall], service: str
+) -> None:
     """Test that turning off / reloading stops any running actions as appropriate."""
     entity_id = "automation.hello"
     test_entity = "test.entity"
@@ -774,7 +779,7 @@ async def test_automation_stops(hass: HomeAssistant, calls, service) -> None:
 
 @pytest.mark.parametrize("extra_config", [{}, {"id": "sun"}])
 async def test_reload_unchanged_does_not_stop(
-    hass: HomeAssistant, calls, extra_config
+    hass: HomeAssistant, calls: list[ServiceCall], extra_config: dict[str, str]
 ) -> None:
     """Test that reloading stops any running actions as appropriate."""
     test_entity = "test.entity"
@@ -820,7 +825,7 @@ async def test_reload_unchanged_does_not_stop(
 
 
 async def test_reload_single_unchanged_does_not_stop(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test that reloading stops any running actions as appropriate."""
     test_entity = "test.entity"
@@ -1052,7 +1057,7 @@ async def test_reload_single_remove_automation(hass: HomeAssistant, calls) -> No
 
 
 async def test_reload_moved_automation_without_alias(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test that changing the order of automations without alias triggers reload."""
     with patch(
@@ -1107,7 +1112,7 @@ async def test_reload_moved_automation_without_alias(
 
 
 async def test_reload_identical_automations_without_id(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test reloading of identical automations without id."""
     with patch(
@@ -1282,7 +1287,7 @@ async def test_reload_identical_automations_without_id(
     ],
 )
 async def test_reload_unchanged_automation(
-    hass: HomeAssistant, calls, automation_config
+    hass: HomeAssistant, calls: list[ServiceCall], automation_config: dict[str, Any]
 ) -> None:
     """Test an unmodified automation is not reloaded."""
     with patch(
@@ -1317,7 +1322,7 @@ async def test_reload_unchanged_automation(
 
 @pytest.mark.parametrize("extra_config", [{}, {"id": "sun"}])
 async def test_reload_automation_when_blueprint_changes(
-    hass: HomeAssistant, calls, extra_config
+    hass: HomeAssistant, calls: list[ServiceCall], extra_config: dict[str, str]
 ) -> None:
     """Test an automation is updated at reload if the blueprint has changed."""
     with patch(

--- a/tests/components/automation/test_recorder.py
+++ b/tests/components/automation/test_recorder.py
@@ -15,7 +15,7 @@ from homeassistant.components.automation import (
 from homeassistant.components.recorder import Recorder
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -24,13 +24,13 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, calls
+    recorder_mock: Recorder, hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test automation registered attributes to be excluded."""
     now = dt_util.utcnow()

--- a/tests/components/binary_sensor/test_device_condition.py
+++ b/tests/components/binary_sensor/test_device_condition.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceCla
 from homeassistant.components.binary_sensor.device_condition import ENTITY_CONDITIONS
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -33,7 +33,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -239,7 +239,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -327,7 +327,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -387,7 +387,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for firing if condition is on with delay."""

--- a/tests/components/binary_sensor/test_device_trigger.py
+++ b/tests/components/binary_sensor/test_device_trigger.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import DOMAIN, BinarySensorDeviceCla
 from homeassistant.components.binary_sensor.device_trigger import ENTITY_TRIGGERS
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -33,7 +33,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -240,7 +240,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for on and off triggers firing."""
@@ -335,7 +335,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for triggers firing with delay."""
@@ -407,7 +407,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_binary_sensor_entities: dict[str, MockBinarySensor],
 ) -> None:
     """Test for triggers firing."""

--- a/tests/components/bthome/test_device_trigger.py
+++ b/tests/components/bthome/test_device_trigger.py
@@ -229,7 +229,9 @@ async def test_get_triggers_for_invalid_device_id(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_if_fires_on_motion_detected(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_motion_detected(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for motion event trigger firing."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_bthome_device(hass, mac)

--- a/tests/components/bthome/test_device_trigger.py
+++ b/tests/components/bthome/test_device_trigger.py
@@ -7,7 +7,7 @@ from homeassistant.components.bluetooth.const import DOMAIN as BLUETOOTH_DOMAIN
 from homeassistant.components.bthome.const import CONF_SUBTYPE, DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     async_get as async_get_dev_reg,
@@ -32,7 +32,7 @@ def get_device_id(mac: str) -> tuple[str, str]:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/button/test_device_trigger.py
+++ b/tests/components/button/test_device_trigger.py
@@ -109,7 +109,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -169,7 +169,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/climate/test_device_condition.py
+++ b/tests/components/climate/test_device_condition.py
@@ -8,7 +8,7 @@ from homeassistant.components import automation
 from homeassistant.components.climate import DOMAIN, HVACMode, const, device_condition
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -151,7 +151,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -272,7 +272,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/climate/test_device_trigger.py
+++ b/tests/components/climate/test_device_trigger.py
@@ -14,7 +14,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.const import EntityCategory, UnitOfTemperature
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -36,7 +36,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -151,7 +151,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -272,7 +272,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/conversation/test_trigger.py
+++ b/tests/components/conversation/test_trigger.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components.conversation import default_agent
 from homeassistant.components.conversation.models import ConversationInput
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import trigger
 from homeassistant.setup import async_setup_component
 
@@ -16,19 +16,21 @@ from tests.typing import WebSocketGenerator
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
 
 @pytest.fixture(autouse=True)
-async def setup_comp(hass):
+async def setup_comp(hass: HomeAssistant) -> None:
     """Initialize components."""
     assert await async_setup_component(hass, "homeassistant", {})
     assert await async_setup_component(hass, "conversation", {})
 
 
-async def test_if_fires_on_event(hass: HomeAssistant, calls, setup_comp) -> None:
+async def test_if_fires_on_event(
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp: None
+) -> None:
     """Test the firing of events."""
     assert await async_setup_component(
         hass,
@@ -134,7 +136,9 @@ async def test_empty_response(hass: HomeAssistant, setup_comp) -> None:
     assert service_response["response"]["speech"]["plain"]["speech"] == ""
 
 
-async def test_response_same_sentence(hass: HomeAssistant, calls, setup_comp) -> None:
+async def test_response_same_sentence(
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp: None
+) -> None:
     """Test the conversation response action with multiple triggers using the same sentence."""
     assert await async_setup_component(
         hass,
@@ -196,7 +200,10 @@ async def test_response_same_sentence(hass: HomeAssistant, calls, setup_comp) ->
 
 
 async def test_response_same_sentence_with_error(
-    hass: HomeAssistant, calls, setup_comp, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    setup_comp: None,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test the conversation response action with multiple triggers using the same sentence and an error."""
     caplog.set_level(logging.ERROR)
@@ -303,7 +310,7 @@ async def test_subscribe_trigger_does_not_interfere_with_responses(
 
 
 async def test_same_trigger_multiple_sentences(
-    hass: HomeAssistant, calls, setup_comp
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp: None
 ) -> None:
     """Test matching of multiple sentences from the same trigger."""
     assert await async_setup_component(
@@ -348,7 +355,7 @@ async def test_same_trigger_multiple_sentences(
 
 
 async def test_same_sentence_multiple_triggers(
-    hass: HomeAssistant, calls, setup_comp
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp: None
 ) -> None:
     """Test use of the same sentence in multiple triggers."""
     assert await async_setup_component(
@@ -467,7 +474,9 @@ async def test_fails_on_no_sentences(hass: HomeAssistant) -> None:
         )
 
 
-async def test_wildcards(hass: HomeAssistant, calls, setup_comp) -> None:
+async def test_wildcards(
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp: None
+) -> None:
     """Test wildcards in trigger sentences."""
     assert await async_setup_component(
         hass,

--- a/tests/components/cover/test_device_condition.py
+++ b/tests/components/cover/test_device_condition.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -36,7 +36,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -358,7 +358,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -501,7 +501,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -557,7 +557,7 @@ async def test_if_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     mock_cover_entities: list[MockCover],
 ) -> None:
@@ -717,7 +717,7 @@ async def test_if_tilt_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     mock_cover_entities: list[MockCover],
 ) -> None:

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     STATE_OPENING,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -39,7 +39,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -380,7 +380,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for state triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -533,7 +533,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for state triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -593,7 +593,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -659,7 +659,7 @@ async def test_if_fires_on_position(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     mock_cover_entities: list[MockCover],
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for position triggers."""
     setup_test_component_platform(hass, DOMAIN, mock_cover_entities)
@@ -811,7 +811,7 @@ async def test_if_fires_on_tilt_position(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_cover_entities: list[MockCover],
 ) -> None:
     """Test for tilt position triggers."""

--- a/tests/components/device_automation/test_init.py
+++ b/tests/components/device_automation/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.components.device_automation import (
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import IntegrationNotFound
@@ -1385,14 +1385,14 @@ async def test_automation_with_bad_condition(
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
 
 async def test_automation_with_sub_condition(
     hass: HomeAssistant,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:

--- a/tests/components/device_automation/test_toggle_entity.py
+++ b/tests/components/device_automation/test_toggle_entity.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components import automation
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -20,7 +20,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -29,7 +29,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing.
 
@@ -145,8 +145,8 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
-    trigger,
+    calls: list[ServiceCall],
+    trigger: str,
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/device_tracker/test_device_condition.py
+++ b/tests/components/device_tracker/test_device_condition.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_tracker import DOMAIN
 from homeassistant.const import STATE_HOME, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -25,7 +25,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -114,7 +114,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -199,7 +199,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/device_tracker/test_device_trigger.py
+++ b/tests/components/device_tracker/test_device_trigger.py
@@ -8,7 +8,7 @@ from homeassistant.components import automation, zone
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.device_tracker import DOMAIN, device_trigger
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -37,7 +37,7 @@ HOME_LONGITUDE = -117.237561
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -145,7 +145,7 @@ async def test_if_fires_on_zone_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for enter and leave triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -252,7 +252,7 @@ async def test_if_fires_on_zone_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for enter and leave triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/dialogflow/test_init.py
+++ b/tests/components/dialogflow/test_init.py
@@ -9,7 +9,7 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import dialogflow, intent_script
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
 
@@ -22,12 +22,12 @@ CONTEXT_NAME = "78a5db95-b7d6-4d50-9c9b-2fc73a5e34c3_id_dialog_context"
 
 
 @pytest.fixture
-async def calls(hass, fixture):
+async def calls(hass: HomeAssistant, fixture) -> list[ServiceCall]:
     """Return a list of Dialogflow calls triggered."""
-    calls = []
+    calls: list[ServiceCall] = []
 
     @callback
-    def mock_service(call):
+    def mock_service(call: ServiceCall) -> None:
         """Mock action call."""
         calls.append(call)
 
@@ -343,7 +343,9 @@ async def test_intent_request_without_slots_v2(hass: HomeAssistant, fixture) -> 
     assert text == "You are both home, you silly"
 
 
-async def test_intent_request_calling_service_v1(fixture, calls) -> None:
+async def test_intent_request_calling_service_v1(
+    fixture, calls: list[ServiceCall]
+) -> None:
     """Test a request for calling a service.
 
     If this request is done async the test could finish before the action
@@ -365,7 +367,9 @@ async def test_intent_request_calling_service_v1(fixture, calls) -> None:
     assert call.data.get("hello") == "virgo"
 
 
-async def test_intent_request_calling_service_v2(fixture, calls) -> None:
+async def test_intent_request_calling_service_v2(
+    fixture, calls: list[ServiceCall]
+) -> None:
     """Test a request for calling a service.
 
     If this request is done async the test could finish before the action

--- a/tests/components/fan/test_device_condition.py
+++ b/tests/components/fan/test_device_condition.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -25,7 +25,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -114,7 +114,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -199,7 +199,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/fan/test_device_trigger.py
+++ b/tests/components/fan/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.fan import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -180,7 +180,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -293,7 +293,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -353,7 +353,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/geo_location/test_trigger.py
+++ b/tests/components/geo_location/test_trigger.py
@@ -48,7 +48,9 @@ def setup_comp(hass):
     )
 
 
-async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_enter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on zone enter."""
     context = Context()
     hass.states.async_set(
@@ -126,7 +128,9 @@ async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_for_enter_on_zone_leave(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing on zone leave."""
     hass.states.async_set(
         "geo_location.entity",
@@ -161,7 +165,9 @@ async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) 
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_leave(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on zone leave."""
     hass.states.async_set(
         "geo_location.entity",
@@ -196,7 +202,9 @@ async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_on_zone_leave_2(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_leave_2(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on zone leave for unavailable entity."""
     hass.states.async_set(
         "geo_location.entity",
@@ -231,7 +239,9 @@ async def test_if_fires_on_zone_leave_2(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 0
 
 
-async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_for_leave_on_zone_enter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing on zone enter."""
     hass.states.async_set(
         "geo_location.entity",
@@ -266,7 +276,9 @@ async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) 
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_appear(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_appear(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing if entity appears in zone."""
     assert await async_setup_component(
         hass,
@@ -312,7 +324,9 @@ async def test_if_fires_on_zone_appear(hass: HomeAssistant, calls) -> None:
     )
 
 
-async def test_if_fires_on_zone_appear_2(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_appear_2(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing if entity appears in zone."""
     assert await async_setup_component(
         hass,
@@ -367,7 +381,9 @@ async def test_if_fires_on_zone_appear_2(hass: HomeAssistant, calls) -> None:
     )
 
 
-async def test_if_fires_on_zone_disappear(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_disappear(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing if entity disappears from zone."""
     hass.states.async_set(
         "geo_location.entity",

--- a/tests/components/geo_location/test_trigger.py
+++ b/tests/components/geo_location/test_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, mock_component
@@ -23,7 +23,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -414,7 +414,7 @@ async def test_if_fires_on_zone_disappear(hass: HomeAssistant, calls) -> None:
 
 
 async def test_zone_undefined(
-    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for undefined zone."""
     hass.states.async_set(

--- a/tests/components/google_translate/test_tts.py
+++ b/tests/components/google_translate/test_tts.py
@@ -39,7 +39,7 @@ def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
 
 
 @pytest.fixture
-async def calls(hass: HomeAssistant) -> list[ServiceCall]:
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Mock media player calls."""
     return async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -4,14 +4,14 @@ import pytest
 
 from homeassistant.components import automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, mock_component
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -125,7 +125,7 @@ async def test_if_fires_on_multiple_events(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_event_extra_data(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test the firing of events still matches with event data and context."""
     assert await async_setup_component(
@@ -157,7 +157,7 @@ async def test_if_fires_on_event_extra_data(
 
 
 async def test_if_fires_on_event_with_data_and_context(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test the firing of events with data and context."""
     assert await async_setup_component(
@@ -204,7 +204,7 @@ async def test_if_fires_on_event_with_data_and_context(
 
 
 async def test_if_fires_on_event_with_templated_data_and_context(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test the firing of events with templated data and context."""
     assert await async_setup_component(
@@ -256,7 +256,7 @@ async def test_if_fires_on_event_with_templated_data_and_context(
 
 
 async def test_if_fires_on_event_with_empty_data_and_context_config(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test the firing of events with empty data and context config.
 
@@ -398,7 +398,7 @@ async def test_if_fires_on_sample_zha_event(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_not_fires_if_event_data_not_matches(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test firing of event if no data match."""
     assert await async_setup_component(
@@ -422,7 +422,7 @@ async def test_if_not_fires_if_event_data_not_matches(
 
 
 async def test_if_not_fires_if_event_context_not_matches(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test firing of event if no context match."""
     assert await async_setup_component(
@@ -446,7 +446,7 @@ async def test_if_not_fires_if_event_context_not_matches(
 
 
 async def test_if_fires_on_multiple_user_ids(
-    hass: HomeAssistant, calls, context_with_user
+    hass: HomeAssistant, calls: list[ServiceCall], context_with_user: Context
 ) -> None:
     """Test the firing of event when the trigger has multiple user ids.
 
@@ -511,7 +511,10 @@ async def test_event_data_with_list(hass: HomeAssistant, calls) -> None:
     "event_type", ["state_reported", ["test_event", "state_reported"]]
 )
 async def test_state_reported_event(
-    hass: HomeAssistant, calls, caplog, event_type: list[str]
+    hass: HomeAssistant,
+    calls: list[ServiceCall],
+    caplog: pytest.LogCaptureFixture,
+    event_type: str | list[str],
 ) -> None:
     """Test triggering on state reported event."""
     context = Context()
@@ -541,7 +544,7 @@ async def test_state_reported_event(
 
 
 async def test_templated_state_reported_event(
-    hass: HomeAssistant, calls, caplog
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test triggering on state reported event."""
     context = Context()

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -28,7 +28,7 @@ def setup_comp(hass):
     mock_component(hass, "group")
 
 
-async def test_if_fires_on_event(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_event(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -64,7 +64,9 @@ async def test_if_fires_on_event(hass: HomeAssistant, calls) -> None:
     assert calls[0].data["id"] == 0
 
 
-async def test_if_fires_on_templated_event(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_templated_event(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -97,7 +99,9 @@ async def test_if_fires_on_templated_event(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_on_multiple_events(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_multiple_events(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the firing of events."""
     context = Context()
 
@@ -288,7 +292,9 @@ async def test_if_fires_on_event_with_empty_data_and_context_config(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_with_nested_data(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_event_with_nested_data(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the firing of events with nested data.
 
     This test exercises the slow path of using vol.Schema to validate
@@ -316,7 +322,9 @@ async def test_if_fires_on_event_with_nested_data(hass: HomeAssistant, calls) ->
     assert len(calls) == 1
 
 
-async def test_if_fires_on_event_with_empty_data(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_event_with_empty_data(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the firing of events with empty data.
 
     This test exercises the fast path to validate matching event data.
@@ -340,7 +348,9 @@ async def test_if_fires_on_event_with_empty_data(hass: HomeAssistant, calls) -> 
     assert len(calls) == 1
 
 
-async def test_if_fires_on_sample_zha_event(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_sample_zha_event(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the firing of events with a sample zha event.
 
     This test exercises the fast path to validate matching event data.
@@ -474,7 +484,9 @@ async def test_if_fires_on_multiple_user_ids(
     assert len(calls) == 1
 
 
-async def test_event_data_with_list(hass: HomeAssistant, calls) -> None:
+async def test_event_data_with_list(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the (non)firing of event when the data schema has lists."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -32,7 +32,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -63,7 +63,7 @@ async def setup_comp(hass):
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_entity_removal(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with removed entity."""
     hass.states.async_set("test.entity", 11)
@@ -93,7 +93,7 @@ async def test_if_not_fires_on_entity_removal(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -142,7 +142,10 @@ async def test_if_fires_on_entity_change_below(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_below_uuid(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, below
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    below: int | str,
 ) -> None:
     """Test the firing with changed entity specified by registry entry id."""
     entry = entity_registry.async_get_or_create(
@@ -196,7 +199,7 @@ async def test_if_fires_on_entity_change_below_uuid(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_over_to_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -227,7 +230,7 @@ async def test_if_fires_on_entity_change_over_to_below(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entities_change_over_to_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with changed entities."""
     hass.states.async_set("test.entity_1", 11)
@@ -262,7 +265,7 @@ async def test_if_fires_on_entities_change_over_to_below(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_entity_change_below_to_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     context = Context()
@@ -305,7 +308,7 @@ async def test_if_not_fires_on_entity_change_below_to_below(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_below_fires_on_entity_change_to_equal(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -336,7 +339,7 @@ async def test_if_not_below_fires_on_entity_change_to_equal(
     "below", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_initial_entity_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 9)
@@ -367,7 +370,7 @@ async def test_if_not_fires_on_initial_entity_below(
     "above", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_not_fires_on_initial_entity_above(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 11)
@@ -398,7 +401,7 @@ async def test_if_not_fires_on_initial_entity_above(
     "above", [10, "input_number.value_10", "number.value_10", "sensor.value_10"]
 )
 async def test_if_fires_on_entity_change_above(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 9)
@@ -425,7 +428,7 @@ async def test_if_fires_on_entity_change_above(
 
 
 async def test_if_fires_on_entity_unavailable_at_startup(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test the firing with changed entity at startup."""
     assert await async_setup_component(
@@ -450,7 +453,7 @@ async def test_if_fires_on_entity_unavailable_at_startup(
 
 @pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_fires_on_entity_change_below_to_above(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test the firing with changed entity."""
     # set initial state
@@ -480,7 +483,7 @@ async def test_if_fires_on_entity_change_below_to_above(
 
 @pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_above_to_above(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test the firing with changed entity."""
     # set initial state
@@ -515,7 +518,7 @@ async def test_if_not_fires_on_entity_change_above_to_above(
 
 @pytest.mark.parametrize("above", [10, "input_number.value_10"])
 async def test_if_not_above_fires_on_entity_change_to_equal(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test the firing with changed entity."""
     # set initial state
@@ -553,7 +556,7 @@ async def test_if_not_above_fires_on_entity_change_to_equal(
     ],
 )
 async def test_if_fires_on_entity_change_below_range(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -590,7 +593,7 @@ async def test_if_fires_on_entity_change_below_range(
     ],
 )
 async def test_if_fires_on_entity_change_below_above_range(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     assert await async_setup_component(
@@ -624,7 +627,7 @@ async def test_if_fires_on_entity_change_below_above_range(
     ],
 )
 async def test_if_fires_on_entity_change_over_to_below_range(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -662,7 +665,7 @@ async def test_if_fires_on_entity_change_over_to_below_range(
     ],
 )
 async def test_if_fires_on_entity_change_over_to_below_above_range(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -692,7 +695,7 @@ async def test_if_fires_on_entity_change_over_to_below_above_range(
 
 @pytest.mark.parametrize("below", [100, "input_number.value_100"])
 async def test_if_not_fires_if_entity_not_match(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test if not fired with non matching entity."""
     assert await async_setup_component(
@@ -716,7 +719,7 @@ async def test_if_not_fires_if_entity_not_match(
 
 
 async def test_if_not_fires_and_warns_if_below_entity_unknown(
-    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, calls: list[ServiceCall]
 ) -> None:
     """Test if warns with unknown below entity."""
     assert await async_setup_component(
@@ -747,7 +750,7 @@ async def test_if_not_fires_and_warns_if_below_entity_unknown(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_fires_on_entity_change_below_with_attribute(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     hass.states.async_set("test.entity", 11, {"test_attribute": 11})
@@ -775,7 +778,7 @@ async def test_if_fires_on_entity_change_below_with_attribute(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_not_below_with_attribute(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes."""
     assert await async_setup_component(
@@ -800,7 +803,7 @@ async def test_if_not_fires_on_entity_change_not_below_with_attribute(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_fires_on_attribute_change_with_attribute_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": 11})
@@ -829,7 +832,7 @@ async def test_if_fires_on_attribute_change_with_attribute_below(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     assert await async_setup_component(
@@ -855,7 +858,7 @@ async def test_if_not_fires_on_attribute_change_with_attribute_not_below(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_with_attribute_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     assert await async_setup_component(
@@ -881,7 +884,7 @@ async def test_if_not_fires_on_entity_change_with_attribute_below(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_if_not_fires_on_entity_change_with_not_attribute_below(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     assert await async_setup_component(
@@ -907,7 +910,7 @@ async def test_if_not_fires_on_entity_change_with_not_attribute_below(
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
 async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
-    hass: HomeAssistant, calls, below
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
 ) -> None:
     """Test attributes change."""
     hass.states.async_set(
@@ -938,7 +941,9 @@ async def test_fires_on_attr_change_with_attribute_below_and_multiple_attr(
 
 
 @pytest.mark.parametrize("below", [10, "input_number.value_10"])
-async def test_template_list(hass: HomeAssistant, calls, below) -> None:
+async def test_template_list(
+    hass: HomeAssistant, calls: list[ServiceCall], below: int | str
+) -> None:
     """Test template list."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
     await hass.async_block_till_done()
@@ -964,7 +969,9 @@ async def test_template_list(hass: HomeAssistant, calls, below) -> None:
 
 
 @pytest.mark.parametrize("below", [10.0, "input_number.value_10"])
-async def test_template_string(hass: HomeAssistant, calls, below) -> None:
+async def test_template_string(
+    hass: HomeAssistant, calls: list[ServiceCall], below: float | str
+) -> None:
     """Test template string."""
     assert await async_setup_component(
         hass,
@@ -1005,7 +1012,7 @@ async def test_template_string(hass: HomeAssistant, calls, below) -> None:
 
 
 async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test if not fired changed attributes."""
     assert await async_setup_component(
@@ -1040,7 +1047,9 @@ async def test_not_fires_on_attr_change_with_attr_not_below_multiple_attr(
         ("input_number.value_8", "input_number.value_12"),
     ],
 )
-async def test_if_action(hass: HomeAssistant, calls, above, below) -> None:
+async def test_if_action(
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
+) -> None:
     """Test if action."""
     entity_id = "domain.test_entity"
     assert await async_setup_component(
@@ -1088,7 +1097,9 @@ async def test_if_action(hass: HomeAssistant, calls, above, below) -> None:
         ("input_number.value_8", "input_number.value_12"),
     ],
 )
-async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls, above, below) -> None:
+async def test_if_fails_setup_bad_for(
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
+) -> None:
     """Test for setup failure for bad for."""
     hass.states.async_set("test.entity", 5)
     await hass.async_block_till_done()
@@ -1114,7 +1125,7 @@ async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls, above, below) 
 
 
 async def test_if_fails_setup_for_without_above_below(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for setup failures for missing above or below."""
     with assert_setup_component(1, automation.DOMAIN):
@@ -1145,7 +1156,11 @@ async def test_if_fails_setup_for_without_above_below(
     ],
 )
 async def test_if_not_fires_on_entity_change_with_for(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int | str,
+    below: int | str,
 ) -> None:
     """Test for not firing on entity change with for."""
     assert await async_setup_component(
@@ -1185,7 +1200,7 @@ async def test_if_not_fires_on_entity_change_with_for(
     ],
 )
 async def test_if_not_fires_on_entities_change_with_for_after_stop(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test for not firing on entities change with for after stop."""
     hass.states.async_set("test.entity_1", 0)
@@ -1246,7 +1261,11 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
     ],
 )
 async def test_if_fires_on_entity_change_with_for_attribute_change(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int | str,
+    below: int | str,
 ) -> None:
     """Test for firing on entity change with for and attribute change."""
     hass.states.async_set("test.entity", 0)
@@ -1292,7 +1311,7 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
     ],
 )
 async def test_if_fires_on_entity_change_with_for(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test for firing on entity change with for."""
     hass.states.async_set("test.entity", 0)
@@ -1323,7 +1342,9 @@ async def test_if_fires_on_entity_change_with_for(
 
 
 @pytest.mark.parametrize("above", [10, "input_number.value_10"])
-async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> None:
+async def test_wait_template_with_trigger(
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
+) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     hass.states.async_set("test.entity", "0")
     await hass.async_block_till_done()
@@ -1374,7 +1395,11 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, calls, above) -> 
     ],
 )
 async def test_if_fires_on_entities_change_no_overlap(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int | str,
+    below: int | str,
 ) -> None:
     """Test for firing on entities change with no overlap."""
     hass.states.async_set("test.entity_1", 0)
@@ -1429,7 +1454,11 @@ async def test_if_fires_on_entities_change_no_overlap(
     ],
 )
 async def test_if_fires_on_entities_change_overlap(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int | str,
+    below: int | str,
 ) -> None:
     """Test for firing on entities change with overlap."""
     hass.states.async_set("test.entity_1", 0)
@@ -1495,7 +1524,7 @@ async def test_if_fires_on_entities_change_overlap(
     ],
 )
 async def test_if_fires_on_change_with_for_template_1(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
@@ -1536,7 +1565,7 @@ async def test_if_fires_on_change_with_for_template_1(
     ],
 )
 async def test_if_fires_on_change_with_for_template_2(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
@@ -1577,7 +1606,7 @@ async def test_if_fires_on_change_with_for_template_2(
     ],
 )
 async def test_if_fires_on_change_with_for_template_3(
-    hass: HomeAssistant, calls, above, below
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
 ) -> None:
     """Test for firing on  change with for template."""
     hass.states.async_set("test.entity", 0)
@@ -1609,7 +1638,7 @@ async def test_if_fires_on_change_with_for_template_3(
 
 
 async def test_if_not_fires_on_error_with_for_template(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing on error with for template."""
     hass.states.async_set("test.entity", 0)
@@ -1655,7 +1684,9 @@ async def test_if_not_fires_on_error_with_for_template(
         ("input_number.value_8", "input_number.value_12"),
     ],
 )
-async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) -> None:
+async def test_invalid_for_template(
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str, below: int | str
+) -> None:
     """Test for invalid for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1693,7 +1724,11 @@ async def test_invalid_for_template(hass: HomeAssistant, calls, above, below) ->
     ],
 )
 async def test_if_fires_on_entities_change_overlap_for_template(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int | str,
+    below: int | str,
 ) -> None:
     """Test for firing on entities change with overlap and for template."""
     hass.states.async_set("test.entity_1", 0)
@@ -1788,7 +1823,7 @@ async def test_schema_unacceptable_entities(hass: HomeAssistant) -> None:
 
 @pytest.mark.parametrize("above", [3, "input_number.value_3"])
 async def test_attribute_if_fires_on_entity_change_with_both_filters(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"test-measurement": 1})
@@ -1817,7 +1852,7 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(
 
 @pytest.mark.parametrize("above", [3, "input_number.value_3"])
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
-    hass: HomeAssistant, calls, above
+    hass: HomeAssistant, calls: list[ServiceCall], above: int | str
 ) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     hass.states.async_set("test.entity", "bla", {"test-measurement": 1})
@@ -1856,7 +1891,11 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
     [(8, 12)],
 )
 async def test_variables_priority(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, above, below
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    above: int,
+    below: int,
 ) -> None:
     """Test an externally defined trigger variable is overridden."""
     hass.states.async_set("test.entity_1", 0)
@@ -1911,7 +1950,9 @@ async def test_variables_priority(
 
 
 @pytest.mark.parametrize("multiplier", [1, 5])
-async def test_template_variable(hass: HomeAssistant, calls, multiplier) -> None:
+async def test_template_variable(
+    hass: HomeAssistant, calls: list[ServiceCall], multiplier: int
+) -> None:
     """Test template variable."""
     hass.states.async_set("test.entity", "entity", {"test_attribute": [11, 15, 11]})
     await hass.async_block_till_done()

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -88,7 +88,7 @@ async def test_if_fires_on_entity_change(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_entity_change_uuid(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change."""
     context = Context()
@@ -144,7 +144,7 @@ async def test_if_fires_on_entity_change_uuid(
 
 
 async def test_if_fires_on_entity_change_with_from_filter(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with filter."""
     assert await async_setup_component(
@@ -199,7 +199,7 @@ async def test_if_fires_on_entity_change_with_not_from_filter(
 
 
 async def test_if_fires_on_entity_change_with_to_filter(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with to filter."""
     assert await async_setup_component(
@@ -254,7 +254,7 @@ async def test_if_fires_on_entity_change_with_not_to_filter(
 
 
 async def test_if_fires_on_entity_change_with_from_filter_all(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with filter."""
     assert await async_setup_component(
@@ -280,7 +280,7 @@ async def test_if_fires_on_entity_change_with_from_filter_all(
 
 
 async def test_if_fires_on_entity_change_with_to_filter_all(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with to filter."""
     assert await async_setup_component(
@@ -306,7 +306,7 @@ async def test_if_fires_on_entity_change_with_to_filter_all(
 
 
 async def test_if_fires_on_attribute_change_with_to_filter(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing on attribute change."""
     assert await async_setup_component(
@@ -332,7 +332,7 @@ async def test_if_fires_on_attribute_change_with_to_filter(
 
 
 async def test_if_fires_on_entity_change_with_both_filters(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if both filters are a non match."""
     assert await async_setup_component(
@@ -476,7 +476,7 @@ async def test_if_not_fires_if_to_filter_not_match(hass: HomeAssistant, calls) -
 
 
 async def test_if_not_fires_if_from_filter_not_match(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing if from filter is not a match."""
     hass.states.async_set("test.entity", "bye")
@@ -616,7 +616,7 @@ async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_not_fires_on_entity_change_with_for(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing on entity change with for."""
     assert await async_setup_component(
@@ -646,7 +646,7 @@ async def test_if_not_fires_on_entity_change_with_for(
 
 
 async def test_if_not_fires_on_entities_change_with_for_after_stop(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     assert await async_setup_component(
@@ -695,7 +695,7 @@ async def test_if_not_fires_on_entities_change_with_for_after_stop(
 
 
 async def test_if_fires_on_entity_change_with_for_attribute_change(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with for and attribute change."""
     assert await async_setup_component(
@@ -731,7 +731,7 @@ async def test_if_fires_on_entity_change_with_for_attribute_change(
 
 
 async def test_if_fires_on_entity_change_with_for_multiple_force_update(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with for and force update."""
     assert await async_setup_component(
@@ -792,7 +792,7 @@ async def test_if_fires_on_entity_change_with_for(hass: HomeAssistant, calls) ->
 
 
 async def test_if_fires_on_entity_change_with_for_without_to(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
@@ -831,7 +831,7 @@ async def test_if_fires_on_entity_change_with_for_without_to(
 
 
 async def test_if_does_not_fires_on_entity_change_with_for_without_to_2(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
@@ -861,7 +861,7 @@ async def test_if_does_not_fires_on_entity_change_with_for_without_to_2(
 
 
 async def test_if_fires_on_entity_creation_and_removal(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entity creation and removal, with to/from constraints."""
     # set automations for multiple combinations to/from
@@ -965,7 +965,7 @@ async def test_if_fires_on_for_condition(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_for_condition_attribute_change(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if condition is on with attribute change."""
     point1 = dt_util.utcnow()
@@ -1096,7 +1096,7 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_entities_change_no_overlap(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entities change with no overlap."""
     assert await async_setup_component(
@@ -1137,7 +1137,7 @@ async def test_if_fires_on_entities_change_no_overlap(
 
 
 async def test_if_fires_on_entities_change_overlap(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entities change with overlap."""
     assert await async_setup_component(
@@ -1189,7 +1189,7 @@ async def test_if_fires_on_entities_change_overlap(
 
 
 async def test_if_fires_on_change_with_for_template_1(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
@@ -1217,7 +1217,7 @@ async def test_if_fires_on_change_with_for_template_1(
 
 
 async def test_if_fires_on_change_with_for_template_2(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
@@ -1245,7 +1245,7 @@ async def test_if_fires_on_change_with_for_template_2(
 
 
 async def test_if_fires_on_change_with_for_template_3(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
@@ -1273,7 +1273,7 @@ async def test_if_fires_on_change_with_for_template_3(
 
 
 async def test_if_fires_on_change_with_for_template_4(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     assert await async_setup_component(
@@ -1384,7 +1384,7 @@ async def test_invalid_for_template_1(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_entities_change_overlap_for_template(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on entities change with overlap and for template."""
     assert await async_setup_component(
@@ -1443,7 +1443,7 @@ async def test_if_fires_on_entities_change_overlap_for_template(
 
 
 async def test_attribute_if_fires_on_entity_change_with_both_filters(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"name": "hello"})
@@ -1472,7 +1472,7 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters(
 
 
 async def test_attribute_if_fires_on_entity_where_attr_stays_constant(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
@@ -1510,7 +1510,7 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant(
 
 
 async def test_attribute_if_fires_on_entity_where_attr_stays_constant_filter(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "other_name"})
@@ -1555,7 +1555,7 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant_filter(
 
 
 async def test_attribute_if_fires_on_entity_where_attr_stays_constant_all(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if attribute stays the same."""
     hass.states.async_set("test.entity", "bla", {"name": "hello", "other": "old_value"})
@@ -1600,7 +1600,7 @@ async def test_attribute_if_fires_on_entity_where_attr_stays_constant_all(
 
 
 async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing on entity change with for after stop trigger."""
     hass.states.async_set("test.entity", "bla", {"name": "hello"})
@@ -1656,7 +1656,7 @@ async def test_attribute_if_not_fires_on_entities_change_with_for_after_stop(
 
 
 async def test_attribute_if_fires_on_entity_change_with_both_filters_boolean(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if both filters are match attribute."""
     hass.states.async_set("test.entity", "bla", {"happening": False})
@@ -1685,7 +1685,7 @@ async def test_attribute_if_fires_on_entity_change_with_both_filters_boolean(
 
 
 async def test_variables_priority(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test an externally defined trigger variable is overridden."""
     assert await async_setup_component(

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -40,7 +40,9 @@ def setup_comp(hass):
     hass.states.async_set("test.entity", "hello")
 
 
-async def test_if_fires_on_entity_change(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_entity_change(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on entity change."""
     context = Context()
     hass.states.async_set("test.entity", "hello")
@@ -451,7 +453,9 @@ async def test_if_fires_on_entity_change_with_from_not_to(
     assert len(calls) == 2
 
 
-async def test_if_not_fires_if_to_filter_not_match(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_if_to_filter_not_match(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing if to filter is not a match."""
     assert await async_setup_component(
         hass,
@@ -503,7 +507,9 @@ async def test_if_not_fires_if_from_filter_not_match(
     assert len(calls) == 0
 
 
-async def test_if_not_fires_if_entity_not_match(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_if_entity_not_match(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing if entity is not matching."""
     assert await async_setup_component(
         hass,
@@ -522,7 +528,7 @@ async def test_if_not_fires_if_entity_not_match(hass: HomeAssistant, calls) -> N
     assert len(calls) == 0
 
 
-async def test_if_action(hass: HomeAssistant, calls) -> None:
+async def test_if_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test for to action."""
     entity_id = "domain.test_entity"
     test_state = "new_state"
@@ -554,7 +560,9 @@ async def test_if_action(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fails_setup_if_to_boolean_value(hass: HomeAssistant, calls) -> None:
+async def test_if_fails_setup_if_to_boolean_value(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for setup failure for boolean to."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -574,7 +582,9 @@ async def test_if_fails_setup_if_to_boolean_value(hass: HomeAssistant, calls) ->
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
 
 
-async def test_if_fails_setup_if_from_boolean_value(hass: HomeAssistant, calls) -> None:
+async def test_if_fails_setup_if_from_boolean_value(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for setup failure for boolean from."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -594,7 +604,9 @@ async def test_if_fails_setup_if_from_boolean_value(hass: HomeAssistant, calls) 
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
 
 
-async def test_if_fails_setup_bad_for(hass: HomeAssistant, calls) -> None:
+async def test_if_fails_setup_bad_for(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for setup failure for bad for."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -765,7 +777,9 @@ async def test_if_fires_on_entity_change_with_for_multiple_force_update(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_entity_change_with_for(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_entity_change_with_for(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on entity change with for."""
     assert await async_setup_component(
         hass,
@@ -927,7 +941,9 @@ async def test_if_fires_on_entity_creation_and_removal(
     assert calls[3].context.parent_id == context_0.id
 
 
-async def test_if_fires_on_for_condition(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_for_condition(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing if condition is on."""
     point1 = dt_util.utcnow()
     point2 = point1 + timedelta(seconds=10)
@@ -1013,7 +1029,9 @@ async def test_if_fires_on_for_condition_attribute_change(
         assert len(calls) == 1
 
 
-async def test_if_fails_setup_for_without_time(hass: HomeAssistant, calls) -> None:
+async def test_if_fails_setup_for_without_time(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for setup failure if no time is provided."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -1035,7 +1053,9 @@ async def test_if_fails_setup_for_without_time(hass: HomeAssistant, calls) -> No
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
 
 
-async def test_if_fails_setup_for_without_entity(hass: HomeAssistant, calls) -> None:
+async def test_if_fails_setup_for_without_entity(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for setup failure if no entity is provided."""
     with assert_setup_component(1, automation.DOMAIN):
         assert await async_setup_component(
@@ -1056,7 +1076,9 @@ async def test_if_fails_setup_for_without_entity(hass: HomeAssistant, calls) -> 
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
 
 
-async def test_wait_template_with_trigger(hass: HomeAssistant, calls) -> None:
+async def test_wait_template_with_trigger(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     assert await async_setup_component(
         hass,
@@ -1301,7 +1323,9 @@ async def test_if_fires_on_change_with_for_template_4(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_change_from_with_for(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_change_from_with_for(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on change with from/for."""
     assert await async_setup_component(
         hass,
@@ -1330,7 +1354,9 @@ async def test_if_fires_on_change_from_with_for(hass: HomeAssistant, calls) -> N
     assert len(calls) == 1
 
 
-async def test_if_not_fires_on_change_from_with_for(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_on_change_from_with_for(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on change with from/for."""
     assert await async_setup_component(
         hass,
@@ -1359,7 +1385,9 @@ async def test_if_not_fires_on_change_from_with_for(hass: HomeAssistant, calls) 
     assert len(calls) == 0
 
 
-async def test_invalid_for_template_1(hass: HomeAssistant, calls) -> None:
+async def test_invalid_for_template_1(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for invalid for template."""
     assert await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -29,7 +29,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -41,7 +41,7 @@ def setup_comp(hass):
 
 
 async def test_if_fires_using_at(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing at."""
     now = dt_util.now()
@@ -80,7 +80,11 @@ async def test_if_fires_using_at(
     ("has_date", "has_time"), [(True, True), (True, False), (False, True)]
 )
 async def test_if_fires_using_at_input_datetime(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls, has_date, has_time
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    calls: list[ServiceCall],
+    has_date,
+    has_time,
 ) -> None:
     """Test for firing at input_datetime."""
     await async_setup_component(
@@ -161,7 +165,7 @@ async def test_if_fires_using_at_input_datetime(
 
 
 async def test_if_fires_using_multiple_at(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing at."""
 
@@ -202,7 +206,7 @@ async def test_if_fires_using_multiple_at(
 
 
 async def test_if_not_fires_using_wrong_at(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """YAML translates time values to total seconds.
 
@@ -408,7 +412,7 @@ async def test_untrack_time_change(hass: HomeAssistant) -> None:
 
 
 async def test_if_fires_using_at_sensor(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing at sensor time."""
     now = dt_util.now()

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -245,7 +245,7 @@ async def test_if_not_fires_using_wrong_at(
     assert len(calls) == 0
 
 
-async def test_if_action_before(hass: HomeAssistant, calls) -> None:
+async def test_if_action_before(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test for if action before."""
     assert await async_setup_component(
         hass,
@@ -276,7 +276,7 @@ async def test_if_action_before(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_action_after(hass: HomeAssistant, calls) -> None:
+async def test_if_action_after(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test for if action after."""
     assert await async_setup_component(
         hass,
@@ -307,7 +307,9 @@ async def test_if_action_after(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_action_one_weekday(hass: HomeAssistant, calls) -> None:
+async def test_if_action_one_weekday(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for if action with one weekday."""
     assert await async_setup_component(
         hass,
@@ -339,7 +341,9 @@ async def test_if_action_one_weekday(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_action_list_weekday(hass: HomeAssistant, calls) -> None:
+async def test_if_action_list_weekday(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for action with a list of weekdays."""
     assert await async_setup_component(
         hass,
@@ -539,7 +543,9 @@ def test_schema_invalid(conf) -> None:
         time.TRIGGER_SCHEMA(conf)
 
 
-async def test_datetime_in_past_on_load(hass: HomeAssistant, calls) -> None:
+async def test_datetime_in_past_on_load(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test time trigger works if input_datetime is in past."""
     await async_setup_component(
         hass,

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -343,7 +343,7 @@ async def test_default_values(
     assert len(calls) == 2
 
 
-async def test_invalid_schemas(hass: HomeAssistant, calls) -> None:
+async def test_invalid_schemas(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test invalid schemas."""
     schemas = (
         None,

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.components import automation
 from homeassistant.components.homeassistant.triggers import time_pattern
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -17,7 +17,7 @@ from tests.common import async_fire_time_changed, async_mock_service, mock_compo
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -29,7 +29,7 @@ def setup_comp(hass):
 
 
 async def test_if_fires_when_hour_matches(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if hour is matching."""
     now = dt_util.utcnow()
@@ -74,7 +74,7 @@ async def test_if_fires_when_hour_matches(
 
 
 async def test_if_fires_when_minute_matches(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if minutes are matching."""
     now = dt_util.utcnow()
@@ -105,7 +105,7 @@ async def test_if_fires_when_minute_matches(
 
 
 async def test_if_fires_when_second_matches(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
@@ -136,7 +136,7 @@ async def test_if_fires_when_second_matches(
 
 
 async def test_if_fires_when_second_as_string_matches(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if seconds are matching."""
     now = dt_util.utcnow()
@@ -169,7 +169,7 @@ async def test_if_fires_when_second_as_string_matches(
 
 
 async def test_if_fires_when_all_matches(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing if everything matches."""
     now = dt_util.utcnow()
@@ -202,7 +202,7 @@ async def test_if_fires_when_all_matches(
 
 
 async def test_if_fires_periodic_seconds(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing periodically every second."""
     now = dt_util.utcnow()
@@ -235,7 +235,7 @@ async def test_if_fires_periodic_seconds(
 
 
 async def test_if_fires_periodic_minutes(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing periodically every minute."""
 
@@ -269,7 +269,7 @@ async def test_if_fires_periodic_minutes(
 
 
 async def test_if_fires_periodic_hours(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing periodically every hour."""
     now = dt_util.utcnow()
@@ -302,7 +302,7 @@ async def test_if_fires_periodic_hours(
 
 
 async def test_default_values(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing at 2 minutes every hour."""
     now = dt_util.utcnow()

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.homekit_controller.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -24,7 +24,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -239,7 +239,7 @@ async def test_handle_events(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
@@ -359,7 +359,7 @@ async def test_handle_events_late_setup(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test that events are handled when setup happens after startup."""
     helper = await setup_test_component(hass, create_remote)

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -15,6 +15,7 @@ import pytest
 from homeassistant.components import hue
 from homeassistant.components.hue.v1 import sensor_base as hue_sensor_base
 from homeassistant.components.hue.v2.device import async_setup_devices
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -288,6 +289,6 @@ def get_device_reg(hass):
 
 
 @pytest.fixture(name="calls")
-def track_calls(hass):
+def track_calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -5,8 +5,8 @@ from pytest_unordered import unordered
 from homeassistant.components import automation, hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v1 import device_trigger
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .conftest import setup_platform
@@ -18,7 +18,10 @@ REMOTES_RESPONSE = {"7": HUE_TAP_REMOTE_1, "8": HUE_DIMMER_REMOTE_1}
 
 
 async def test_get_triggers(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_bridge_v1, device_reg
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_bridge_v1,
+    device_reg: dr.DeviceRegistry,
 ) -> None:
     """Test we get the expected triggers from a hue remote."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
@@ -86,7 +89,10 @@ async def test_get_triggers(
 
 
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, mock_bridge_v1, device_reg, calls
+    hass: HomeAssistant,
+    mock_bridge_v1,
+    device_reg: dr.DeviceRegistry,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for button press trigger firing."""
     mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)

--- a/tests/components/humidifier/test_device_condition.py
+++ b/tests/components/humidifier/test_device_condition.py
@@ -8,7 +8,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.humidifier import DOMAIN, const, device_condition
 from homeassistant.const import ATTR_MODE, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -153,7 +153,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -273,7 +273,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/humidifier/test_device_trigger.py
+++ b/tests/components/humidifier/test_device_trigger.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     STATE_ON,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -40,7 +40,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -166,7 +166,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -429,7 +429,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -484,7 +484,7 @@ async def test_if_fires_on_state_change_legacy(
 
 
 async def test_invalid_config(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls: list[ServiceCall]
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get_or_create(DOMAIN, "test", "5678")

--- a/tests/components/kodi/test_device_trigger.py
+++ b/tests/components/kodi/test_device_trigger.py
@@ -6,7 +6,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.kodi import DOMAIN
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -25,7 +25,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -75,7 +75,10 @@ async def test_get_triggers(
 
 
 async def test_if_fires_on_state_change(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, kodi_media_player
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    kodi_media_player,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get(kodi_media_player)
@@ -148,7 +151,10 @@ async def test_if_fires_on_state_change(
 
 
 async def test_if_fires_on_state_change_legacy(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls, kodi_media_player
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    calls: list[ServiceCall],
+    kodi_media_player,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     entry = entity_registry.async_get(kodi_media_player)

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -12,6 +12,7 @@ import pytest
 from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.components.lcn.helpers import generate_unique_id
 from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -78,7 +79,7 @@ def create_config_entry(name):
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/lcn/test_device_trigger.py
+++ b/tests/components/lcn/test_device_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.lcn import device_trigger
 from homeassistant.components.lcn.const import DOMAIN, KEY_ACTIONS, SENDKEYS
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -72,7 +72,7 @@ async def test_get_triggers_non_module_device(
 
 
 async def test_if_fires_on_transponder_event(
-    hass: HomeAssistant, calls, entry, lcn_connection
+    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for transponder event triggers firing."""
     address = (0, 7, False)
@@ -119,7 +119,7 @@ async def test_if_fires_on_transponder_event(
 
 
 async def test_if_fires_on_fingerprint_event(
-    hass: HomeAssistant, calls, entry, lcn_connection
+    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for fingerprint event triggers firing."""
     address = (0, 7, False)
@@ -166,7 +166,7 @@ async def test_if_fires_on_fingerprint_event(
 
 
 async def test_if_fires_on_codelock_event(
-    hass: HomeAssistant, calls, entry, lcn_connection
+    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for codelock event triggers firing."""
     address = (0, 7, False)
@@ -213,7 +213,7 @@ async def test_if_fires_on_codelock_event(
 
 
 async def test_if_fires_on_transmitter_event(
-    hass: HomeAssistant, calls, entry, lcn_connection
+    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for transmitter event triggers firing."""
     address = (0, 7, False)
@@ -269,7 +269,7 @@ async def test_if_fires_on_transmitter_event(
 
 
 async def test_if_fires_on_send_keys_event(
-    hass: HomeAssistant, calls, entry, lcn_connection
+    hass: HomeAssistant, calls: list[ServiceCall], entry, lcn_connection
 ) -> None:
     """Test for send_keys event triggers firing."""
     address = (0, 7, False)

--- a/tests/components/lg_netcast/conftest.py
+++ b/tests/components/lg_netcast/conftest.py
@@ -2,10 +2,12 @@
 
 import pytest
 
+from homeassistant.core import HomeAssistant, ServiceCall
+
 from tests.common import async_mock_service
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")

--- a/tests/components/lg_netcast/test_trigger.py
+++ b/tests/components/lg_netcast/test_trigger.py
@@ -77,7 +77,9 @@ async def test_lg_netcast_turn_on_trigger_device_id(
     assert len(calls) == 0
 
 
-async def test_lg_netcast_turn_on_trigger_entity_id(hass: HomeAssistant, calls):
+async def test_lg_netcast_turn_on_trigger_entity_id(
+    hass: HomeAssistant, calls: list[ServiceCall]
+):
     """Test for turn_on triggers by entity firing."""
     await setup_lgnetcast(hass)
 

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -14,7 +14,7 @@ from homeassistant.components.light import (
     LightEntityFeature,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -33,7 +33,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -470,7 +470,7 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
@@ -635,7 +635,7 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""

--- a/tests/components/light/test_device_condition.py
+++ b/tests/components/light/test_device_condition.py
@@ -10,7 +10,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
 from homeassistant.const import CONF_PLATFORM, STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -32,7 +32,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -184,7 +184,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -271,7 +271,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -330,7 +330,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     mock_light_entities: list[MockLight],
 ) -> None:
     """Test for firing if condition is on with delay."""

--- a/tests/components/light/test_device_trigger.py
+++ b/tests/components/light/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.light import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -38,7 +38,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -188,7 +188,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -281,7 +281,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -335,7 +335,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""

--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -9,7 +9,7 @@ import pytest
 
 from homeassistant import setup
 from homeassistant.components import automation
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.util.dt as dt_util
 
 from . import async_init_integration
@@ -31,7 +31,7 @@ ENTITY_OTHER_SWITCH_NUMBER = 2
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -100,7 +100,9 @@ async def setup_automation(hass, trigger):
     await hass.async_block_till_done()
 
 
-async def test_simple(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_simple(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
         hass, {"platform": "litejet", "number": ENTITY_OTHER_SWITCH_NUMBER}
@@ -113,7 +115,9 @@ async def test_simple(hass: HomeAssistant, calls, mock_litejet) -> None:
     assert calls[0].data["id"] == 0
 
 
-async def test_only_release(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_only_release(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test the simplest form of a LiteJet trigger."""
     await setup_automation(
         hass, {"platform": "litejet", "number": ENTITY_OTHER_SWITCH_NUMBER}
@@ -124,7 +128,9 @@ async def test_only_release(hass: HomeAssistant, calls, mock_litejet) -> None:
     assert len(calls) == 0
 
 
-async def test_held_more_than_short(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_more_than_short(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test a too short hold."""
     await setup_automation(
         hass,
@@ -141,7 +147,9 @@ async def test_held_more_than_short(hass: HomeAssistant, calls, mock_litejet) ->
     assert len(calls) == 0
 
 
-async def test_held_more_than_long(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_more_than_long(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test a hold that is long enough."""
     await setup_automation(
         hass,
@@ -161,7 +169,9 @@ async def test_held_more_than_long(hass: HomeAssistant, calls, mock_litejet) -> 
     assert len(calls) == 1
 
 
-async def test_held_less_than_short(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_less_than_short(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test a hold that is short enough."""
     await setup_automation(
         hass,
@@ -180,7 +190,9 @@ async def test_held_less_than_short(hass: HomeAssistant, calls, mock_litejet) ->
     assert calls[0].data["id"] == 0
 
 
-async def test_held_less_than_long(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_less_than_long(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test a hold that is too long."""
     await setup_automation(
         hass,
@@ -199,7 +211,9 @@ async def test_held_less_than_long(hass: HomeAssistant, calls, mock_litejet) -> 
     assert len(calls) == 0
 
 
-async def test_held_in_range_short(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_in_range_short(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test an in-range trigger with a too short hold."""
     await setup_automation(
         hass,
@@ -218,7 +232,7 @@ async def test_held_in_range_short(hass: HomeAssistant, calls, mock_litejet) -> 
 
 
 async def test_held_in_range_just_right(
-    hass: HomeAssistant, calls, mock_litejet
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
 ) -> None:
     """Test an in-range trigger with a just right hold."""
     await setup_automation(
@@ -240,7 +254,9 @@ async def test_held_in_range_just_right(
     assert calls[0].data["id"] == 0
 
 
-async def test_held_in_range_long(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_held_in_range_long(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test an in-range trigger with a too long hold."""
     await setup_automation(
         hass,
@@ -260,7 +276,9 @@ async def test_held_in_range_long(hass: HomeAssistant, calls, mock_litejet) -> N
     assert len(calls) == 0
 
 
-async def test_reload(hass: HomeAssistant, calls, mock_litejet) -> None:
+async def test_reload(
+    hass: HomeAssistant, calls: list[ServiceCall], mock_litejet
+) -> None:
     """Test reloading automation."""
     await setup_automation(
         hass,

--- a/tests/components/lock/test_device_condition.py
+++ b/tests/components/lock/test_device_condition.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     STATE_UNLOCKING,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -34,7 +34,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -139,7 +139,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -336,7 +336,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/lock/test_device_trigger.py
+++ b/tests/components/lock/test_device_trigger.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     STATE_UNLOCKING,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -39,7 +39,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -212,7 +212,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -325,7 +325,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -382,7 +382,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -103,7 +103,7 @@ MOCK_BUTTON_DEVICES = [
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -220,7 +220,7 @@ async def test_none_serial_keypad(
 
 
 async def test_if_fires_on_button_event(
-    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant, calls: list[ServiceCall], device_registry: dr.DeviceRegistry
 ) -> None:
     """Test for press trigger firing."""
     await _async_setup_lutron_with_picos(hass)
@@ -271,7 +271,7 @@ async def test_if_fires_on_button_event(
 
 
 async def test_if_fires_on_button_event_without_lip(
-    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant, calls: list[ServiceCall], device_registry: dr.DeviceRegistry
 ) -> None:
     """Test for press trigger firing on a device that does not support lip."""
     await _async_setup_lutron_with_picos(hass)
@@ -358,7 +358,7 @@ async def test_validate_trigger_config_no_device(hass: HomeAssistant, calls) -> 
 
 
 async def test_validate_trigger_config_unknown_device(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test for no press with an unknown device."""
 
@@ -442,7 +442,7 @@ async def test_validate_trigger_invalid_triggers(
 
 
 async def test_if_fires_on_button_event_late_setup(
-    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant, calls: list[ServiceCall], device_registry: dr.DeviceRegistry
 ) -> None:
     """Test for press trigger firing with integration getting setup late."""
     config_entry_id = await _async_setup_lutron_with_picos(hass)

--- a/tests/components/lutron_caseta/test_device_trigger.py
+++ b/tests/components/lutron_caseta/test_device_trigger.py
@@ -319,7 +319,9 @@ async def test_if_fires_on_button_event_without_lip(
     assert calls[0].data["some"] == "test_trigger_button_press"
 
 
-async def test_validate_trigger_config_no_device(hass: HomeAssistant, calls) -> None:
+async def test_validate_trigger_config_no_device(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for no press with no device."""
 
     assert await async_setup_component(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

```python
@pytest.fixture
def calls(hass: HomeAssistant) -> list[ServiceCall]:
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
