### PR TITLE
Rename calls fixture in components tests

### DIFF
--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -9,7 +9,7 @@ from homeassistant.components import notify
 from homeassistant.components.demo import DOMAIN
 import homeassistant.components.demo.notify as demo
 from homeassistant.const import Platform
-from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, async_capture_events
@@ -40,24 +40,6 @@ async def setup_notify(hass: HomeAssistant, notify_only: None) -> None:
 def events(hass: HomeAssistant) -> list[Event]:
     """Fixture that catches notify events."""
     return async_capture_events(hass, demo.EVENT_NOTIFY)
-
-
-@pytest.fixture
-def calls():
-    """Fixture to calls."""
-    return []
-
-
-@pytest.fixture
-def record_calls(calls):
-    """Fixture to record calls."""
-
-    @callback
-    def record_calls(*args):
-        """Record calls."""
-        calls.append(args)
-
-    return record_calls
 
 
 async def test_sending_message(hass: HomeAssistant, events: list[Event]) -> None:

--- a/tests/components/google_mail/test_config_flow.py
+++ b/tests/components/google_mail/test_config_flow.py
@@ -76,7 +76,7 @@ async def test_full_flow(
 
 
 @pytest.mark.parametrize(
-    ("fixture", "abort_reason", "placeholders", "calls", "access_token"),
+    ("fixture", "abort_reason", "placeholders", "call_count", "access_token"),
     [
         ("get_profile", "reauth_successful", None, 1, "updated-access-token"),
         (
@@ -97,7 +97,7 @@ async def test_reauth(
     fixture: str,
     abort_reason: str,
     placeholders: dict[str, str],
-    calls: int,
+    call_count: int,
     access_token: str,
 ) -> None:
     """Test the re-authentication case updates the correct config entry.
@@ -164,7 +164,7 @@ async def test_reauth(
     assert result.get("type") is FlowResultType.ABORT
     assert result["reason"] == abort_reason
     assert result["description_placeholders"] == placeholders
-    assert len(mock_setup.mock_calls) == calls
+    assert len(mock_setup.mock_calls) == call_count
 
     assert config_entry.unique_id == TITLE
     assert "token" in config_entry.data

--- a/tests/components/hdmi_cec/test_init.py
+++ b/tests/components/hdmi_cec/test_init.py
@@ -277,7 +277,7 @@ async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) 
 
 
 @pytest.mark.parametrize(
-    ("count", "calls"),
+    ("count", "call_count"),
     [
         (3, 3),
         (1, 1),
@@ -294,7 +294,12 @@ async def test_service_update_devices(hass: HomeAssistant, create_hdmi_network) 
 )
 @pytest.mark.parametrize(("direction", "key"), [("up", 65), ("down", 66)])
 async def test_service_volume_x_times(
-    hass: HomeAssistant, create_hdmi_network, count, calls, direction, key
+    hass: HomeAssistant,
+    create_hdmi_network,
+    count: int,
+    call_count: int,
+    direction,
+    key,
 ) -> None:
     """Test the volume service call with steps."""
     mock_hdmi_network_instance = await create_hdmi_network()
@@ -306,8 +311,8 @@ async def test_service_volume_x_times(
         blocking=True,
     )
 
-    assert mock_hdmi_network_instance.send_command.call_count == calls * 2
-    for i in range(calls):
+    assert mock_hdmi_network_instance.send_command.call_count == call_count * 2
+    for i in range(call_count):
         assert_key_press_release(
             mock_hdmi_network_instance.send_command, i, dst=5, key=key
         )

--- a/tests/components/youtube/test_config_flow.py
+++ b/tests/components/youtube/test_config_flow.py
@@ -211,7 +211,7 @@ async def test_flow_http_error(
 
 
 @pytest.mark.parametrize(
-    ("fixture", "abort_reason", "placeholders", "calls", "access_token"),
+    ("fixture", "abort_reason", "placeholders", "call_count", "access_token"),
     [
         (
             "get_channel",
@@ -238,7 +238,7 @@ async def test_reauth(
     fixture: str,
     abort_reason: str,
     placeholders: dict[str, str],
-    calls: int,
+    call_count: int,
     access_token: str,
 ) -> None:
     """Test the re-authentication case updates the correct config entry.
@@ -303,7 +303,7 @@ async def test_reauth(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == abort_reason
     assert result["description_placeholders"] == placeholders
-    assert len(mock_setup.mock_calls) == calls
+    assert len(mock_setup.mock_calls) == call_count
 
     assert config_entry.unique_id == "UC_x5XG1OV2P6uZZ5FSM9Ttw"
     assert "token" in config_entry.data


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA, to avoid confusion with the more common calls fixture:

```python
@pytest.fixture
def calls(hass: HomeAssistant) -> list[ServiceCall]:
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
