### PR TITLE
Rename calls fixture in mqtt tests

### DIFF
--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -100,19 +100,19 @@ def mock_storage(hass_storage: dict[str, Any]) -> None:
 
 
 @pytest.fixture
-def calls() -> list[ReceiveMessage]:
+def recorded_calls() -> list[ReceiveMessage]:
     """Fixture to hold recorded calls."""
     return []
 
 
 @pytest.fixture
-def record_calls(calls: list[ReceiveMessage]) -> MessageCallbackType:
+def record_calls(recorded_calls: list[ReceiveMessage]) -> MessageCallbackType:
     """Fixture to record calls."""
 
     @callback
     def record_calls(msg: ReceiveMessage) -> None:
         """Record calls."""
-        calls.append(msg)
+        recorded_calls.append(msg)
 
     return record_calls
 
@@ -1017,7 +1017,7 @@ async def test_receiving_message_with_non_utf8_topic_gets_logged(
 async def test_all_subscriptions_run_when_decode_fails(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test all other subscriptions still run when decode fails for one."""
@@ -1028,13 +1028,13 @@ async def test_all_subscriptions_run_when_decode_fails(
     async_fire_mqtt_message(hass, "test-topic", UnitOfTemperature.CELSIUS)
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(recorded_calls) == 1
 
 
 async def test_subscribe_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of a topic."""
@@ -1044,16 +1044,16 @@ async def test_subscribe_topic(
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
     unsub()
 
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(recorded_calls) == 1
 
     # Cannot unsubscribe twice
     with pytest.raises(HomeAssistantError):
@@ -1099,7 +1099,7 @@ async def test_subscribe_and_resubscribe(
     client_debug_log: None,
     mqtt_mock_entry: MqttMockHAClientGenerator,
     mqtt_client_mock: MqttMockPahoClient,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test resubscribing within the debounce time."""
@@ -1119,9 +1119,9 @@ async def test_subscribe_and_resubscribe(
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
     await hass.async_block_till_done()
 
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
     # assert unsubscribe was not called
     mqtt_client_mock.unsubscribe.assert_not_called()
 
@@ -1135,7 +1135,7 @@ async def test_subscribe_and_resubscribe(
 async def test_subscribe_topic_non_async(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of a topic using the non-async function."""
@@ -1148,16 +1148,16 @@ async def test_subscribe_topic_non_async(
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
     await hass.async_add_executor_job(unsub)
 
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(recorded_calls) == 1
 
 
 async def test_subscribe_bad_topic(
@@ -1174,7 +1174,7 @@ async def test_subscribe_bad_topic(
 async def test_subscribe_topic_not_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test if subscribed topic is not a match."""
@@ -1184,13 +1184,13 @@ async def test_subscribe_topic_not_match(
     async_fire_mqtt_message(hass, "another-test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_level_wildcard(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1200,15 +1200,15 @@ async def test_subscribe_topic_level_wildcard(
     async_fire_mqtt_message(hass, "test-topic/bier/on", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic/bier/on"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic/bier/on"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_no_subtree_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1218,13 +1218,13 @@ async def test_subscribe_topic_level_wildcard_no_subtree_match(
     async_fire_mqtt_message(hass, "test-topic/bier", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1234,13 +1234,13 @@ async def test_subscribe_topic_level_wildcard_root_topic_no_subtree_match(
     async_fire_mqtt_message(hass, "test-topic-123", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_subtree_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1250,15 +1250,15 @@ async def test_subscribe_topic_subtree_wildcard_subtree_topic(
     async_fire_mqtt_message(hass, "test-topic/bier/on", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic/bier/on"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic/bier/on"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_subtree_wildcard_root_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1268,15 +1268,15 @@ async def test_subscribe_topic_subtree_wildcard_root_topic(
     async_fire_mqtt_message(hass, "test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_subtree_wildcard_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1286,13 +1286,13 @@ async def test_subscribe_topic_subtree_wildcard_no_match(
     async_fire_mqtt_message(hass, "another-test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1302,15 +1302,15 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_root_topic(
     async_fire_mqtt_message(hass, "hi/test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "hi/test-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "hi/test-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1320,15 +1320,15 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_subtree_topic(
     async_fire_mqtt_message(hass, "hi/test-topic/here-iam", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "hi/test-topic/here-iam"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "hi/test-topic/here-iam"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1338,13 +1338,13 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_level_no_match(
     async_fire_mqtt_message(hass, "hi/here-iam/test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of wildcard topics."""
@@ -1354,13 +1354,13 @@ async def test_subscribe_topic_level_wildcard_and_wildcard_no_match(
     async_fire_mqtt_message(hass, "hi/another-test-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 async def test_subscribe_topic_sys_root(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root topics."""
@@ -1370,15 +1370,15 @@ async def test_subscribe_topic_sys_root(
     async_fire_mqtt_message(hass, "$test-topic/subtree/on", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "$test-topic/subtree/on"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "$test-topic/subtree/on"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root and wildcard topics."""
@@ -1388,15 +1388,15 @@ async def test_subscribe_topic_sys_root_and_wildcard_topic(
     async_fire_mqtt_message(hass, "$test-topic/some-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "$test-topic/some-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "$test-topic/some-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription of $ root and wildcard subtree topics."""
@@ -1406,15 +1406,15 @@ async def test_subscribe_topic_sys_root_and_wildcard_subtree_topic(
     async_fire_mqtt_message(hass, "$test-topic/subtree/some-topic", "test-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == "$test-topic/subtree/some-topic"
-    assert calls[0].payload == "test-payload"
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == "$test-topic/subtree/some-topic"
+    assert recorded_calls[0].payload == "test-payload"
 
 
 async def test_subscribe_special_characters(
     hass: HomeAssistant,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test the subscription to topics with special characters."""
@@ -1426,9 +1426,9 @@ async def test_subscribe_special_characters(
 
     async_fire_mqtt_message(hass, topic, payload)
     await hass.async_block_till_done()
-    assert len(calls) == 1
-    assert calls[0].topic == topic
-    assert calls[0].payload == payload
+    assert len(recorded_calls) == 1
+    assert recorded_calls[0].topic == topic
+    assert recorded_calls[0].payload == payload
 
 
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
@@ -1974,7 +1974,7 @@ async def test_reload_entry_with_restored_subscriptions(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     record_calls: MessageCallbackType,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
 ) -> None:
     """Test reloading the config entry with with subscriptions restored."""
     # Setup the MQTT entry
@@ -1992,12 +1992,12 @@ async def test_reload_entry_with_restored_subscriptions(
     async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload")
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload"
-    assert calls[1].topic == "wild/any/card"
-    assert calls[1].payload == "wild-card-payload"
-    calls.clear()
+    assert len(recorded_calls) == 2
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload"
+    assert recorded_calls[1].topic == "wild/any/card"
+    assert recorded_calls[1].payload == "wild-card-payload"
+    recorded_calls.clear()
 
     # Reload the entry
     with patch("homeassistant.config.load_yaml_config_file", return_value={}):
@@ -2009,12 +2009,12 @@ async def test_reload_entry_with_restored_subscriptions(
     async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload2")
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload2"
-    assert calls[1].topic == "wild/any/card"
-    assert calls[1].payload == "wild-card-payload2"
-    calls.clear()
+    assert len(recorded_calls) == 2
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload2"
+    assert recorded_calls[1].topic == "wild/any/card"
+    assert recorded_calls[1].payload == "wild-card-payload2"
+    recorded_calls.clear()
 
     # Reload the entry again
     with patch("homeassistant.config.load_yaml_config_file", return_value={}):
@@ -2026,11 +2026,11 @@ async def test_reload_entry_with_restored_subscriptions(
     async_fire_mqtt_message(hass, "wild/any/card", "wild-card-payload3")
 
     await hass.async_block_till_done()
-    assert len(calls) == 2
-    assert calls[0].topic == "test-topic"
-    assert calls[0].payload == "test-payload3"
-    assert calls[1].topic == "wild/any/card"
-    assert calls[1].payload == "wild-card-payload3"
+    assert len(recorded_calls) == 2
+    assert recorded_calls[0].topic == "test-topic"
+    assert recorded_calls[0].payload == "test-payload3"
+    assert recorded_calls[1].topic == "wild/any/card"
+    assert recorded_calls[1].payload == "wild-card-payload3"
 
 
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 2)
@@ -4455,7 +4455,7 @@ async def test_server_sock_connect_and_disconnect(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test handling the socket connected and disconnected."""
@@ -4486,7 +4486,7 @@ async def test_server_sock_connect_and_disconnect(
     unsub()
 
     # Should have failed
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)
@@ -4561,7 +4561,7 @@ async def test_client_sock_failure_after_connect(
     hass: HomeAssistant,
     mqtt_client_mock: MqttMockPahoClient,
     mqtt_mock_entry: MqttMockHAClientGenerator,
-    calls: list[ReceiveMessage],
+    recorded_calls: list[ReceiveMessage],
     record_calls: MessageCallbackType,
 ) -> None:
     """Test handling the socket connected and disconnected."""
@@ -4592,7 +4592,7 @@ async def test_client_sock_failure_after_connect(
 
     unsub()
     # Should have failed
-    assert len(calls) == 0
+    assert len(recorded_calls) == 0
 
 
 @patch("homeassistant.components.mqtt.client.INITIAL_SUBSCRIBE_COOLDOWN", 0.0)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, to avoid confusion with the more common calls fixture:

```python
@pytest.fixture
def calls(hass: HomeAssistant) -> list[ServiceCall]:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
