### PR TITLE
Improve typing for `calls` fixture in tests (m-z)

### DIFF
--- a/tests/components/media_player/test_device_condition.py
+++ b/tests/components/media_player/test_device_condition.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -33,7 +33,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -136,7 +136,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -337,7 +337,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/media_player/test_device_trigger.py
+++ b/tests/components/media_player/test_device_trigger.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     EntityCategory,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -38,7 +38,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -209,7 +209,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -321,7 +321,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -380,7 +380,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -30,7 +30,7 @@ def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
 
 
 @pytest.fixture
-async def calls(hass: HomeAssistant):
+async def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Mock media player calls."""
     return async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -14,7 +14,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.components.microsoft.tts import SUPPORTED_LANGUAGES
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceNotFound
 from homeassistant.setup import async_setup_component
 
@@ -54,7 +54,10 @@ def mock_tts():
 
 
 async def test_service_say(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say."""
 
@@ -95,7 +98,10 @@ async def test_service_say(
 
 
 async def test_service_say_en_gb_config(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say with en-gb code in the config."""
 
@@ -144,7 +150,10 @@ async def test_service_say_en_gb_config(
 
 
 async def test_service_say_en_gb_service(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say with en-gb code in the service."""
 
@@ -188,7 +197,10 @@ async def test_service_say_en_gb_service(
 
 
 async def test_service_say_fa_ir_config(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say with fa-ir code in the config."""
 
@@ -237,7 +249,10 @@ async def test_service_say_fa_ir_config(
 
 
 async def test_service_say_fa_ir_service(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say with fa-ir code in the service."""
 
@@ -301,7 +316,9 @@ def test_supported_languages() -> None:
     assert len(SUPPORTED_LANGUAGES) > 100
 
 
-async def test_invalid_language(hass: HomeAssistant, mock_tts, calls) -> None:
+async def test_invalid_language(
+    hass: HomeAssistant, mock_tts, calls: list[ServiceCall]
+) -> None:
     """Test setup component with invalid language."""
     await async_setup_component(
         hass,
@@ -326,7 +343,10 @@ async def test_invalid_language(hass: HomeAssistant, mock_tts, calls) -> None:
 
 
 async def test_service_say_error(
-    hass: HomeAssistant, hass_client: ClientSessionGenerator, mock_tts, calls
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_tts,
+    calls: list[ServiceCall],
 ) -> None:
     """Test service call say with http error."""
     mock_tts.return_value.speak.side_effect = pycsspeechtts.requests.HTTPError

--- a/tests/components/microsoft/test_tts.py
+++ b/tests/components/microsoft/test_tts.py
@@ -30,7 +30,7 @@ def mock_tts_cache_dir_autouse(mock_tts_cache_dir):
 
 
 @pytest.fixture
-async def calls(hass: HomeAssistant) -> list[ServiceCall]:
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Mock media player calls."""
     return async_mock_service(hass, DOMAIN_MP, SERVICE_PLAY_MEDIA)
 

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant.components import automation
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import HassJobType, HomeAssistant
+from homeassistant.core import HassJobType, HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_fire_mqtt_message, async_mock_service, mock_component
@@ -18,7 +18,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -30,7 +30,9 @@ async def setup_comp(hass: HomeAssistant, mqtt_mock_entry):
     return await mqtt_mock_entry()
 
 
-async def test_if_fires_on_topic_match(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_topic_match(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test if message is fired on topic match."""
     assert await async_setup_component(
         hass,
@@ -68,7 +70,9 @@ async def test_if_fires_on_topic_match(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_fires_on_topic_and_payload_match(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_topic_and_payload_match(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test if message is fired on topic and payload match."""
     assert await async_setup_component(
         hass,
@@ -90,7 +94,9 @@ async def test_if_fires_on_topic_and_payload_match(hass: HomeAssistant, calls) -
     assert len(calls) == 1
 
 
-async def test_if_fires_on_topic_and_payload_match2(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_topic_and_payload_match2(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test if message is fired on topic and payload match.
 
     Make sure a payload which would render as a non string can still be matched.
@@ -116,7 +122,7 @@ async def test_if_fires_on_topic_and_payload_match2(hass: HomeAssistant, calls) 
 
 
 async def test_if_fires_on_templated_topic_and_payload_match(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
@@ -147,7 +153,9 @@ async def test_if_fires_on_templated_topic_and_payload_match(
     assert len(calls) == 1
 
 
-async def test_if_fires_on_payload_template(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_payload_template(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test if message is fired on templated topic and payload match."""
     assert await async_setup_component(
         hass,
@@ -179,7 +187,7 @@ async def test_if_fires_on_payload_template(hass: HomeAssistant, calls) -> None:
 
 
 async def test_non_allowed_templates(
-    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test non allowed function in template."""
     assert await async_setup_component(
@@ -203,7 +211,7 @@ async def test_non_allowed_templates(
 
 
 async def test_if_not_fires_on_topic_but_no_payload_match(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test if message is not fired on topic but no payload."""
     assert await async_setup_component(
@@ -226,7 +234,9 @@ async def test_if_not_fires_on_topic_but_no_payload_match(
     assert len(calls) == 0
 
 
-async def test_encoding_default(hass: HomeAssistant, calls, setup_comp) -> None:
+async def test_encoding_default(
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp
+) -> None:
     """Test default encoding."""
     assert await async_setup_component(
         hass,
@@ -244,7 +254,9 @@ async def test_encoding_default(hass: HomeAssistant, calls, setup_comp) -> None:
     )
 
 
-async def test_encoding_custom(hass: HomeAssistant, calls, setup_comp) -> None:
+async def test_encoding_custom(
+    hass: HomeAssistant, calls: list[ServiceCall], setup_comp
+) -> None:
     """Test default encoding."""
     assert await async_setup_component(
         hass,

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -11,7 +11,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.nest import DOMAIN
 from homeassistant.components.nest.events import NEST_EVENT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
@@ -80,7 +80,7 @@ async def setup_automation(hass, device_id, trigger_type):
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -244,7 +244,7 @@ async def test_fires_on_camera_motion(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test camera_motion triggers firing."""
     create_device.create(
@@ -278,7 +278,7 @@ async def test_fires_on_camera_person(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test camera_person triggers firing."""
     create_device.create(
@@ -312,7 +312,7 @@ async def test_fires_on_camera_sound(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test camera_sound triggers firing."""
     create_device.create(
@@ -346,7 +346,7 @@ async def test_fires_on_doorbell_chime(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test doorbell_chime triggers firing."""
     create_device.create(
@@ -380,7 +380,7 @@ async def test_trigger_for_wrong_device_id(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test messages for the wrong device are ignored."""
     create_device.create(
@@ -413,7 +413,7 @@ async def test_trigger_for_wrong_event_type(
     device_registry: dr.DeviceRegistry,
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test that messages for the wrong event type are ignored."""
     create_device.create(
@@ -444,7 +444,7 @@ async def test_trigger_for_wrong_event_type(
 async def test_subscriber_automation(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    calls: list,
+    calls: list[ServiceCall],
     create_device: CreateDevice,
     setup_platform: PlatformSetup,
     subscriber: FakeSubscriber,

--- a/tests/components/netatmo/test_device_trigger.py
+++ b/tests/components/netatmo/test_device_trigger.py
@@ -14,7 +14,7 @@ from homeassistant.components.netatmo.const import (
 )
 from homeassistant.components.netatmo.device_trigger import SUBTYPES
 from homeassistant.const import ATTR_DEVICE_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -27,7 +27,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -113,7 +113,7 @@ async def test_get_triggers(
 )
 async def test_if_fires_on_event(
     hass: HomeAssistant,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     platform,
@@ -196,7 +196,7 @@ async def test_if_fires_on_event(
 )
 async def test_if_fires_on_event_legacy(
     hass: HomeAssistant,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     platform,
@@ -277,7 +277,7 @@ async def test_if_fires_on_event_legacy(
 )
 async def test_if_fires_on_event_with_subtype(
     hass: HomeAssistant,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
     platform,

--- a/tests/components/philips_js/test_device_trigger.py
+++ b/tests/components/philips_js/test_device_trigger.py
@@ -6,7 +6,7 @@ from pytest_unordered import unordered
 from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.philips_js.const import DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_get_device_automations, async_mock_service
@@ -18,7 +18,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -42,7 +42,7 @@ async def test_get_triggers(hass: HomeAssistant, mock_device) -> None:
 
 
 async def test_if_fires_on_turn_on_request(
-    hass: HomeAssistant, calls, mock_tv, mock_entity, mock_device
+    hass: HomeAssistant, calls: list[ServiceCall], mock_tv, mock_entity, mock_device
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
 

--- a/tests/components/remote/test_device_action.py
+++ b/tests/components/remote/test_device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -25,7 +25,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -113,7 +113,7 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
@@ -188,7 +188,7 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""

--- a/tests/components/remote/test_device_condition.py
+++ b/tests/components/remote/test_device_condition.py
@@ -10,7 +10,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -182,7 +182,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -269,7 +269,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -328,7 +328,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""

--- a/tests/components/remote/test_device_trigger.py
+++ b/tests/components/remote/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.remote import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -180,7 +180,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -290,7 +290,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -350,7 +350,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""

--- a/tests/components/script/test_init.py
+++ b/tests/components/script/test_init.py
@@ -24,6 +24,7 @@ from homeassistant.core import (
     Context,
     CoreState,
     HomeAssistant,
+    ServiceCall,
     State,
     callback,
     split_entity_id,
@@ -57,7 +58,7 @@ ENTITY_ID = "script.test"
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "script")
 
@@ -374,7 +375,9 @@ async def test_reload_service(hass: HomeAssistant, running) -> None:
         assert hass.services.has_service(script.DOMAIN, "test")
 
 
-async def test_reload_unchanged_does_not_stop(hass: HomeAssistant, calls) -> None:
+async def test_reload_unchanged_does_not_stop(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test that reloading stops any running actions as appropriate."""
     test_entity = "test.entity"
 
@@ -461,7 +464,7 @@ async def test_reload_unchanged_does_not_stop(hass: HomeAssistant, calls) -> Non
     ],
 )
 async def test_reload_unchanged_script(
-    hass: HomeAssistant, calls, script_config
+    hass: HomeAssistant, calls: list[ServiceCall], script_config
 ) -> None:
     """Test an unmodified script is not reloaded."""
     with patch(
@@ -1560,7 +1563,9 @@ async def test_script_service_changed_entity_id(
     assert calls[1].data["entity_id"] == "script.custom_entity_id_2"
 
 
-async def test_blueprint_automation(hass: HomeAssistant, calls) -> None:
+async def test_blueprint_automation(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test blueprint script."""
     assert await async_setup_component(
         hass,

--- a/tests/components/script/test_recorder.py
+++ b/tests/components/script/test_recorder.py
@@ -15,7 +15,7 @@ from homeassistant.components.script import (
     ATTR_MODE,
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME
-from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, ServiceCall, callback
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -24,13 +24,13 @@ from tests.components.recorder.common import async_wait_recording_done
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
 
 async def test_exclude_attributes(
-    recorder_mock: Recorder, hass: HomeAssistant, calls
+    recorder_mock: Recorder, hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test automation registered attributes to be excluded."""
     now = dt_util.utcnow()

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -117,7 +117,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -239,7 +239,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/sensor/test_device_condition.py
+++ b/tests/components/sensor/test_device_condition.py
@@ -466,7 +466,7 @@ async def test_if_state_not_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
 ) -> None:
@@ -509,7 +509,7 @@ async def test_if_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
@@ -578,7 +578,7 @@ async def test_if_state_above_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
@@ -647,7 +647,7 @@ async def test_if_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""
@@ -716,7 +716,7 @@ async def test_if_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value conditions."""

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -423,7 +423,7 @@ async def test_if_fires_not_on_above_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
     enable_custom_integrations: None,
 ) -> None:
@@ -463,7 +463,7 @@ async def test_if_fires_on_state_above(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
@@ -528,7 +528,7 @@ async def test_if_fires_on_state_below(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
@@ -593,7 +593,7 @@ async def test_if_fires_on_state_between(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
@@ -670,7 +670,7 @@ async def test_if_fires_on_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for value triggers firing."""
@@ -735,7 +735,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -11,7 +11,7 @@ from homeassistant.components.shelly.const import (
     EVENT_SHELLY_CLICK,
     REST_SENSORS_UPDATE_INTERVAL,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from . import MOCK_MAC
 
@@ -293,7 +293,7 @@ def device_reg(hass: HomeAssistant):
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     SUN_EVENT_SUNRISE,
     SUN_EVENT_SUNSET,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -27,7 +27,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -41,7 +41,7 @@ def setup_comp(hass):
     )
 
 
-async def test_sunset_trigger(hass: HomeAssistant, calls) -> None:
+async def test_sunset_trigger(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the sunset trigger."""
     now = datetime(2015, 9, 15, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 2, tzinfo=dt_util.UTC)
@@ -86,7 +86,7 @@ async def test_sunset_trigger(hass: HomeAssistant, calls) -> None:
         assert calls[0].data["id"] == 0
 
 
-async def test_sunrise_trigger(hass: HomeAssistant, calls) -> None:
+async def test_sunrise_trigger(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test the sunrise trigger."""
     now = datetime(2015, 9, 13, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 14, tzinfo=dt_util.UTC)
@@ -108,7 +108,9 @@ async def test_sunrise_trigger(hass: HomeAssistant, calls) -> None:
         assert len(calls) == 1
 
 
-async def test_sunset_trigger_with_offset(hass: HomeAssistant, calls) -> None:
+async def test_sunset_trigger_with_offset(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the sunset trigger with offset."""
     now = datetime(2015, 9, 15, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 2, 30, tzinfo=dt_util.UTC)
@@ -144,7 +146,9 @@ async def test_sunset_trigger_with_offset(hass: HomeAssistant, calls) -> None:
         assert calls[0].data["some"] == "sun - sunset - 0:30:00"
 
 
-async def test_sunrise_trigger_with_offset(hass: HomeAssistant, calls) -> None:
+async def test_sunrise_trigger_with_offset(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test the sunrise trigger with offset."""
     now = datetime(2015, 9, 13, 23, tzinfo=dt_util.UTC)
     trigger_time = datetime(2015, 9, 16, 13, 30, tzinfo=dt_util.UTC)

--- a/tests/components/switch/test_device_action.py
+++ b/tests/components/switch/test_device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -25,7 +25,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -114,7 +114,7 @@ async def test_action(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""
@@ -189,7 +189,7 @@ async def test_action_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off actions."""

--- a/tests/components/switch/test_device_condition.py
+++ b/tests/components/switch/test_device_condition.py
@@ -10,7 +10,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -182,7 +182,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -269,7 +269,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off conditions."""
@@ -327,7 +327,7 @@ async def test_if_fires_on_for_condition(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for firing if condition is on with delay."""

--- a/tests/components/switch/test_device_trigger.py
+++ b/tests/components/switch/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.switch import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON, EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -180,7 +180,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -291,7 +291,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
@@ -352,7 +352,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
     enable_custom_integrations: None,
 ) -> None:
     """Test for triggers firing with delay."""

--- a/tests/components/tag/test_trigger.py
+++ b/tests/components/tag/test_trigger.py
@@ -37,7 +37,7 @@ def tag_setup(hass: HomeAssistant, hass_storage):
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/tag/test_trigger.py
+++ b/tests/components/tag/test_trigger.py
@@ -6,7 +6,7 @@ from homeassistant.components import automation
 from homeassistant.components.tag import async_scan_tag
 from homeassistant.components.tag.const import DEVICE_ID, DOMAIN, TAG_ID
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service
@@ -42,7 +42,9 @@ def calls(hass: HomeAssistant):
     return async_mock_service(hass, "test", "automation")
 
 
-async def test_triggers(hass: HomeAssistant, tag_setup, calls) -> None:
+async def test_triggers(
+    hass: HomeAssistant, tag_setup, calls: list[ServiceCall]
+) -> None:
     """Test tag triggers."""
     assert await tag_setup()
     assert await async_setup_component(
@@ -88,7 +90,7 @@ async def test_triggers(hass: HomeAssistant, tag_setup, calls) -> None:
 
 
 async def test_exception_bad_trigger(
-    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for exception on event triggers firing."""
 
@@ -112,7 +114,7 @@ async def test_exception_bad_trigger(
 
 
 async def test_multiple_tags_and_devices_trigger(
-    hass: HomeAssistant, tag_setup, calls
+    hass: HomeAssistant, tag_setup, calls: list[ServiceCall]
 ) -> None:
     """Test multiple tags and devices triggers."""
     assert await tag_setup()

--- a/tests/components/tasmota/conftest.py
+++ b/tests/components/tasmota/conftest.py
@@ -10,6 +10,7 @@ from homeassistant.components.tasmota.const import (
     DEFAULT_PREFIX,
     DOMAIN,
 )
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.common import (
     MockConfigEntry,
@@ -33,7 +34,7 @@ def entity_reg(hass):
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/tasmota/test_device_trigger.py
+++ b/tests/components/tasmota/test_device_trigger.py
@@ -12,7 +12,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.tasmota import _LOGGER
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX, DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.setup import async_setup_component
@@ -350,7 +350,11 @@ async def test_update_remove_triggers(
 
 
 async def test_if_fires_on_mqtt_message_btn(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_reg,
+    calls: list[ServiceCall],
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test button triggers firing."""
     # Discover a device with 2 device triggers
@@ -421,7 +425,11 @@ async def test_if_fires_on_mqtt_message_btn(
 
 
 async def test_if_fires_on_mqtt_message_swc(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_reg,
+    calls: list[ServiceCall],
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test switch triggers firing."""
     # Discover a device with 2 device triggers
@@ -515,7 +523,11 @@ async def test_if_fires_on_mqtt_message_swc(
 
 
 async def test_if_fires_on_mqtt_message_late_discover(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_reg,
+    calls: list[ServiceCall],
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test triggers firing of MQTT device triggers discovered after setup."""
     # Discover a device without device triggers
@@ -594,7 +606,11 @@ async def test_if_fires_on_mqtt_message_late_discover(
 
 
 async def test_if_fires_on_mqtt_message_after_update(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_reg,
+    calls: list[ServiceCall],
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test triggers firing after update."""
     # Discover a device with device trigger
@@ -724,7 +740,11 @@ async def test_no_resubscribe_same_topic(
 
 
 async def test_not_fires_on_mqtt_message_after_remove_by_mqtt(
-    hass: HomeAssistant, device_reg, calls, mqtt_mock: MqttMockHAClient, setup_tasmota
+    hass: HomeAssistant,
+    device_reg,
+    calls: list[ServiceCall],
+    mqtt_mock: MqttMockHAClient,
+    setup_tasmota,
 ) -> None:
     """Test triggers not firing after removal."""
     # Discover a device with device trigger
@@ -798,7 +818,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_reg,
-    calls,
+    calls: list[ServiceCall],
     mqtt_mock: MqttMockHAClient,
     setup_tasmota,
 ) -> None:

--- a/tests/components/template/conftest.py
+++ b/tests/components/template/conftest.py
@@ -2,13 +2,14 @@
 
 import pytest
 
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, async_mock_service
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/template/test_button.py
+++ b/tests/components/template/test_button.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     CONF_ICON,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component
@@ -62,7 +62,7 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
 
 
 async def test_all_optional_config(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test: including all optional templates is ok."""
     with assert_setup_component(1, "template"):

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.common import assert_setup_component
 
@@ -445,7 +445,9 @@ async def test_template_open_or_position(
         },
     ],
 )
-async def test_open_action(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_open_action(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test the open_cover command."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_CLOSED
@@ -484,7 +486,9 @@ async def test_open_action(hass: HomeAssistant, start_ha, calls) -> None:
         },
     ],
 )
-async def test_close_stop_action(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_close_stop_action(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test the close-cover and stop_cover commands."""
     state = hass.states.get("cover.test_template_cover")
     assert state.state == STATE_OPEN
@@ -513,7 +517,9 @@ async def test_close_stop_action(hass: HomeAssistant, start_ha, calls) -> None:
         {"input_number": {"test": {"min": "0", "max": "100", "initial": "42"}}},
     ],
 )
-async def test_set_position(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_set_position(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test the set_position command."""
     with assert_setup_component(1, "cover"):
         assert await setup.async_setup_component(
@@ -643,7 +649,12 @@ async def test_set_position(hass: HomeAssistant, start_ha, calls) -> None:
     ],
 )
 async def test_set_tilt_position(
-    hass: HomeAssistant, service, attr, start_ha, calls, tilt_position
+    hass: HomeAssistant,
+    service,
+    attr,
+    start_ha,
+    calls: list[ServiceCall],
+    tilt_position,
 ) -> None:
     """Test the set_tilt_position command."""
     await hass.services.async_call(
@@ -676,7 +687,9 @@ async def test_set_tilt_position(
         },
     ],
 )
-async def test_set_position_optimistic(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_set_position_optimistic(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test optimistic position mode."""
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_position") is None
@@ -724,7 +737,7 @@ async def test_set_position_optimistic(hass: HomeAssistant, start_ha, calls) -> 
     ],
 )
 async def test_set_tilt_position_optimistic(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test the optimistic tilt_position mode."""
     state = hass.states.get("cover.test_template_cover")

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -16,7 +16,7 @@ from homeassistant.components.fan import (
     NotValidPresetModeError,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from tests.common import assert_setup_component
 from tests.components.fan import common
@@ -387,7 +387,7 @@ async def test_invalid_availability_template_keeps_component_available(
     assert "x" in caplog_setup_text
 
 
-async def test_on_off(hass: HomeAssistant, calls) -> None:
+async def test_on_off(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test turn on and turn off."""
     await _register_components(hass)
 
@@ -406,7 +406,7 @@ async def test_on_off(hass: HomeAssistant, calls) -> None:
 
 
 async def test_set_invalid_direction_from_initial_stage(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set invalid direction when fan is in initial state."""
     await _register_components(hass)
@@ -419,7 +419,7 @@ async def test_set_invalid_direction_from_initial_stage(
     _verify(hass, STATE_ON, 0, None, None, None)
 
 
-async def test_set_osc(hass: HomeAssistant, calls) -> None:
+async def test_set_osc(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set oscillating."""
     await _register_components(hass)
     expected_calls = 0
@@ -437,7 +437,7 @@ async def test_set_osc(hass: HomeAssistant, calls) -> None:
         assert calls[-1].data["option"] == state
 
 
-async def test_set_direction(hass: HomeAssistant, calls) -> None:
+async def test_set_direction(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set valid direction."""
     await _register_components(hass)
     expected_calls = 0
@@ -455,7 +455,9 @@ async def test_set_direction(hass: HomeAssistant, calls) -> None:
         assert calls[-1].data["option"] == cmd
 
 
-async def test_set_invalid_direction(hass: HomeAssistant, calls) -> None:
+async def test_set_invalid_direction(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test set invalid direction when fan has valid direction."""
     await _register_components(hass)
 
@@ -466,7 +468,7 @@ async def test_set_invalid_direction(hass: HomeAssistant, calls) -> None:
         _verify(hass, STATE_ON, 0, None, DIRECTION_FORWARD, None)
 
 
-async def test_preset_modes(hass: HomeAssistant, calls) -> None:
+async def test_preset_modes(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test preset_modes."""
     await _register_components(
         hass, ["off", "low", "medium", "high", "auto", "smart"], ["auto", "smart"]
@@ -493,7 +495,7 @@ async def test_preset_modes(hass: HomeAssistant, calls) -> None:
     assert hass.states.get(_PRESET_MODE_INPUT_SELECT).state == "auto"
 
 
-async def test_set_percentage(hass: HomeAssistant, calls) -> None:
+async def test_set_percentage(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set valid speed percentage."""
     await _register_components(hass)
     expected_calls = 0
@@ -519,7 +521,9 @@ async def test_set_percentage(hass: HomeAssistant, calls) -> None:
     _verify(hass, STATE_ON, 50, None, None, None)
 
 
-async def test_increase_decrease_speed(hass: HomeAssistant, calls) -> None:
+async def test_increase_decrease_speed(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test set valid increase and decrease speed."""
     await _register_components(hass, speed_count=3)
 
@@ -536,7 +540,7 @@ async def test_increase_decrease_speed(hass: HomeAssistant, calls) -> None:
         _verify(hass, state, value, None, None, None)
 
 
-async def test_no_value_template(hass: HomeAssistant, calls) -> None:
+async def test_no_value_template(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test a fan without a value_template."""
     await _register_fan_sources(hass)
 
@@ -648,7 +652,7 @@ async def test_no_value_template(hass: HomeAssistant, calls) -> None:
 
 
 async def test_increase_decrease_speed_default_speed_count(
-    hass: HomeAssistant, calls
+    hass: HomeAssistant, calls: list[ServiceCall]
 ) -> None:
     """Test set valid increase and decrease speed."""
     await _register_components(hass)
@@ -666,7 +670,9 @@ async def test_increase_decrease_speed_default_speed_count(
         _verify(hass, state, value, None, None, None)
 
 
-async def test_set_invalid_osc_from_initial_state(hass: HomeAssistant, calls) -> None:
+async def test_set_invalid_osc_from_initial_state(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test set invalid oscillating when fan is in initial state."""
     await _register_components(hass)
 
@@ -677,7 +683,7 @@ async def test_set_invalid_osc_from_initial_state(hass: HomeAssistant, calls) ->
     _verify(hass, STATE_ON, 0, None, None, None)
 
 
-async def test_set_invalid_osc(hass: HomeAssistant, calls) -> None:
+async def test_set_invalid_osc(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set invalid oscillating when fan has valid osc."""
     await _register_components(hass)
 

--- a/tests/components/template/test_light.py
+++ b/tests/components/template/test_light.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component
@@ -340,7 +340,9 @@ async def test_missing_key(hass: HomeAssistant, count, setup_light) -> None:
         },
     ],
 )
-async def test_on_action(hass: HomeAssistant, setup_light, calls) -> None:
+async def test_on_action(
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
+) -> None:
     """Test on action."""
     hass.states.async_set("light.test_state", STATE_OFF)
     await hass.async_block_till_done()
@@ -399,7 +401,7 @@ async def test_on_action(hass: HomeAssistant, setup_light, calls) -> None:
     ],
 )
 async def test_on_action_with_transition(
-    hass: HomeAssistant, setup_light, calls
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
 ) -> None:
     """Test on action with transition."""
     hass.states.async_set("light.test_state", STATE_OFF)
@@ -441,7 +443,7 @@ async def test_on_action_with_transition(
 async def test_on_action_optimistic(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test on action with optimistic state."""
     hass.states.async_set("light.test_state", STATE_OFF)
@@ -499,7 +501,9 @@ async def test_on_action_optimistic(
         },
     ],
 )
-async def test_off_action(hass: HomeAssistant, setup_light, calls) -> None:
+async def test_off_action(
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
+) -> None:
     """Test off action."""
     hass.states.async_set("light.test_state", STATE_ON)
     await hass.async_block_till_done()
@@ -557,7 +561,7 @@ async def test_off_action(hass: HomeAssistant, setup_light, calls) -> None:
     ],
 )
 async def test_off_action_with_transition(
-    hass: HomeAssistant, setup_light, calls
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
 ) -> None:
     """Test off action with transition."""
     hass.states.async_set("light.test_state", STATE_ON)
@@ -595,7 +599,9 @@ async def test_off_action_with_transition(
         },
     ],
 )
-async def test_off_action_optimistic(hass: HomeAssistant, setup_light, calls) -> None:
+async def test_off_action_optimistic(
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
+) -> None:
     """Test off action with optimistic state."""
     state = hass.states.get("light.test_template_light")
     assert state.state == STATE_OFF
@@ -633,7 +639,7 @@ async def test_off_action_optimistic(hass: HomeAssistant, setup_light, calls) ->
 async def test_level_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting brightness with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -752,7 +758,7 @@ async def test_temperature_template(
 async def test_temperature_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -872,9 +878,9 @@ async def test_entity_picture_template(hass: HomeAssistant, setup_light) -> None
     ],
 )
 async def test_legacy_color_action_no_template(
-    hass,
+    hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ):
     """Test setting color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -916,7 +922,7 @@ async def test_legacy_color_action_no_template(
 async def test_hs_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting hs color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -958,7 +964,7 @@ async def test_hs_color_action_no_template(
 async def test_rgb_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting rgb color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -1001,7 +1007,7 @@ async def test_rgb_color_action_no_template(
 async def test_rgbw_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting rgbw color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -1048,7 +1054,7 @@ async def test_rgbw_color_action_no_template(
 async def test_rgbww_color_action_no_template(
     hass: HomeAssistant,
     setup_light,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test setting rgbww color with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -1348,7 +1354,7 @@ async def test_rgbww_template(
     ],
 )
 async def test_all_colors_mode_no_template(
-    hass: HomeAssistant, setup_light, calls
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
 ) -> None:
     """Test setting color and color temperature with optimistic template."""
     state = hass.states.get("light.test_template_light")
@@ -1564,7 +1570,7 @@ async def test_all_colors_mode_no_template(
     ],
 )
 async def test_effect_action_valid_effect(
-    hass: HomeAssistant, setup_light, calls
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
 ) -> None:
     """Test setting valid effect with template."""
     state = hass.states.get("light.test_template_light")
@@ -1609,7 +1615,7 @@ async def test_effect_action_valid_effect(
     ],
 )
 async def test_effect_action_invalid_effect(
-    hass: HomeAssistant, setup_light, calls
+    hass: HomeAssistant, setup_light, calls: list[ServiceCall]
 ) -> None:
     """Test setting invalid effect with template."""
     state = hass.states.get("light.test_template_light")

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -5,7 +5,7 @@ import pytest
 from homeassistant import setup
 from homeassistant.components import lock
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, STATE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 
 OPTIMISTIC_LOCK_CONFIG = {
     "platform": "template",
@@ -180,7 +180,9 @@ async def test_template_static(hass: HomeAssistant, start_ha) -> None:
         },
     ],
 )
-async def test_lock_action(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_lock_action(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test lock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_OFF)
@@ -211,7 +213,9 @@ async def test_lock_action(hass: HomeAssistant, start_ha, calls) -> None:
         },
     ],
 )
-async def test_unlock_action(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_unlock_action(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test unlock action."""
     await setup.async_setup_component(hass, "switch", {})
     hass.states.async_set("switch.test_state", STATE_ON)

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -15,7 +15,7 @@ from homeassistant.components.number import (
     SERVICE_SET_VALUE as NUMBER_SERVICE_SET_VALUE,
 )
 from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component, async_capture_events
@@ -127,7 +127,9 @@ async def test_all_optional_config(hass: HomeAssistant) -> None:
     _verify(hass, 4, 1, 3, 5)
 
 
-async def test_templates_with_entities(hass: HomeAssistant, calls) -> None:
+async def test_templates_with_entities(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test templates with values from other entities."""
     with assert_setup_component(4, "input_number"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -15,7 +15,7 @@ from homeassistant.components.select import (
     SERVICE_SELECT_OPTION as SELECT_SERVICE_SELECT_OPTION,
 )
 from homeassistant.const import ATTR_ICON, CONF_ENTITY_ID, STATE_UNKNOWN
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers.entity_registry import async_get
 
 from tests.common import assert_setup_component, async_capture_events
@@ -132,7 +132,9 @@ async def test_missing_required_keys(hass: HomeAssistant) -> None:
     assert hass.states.async_all("select") == []
 
 
-async def test_templates_with_entities(hass: HomeAssistant, calls) -> None:
+async def test_templates_with_entities(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test templates with values from other entities."""
     with assert_setup_component(1, "input_select"):
         assert await setup.async_setup_component(

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import CoreState, HomeAssistant, State
+from homeassistant.core import CoreState, HomeAssistant, ServiceCall, State
 from homeassistant.setup import async_setup_component
 
 from tests.common import assert_setup_component, mock_component, mock_restore_cache
@@ -354,7 +354,7 @@ async def test_missing_off_does_not_create(hass: HomeAssistant) -> None:
     assert hass.states.async_all("switch") == []
 
 
-async def test_on_action(hass: HomeAssistant, calls) -> None:
+async def test_on_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test on action."""
     assert await async_setup_component(
         hass,
@@ -394,7 +394,9 @@ async def test_on_action(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_on_action_optimistic(hass: HomeAssistant, calls) -> None:
+async def test_on_action_optimistic(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test on action in optimistic mode."""
     assert await async_setup_component(
         hass,
@@ -435,7 +437,7 @@ async def test_on_action_optimistic(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_off_action(hass: HomeAssistant, calls) -> None:
+async def test_off_action(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test off action."""
     assert await async_setup_component(
         hass,
@@ -475,7 +477,9 @@ async def test_off_action(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == "switch.test_template_switch"
 
 
-async def test_off_action_optimistic(hass: HomeAssistant, calls) -> None:
+async def test_off_action_optimistic(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test off action in optimistic mode."""
     assert await async_setup_component(
         hass,

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -14,7 +14,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     STATE_UNAVAILABLE,
 )
-from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, ServiceCall, callback
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -22,7 +22,7 @@ from tests.common import async_fire_time_changed, mock_component
 
 
 @pytest.fixture(autouse=True)
-def setup_comp(hass, calls):
+def setup_comp(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Initialize components."""
     mock_component(hass, "group")
     hass.states.async_set("test.entity", "hello")
@@ -48,7 +48,9 @@ def setup_comp(hass, calls):
         },
     ],
 )
-async def test_if_fires_on_change_bool(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_if_fires_on_change_bool(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test for firing on boolean change."""
     assert len(calls) == 0
 
@@ -269,7 +271,9 @@ async def test_if_fires_on_change_bool(hass: HomeAssistant, start_ha, calls) -> 
         ),
     ],
 )
-async def test_general(hass: HomeAssistant, call_setup, start_ha, calls) -> None:
+async def test_general(
+    hass: HomeAssistant, call_setup, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test for firing on change."""
     assert len(calls) == 0
 
@@ -305,7 +309,7 @@ async def test_general(hass: HomeAssistant, call_setup, start_ha, calls) -> None
     ],
 )
 async def test_if_not_fires_because_fail(
-    hass: HomeAssistant, call_setup, start_ha, calls
+    hass: HomeAssistant, call_setup, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for not firing after TemplateError."""
     assert len(calls) == 0
@@ -343,7 +347,7 @@ async def test_if_not_fires_because_fail(
     ],
 )
 async def test_if_fires_on_change_with_template_advanced(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with template advanced."""
     context = Context()
@@ -374,7 +378,9 @@ async def test_if_fires_on_change_with_template_advanced(
         },
     ],
 )
-async def test_if_action(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_if_action(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test for firing if action."""
     # Condition is not true yet
     hass.bus.async_fire("test_event")
@@ -405,7 +411,7 @@ async def test_if_action(hass: HomeAssistant, start_ha, calls) -> None:
     ],
 )
 async def test_if_fires_on_change_with_bad_template(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with bad template."""
     assert hass.states.get("automation.automation_0").state == STATE_UNAVAILABLE
@@ -441,7 +447,9 @@ async def test_if_fires_on_change_with_bad_template(
         },
     ],
 )
-async def test_wait_template_with_trigger(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_wait_template_with_trigger(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test using wait template with 'trigger.entity_id'."""
     await hass.async_block_till_done()
 
@@ -457,7 +465,9 @@ async def test_wait_template_with_trigger(hass: HomeAssistant, start_ha, calls) 
     assert calls[0].data["some"] == "template - test.entity - hello - world - None"
 
 
-async def test_if_fires_on_change_with_for(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_change_with_for(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on change with for."""
     assert await async_setup_component(
         hass,
@@ -510,7 +520,7 @@ async def test_if_fires_on_change_with_for(hass: HomeAssistant, calls) -> None:
     ],
 )
 async def test_if_fires_on_change_with_for_advanced(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for advanced."""
     context = Context()
@@ -554,7 +564,7 @@ async def test_if_fires_on_change_with_for_advanced(
     ],
 )
 async def test_if_fires_on_change_with_for_0_advanced(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for: 0 advanced."""
     context = Context()
@@ -595,7 +605,7 @@ async def test_if_fires_on_change_with_for_0_advanced(
     ],
 )
 async def test_if_fires_on_change_with_for_2(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     context = Context()
@@ -626,7 +636,7 @@ async def test_if_fires_on_change_with_for_2(
     ],
 )
 async def test_if_not_fires_on_change_with_for(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
@@ -660,7 +670,7 @@ async def test_if_not_fires_on_change_with_for(
     ],
 )
 async def test_if_not_fires_when_turned_off_with_for(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for."""
     hass.states.async_set("test.entity", "world")
@@ -698,7 +708,7 @@ async def test_if_not_fires_when_turned_off_with_for(
     ],
 )
 async def test_if_fires_on_change_with_for_template_1(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -726,7 +736,7 @@ async def test_if_fires_on_change_with_for_template_1(
     ],
 )
 async def test_if_fires_on_change_with_for_template_2(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -754,7 +764,7 @@ async def test_if_fires_on_change_with_for_template_2(
     ],
 )
 async def test_if_fires_on_change_with_for_template_3(
-    hass: HomeAssistant, start_ha, calls
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on change with for template."""
     hass.states.async_set("test.entity", "world")
@@ -781,7 +791,9 @@ async def test_if_fires_on_change_with_for_template_3(
         },
     ],
 )
-async def test_invalid_for_template_1(hass: HomeAssistant, start_ha, calls) -> None:
+async def test_invalid_for_template_1(
+    hass: HomeAssistant, start_ha, calls: list[ServiceCall]
+) -> None:
     """Test for invalid for template."""
     with mock.patch.object(template_trigger, "_LOGGER") as mock_logger:
         hass.states.async_set("test.entity", "world")
@@ -790,7 +802,7 @@ async def test_invalid_for_template_1(hass: HomeAssistant, start_ha, calls) -> N
 
 
 async def test_if_fires_on_time_change(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on time changes."""
     start_time = dt_util.utcnow() + timedelta(hours=24)

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -12,7 +12,7 @@ from homeassistant.components.vacuum import (
     STATE_RETURNING,
 )
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE, STATE_UNKNOWN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_component import async_update_entity
 
@@ -355,7 +355,7 @@ async def test_unused_services(hass: HomeAssistant) -> None:
     _verify(hass, STATE_UNKNOWN, None)
 
 
-async def test_state_services(hass: HomeAssistant, calls) -> None:
+async def test_state_services(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test state services."""
     await _register_components(hass)
 
@@ -404,7 +404,9 @@ async def test_state_services(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_clean_spot_service(hass: HomeAssistant, calls) -> None:
+async def test_clean_spot_service(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test clean spot service."""
     await _register_components(hass)
 
@@ -419,7 +421,7 @@ async def test_clean_spot_service(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_locate_service(hass: HomeAssistant, calls) -> None:
+async def test_locate_service(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test locate service."""
     await _register_components(hass)
 
@@ -434,7 +436,7 @@ async def test_locate_service(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["caller"] == _TEST_VACUUM
 
 
-async def test_set_fan_speed(hass: HomeAssistant, calls) -> None:
+async def test_set_fan_speed(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test set valid fan speed."""
     await _register_components(hass)
 
@@ -461,7 +463,9 @@ async def test_set_fan_speed(hass: HomeAssistant, calls) -> None:
     assert calls[-1].data["option"] == "medium"
 
 
-async def test_set_invalid_fan_speed(hass: HomeAssistant, calls) -> None:
+async def test_set_invalid_fan_speed(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test set invalid fan speed when fan has valid speed."""
     await _register_components(hass)
 

--- a/tests/components/vacuum/test_device_condition.py
+++ b/tests/components/vacuum/test_device_condition.py
@@ -12,7 +12,7 @@ from homeassistant.components.vacuum import (
     STATE_RETURNING,
 )
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -119,7 +119,7 @@ async def test_if_state(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -204,7 +204,7 @@ async def test_if_state_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off conditions."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/vacuum/test_device_trigger.py
+++ b/tests/components/vacuum/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.vacuum import DOMAIN, STATE_CLEANING, STATE_DOCKED
 from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import RegistryEntryHider
 from homeassistant.setup import async_setup_component
@@ -30,7 +30,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -182,7 +182,7 @@ async def test_if_fires_on_state_change(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -267,7 +267,7 @@ async def test_if_fires_on_state_change_legacy(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for turn_on and turn_off triggers firing."""
     config_entry = MockConfigEntry(domain="test", data={})
@@ -324,7 +324,7 @@ async def test_if_fires_on_state_change_with_for(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    calls,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for triggers firing with delay."""
     config_entry = MockConfigEntry(domain="test", data={})

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from homeassistant.components.webostv.const import LIVE_TV_APP_ID
+from homeassistant.core import HomeAssistant, ServiceCall
 
 from .const import CHANNEL_1, CHANNEL_2, CLIENT_KEY, FAKE_UUID, MOCK_APPS, MOCK_INPUTS
 
@@ -22,7 +23,7 @@ def mock_setup_entry() -> Generator[AsyncMock, None, None]:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/webostv/test_device_trigger.py
+++ b/tests/components/webostv/test_device_trigger.py
@@ -9,7 +9,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.webostv import DOMAIN, device_trigger
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -41,7 +41,9 @@ async def test_get_triggers(hass: HomeAssistant, client) -> None:
     assert turn_on_trigger in triggers
 
 
-async def test_if_fires_on_turn_on_request(hass: HomeAssistant, calls, client) -> None:
+async def test_if_fires_on_turn_on_request(
+    hass: HomeAssistant, calls: list[ServiceCall], client
+) -> None:
     """Test for turn_on and turn_off triggers firing."""
     await setup_webostv(hass)
 

--- a/tests/components/webostv/test_trigger.py
+++ b/tests/components/webostv/test_trigger.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.components import automation
 from homeassistant.components.webostv import DOMAIN
 from homeassistant.const import SERVICE_RELOAD
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import async_get as get_dev_reg
 from homeassistant.setup import async_setup_component
@@ -19,7 +19,7 @@ from tests.common import MockEntity, MockEntityPlatform
 
 
 async def test_webostv_turn_on_trigger_device_id(
-    hass: HomeAssistant, calls, client
+    hass: HomeAssistant, calls: list[ServiceCall], client
 ) -> None:
     """Test for turn_on triggers by device_id firing."""
     await setup_webostv(hass)
@@ -77,7 +77,7 @@ async def test_webostv_turn_on_trigger_device_id(
 
 
 async def test_webostv_turn_on_trigger_entity_id(
-    hass: HomeAssistant, calls, client
+    hass: HomeAssistant, calls: list[ServiceCall], client
 ) -> None:
     """Test for turn_on triggers by entity_id firing."""
     await setup_webostv(hass)

--- a/tests/components/xiaomi_ble/test_device_trigger.py
+++ b/tests/components/xiaomi_ble/test_device_trigger.py
@@ -7,7 +7,7 @@ from homeassistant.components.bluetooth.const import DOMAIN as BLUETOOTH_DOMAIN
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.xiaomi_ble.const import CONF_SUBTYPE, DOMAIN
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM, CONF_TYPE
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     async_get as async_get_dev_reg,
@@ -33,7 +33,7 @@ def get_device_id(mac: str) -> tuple[str, str]:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -394,7 +394,9 @@ async def test_get_triggers_for_invalid_device_id(hass: HomeAssistant) -> None:
     await hass.async_block_till_done()
 
 
-async def test_if_fires_on_button_press(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_button_press(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for button press event trigger firing."""
     mac = "54:EF:44:E3:9C:BC"
     data = {"bindkey": "5b51a7c91cde6707c9ef18dfda143a58"}
@@ -454,7 +456,9 @@ async def test_if_fires_on_button_press(hass: HomeAssistant, calls) -> None:
     await hass.async_block_till_done()
 
 
-async def test_if_fires_on_double_button_long_press(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_double_button_long_press(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for button press event trigger firing."""
     mac = "DC:ED:83:87:12:73"
     data = {"bindkey": "b93eb3787eabda352edd94b667f5d5a9"}
@@ -514,7 +518,9 @@ async def test_if_fires_on_double_button_long_press(hass: HomeAssistant, calls) 
     await hass.async_block_till_done()
 
 
-async def test_if_fires_on_motion_detected(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_motion_detected(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for motion event trigger firing."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)
@@ -668,7 +674,9 @@ async def test_automation_with_invalid_trigger_event_property(
     await hass.async_block_till_done()
 
 
-async def test_triggers_for_invalid__model(hass: HomeAssistant, calls) -> None:
+async def test_triggers_for_invalid__model(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test invalid model doesn't return triggers."""
     mac = "DE:70:E8:B2:39:0C"
     entry = await _async_setup_xiaomi_device(hass, mac)

--- a/tests/components/yolink/test_device_trigger.py
+++ b/tests/components/yolink/test_device_trigger.py
@@ -19,7 +19,7 @@ from tests.common import (
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "yolink", "automation")
 

--- a/tests/components/yolink/test_device_trigger.py
+++ b/tests/components/yolink/test_device_trigger.py
@@ -7,7 +7,7 @@ from yolink.const import ATTR_DEVICE_DIMMER, ATTR_DEVICE_SMART_REMOTER
 from homeassistant.components import automation
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.yolink import DOMAIN, YOLINK_EVENT
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -120,7 +120,7 @@ async def test_get_triggers_exception(
 
 
 async def test_if_fires_on_event(
-    hass: HomeAssistant, calls, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant, calls: list[ServiceCall], device_registry: dr.DeviceRegistry
 ) -> None:
     """Test for event triggers firing."""
     mac_address = "12:34:56:AB:CD:EF"

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -16,7 +16,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.zha.core.const import ATTR_ENDPOINT_ID
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -76,7 +76,7 @@ def _same_lists(list_a, list_b):
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -195,7 +195,10 @@ async def test_no_triggers(
 
 
 async def test_if_fires_on_event(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_devices, calls
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_devices,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for remote triggers firing."""
 
@@ -245,7 +248,10 @@ async def test_if_fires_on_event(
 
 
 async def test_device_offline_fires(
-    hass: HomeAssistant, zigpy_device_mock, zha_device_restored, calls
+    hass: HomeAssistant,
+    zigpy_device_mock,
+    zha_device_restored,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for device offline triggers firing."""
 
@@ -314,7 +320,7 @@ async def test_exception_no_triggers(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     mock_devices,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test for exception when validating device triggers."""
@@ -356,7 +362,7 @@ async def test_exception_bad_trigger(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     mock_devices,
-    calls,
+    calls: list[ServiceCall],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test for exception when validating device triggers."""

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -4,7 +4,7 @@ import pytest
 
 from homeassistant.components import automation, zone
 from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, ServiceCall
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -17,7 +17,7 @@ def stub_blueprint_populate_autouse(stub_blueprint_populate: None) -> None:
 
 
 @pytest.fixture
-def calls(hass):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 
@@ -42,7 +42,9 @@ def setup_comp(hass):
     )
 
 
-async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_enter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on zone enter."""
     context = Context()
     hass.states.async_set(
@@ -112,7 +114,7 @@ async def test_if_fires_on_zone_enter(hass: HomeAssistant, calls) -> None:
 
 
 async def test_if_fires_on_zone_enter_uuid(
-    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, calls: list[ServiceCall]
 ) -> None:
     """Test for firing on zone enter when device is specified by entity registry id."""
     context = Context()
@@ -188,7 +190,9 @@ async def test_if_fires_on_zone_enter_uuid(
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_for_enter_on_zone_leave(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing on zone leave."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -219,7 +223,9 @@ async def test_if_not_fires_for_enter_on_zone_leave(hass: HomeAssistant, calls) 
     assert len(calls) == 0
 
 
-async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
+async def test_if_fires_on_zone_leave(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for firing on zone leave."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -250,7 +256,9 @@ async def test_if_fires_on_zone_leave(hass: HomeAssistant, calls) -> None:
     assert len(calls) == 1
 
 
-async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) -> None:
+async def test_if_not_fires_for_leave_on_zone_enter(
+    hass: HomeAssistant, calls: list[ServiceCall]
+) -> None:
     """Test for not firing on zone enter."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.881011, "longitude": -117.234758}
@@ -281,7 +289,7 @@ async def test_if_not_fires_for_leave_on_zone_enter(hass: HomeAssistant, calls) 
     assert len(calls) == 0
 
 
-async def test_zone_condition(hass: HomeAssistant, calls) -> None:
+async def test_zone_condition(hass: HomeAssistant, calls: list[ServiceCall]) -> None:
     """Test for zone condition."""
     hass.states.async_set(
         "test.entity", "hello", {"latitude": 32.880586, "longitude": -117.237564}
@@ -310,7 +318,7 @@ async def test_zone_condition(hass: HomeAssistant, calls) -> None:
 
 
 async def test_unknown_zone(
-    hass: HomeAssistant, calls, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant, calls: list[ServiceCall], caplog: pytest.LogCaptureFixture
 ) -> None:
     """Test for firing on zone enter."""
     context = Context()

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -29,7 +29,7 @@ from tests.common import async_get_device_automations, async_mock_service
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -20,7 +20,7 @@ from homeassistant.components.zwave_js.helpers import (
     get_device_id,
     get_zwave_value_from_config,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.setup import async_setup_component
@@ -99,7 +99,7 @@ async def test_node_status_state(
     client,
     lock_schlage_be469,
     integration,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for node_status conditions."""
@@ -264,7 +264,7 @@ async def test_config_parameter_state(
     client,
     lock_schlage_be469,
     integration,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for config_parameter conditions."""
@@ -384,7 +384,7 @@ async def test_value_state(
     client,
     lock_schlage_be469,
     integration,
-    calls,
+    calls: list[ServiceCall],
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test for value conditions."""

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -19,7 +19,7 @@ from homeassistant.components.zwave_js.helpers import (
     async_get_node_status_sensor_entity_id,
     get_device_id,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
@@ -74,7 +74,11 @@ async def test_get_notification_notification_triggers(
 
 
 async def test_if_notification_notification_fires(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for event.notification.notification trigger firing."""
     node: Node = lock_schlage_be469
@@ -203,7 +207,11 @@ async def test_get_trigger_capabilities_notification_notification(
 
 
 async def test_if_entry_control_notification_fires(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for notification.entry_control trigger firing."""
     node: Node = lock_schlage_be469
@@ -360,7 +368,11 @@ async def test_get_node_status_triggers(
 
 
 async def test_if_node_status_change_fires(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
@@ -439,7 +451,11 @@ async def test_if_node_status_change_fires(
 
 
 async def test_if_node_status_change_fires_legacy(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for node_status trigger firing."""
     node: Node = lock_schlage_be469
@@ -603,7 +619,11 @@ async def test_get_basic_value_notification_triggers(
 
 
 async def test_if_basic_value_notification_fires(
-    hass: HomeAssistant, client, ge_in_wall_dimmer_switch, integration, calls
+    hass: HomeAssistant,
+    client,
+    ge_in_wall_dimmer_switch,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.basic trigger firing."""
     node: Node = ge_in_wall_dimmer_switch
@@ -778,7 +798,11 @@ async def test_get_central_scene_value_notification_triggers(
 
 
 async def test_if_central_scene_value_notification_fires(
-    hass: HomeAssistant, client, wallmote_central_scene, integration, calls
+    hass: HomeAssistant,
+    client,
+    wallmote_central_scene,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.central_scene trigger firing."""
     node: Node = wallmote_central_scene
@@ -958,7 +982,11 @@ async def test_get_scene_activation_value_notification_triggers(
 
 
 async def test_if_scene_activation_value_notification_fires(
-    hass: HomeAssistant, client, hank_binary_switch, integration, calls
+    hass: HomeAssistant,
+    client,
+    hank_binary_switch,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for event.value_notification.scene_activation trigger firing."""
     node: Node = hank_binary_switch
@@ -1128,7 +1156,11 @@ async def test_get_value_updated_value_triggers(
 
 
 async def test_if_value_updated_value_fires(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for zwave_js.value_updated.value trigger firing."""
     node: Node = lock_schlage_be469
@@ -1220,7 +1252,11 @@ async def test_if_value_updated_value_fires(
 
 
 async def test_value_updated_value_no_driver(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test zwave_js.value_updated.value trigger with missing driver."""
     node: Node = lock_schlage_be469
@@ -1369,7 +1405,11 @@ async def test_get_value_updated_config_parameter_triggers(
 
 
 async def test_if_value_updated_config_parameter_fires(
-    hass: HomeAssistant, client, lock_schlage_be469, integration, calls
+    hass: HomeAssistant,
+    client,
+    lock_schlage_be469,
+    integration,
+    calls: list[ServiceCall],
 ) -> None:
     """Test for zwave_js.value_updated.config_parameter trigger firing."""
     node: Node = lock_schlage_be469

--- a/tests/components/zwave_js/test_device_trigger.py
+++ b/tests/components/zwave_js/test_device_trigger.py
@@ -30,7 +30,7 @@ from tests.common import async_get_device_automations, async_mock_service
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant):
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
     """Track calls to a mock service."""
     return async_mock_service(hass, "test", "automation")
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

```python
@pytest.fixture
def calls(hass: HomeAssistant) -> list[ServiceCall]:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
