### PR TITLE
Rename calls fixture in calendar tests

### DIFF
--- a/tests/components/calendar/test_trigger.py
+++ b/tests/components/calendar/test_trigger.py
@@ -150,7 +150,7 @@ async def create_automation(
 
 
 @pytest.fixture
-def calls(hass: HomeAssistant) -> Callable[[], list[dict[str, Any]]]:
+def calls_data(hass: HomeAssistant) -> Callable[[], list[dict[str, Any]]]:
     """Fixture to return payload data for automation calls."""
     service_calls = async_mock_service(hass, "test", "automation")
 
@@ -172,7 +172,7 @@ def mock_update_interval() -> Generator[None, None, None]:
 
 async def test_event_start_trigger(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -182,13 +182,13 @@ async def test_event_start_trigger(
         end=datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
     )
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00"),
         )
 
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -206,7 +206,7 @@ async def test_event_start_trigger(
 )
 async def test_event_start_trigger_with_offset(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
     offset_str,
@@ -222,13 +222,13 @@ async def test_event_start_trigger_with_offset(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:55:00+00:00") + offset_delta,
         )
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         # Event has started w/ offset
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 12:05:00+00:00") + offset_delta,
         )
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_START,
@@ -239,7 +239,7 @@ async def test_event_start_trigger_with_offset(
 
 async def test_event_end_trigger(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -253,13 +253,13 @@ async def test_event_end_trigger(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:10:00+00:00")
         )
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         # Event ends
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 12:10:00+00:00")
         )
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_END,
@@ -277,7 +277,7 @@ async def test_event_end_trigger(
 )
 async def test_event_end_trigger_with_offset(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
     offset_str,
@@ -293,13 +293,13 @@ async def test_event_end_trigger_with_offset(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 12:05:00+00:00") + offset_delta,
         )
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         # Event has started w/ offset
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 12:35:00+00:00") + offset_delta,
         )
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_END,
@@ -310,7 +310,7 @@ async def test_event_end_trigger_with_offset(
 
 async def test_calendar_trigger_with_no_events(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
 ) -> None:
     """Test a calendar trigger setup  with no events."""
@@ -320,12 +320,12 @@ async def test_calendar_trigger_with_no_events(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:00:00+00:00")
         )
-    assert len(calls()) == 0
+    assert len(calls_data()) == 0
 
 
 async def test_multiple_start_events(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -343,7 +343,7 @@ async def test_multiple_start_events(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00")
         )
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -359,7 +359,7 @@ async def test_multiple_start_events(
 
 async def test_multiple_end_events(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -378,7 +378,7 @@ async def test_multiple_end_events(
             datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00")
         )
 
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_END,
@@ -394,7 +394,7 @@ async def test_multiple_end_events(
 
 async def test_multiple_events_sharing_start_time(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -413,7 +413,7 @@ async def test_multiple_events_sharing_start_time(
             datetime.datetime.fromisoformat("2022-04-19 11:35:00+00:00")
         )
 
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -429,7 +429,7 @@ async def test_multiple_events_sharing_start_time(
 
 async def test_overlap_events(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -448,7 +448,7 @@ async def test_overlap_events(
             datetime.datetime.fromisoformat("2022-04-19 11:20:00+00:00")
         )
 
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -506,7 +506,7 @@ async def test_legacy_entity_type(
 
 async def test_update_next_event(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -521,7 +521,7 @@ async def test_update_next_event(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 10:45:00+00:00")
         )
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         # Create a new event between now and when the event fires
         event_data2 = test_entity.create_event(
@@ -533,7 +533,7 @@ async def test_update_next_event(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00")
         )
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -549,7 +549,7 @@ async def test_update_next_event(
 
 async def test_update_missed(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
 ) -> None:
@@ -565,7 +565,7 @@ async def test_update_missed(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 10:38:00+00:00")
         )
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         test_entity.create_event(
             start=datetime.datetime.fromisoformat("2022-04-19 10:40:00+00:00"),
@@ -576,7 +576,7 @@ async def test_update_missed(
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:05:00+00:00")
         )
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_START,
@@ -639,7 +639,7 @@ async def test_update_missed(
 )
 async def test_event_payload(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
     set_time_zone: None,
@@ -650,10 +650,10 @@ async def test_event_payload(
     """Test the fields in the calendar event payload are set."""
     test_entity.create_event(**create_data)
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         await fake_schedule.fire_until(fire_time)
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_START,
@@ -664,7 +664,7 @@ async def test_event_payload(
 
 async def test_trigger_timestamp_window_edge(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
     freezer: FrozenDateTimeFactory,
@@ -678,12 +678,12 @@ async def test_trigger_timestamp_window_edge(
         end=datetime.datetime.fromisoformat("2022-04-19 11:30:00+00:00"),
     )
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2022-04-19 11:20:00+00:00")
         )
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_START,
@@ -694,7 +694,7 @@ async def test_trigger_timestamp_window_edge(
 
 async def test_event_start_trigger_dst(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entity: MockCalendarEntity,
     freezer: FrozenDateTimeFactory,
@@ -723,13 +723,13 @@ async def test_event_start_trigger_dst(
         end=datetime.datetime(2023, 3, 12, 3, 45, tzinfo=tzinfo),
     )
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         await fake_schedule.fire_until(
             datetime.datetime.fromisoformat("2023-03-12 05:00:00-08:00"),
         )
 
-        assert calls() == [
+        assert calls_data() == [
             {
                 "platform": "calendar",
                 "event": EVENT_START,
@@ -750,7 +750,7 @@ async def test_event_start_trigger_dst(
 
 async def test_config_entry_reload(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entities: list[MockCalendarEntity],
     setup_platform: None,
@@ -764,7 +764,7 @@ async def test_config_entry_reload(
     invalid after a config entry was reloaded.
     """
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         assert await hass.config_entries.async_reload(config_entry.entry_id)
 
@@ -779,7 +779,7 @@ async def test_config_entry_reload(
             datetime.datetime.fromisoformat("2022-04-19 11:15:00+00:00"),
         )
 
-    assert calls() == [
+    assert calls_data() == [
         {
             "platform": "calendar",
             "event": EVENT_START,
@@ -790,7 +790,7 @@ async def test_config_entry_reload(
 
 async def test_config_entry_unload(
     hass: HomeAssistant,
-    calls: Callable[[], list[dict[str, Any]]],
+    calls_data: Callable[[], list[dict[str, Any]]],
     fake_schedule: FakeSchedule,
     test_entities: list[MockCalendarEntity],
     setup_platform: None,
@@ -799,7 +799,7 @@ async def test_config_entry_unload(
 ) -> None:
     """Test an automation that references a calendar entity that is unloaded."""
     async with create_automation(hass, EVENT_START):
-        assert len(calls()) == 0
+        assert len(calls_data()) == 0
 
         assert await hass.config_entries.async_unload(config_entry.entry_id)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, to avoid confusion with the more common calls fixture:

```python
@pytest.fixture
def calls(hass: HomeAssistant) -> list[ServiceCall]:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
