### PR TITLE
Add SnapshotAssertion type hints in tests

### DIFF
--- a/tests/components/blueprint/test_importer.py
+++ b/tests/components/blueprint/test_importer.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import pytest
+from syrupy import SnapshotAssertion
 
 from homeassistant.components.blueprint import importer
 from homeassistant.core import HomeAssistant
@@ -53,7 +54,9 @@ def test_get_github_import_url() -> None:
     )
 
 
-def test_extract_blueprint_from_community_topic(community_post, snapshot) -> None:
+def test_extract_blueprint_from_community_topic(
+    community_post, snapshot: SnapshotAssertion
+) -> None:
     """Test extracting blueprint."""
     imported_blueprint = importer._extract_blueprint_from_community_topic(
         "http://example.com", json.loads(community_post)
@@ -94,7 +97,10 @@ def test_extract_blueprint_from_community_topic_wrong_lang() -> None:
 
 
 async def test_fetch_blueprint_from_community_url(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, community_post, snapshot
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    community_post,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test fetching blueprint from url."""
     aioclient_mock.get(
@@ -148,7 +154,9 @@ async def test_fetch_blueprint_from_github_url(
 
 
 async def test_fetch_blueprint_from_github_gist_url(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, snapshot
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test fetching blueprint from url."""
     aioclient_mock.get(

--- a/tests/components/conversation/test_init.py
+++ b/tests/components/conversation/test_init.py
@@ -502,7 +502,12 @@ async def test_http_processing_intent_conversion_not_expose_new(
 @pytest.mark.parametrize("sentence", ["turn on kitchen", "turn kitchen on"])
 @pytest.mark.parametrize("conversation_id", ["my_new_conversation", None])
 async def test_turn_on_intent(
-    hass: HomeAssistant, init_components, conversation_id, sentence, agent_id, snapshot
+    hass: HomeAssistant,
+    init_components,
+    conversation_id,
+    sentence,
+    agent_id,
+    snapshot: SnapshotAssertion,
 ) -> None:
     """Test calling the turn on intent."""
     hass.states.async_set("light.kitchen", "off")

--- a/tests/components/wyoming/test_stt.py
+++ b/tests/components/wyoming/test_stt.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from syrupy import SnapshotAssertion
 from wyoming.asr import Transcript
 
 from homeassistant.components import stt
@@ -29,7 +30,7 @@ async def test_support(hass: HomeAssistant, init_wyoming_stt) -> None:
 
 
 async def test_streaming_audio(
-    hass: HomeAssistant, init_wyoming_stt, metadata, snapshot
+    hass: HomeAssistant, init_wyoming_stt, metadata, snapshot: SnapshotAssertion
 ) -> None:
     """Test streaming audio."""
     entity = stt.async_get_speech_to_text_entity(hass, "stt.test_asr")

--- a/tests/components/wyoming/test_tts.py
+++ b/tests/components/wyoming/test_tts.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import wave
 
 import pytest
+from syrupy import SnapshotAssertion
 from wyoming.audio import AudioChunk, AudioStop
 
 from homeassistant.components import tts, wyoming
@@ -38,7 +39,9 @@ async def test_support(hass: HomeAssistant, init_wyoming_tts) -> None:
     assert not entity.async_get_supported_voices("de-DE")
 
 
-async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) -> None:
+async def test_get_tts_audio(
+    hass: HomeAssistant, init_wyoming_tts, snapshot: SnapshotAssertion
+) -> None:
     """Test get audio."""
     audio = bytes(100)
     audio_events = [
@@ -79,7 +82,7 @@ async def test_get_tts_audio(hass: HomeAssistant, init_wyoming_tts, snapshot) ->
 
 
 async def test_get_tts_audio_different_formats(
-    hass: HomeAssistant, init_wyoming_tts, snapshot
+    hass: HomeAssistant, init_wyoming_tts, snapshot: SnapshotAssertion
 ) -> None:
     """Test changing preferred audio format."""
     audio = bytes(16000 * 2 * 1)  # one second
@@ -190,7 +193,9 @@ async def test_get_tts_audio_audio_oserror(
         )
 
 
-async def test_voice_speaker(hass: HomeAssistant, init_wyoming_tts, snapshot) -> None:
+async def test_voice_speaker(
+    hass: HomeAssistant, init_wyoming_tts, snapshot: SnapshotAssertion
+) -> None:
     """Test using a different voice and speaker."""
     audio = bytes(100)
     audio_events = [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
